### PR TITLE
SWIFT-41, SWIFT-42

### DIFF
--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -46,9 +46,7 @@ public class MongoClient {
         }
 
         self._client = mongoc_client_new_from_uri(uri)
-        if self._client == nil {
-            throw MongoError.invalidClient()
-        }
+        _ = try unwrapClient()
     }
 
     /**
@@ -128,9 +126,6 @@ public class MongoClient {
     /// This function should be called rather than accessing self._client directly.
     /// It ensures that the `OpaquePointer` to a `mongoc_database_t` is still valid. 
     internal func unwrapClient() throws -> OpaquePointer {
-        guard let client = self._client else {
-            throw MongoError.invalidClient()
-        }
-        return client
+        return try unwrap(self._client, elseThrow: MongoError.invalidClient())
     }
 }

--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -104,7 +104,7 @@ public class MongoClient {
     public func listDatabases(options: ListDatabasesOptions? = nil) throws -> MongoCursor {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
-        guard let cursor = mongoc_client_find_databases_with_opts(self._client, opts?.data) else {
+        guard let cursor = mongoc_client_find_databases_with_opts(try unwrapClient(), opts?.data) else {
             throw MongoError.invalidResponse()
         }
         return MongoCursor(fromCursor: cursor, withClient: self)
@@ -119,9 +119,16 @@ public class MongoClient {
      * - Returns: a `MongoDatabase` corresponding to the provided database name
      */
     public func db(_ name: String) throws -> MongoDatabase {
-        guard let db = mongoc_client_get_database(self._client, name) else {
+        guard let db = mongoc_client_get_database(try unwrapClient(), name) else {
             throw MongoError.invalidClient()
         }
         return MongoDatabase(fromDatabase: db, withClient: self)
+    }
+
+    internal func unwrapClient() throws -> OpaquePointer {
+        guard let client = self._client else {
+            throw MongoError.invalidClient()
+        }
+        return client
     }
 }

--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -30,7 +30,7 @@ public struct ListDatabasesOptions: BsonEncodable {
 
 // A MongoDB Client
 public class MongoClient {
-    internal var _client = OpaquePointer(bitPattern: 1)
+    private var _client = OpaquePointer(bitPattern: 1)
 
     /**
      * Create a new client connection to a MongoDB server
@@ -125,6 +125,8 @@ public class MongoClient {
         return MongoDatabase(fromDatabase: db, withClient: self)
     }
 
+    /// This function should be called rather than accessing self._client directly.
+    /// It ensures that the `OpaquePointer` to a `mongoc_database_t` is still valid. 
     internal func unwrapClient() throws -> OpaquePointer {
         guard let client = self._client else {
             throw MongoError.invalidClient()

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -460,7 +460,8 @@ public class MongoCollection {
     private var _client: MongoClient?
 
     /**
-        Initializes a new MongoCollection instance, not meant to be instantiated directly
+     *  Initializes a new MongoCollection instance. This assumes the caller has checked
+     *  the validity of the collection pointer and the client's internal pointer.
      */
     internal init(fromCollection: OpaquePointer, withClient: MongoClient) {
         self._collection = fromCollection

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -901,9 +901,11 @@ public class MongoCollection {
         return MongoCursor(fromCursor: cursor, withClient: client)
     }
 
+    /// This function should be called rather than accessing self._collection directly.
+    /// It ensures that the `OpaquePointer` to a `mongoc_collection_t` is still valid. 
     internal func unwrapCollection() throws -> OpaquePointer {
         guard let collection = self._collection else {
-            throw MongoError.invalidCollection(message: "Invalid collection")
+            throw MongoError.invalidCollection()
         }
         return collection
     }

--- a/Sources/MongoSwift/Cursor.swift
+++ b/Sources/MongoSwift/Cursor.swift
@@ -6,7 +6,8 @@ public class MongoCursor: Sequence, IteratorProtocol {
     private var _client: MongoClient?
 
     /**
-     * Initializes a new MongoCursor instance, not meant to be instantiated directly
+     *  Initializes a new MongoCursor instance. This assumes the caller has checked
+     *  the validity of the cursor pointer and the client's internal pointer.
      */
     internal init(fromCursor: OpaquePointer, withClient: MongoClient) {
         self._cursor = fromCursor

--- a/Sources/MongoSwift/Cursor.swift
+++ b/Sources/MongoSwift/Cursor.swift
@@ -38,7 +38,7 @@ public class MongoCursor: Sequence, IteratorProtocol {
      */
     public func next() -> Document? {
         do {
-            let cursor = try unwrapCursor()
+            _ = try unwrapCursor()
         } catch {
             print("error unwrapping cursor")
             return nil

--- a/Sources/MongoSwift/Cursor.swift
+++ b/Sources/MongoSwift/Cursor.swift
@@ -59,7 +59,7 @@ public class MongoCursor: Sequence, IteratorProtocol {
             return nil
         }
 
-        return Document(fromData: UnsafeMutablePointer(mutating: out.pointee!))
+        return Document(fromPointer: UnsafeMutablePointer(mutating: out.pointee!))
     }
 
     /// This function should be called rather than accessing self._cursor directly.

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -129,7 +129,7 @@ public class MongoDatabase {
      */
     public func collection(_ name: String) throws -> MongoCollection {
         guard let collection = mongoc_database_get_collection(try unwrapDatabase(), name) else {
-            throw MongoError.invalidCollection(message: "Could not get collection '\(name)'")
+            throw MongoError.invalidCollection()
         }
         guard let client = self._client else {
             throw MongoError.invalidClient()
@@ -203,6 +203,8 @@ public class MongoDatabase {
         return Document(fromPointer: reply)
     }
 
+    /// This function should be called rather than accessing self._database directly.
+    /// It ensures that the `OpaquePointer` to a `mongoc_database_t` is still valid. 
     internal func unwrapDatabase() throws -> OpaquePointer {
         guard let database = self._database else {
             throw MongoError.invalidDatabase()

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -132,9 +132,8 @@ public class MongoDatabase {
         guard let collection = mongoc_database_get_collection(try unwrapDatabase(), name) else {
             throw MongoError.invalidCollection()
         }
-        guard let client = self._client else {
-            throw MongoError.invalidClient()
-        }
+
+        let client = try unwrap(self._client, elseThrow: MongoError.invalidClient())
         _ = try client.unwrapClient()
         return MongoCollection(fromCollection: collection, withClient: client)
     }
@@ -155,9 +154,8 @@ public class MongoDatabase {
         guard let collection = mongoc_database_create_collection(try unwrapDatabase(), name, opts?.data, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
-        guard let client = self._client else {
-            throw MongoError.invalidClient()
-        }
+
+        let client = try unwrap(self._client, elseThrow: MongoError.invalidClient())
         _ = try client.unwrapClient()
         return MongoCollection(fromCollection: collection, withClient: client)
     }
@@ -177,9 +175,7 @@ public class MongoDatabase {
         guard let collections = mongoc_database_find_collections_with_opts(try unwrapDatabase(), opts?.data) else {
             throw MongoError.invalidResponse()
         }
-        guard let client = self._client else {
-            throw MongoError.invalidClient()
-        }
+        let client = try unwrap(self._client, elseThrow: MongoError.invalidClient())
         _ = try client.unwrapClient()
         return MongoCursor(fromCursor: collections, withClient: client)
     }
@@ -207,9 +203,6 @@ public class MongoDatabase {
     /// This function should be called rather than accessing self._database directly.
     /// It ensures that the `OpaquePointer` to a `mongoc_database_t` is still valid. 
     internal func unwrapDatabase() throws -> OpaquePointer {
-        guard let database = self._database else {
-            throw MongoError.invalidDatabase()
-        }
-        return database
+        return try unwrap(self._database, elseThrow: MongoError.invalidDatabase())
     }
 }

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -92,7 +92,8 @@ public class MongoDatabase {
     private var _client: MongoClient?
 
     /**
-     * Initializes a new MongoDatabase instance, not meant to be instantiated directly
+     *  Initializes a new MongoDatabase instance. This assumes the caller has checked
+     *  the validity of the database pointer and the client's internal pointer.
      */
     internal init(fromDatabase: OpaquePointer, withClient: MongoClient) {
         self._database = fromDatabase

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -4,6 +4,7 @@ import libmongoc
 public enum MongoError {
     case invalidUri(message: String)
     case invalidClient()
+    case invalidDatabase()
     case invalidResponse()
     case invalidCursor(message: String)
     case invalidCollection(message: String)
@@ -21,8 +22,12 @@ extension MongoError: LocalizedError {
             let .bsonParseError(_, _, message), let .bsonEncodeError(message),
             let .typeError(message):
             return message
-        default:
-            return nil
+        case .invalidClient:
+            return "Invalid client"
+        case .invalidDatabase:
+            return "Invalid client"
+        case .invalidResponse:
+            return "Invalid response"
         }
     }
 }

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -6,8 +6,8 @@ public enum MongoError {
     case invalidClient()
     case invalidDatabase()
     case invalidResponse()
+    case invalidCollection()
     case invalidCursor(message: String)
-    case invalidCollection(message: String)
     case commandError(message: String)
     case bsonParseError(domain: UInt32, code: UInt32, message: String)
     case bsonEncodeError(message: String)
@@ -18,14 +18,15 @@ extension MongoError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case let .invalidUri(message), let .invalidCursor(message),
-            let .invalidCollection(message), let .commandError(message),
-            let .bsonParseError(_, _, message), let .bsonEncodeError(message),
-            let .typeError(message):
+            let .commandError(message), let .bsonParseError(_, _, message),
+            let .bsonEncodeError(message), let .typeError(message):
             return message
+        case .invalidCollection:
+            return "Invalid collection"
         case .invalidClient:
             return "Invalid client"
         case .invalidDatabase:
-            return "Invalid client"
+            return "Invalid database"
         case .invalidResponse:
             return "Invalid response"
         }

--- a/Sources/MongoSwift/Utilities.swift
+++ b/Sources/MongoSwift/Utilities.swift
@@ -1,0 +1,5 @@
+/// Unwraps the optional value `obj`, and throws `error` if `obj` is nil.
+internal func unwrap<T>(_ obj: T?, elseThrow error: MongoError) throws -> T {
+    guard let o = obj else { throw error }
+    return o
+}

--- a/Tests/MongoSwiftTests/CollectionTests.swift
+++ b/Tests/MongoSwiftTests/CollectionTests.swift
@@ -139,15 +139,6 @@ final class CollectionTests: XCTestCase {
         expect(findResult.next()).to(beNil())
     }
 
-    func testCursorIteration() throws {
-        let findResult1 = try coll.find(["cat": "cat"])
-        while let _  = try findResult1.nextOrError() { }
-
-        let findResult2 = try coll.find(["cat": "cat"])
-        for _ in findResult2 { }
-        XCTAssertNil(findResult2.getError())
-    }
-
     func testDeleteOne() throws {
         expect(try self.coll.deleteOne(["cat": "cat"])?.deletedCount).to(equal(1))
     }

--- a/Tests/MongoSwiftTests/CollectionTests.swift
+++ b/Tests/MongoSwiftTests/CollectionTests.swift
@@ -139,6 +139,15 @@ final class CollectionTests: XCTestCase {
         expect(findResult.next()).to(beNil())
     }
 
+    func testCursorIteration() throws {
+        let findResult1 = try coll.find(["cat": "cat"])
+        while let _  = try findResult1.nextOrError() { }
+
+        let findResult2 = try coll.find(["cat": "cat"])
+        for _ in findResult2 { }
+        XCTAssertNil(findResult2.getError())
+    }
+
     func testDeleteOne() throws {
         expect(try self.coll.deleteOne(["cat": "cat"])?.deletedCount).to(equal(1))
     }


### PR DESCRIPTION
Since I ended up having to edit `MongoCursor` anyway I lumped in the cursor error handling stuff with this. 

For the optional pointers, I've added a `unwrapX` method to each type that should be used rather than directly accessing the pointers. We might want to think about doing some kind of checking in `Document` where we are keeping around these forced `UnsafeMutablePointer<bson_t>!`s, but I think it probably makes more sense to hold off on that until the `Document` as`struct` refactor is merged in. 

For the cursor errors, I added a `getError` function as well as a way to iterate the cursor `nextOrError` that does throw, if you really want to do that instead of checking at the end. Both of these feel kinda weird to me though so let me know if you have any better ideas 