### PR TITLE
SWIFT-43 Nil out pointer to bson_t when deinitializing a Document

### DIFF
--- a/Sources/MongoSwift/Document.swift
+++ b/Sources/MongoSwift/Document.swift
@@ -110,7 +110,9 @@ public class Document: BsonValue, ExpressibleByDictionaryLiteral, ExpressibleByA
     }
 
     deinit {
+        guard let data = self.data else { return }
         bson_destroy(data)
+        self.data = nil
     }
 
     public var description: String {


### PR DESCRIPTION
In addition to destroying the bson_t, nil out the pointer to it so that garbage collection can happen properly