### PR TITLE
SWIFT-24 Make Documents Equatable

### DIFF
--- a/Sources/MongoSwift/Document.swift
+++ b/Sources/MongoSwift/Document.swift
@@ -190,3 +190,9 @@ public class Document: BsonValue, ExpressibleByDictionaryLiteral, CustomStringCo
         }
     }
 }
+
+extension Document: Equatable {
+    public static func == (lhs: Document, rhs: Document) -> Bool {
+        return bson_compare(lhs.getData(), rhs.getData()) == 0
+    }
+}

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -5,7 +5,8 @@ import XCTest
 final class DocumentTests: XCTestCase {
     static var allTests: [(String, (DocumentTests) -> () throws -> Void)] {
         return [
-            ("testDocument", testDocument)
+            ("testDocument", testDocument),
+            ("testEquatable", testEquatable)
         ]
     }
 
@@ -130,5 +131,12 @@ final class DocumentTests: XCTestCase {
         XCTAssertEqual(doc2["hello"] as? String, "hi")
         XCTAssertEqual(doc2["cat"] as? Int, 2)
 
+    }
+
+    func testEquatable() {
+        XCTAssertEqual(
+            ["hi": true, "hello": "hi", "cat": 2] as Document,
+            ["hi": true, "hello": "hi", "cat": 2] as Document
+        )
     }
 }


### PR DESCRIPTION
This utilizes the existing `bson_compare` method in order to
provide a means of determining Document equality.