### PR TITLE
SWIFT-46 Implement Database.drop

### DIFF
--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -79,6 +79,16 @@ public class Database {
     }
 
     /**
+     * Drops this database.
+     */
+    func drop() throws {
+        var error = bson_error_t()
+        if !mongoc_database_drop(self._database, &error) {
+            throw MongoError.commandError(message: toErrorString(error))
+        }
+    }
+
+    /**
      * Access a collection within this database.
      *
      * - Parameters:

--- a/Tests/MongoSwiftTests/CollectionTests.swift
+++ b/Tests/MongoSwiftTests/CollectionTests.swift
@@ -58,8 +58,8 @@ final class CollectionTests: XCTestCase {
     override class func tearDown() {
         super.tearDown()
         do {
-            print("drop DB")
-            // TODO SWIFT-46: drop database here
+            let db = try Client().db("collectionTest")
+            try db.drop()
         } catch {
             XCTFail("Dropping test database collectionTest failed: \(error)")
         }

--- a/Tests/MongoSwiftTests/DatabaseTests.swift
+++ b/Tests/MongoSwiftTests/DatabaseTests.swift
@@ -9,35 +9,26 @@ final class DatabaseTests: XCTestCase {
         ]
     }
 
-    func testDatabase() {
-    	do {
-    		let client = try Client(connectionString: "mongodb://localhost:27017/")
-    		let db = try client.db("local")
+    func testDatabase() throws {
+		let client = try Client(connectionString: "mongodb://localhost:27017/")
+		let db = try client.db("testDB")
 
-    		// generate a collection name based on current datetime,
-    		// so we won't choose a name that already exists 
-    		let coll1name = "coll1" + String(describing: Date())
+        // create collection using runCommand
+    	let command: Document = ["create": "coll1"]
+    	let res = try db.runCommand(command: command)
+    	XCTAssertEqual(res, ["ok": 1.0] as Document)
+        let coll1 = try db.collection("coll1")
 
-            // create collection using runCommand
-        	let command: Document = ["create": coll1name]
-        	let res = try db.runCommand(command: command)
-        	XCTAssertEqual(res, ["ok": 1.0] as Document)
-            let coll1 = try db.collection(coll1name)
+        // create collection using createCollection
+        let coll2 = try db.createCollection("coll2")
 
-            // create collection using createCollection
-            let coll2name = "coll2" + String(describing: Date())
-            let coll2 = try db.createCollection(coll2name)
+    	let collections = try db.listCollections()
 
-        	let collections = try db.listCollections()
+        let opts = ListCollectionsOptions(filter: ["type": "view"] as Document, batchSize: nil, session: nil)
+        let views = try db.listCollections(options: opts)
 
-            let opts = ListCollectionsOptions(filter: ["type": "view"] as Document, batchSize: nil, session: nil)
-            let views = try db.listCollections(options: opts)
-
-            try coll1.drop()
-            try coll2.drop()
-
-    	} catch {
-    		XCTFail("Error: \(error)")
-    	}
+        try db.drop()
+        let dbs = try client.listDatabases(options: ListDatabasesOptions(nameOnly: true))
+        XCTAssertFalse(dbs.contains {$0 as? String == "testDB"})
     }
 }


### PR DESCRIPTION
This adds the `drop()` method for `Database`. It also updates existing tests -
-  in `CollectionTests` cleanup, drop the database we use at the end
- in `DatabaseTests`, use a test DB rather than `local`, and drop it at the end 
- mark `testDatabase` throws so we don't have to wrap in `do/catch` 