### PR TITLE
Add missing convenience initializers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,19 +12,19 @@
       },
       {
         "package": "libbson",
-        "repositoryURL": "ssh://git@github.com/10gen/swift-bson",
+        "repositoryURL": "https://github.com/mongodb/swift-bson",
         "state": {
           "branch": "master",
-          "revision": "725977b1c0d3a9f7938d0bec0522edc6cdc95f83",
+          "revision": "077a71336aead18a26223b6c3c07f94478c7921a",
           "version": null
         }
       },
       {
         "package": "libmongoc",
-        "repositoryURL": "ssh://git@github.com/10gen/swift-mongoc",
+        "repositoryURL": "https://github.com/mongodb/swift-mongoc",
         "state": {
           "branch": "master",
-          "revision": "5e804353cdf36afda932aae831384f5c5afa88c3",
+          "revision": "b30d530dde407048a371a86fdbae77895e8635dd",
           "version": null
         }
       }

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -81,6 +81,12 @@ public protocol BsonValue {
     static func from(iter: inout bson_iter_t) -> BsonValue
 }
 
+/// A protocol for types that can be represented as Int32 and Int64 values. 
+public protocol IntType {
+    var int32Value: Int32 { get }
+    var int64Value: Int64 { get }
+}
+
 /// An extension of Array type to represent the BSON array type
 extension Array: BsonValue {
     public var bsonType: BsonType { return .array }
@@ -333,7 +339,7 @@ extension Double: BsonValue {
 /// An extension of Int to represent the BSON Int32 type.
 /// While the bitwidth of Int is machine-dependent, we assume for simplicity
 /// that it is always 32 bits. Use Int64 if 64 bits are needed.
-extension Int: BsonValue {
+extension Int: BsonValue, IntType {
     public var bsonType: BsonType { return .int32 }
     public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
         if !bson_append_int32(data, key, Int32(key.count), Int32(self)) {
@@ -344,10 +350,13 @@ extension Int: BsonValue {
     public static func from(iter: inout bson_iter_t) -> BsonValue {
         return Int(bson_iter_int32(&iter))
     }
+
+    public var int32Value: Int32 { return Int32(self) }
+    public var int64Value: Int64 { return Int64(self) }
 }
 
 /// An extension of Int32 to represent the BSON Int32 type
-extension Int32: BsonValue {
+extension Int32: BsonValue, IntType {
     public var bsonType: BsonType { return .int32 }
     public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
         if !bson_append_int32(data, key, Int32(key.count), self) {
@@ -358,10 +367,13 @@ extension Int32: BsonValue {
     public static func from(iter: inout bson_iter_t) -> BsonValue {
         return bson_iter_int32(&iter)
     }
+
+    public var int32Value: Int32 { return self }
+    public var int64Value: Int64 { return Int64(self) }
 }
 
 /// An extension of Int64 to represent the BSON Int64 type
-extension Int64: BsonValue {
+extension Int64: BsonValue, IntType {
     public var bsonType: BsonType { return .int64 }
     public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
         if !bson_append_int64(data, key, Int32(key.count), self) {
@@ -372,6 +384,9 @@ extension Int64: BsonValue {
     public static func from(iter: inout bson_iter_t) -> BsonValue {
         return bson_iter_int64(&iter)
     }
+
+    public var int32Value: Int32 { return Int32(self) }
+    public var int64Value: Int64 { return self }
 }
 
 /// A struct to represent the BSON Code and CodeWithScope types

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -81,12 +81,6 @@ public protocol BsonValue {
     static func from(iter: inout bson_iter_t) -> BsonValue
 }
 
-/// A protocol for types that can be represented as Int32 and Int64 values. 
-public protocol IntType {
-    var int32Value: Int32 { get }
-    var int64Value: Int64 { get }
-}
-
 /// An extension of Array type to represent the BSON array type
 extension Array: BsonValue {
     public var bsonType: BsonType { return .array }
@@ -339,7 +333,7 @@ extension Double: BsonValue {
 /// An extension of Int to represent the BSON Int32 type.
 /// While the bitwidth of Int is machine-dependent, we assume for simplicity
 /// that it is always 32 bits. Use Int64 if 64 bits are needed.
-extension Int: BsonValue, IntType {
+extension Int: BsonValue {
     public var bsonType: BsonType { return .int32 }
     public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
         if !bson_append_int32(data, key, Int32(key.count), Int32(self)) {
@@ -350,13 +344,10 @@ extension Int: BsonValue, IntType {
     public static func from(iter: inout bson_iter_t) -> BsonValue {
         return Int(bson_iter_int32(&iter))
     }
-
-    public var int32Value: Int32 { return Int32(self) }
-    public var int64Value: Int64 { return Int64(self) }
 }
 
 /// An extension of Int32 to represent the BSON Int32 type
-extension Int32: BsonValue, IntType {
+extension Int32: BsonValue {
     public var bsonType: BsonType { return .int32 }
     public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
         if !bson_append_int32(data, key, Int32(key.count), self) {
@@ -367,13 +358,10 @@ extension Int32: BsonValue, IntType {
     public static func from(iter: inout bson_iter_t) -> BsonValue {
         return bson_iter_int32(&iter)
     }
-
-    public var int32Value: Int32 { return self }
-    public var int64Value: Int64 { return Int64(self) }
 }
 
 /// An extension of Int64 to represent the BSON Int64 type
-extension Int64: BsonValue, IntType {
+extension Int64: BsonValue {
     public var bsonType: BsonType { return .int64 }
     public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
         if !bson_append_int64(data, key, Int32(key.count), self) {
@@ -384,9 +372,6 @@ extension Int64: BsonValue, IntType {
     public static func from(iter: inout bson_iter_t) -> BsonValue {
         return bson_iter_int64(&iter)
     }
-
-    public var int32Value: Int32 { return Int32(self) }
-    public var int64Value: Int64 { return self }
 }
 
 /// A struct to represent the BSON Code and CodeWithScope types

--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -3,6 +3,11 @@ import libmongoc
 public struct ClientOptions {
     /// Determines whether the client should retry supported write operations
     let retryWrites: Bool?
+
+    /// Convenience initializer allowing retryWrites to be omitted or optional
+    public init(retryWrites: Bool? = nil) {
+        self.retryWrites = retryWrites
+    }
 }
 
 public struct ListDatabasesOptions: BsonEncodable {

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -26,13 +26,13 @@ public struct AggregateOptions: BsonEncodable {
     // let hint: Optional<(String | Document)>
 
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(allowDiskUse: Bool? = nil, batchSize: Int32? = nil, bypassDocumentValidation: Bool? = nil,
-                collation: Document? = nil, maxTimeMS: Int64? = nil, comment: String? = nil) {
+    public init(allowDiskUse: Bool? = nil, batchSize: IntType? = nil, bypassDocumentValidation: Bool? = nil,
+                collation: Document? = nil, maxTimeMS: IntType? = nil, comment: String? = nil) {
         self.allowDiskUse = allowDiskUse
-        self.batchSize = batchSize
+        self.batchSize = batchSize?.int32Value
         self.bypassDocumentValidation = bypassDocumentValidation
         self.collation = collation
-        self.maxTimeMS = maxTimeMS
+        self.maxTimeMS = maxTimeMS?.int64Value
         self.comment = comment
     }
 }
@@ -54,11 +54,11 @@ public struct CountOptions: BsonEncodable {
     let skip: Int64?
 
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(collation: Document? = nil, limit: Int64? = nil, maxTimeMS: Int64? = nil, skip: Int64? = nil) {
+    public init(collation: Document? = nil, limit: IntType? = nil, maxTimeMS: IntType? = nil, skip: IntType? = nil) {
         self.collation = collation
-        self.limit = limit
-        self.maxTimeMS = maxTimeMS
-        self.skip = skip
+        self.limit = limit?.int64Value
+        self.maxTimeMS = maxTimeMS?.int64Value
+        self.skip = skip?.int64Value
     }
 }
 
@@ -70,9 +70,9 @@ public struct DistinctOptions: BsonEncodable {
     let maxTimeMS: Int64?
 
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(collation: Document? = nil, maxTimeMS: Int64? = nil) {
+    public init(collation: Document? = nil, maxTimeMS: IntType? = nil) {
         self.collation = collation
-        self.maxTimeMS = maxTimeMS
+        self.maxTimeMS = maxTimeMS?.int64Value
     }
 }
 
@@ -168,26 +168,26 @@ public struct FindOptions: BsonEncodable {
     let sort: Document?
 
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(allowPartialResults: Bool? = nil, batchSize: Int32? = nil, collation: Document? = nil,
-                comment: String? = nil, limit: Int64? = nil, max: Document? = nil, maxAwaitTimeMS: Int64? = nil,
-                maxScan: Int64? = nil, maxTimeMS: Int64? = nil, min: Document? = nil, noCursorTimeout: Bool? = nil,
-                projection: Document? = nil, returnKey: Bool? = nil, showRecordId: Bool? = nil, skip: Int64? = nil,
+    public init(allowPartialResults: Bool? = nil, batchSize: IntType? = nil, collation: Document? = nil,
+                comment: String? = nil, limit: IntType? = nil, max: Document? = nil, maxAwaitTimeMS: IntType? = nil,
+                maxScan: IntType? = nil, maxTimeMS: IntType? = nil, min: Document? = nil, noCursorTimeout: Bool? = nil,
+                projection: Document? = nil, returnKey: Bool? = nil, showRecordId: Bool? = nil, skip: IntType? = nil,
                 sort: Document? = nil) {
         self.allowPartialResults = allowPartialResults
-        self.batchSize = batchSize
+        self.batchSize = batchSize?.int32Value
         self.collation = collation
         self.comment = comment
-        self.limit = limit
+        self.limit = limit?.int64Value
         self.max = max
-        self.maxAwaitTimeMS = maxAwaitTimeMS
-        self.maxScan = maxScan
-        self.maxTimeMS = maxTimeMS
+        self.maxAwaitTimeMS = maxAwaitTimeMS?.int64Value
+        self.maxScan = maxScan?.int64Value
+        self.maxTimeMS = maxTimeMS?.int64Value
         self.min = min
         self.noCursorTimeout = noCursorTimeout
         self.projection = projection
         self.returnKey = returnKey
         self.showRecordId = showRecordId
-        self.skip = skip
+        self.skip = skip?.int64Value
         self.sort = sort
     }
 }
@@ -196,6 +196,7 @@ public struct InsertOneOptions: BsonEncodable {
     /// If true, allows the write to opt-out of document level validation.
     let bypassDocumentValidation: Bool?
 
+    /// Convenience initializer allowing bypassDocumentValidation to be omitted or optional
     public init(bypassDocumentValidation: Bool? = nil) {
         self.bypassDocumentValidation = bypassDocumentValidation
     }
@@ -210,6 +211,7 @@ public struct InsertManyOptions: BsonEncodable {
     /// Defaults to true.
     var ordered: Bool = true
 
+    /// Convenience initializer allowing any/all parameters to be omitted or optional
     public init(bypassDocumentValidation: Bool? = nil, ordered: Bool? = true) {
         self.bypassDocumentValidation = bypassDocumentValidation
         if let o = ordered { self.ordered = o }
@@ -261,6 +263,7 @@ public struct DeleteOptions: BsonEncodable {
     /// Specifies a collation.
     let collation: Document?
 
+    /// Convenience initializer allowing collation to be omitted or optional
     public init(collation: Document? = nil) {
         self.collation = collation
     }
@@ -424,28 +427,29 @@ public struct IndexOptions: BsonEncodable {
     /// server-side is used.
     let collation: Document?
 
-    public init(background: Bool? = nil, expireAfter: Int32? = nil, name: String? = nil, sparse: Bool? = nil,
-                storageEngine: String? = nil, unique: Bool? = nil, version: Int32? = nil,
-                defaultLanguage: String? = nil, languageOverride: String? = nil, textVersion: Int32? = nil,
-                weights: Document? = nil, sphereVersion: Int32? = nil, bits: Int32? = nil, max: Double? = nil,
-                min: Double? = nil, bucketSize: Int32? = nil, partialFilterExpression: Document? = nil,
+    /// Convenience initializer allowing any/all parameters to be omitted or optional
+    public init(background: Bool? = nil, expireAfter: IntType? = nil, name: String? = nil, sparse: Bool? = nil,
+                storageEngine: String? = nil, unique: Bool? = nil, version: IntType? = nil,
+                defaultLanguage: String? = nil, languageOverride: String? = nil, textVersion: IntType? = nil,
+                weights: Document? = nil, sphereVersion: IntType? = nil, bits: IntType? = nil, max: Double? = nil,
+                min: Double? = nil, bucketSize: IntType? = nil, partialFilterExpression: Document? = nil,
                 collation: Document? = nil) {
         self.background = background
-        self.expireAfter = expireAfter
+        self.expireAfter = expireAfter?.int32Value
         self.name = name
         self.sparse = sparse
         self.storageEngine = storageEngine
         self.unique = unique
-        self.version = version
+        self.version = version?.int32Value
         self.defaultLanguage = defaultLanguage
         self.languageOverride = languageOverride
-        self.textVersion = textVersion
+        self.textVersion = textVersion?.int32Value
         self.weights = weights
-        self.sphereVersion = sphereVersion
-        self.bits = bits
+        self.sphereVersion = sphereVersion?.int32Value
+        self.bits = bits?.int32Value
         self.max = max
         self.min = min
-        self.bucketSize = bucketSize
+        self.bucketSize = bucketSize?.int32Value
         self.partialFilterExpression = partialFilterExpression
         self.collation = collation
     }

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -26,13 +26,13 @@ public struct AggregateOptions: BsonEncodable {
     // let hint: Optional<(String | Document)>
 
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(allowDiskUse: Bool? = nil, batchSize: IntType? = nil, bypassDocumentValidation: Bool? = nil,
-                collation: Document? = nil, maxTimeMS: IntType? = nil, comment: String? = nil) {
+    public init(allowDiskUse: Bool? = nil, batchSize: Int32? = nil, bypassDocumentValidation: Bool? = nil,
+                collation: Document? = nil, maxTimeMS: Int64? = nil, comment: String? = nil) {
         self.allowDiskUse = allowDiskUse
-        self.batchSize = batchSize?.int32Value
+        self.batchSize = batchSize
         self.bypassDocumentValidation = bypassDocumentValidation
         self.collation = collation
-        self.maxTimeMS = maxTimeMS?.int64Value
+        self.maxTimeMS = maxTimeMS
         self.comment = comment
     }
 }
@@ -54,11 +54,11 @@ public struct CountOptions: BsonEncodable {
     let skip: Int64?
 
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(collation: Document? = nil, limit: IntType? = nil, maxTimeMS: IntType? = nil, skip: IntType? = nil) {
+    public init(collation: Document? = nil, limit: Int64? = nil, maxTimeMS: Int64? = nil, skip: Int64? = nil) {
         self.collation = collation
-        self.limit = limit?.int64Value
-        self.maxTimeMS = maxTimeMS?.int64Value
-        self.skip = skip?.int64Value
+        self.limit = limit
+        self.maxTimeMS = maxTimeMS
+        self.skip = skip
     }
 }
 
@@ -70,9 +70,9 @@ public struct DistinctOptions: BsonEncodable {
     let maxTimeMS: Int64?
 
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(collation: Document? = nil, maxTimeMS: IntType? = nil) {
+    public init(collation: Document? = nil, maxTimeMS: Int64? = nil) {
         self.collation = collation
-        self.maxTimeMS = maxTimeMS?.int64Value
+        self.maxTimeMS = maxTimeMS
     }
 }
 
@@ -168,26 +168,26 @@ public struct FindOptions: BsonEncodable {
     let sort: Document?
 
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(allowPartialResults: Bool? = nil, batchSize: IntType? = nil, collation: Document? = nil,
-                comment: String? = nil, limit: IntType? = nil, max: Document? = nil, maxAwaitTimeMS: IntType? = nil,
-                maxScan: IntType? = nil, maxTimeMS: IntType? = nil, min: Document? = nil, noCursorTimeout: Bool? = nil,
-                projection: Document? = nil, returnKey: Bool? = nil, showRecordId: Bool? = nil, skip: IntType? = nil,
+    public init(allowPartialResults: Bool? = nil, batchSize: Int32? = nil, collation: Document? = nil,
+                comment: String? = nil, limit: Int64? = nil, max: Document? = nil, maxAwaitTimeMS: Int64? = nil,
+                maxScan: Int64? = nil, maxTimeMS: Int64? = nil, min: Document? = nil, noCursorTimeout: Bool? = nil,
+                projection: Document? = nil, returnKey: Bool? = nil, showRecordId: Bool? = nil, skip: Int64? = nil,
                 sort: Document? = nil) {
         self.allowPartialResults = allowPartialResults
-        self.batchSize = batchSize?.int32Value
+        self.batchSize = batchSize
         self.collation = collation
         self.comment = comment
-        self.limit = limit?.int64Value
+        self.limit = limit
         self.max = max
-        self.maxAwaitTimeMS = maxAwaitTimeMS?.int64Value
-        self.maxScan = maxScan?.int64Value
-        self.maxTimeMS = maxTimeMS?.int64Value
+        self.maxAwaitTimeMS = maxAwaitTimeMS
+        self.maxScan = maxScan
+        self.maxTimeMS = maxTimeMS
         self.min = min
         self.noCursorTimeout = noCursorTimeout
         self.projection = projection
         self.returnKey = returnKey
         self.showRecordId = showRecordId
-        self.skip = skip?.int64Value
+        self.skip = skip
         self.sort = sort
     }
 }
@@ -263,7 +263,7 @@ public struct DeleteOptions: BsonEncodable {
     /// Specifies a collation.
     let collation: Document?
 
-    /// Convenience initializer allowing collation to be omitted or optional
+     /// Convenience initializer allowing collation to be omitted or optional
     public init(collation: Document? = nil) {
         self.collation = collation
     }
@@ -427,29 +427,28 @@ public struct IndexOptions: BsonEncodable {
     /// server-side is used.
     let collation: Document?
 
-    /// Convenience initializer allowing any/all parameters to be omitted or optional
-    public init(background: Bool? = nil, expireAfter: IntType? = nil, name: String? = nil, sparse: Bool? = nil,
-                storageEngine: String? = nil, unique: Bool? = nil, version: IntType? = nil,
-                defaultLanguage: String? = nil, languageOverride: String? = nil, textVersion: IntType? = nil,
-                weights: Document? = nil, sphereVersion: IntType? = nil, bits: IntType? = nil, max: Double? = nil,
-                min: Double? = nil, bucketSize: IntType? = nil, partialFilterExpression: Document? = nil,
+    public init(background: Bool? = nil, expireAfter: Int32? = nil, name: String? = nil, sparse: Bool? = nil,
+                storageEngine: String? = nil, unique: Bool? = nil, version: Int32? = nil,
+                defaultLanguage: String? = nil, languageOverride: String? = nil, textVersion: Int32? = nil,
+                weights: Document? = nil, sphereVersion: Int32? = nil, bits: Int32? = nil, max: Double? = nil,
+                min: Double? = nil, bucketSize: Int32? = nil, partialFilterExpression: Document? = nil,
                 collation: Document? = nil) {
         self.background = background
-        self.expireAfter = expireAfter?.int32Value
+        self.expireAfter = expireAfter
         self.name = name
         self.sparse = sparse
         self.storageEngine = storageEngine
         self.unique = unique
-        self.version = version?.int32Value
+        self.version = version
         self.defaultLanguage = defaultLanguage
         self.languageOverride = languageOverride
-        self.textVersion = textVersion?.int32Value
+        self.textVersion = textVersion
         self.weights = weights
-        self.sphereVersion = sphereVersion?.int32Value
-        self.bits = bits?.int32Value
+        self.sphereVersion = sphereVersion
+        self.bits = bits
         self.max = max
         self.min = min
-        self.bucketSize = bucketSize?.int32Value
+        self.bucketSize = bucketSize
         self.partialFilterExpression = partialFilterExpression
         self.collation = collation
     }

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -3,6 +3,11 @@ import libmongoc
 public struct RunCommandOptions: BsonEncodable {
     /// A session to associate with this operation
     let session: ClientSession?
+
+    /// Convenience initializer allowing session to be omitted or optional
+    public init(session: ClientSession? = nil) {
+        self.session = session
+    }
 }
 
 public struct ListCollectionsOptions: BsonEncodable {
@@ -14,6 +19,13 @@ public struct ListCollectionsOptions: BsonEncodable {
 
     /// A session to associate with this operation
     let session: ClientSession?
+
+    /// Convenience initializer allowing any/all parameters to be omitted or optional
+    public init(batchSize: Int? = nil, filter: Document? = nil, session: ClientSession? = nil) {
+        self.batchSize = batchSize
+        self.filter = filter
+        self.session = session
+    }
 }
 
 public struct CreateCollectionOptions: BsonEncodable {
@@ -53,6 +65,25 @@ public struct CreateCollectionOptions: BsonEncodable {
 
     /// A session to associate with this operation
     let session: ClientSession?
+
+    /// Convenience initializer allowing any/all parameters to be omitted or optional
+    public init(autoIndexId: Bool? = nil, capped: Bool? = nil, collation: Document? = nil,
+                indexOptionDefaults: Document? = nil, max: IntType? = nil, session: ClientSession? = nil,
+                size: IntType? = nil, storageEngine: Document? = nil, validationAction: String? = nil,
+                validationLevel: String? = nil, validator: Document? = nil, viewOn: String? = nil) {
+        self.autoIndexId = autoIndexId
+        self.capped = capped
+        self.collation = collation
+        self.indexOptionDefaults = indexOptionDefaults
+        self.max = max?.int64Value
+        self.session = session
+        self.size = size?.int64Value
+        self.storageEngine = storageEngine
+        self.validationAction = validationAction
+        self.validationLevel = validationLevel
+        self.validator = validator
+        self.viewOn = viewOn
+    }
 }
 
 // A MongoDB Database

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -68,16 +68,16 @@ public struct CreateCollectionOptions: BsonEncodable {
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional
     public init(autoIndexId: Bool? = nil, capped: Bool? = nil, collation: Document? = nil,
-                indexOptionDefaults: Document? = nil, max: IntType? = nil, session: ClientSession? = nil,
-                size: IntType? = nil, storageEngine: Document? = nil, validationAction: String? = nil,
+                indexOptionDefaults: Document? = nil, max: Int64? = nil, session: ClientSession? = nil,
+                size: Int64? = nil, storageEngine: Document? = nil, validationAction: String? = nil,
                 validationLevel: String? = nil, validator: Document? = nil, viewOn: String? = nil) {
         self.autoIndexId = autoIndexId
         self.capped = capped
         self.collation = collation
         self.indexOptionDefaults = indexOptionDefaults
-        self.max = max?.int64Value
+        self.max = max
         self.session = session
-        self.size = size?.int64Value
+        self.size = size
         self.storageEngine = storageEngine
         self.validationAction = validationAction
         self.validationLevel = validationLevel

--- a/Tests/MongoSwiftTests/DatabaseTests.swift
+++ b/Tests/MongoSwiftTests/DatabaseTests.swift
@@ -25,7 +25,7 @@ final class DatabaseTests: XCTestCase {
         expect(try db.createCollection("coll2")).toNot(throwError())
         expect(try (Array(db.listCollections()) as [Document]).count).to(equal(2))
 
-        let opts = ListCollectionsOptions(filter: ["type": "view"] as Document, batchSize: nil, session: nil)
+        let opts = ListCollectionsOptions(filter: ["type": "view"] as Document)
         expect(try db.listCollections(options: opts)).to(beEmpty())
 
         expect(try db.drop()).toNot(throwError())


### PR DESCRIPTION
This adds an `IntType` protocol which `Int`, `Int32`, and `Int64` conform to. This will allow users to pass in any of the three types.
Also added a few options initializers in places we forgot them the first time around. 