### PR TITLE
basic types

### DIFF
--- a/Sources/MongoSwift/BsonValue.swift
+++ b/Sources/MongoSwift/BsonValue.swift
@@ -37,21 +37,12 @@ extension Bool: BsonValue {
     public var bsonType: BsonType { return .boolean }
 }
 
-// class wrapping string representation of BSON value
-class Decimal128: BsonValue, Equatable {
-    var data = ""
-    init(_ data: String) {
-        self.data = data
-    }
-    public var bsonType: BsonType { return .decimal128 }
-
-    static func == (lhs: Decimal128, rhs: Decimal128) -> Bool {
-        return lhs.data == rhs.data
-    }
-}
-
 extension Double: BsonValue {
     public var bsonType: BsonType { return .double }
+}
+
+extension Int: BsonValue {
+    public var bsonType: BsonType { return .int32 }
 }
 
 extension Int32: BsonValue {

--- a/Sources/MongoSwift/Document.swift
+++ b/Sources/MongoSwift/Document.swift
@@ -72,19 +72,11 @@ public class Document: ExpressibleByDictionaryLiteral {
                     case BSON_TYPE_BOOL:
                         return bson_iter_bool(&iter)
 
-                    case BSON_TYPE_DECIMAL128:
-                        let decimal128 = UnsafeMutablePointer<bson_decimal128_t>.allocate(capacity: 1)
-                        let stringVal = UnsafeMutablePointer<Int8>.allocate(capacity: Int(BSON_DECIMAL128_STRING))
-                        precondition(bson_iter_decimal128(&iter, decimal128), retrieveErrorMsg("Decimal128"))
-                        // this returns void so I guess we can't make sure it worked..
-                        bson_decimal128_to_string(decimal128, stringVal)
-                        return Decimal128(String(cString: stringVal))
-
                     case BSON_TYPE_DOUBLE:
                         return bson_iter_double(&iter)
 
                     case BSON_TYPE_INT32:
-                        return bson_iter_int32(&iter)
+                        return Int(bson_iter_int32(&iter))
 
                     case BSON_TYPE_INT64:
                         return bson_iter_int64(&iter)
@@ -124,16 +116,13 @@ public class Document: ExpressibleByDictionaryLiteral {
             case (.boolean, let val as Bool):
                 res = bson_append_bool(data, key, keySize, val)
 
-            case (.decimal128, let val as Decimal128):
-                let decimal128 = UnsafeMutablePointer<bson_decimal128_t>.allocate(capacity: 1)
-                precondition(bson_decimal128_from_string(val.data, decimal128),
-                    "Failed to parse Decimal128 string \(val.data)")
-                res = bson_append_decimal128(data, key, keySize, decimal128)
-
             case (.double, let val as Double):
                 res = bson_append_double(data, key, keySize, val)
 
             case (.int32, let val as Int32):
+                res = bson_append_int32(data, key, keySize, val)
+
+            case (.int32, let val as Int):
                 res = bson_append_int32(data, key, keySize, Int32(val))
 
             case (.int64, let val as Int64):

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -10,42 +10,43 @@ final class DocumentTests: XCTestCase {
     }
 
     func testDocument() {
+
         let doc = Document()
         doc["string"] = "test string"
         doc["true"] = true
         doc["false"] = false
+        doc["int"] = 25
         doc["int32"] = Int32(5)
         doc["int64"] = Int64(10)
         doc["double"] = Double(15)
-        doc["array1"] = [Int32(1), Int32(2)]
+        doc["array1"] = [1, 2]
         doc["array2"] = ["string1", "string2"]
-        doc["decimal128"] = Decimal128("2.0")
-        doc["nestedarray"] = [[Int32(1), Int32(2)], [Int32(3), Int32(4)]]
+        doc["nestedarray"] = [[1, 2], [Int32(3), Int32(4)]]
 
         XCTAssertEqual(doc["string"] as? String, "test string")
         XCTAssertEqual(doc["true"] as? Bool, true)
         XCTAssertEqual(doc["false"] as? Bool, false)
-        XCTAssertEqual(doc["int32"] as? Int32, 5)
+        XCTAssertEqual(doc["int"] as? Int, 25)
+        XCTAssertEqual(doc["int32"] as? Int, 5)
         XCTAssertEqual(doc["int64"] as? Int64, 10)
         XCTAssertEqual(doc["double"] as? Double, 15)
-        XCTAssertEqual(doc["array1"] as! [Int32], [1, 2])
+        XCTAssertEqual(doc["array1"] as! [Int], [1, 2])
         XCTAssertEqual(doc["array2"] as! [String], ["string1", "string2"])
-        XCTAssertEqual(doc["decimal128"] as? Decimal128, Decimal128("2.0"))
 
         guard let nestedArray = doc["nestedarray"] else { return }
-        let intArrays = nestedArray as! [[Int32]]
+        let intArrays = nestedArray as! [[Int]]
         XCTAssertEqual(intArrays.count, 2)
-        XCTAssertEqual(intArrays[0], [Int32(1), Int32(2)])
-        XCTAssertEqual(intArrays[1], [Int32(3), Int32(4)])
+        XCTAssertEqual(intArrays[0], [1, 2])
+        XCTAssertEqual(intArrays[1], [3, 4])
 
-        let doc2: Document = ["hi": true, "hello": "hi", "cat": Int32(2)]
+        let doc2: Document = ["hi": true, "hello": "hi", "cat": 2]
         XCTAssertEqual(doc2["hi"] as? Bool, true)
         XCTAssertEqual(doc2["hello"] as? String, "hi")
-        XCTAssertEqual(doc2["cat"] as? Int32, 2)
+        XCTAssertEqual(doc2["cat"] as? Int, 2)
 
-        let doc3 = Document(["hi": true, "hello": "hi", "cat": Int32(2)])
+        let doc3 = Document(["hi": true, "hello": "hi", "cat": 2])
         XCTAssertEqual(doc3["hi"] as? Bool, true)
         XCTAssertEqual(doc3["hello"] as? String, "hi")
-        XCTAssertEqual(doc3["cat"] as? Int32, 2)
+        XCTAssertEqual(doc3["cat"] as? Int, 2)
     }
 }


### PR DESCRIPTION
something to think about... the Int type in Swift is either Int32 or Int64 depending on your machine. and if you just type like `2` it's considered an Int (vs `Int32(2)` or `Int64(2)`). but it's a pain for anyone using this to have to explicitly set the type on every number... as you see in tests I have to do like ` doc["int32"] = Int32(5)` etc. ideally you could just do doc["x"] = 5 and we'd figure out whether the int is 32 or 64 and store in BSON appropriately. so... we could maybe also extend Ints and have them conditionally return either .int32 or .int64 for BSON type? thoughts? 

