### PR TITLE
SWIFT-45: Add documentation for and clean up Document class

### DIFF
--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -88,7 +88,7 @@ public class Client {
     func listDatabases(options: ListDatabasesOptions? = nil) throws -> Cursor {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
-        guard let cursor = mongoc_client_find_databases_with_opts(self._client, getDataOrNil(opts)) else {
+        guard let cursor = mongoc_client_find_databases_with_opts(self._client, opts?.data) else {
             throw MongoError.invalidResponse()
         }
         return Cursor(fromCursor: cursor, withClient: self)

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -484,7 +484,7 @@ public class Collection {
     func find(_ filter: Document, options: FindOptions? = nil) throws -> Cursor {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
-        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, getDataOrNil(opts), nil) else {
+        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts?.data, nil) else {
             throw MongoError.invalidResponse()
         }
         guard let client = self._client else {
@@ -507,7 +507,7 @@ public class Collection {
         let opts = try encoder.encode(options)
         let pipeline: Document = ["pipeline": pipeline]
         guard let cursor = mongoc_collection_aggregate(
-            self._collection, MONGOC_QUERY_NONE, pipeline.data, getDataOrNil(opts), nil) else {
+            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts?.data, nil) else {
             throw MongoError.invalidResponse()
         }
         guard let client = self._client else {
@@ -532,7 +532,7 @@ public class Collection {
         // because we already encode skip and limit in the options, 
         // pass in 0s so we don't get duplicate parameter errors. 
         let count = mongoc_collection_count_with_opts(
-            self._collection, MONGOC_QUERY_NONE, filter.data, 0, 0, getDataOrNil(opts), nil, &error)
+            self._collection, MONGOC_QUERY_NONE, filter.data, 0, 0, opts?.data, nil, &error)
 
         if count == -1 { throw MongoError.commandError(message: toErrorString(error)) }
 
@@ -569,7 +569,7 @@ public class Collection {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
         var error = bson_error_t()
-        if !mongoc_collection_insert_one(self._collection, document.data, getDataOrNil(opts), nil, &error) {
+        if !mongoc_collection_insert_one(self._collection, document.data, opts?.data, nil, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         // Only return a result if we know the _id of the inserted document.
@@ -595,7 +595,7 @@ public class Collection {
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_insert_many(
-            self._collection, &docPointers, documents.count, getDataOrNil(opts), reply.data, &error) {
+            self._collection, &docPointers, documents.count, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return InsertManyResult(from: reply)
@@ -618,7 +618,7 @@ public class Collection {
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_replace_one(
-            self._collection, filter.data, replacement.data, getDataOrNil(opts), reply.data, &error) {
+            self._collection, filter.data, replacement.data, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return UpdateResult(from: reply)
@@ -641,7 +641,7 @@ public class Collection {
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_update_one(
-            self._collection, filter.data, update.data, getDataOrNil(opts), reply.data, &error) {
+            self._collection, filter.data, update.data, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return UpdateResult(from: reply)
@@ -664,7 +664,7 @@ public class Collection {
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_update_many(
-            self._collection, filter.data, update.data, getDataOrNil(opts), reply.data, &error) {
+            self._collection, filter.data, update.data, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return UpdateResult(from: reply)
@@ -686,7 +686,7 @@ public class Collection {
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_delete_one(
-            self._collection, filter.data, getDataOrNil(opts), reply.data, &error) {
+            self._collection, filter.data, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return DeleteResult(from: reply)
@@ -708,7 +708,7 @@ public class Collection {
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_delete_many(
-            self._collection, filter.data, getDataOrNil(opts), reply.data, &error) {
+            self._collection, filter.data, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return DeleteResult(from: reply)

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -109,7 +109,7 @@ public class Database {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
         var error = bson_error_t()
-        guard let collection = mongoc_database_create_collection(self._database, name, getDataOrNil(opts), &error) else {
+        guard let collection = mongoc_database_create_collection(self._database, name, opts?.data, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
         guard let client = self._client else {
@@ -130,7 +130,7 @@ public class Database {
     func listCollections(options: ListCollectionsOptions? = nil) throws -> Cursor {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
-        guard let collections = mongoc_database_find_collections_with_opts(self._database, getDataOrNil(opts)) else {
+        guard let collections = mongoc_database_find_collections_with_opts(self._database, opts?.data) else {
             throw MongoError.invalidResponse()
         }
         guard let client = self._client else {
@@ -153,7 +153,7 @@ public class Database {
         let opts = try encoder.encode(options)
         let reply: UnsafeMutablePointer<bson_t> = bson_new()
         var error = bson_error_t()
-        if !mongoc_database_command_with_opts(self._database, command.data, nil, getDataOrNil(opts), reply, &error) {
+        if !mongoc_database_command_with_opts(self._database, command.data, nil, opts?.data, reply, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return Document(fromData: reply)


### PR DESCRIPTION
- Added documentation throughout the `Document` class
-  We can just say `opts?.data` instead of using `getDataOrNil`, thanks optional chaining, so remove that function
- Make the initializer that takes in a `bson_t` an `internal` 
- Make consistent what types of values we take in when setting keys on a `Document` across the different initializers and subscript setter... There was a mix of `Any`, `BsonValue`, and `BsonValue?`... Now all are `BsonValue?`
