### PR TITLE
Fix compilation error and warnings

### DIFF
--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -73,7 +73,7 @@ final class CodecTests: XCTestCase {
         let emptyOptions = ListDatabasesOptions(filter: nil, nameOnly: nil, session: nil)
         XCTAssertNil(try encoderNoNils.encode(emptyOptions))
 
-        XCTAssertEqual(try encoderWithNils.encode(emptyOptions) as? Document,
+        XCTAssertEqual(try encoderWithNils.encode(emptyOptions),
             ["session": nil, "filter": nil, "nameOnly": nil] as Document)
 
         let options = ListDatabasesOptions(filter: nil, nameOnly: true, session: nil)

--- a/Tests/MongoSwiftTests/CollectionTests.swift
+++ b/Tests/MongoSwiftTests/CollectionTests.swift
@@ -38,7 +38,7 @@ final class CollectionTests: XCTestCase {
         super.setUp()
         do {
             coll = try MongoClient().db("collectionTest").createCollection("coll1")
-            try coll.insertMany([doc1, doc2])
+            _ = try coll.insertMany([doc1, doc2])
         } catch {
             XCTFail("Setup failed: \(error)")
         }
@@ -73,11 +73,11 @@ final class CollectionTests: XCTestCase {
     }
 
     func testInsertOne() throws {
-        try coll.deleteMany([:])
+        _ = try coll.deleteMany([:])
         let result = try coll.insertOne(doc1)
         XCTAssertEqual(result?.insertedId as? Int, 1)
 
-        try coll.insertOne(doc2)
+        _ = try coll.insertOne(doc2)
         XCTAssertEqual(try coll.count(), 2)
 
         // try inserting a document without an ID to verify one is generated and returned
@@ -96,7 +96,7 @@ final class CollectionTests: XCTestCase {
         XCTAssertEqual(try coll.count(), 0)
         // insert something so we don't error when trying to drop
         // in the cleanup func
-        try coll.insertOne(doc1)
+        _ = try coll.insertOne(doc1)
     }
 
     func testInsertMany() throws {

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -65,7 +65,7 @@ final class CrudTests: XCTestCase {
                 // 4) verify that expected data is present
                 // 5) drop the collection to clean up
                 let collection = try db.collection("\(file.name)+\(i)")
-                try collection.insertMany(file.data)
+                _ = try collection.insertMany(file.data)
                 try test.execute(usingCollection: collection)
                 try test.verifyData(testCollection: collection, db: db)
                 try collection.drop()

--- a/Tests/MongoSwiftTests/DatabaseTests.swift
+++ b/Tests/MongoSwiftTests/DatabaseTests.swift
@@ -17,18 +17,18 @@ final class DatabaseTests: XCTestCase {
     	let command: Document = ["create": "coll1"]
         let res = try db.runCommand(command)
         XCTAssertEqual(res["ok"] as? Double, 1.0)
-        let coll1 = try db.collection("coll1")
+        _ = try db.collection("coll1")
 
         // create collection using createCollection
-        let coll2 = try db.createCollection("coll2")
+        _ = try db.createCollection("coll2")
 
-    	let collections = try db.listCollections()
+    	_ = try db.listCollections()
 
         let opts = ListCollectionsOptions(filter: ["type": "view"] as Document, batchSize: nil, session: nil)
-        let views = try db.listCollections(options: opts)
+        _ = try db.listCollections(options: opts)
 
         try db.drop()
         let dbs = try client.listDatabases(options: ListDatabasesOptions(nameOnly: true))
-        XCTAssertFalse(dbs.contains {$0 as? String == "testDB"})
+        XCTAssertFalse(dbs.contains {$0["name"] as? String == "testDB"})
     }
 }

--- a/Tests/MongoSwiftTests/DocumentBenchmarks.swift
+++ b/Tests/MongoSwiftTests/DocumentBenchmarks.swift
@@ -67,7 +67,7 @@ public class SingleDocumentBenchmarks: XCTestCase {
 
         // Insert the document with the insertOne CRUD method. DO NOT manually add an _id field;
         // leave it to the driver or database. Repeat this `numDocs` times.
-        measureMetrics([XCTPerformanceMetric_WallClockTime],
+        measureMetrics([XCTPerformanceMetric.wallClockTime],
             automaticallyStartMeasuring: false, for: {
                 do {
                     // since we can't re-insert the same object, create `numDocs`
@@ -133,7 +133,7 @@ public class MultiDocumentBenchmarks: XCTestCase {
 
         // Do an ordered 'insert_many' with `numDocs` copies of the document.
         // DO NOT manually add an _id field; leave it to the driver or database.
-        measureMetrics([XCTPerformanceMetric_WallClockTime],
+        measureMetrics([XCTPerformanceMetric.wallClockTime],
             automaticallyStartMeasuring: false, for: {
                 do {
                     var documents = [Document]()

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -202,7 +202,7 @@ final class DocumentTests: XCTestCase {
             "timestamp": Timestamp(timestamp: 5, inc: 10)
         ]
 
-        for (k, v) in doc { }
+        for (_, _) in doc { }
 
     }
 
@@ -306,7 +306,7 @@ final class DocumentTests: XCTestCase {
                         }
 
                         // bson_to_canonical_extended_json(dB) = cEJ
-                        assertJsonEqual(try Document(fromBSON: dBData).canonicalExtendedJSON, cEJ)
+                        assertJsonEqual(Document(fromBSON: dBData).canonicalExtendedJSON, cEJ)
 
                         // bson_to_relaxed_extended_json(dB) = rEJ (if rEJ exists)
                         if let rEJ = validCase["relaxed_extjson"] as? String {


### PR DESCRIPTION
Change to Swift 4 version of the `wallClockTime` performance metric, and also fix a bunch of the lines that gave compilation warnings