### PR TITLE
SWIFT-45 Display error message when an error is thrown

### DIFF
--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -1,7 +1,7 @@
 import Foundation
 import libmongoc
 
-public enum MongoError: LocalizedError {
+public enum MongoError {
     case invalidUri(message: String)
     case invalidClient()
     case invalidResponse()
@@ -12,7 +12,7 @@ public enum MongoError: LocalizedError {
     case bsonEncodeError(message: String)
 }
 
-extension MongoError {
+extension MongoError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case let .invalidUri(message), let .invalidCursor(message),


### PR DESCRIPTION
Implement the `LocalizedError` protocol (which inherits from `Error`) so that we can provide an `errorDescription`for errors with `message` associated values 