### PR TITLE
Add custom measurement code for benchmarks, and script to parse results

### DIFF
--- a/Tests/MongoSwiftBenchmarks/BenchmarkUtils.swift
+++ b/Tests/MongoSwiftBenchmarks/BenchmarkUtils.swift
@@ -1,0 +1,33 @@
+import Foundation
+import XCTest
+
+extension XCTestCase {
+
+    /// Measure the time for a single execution of operation
+    func measureTime(_ operation: () throws -> Void) throws -> Double {
+        let startTime = ProcessInfo.processInfo.systemUptime
+        try operation()
+        let timeElapsed = ProcessInfo.processInfo.systemUptime - startTime
+        return Double(timeElapsed)
+    }
+
+    /// Measure the median time for iterations executions of operation
+    func measureOp(_ operation: () throws -> Void, iterations: Int = 100) throws -> Double {
+        var results = [Double]()
+        for _ in 1...iterations {
+            results.append(try measureTime(operation))
+        }
+        return median(results)
+    }
+
+    /// Compute the median of an array of doubles 
+    func median(_ input: [Double]) -> Double {
+        return input.sorted(by: <)[input.count / 2]
+    }
+
+    func printResults(time: Double, size: Double) {
+        let roundedTime = Double(floor(time * 1000) / 1000)
+        let roundedScore = Double(floor(size / time * 10000) / 10000)
+        print("Results for \(self.name): median time \(roundedTime) seconds, score \(roundedScore) MB/s")
+    }
+}

--- a/Tests/MongoSwiftBenchmarks/benchmark.py
+++ b/Tests/MongoSwiftBenchmarks/benchmark.py
@@ -1,10 +1,13 @@
-import sys
 import re
+import sys
 
-results = [line for line in sys.stdin.read().split('\n') if "measured" in line]
+# this should be run from the root project directory with:
+# `make benchmark 2>&1 | python Tests/MongoSwiftBenchmarks/benchmark.py`
+# the test results go to stderr so the 2>&1 is to redirect stderr to stdout.
+output = sys.stdin.read()
+results = filter(lambda x: "measured" in x, output.split('\n'))
 
 benchmarks = {}
-
 for r in results:
 	name = re.search(r"\[.*?\]", r).group(0)[22:-1]
 	avg = re.search(r"average: .*?,", r).group(0)[9:-1]

--- a/Tests/MongoSwiftBenchmarks/benchmark.py
+++ b/Tests/MongoSwiftBenchmarks/benchmark.py
@@ -1,0 +1,15 @@
+import sys
+import re
+
+results = [line for line in sys.stdin.read().split('\n') if "measured" in line]
+
+benchmarks = {}
+
+for r in results:
+	name = re.search(r"\[.*?\]", r).group(0)[22:-1]
+	avg = re.search(r"average: .*?,", r).group(0)[9:-1]
+	benchmarks[name] = float(avg)
+
+print benchmarks
+
+

--- a/Tests/MongoSwiftBenchmarks/benchmark.py
+++ b/Tests/MongoSwiftBenchmarks/benchmark.py
@@ -2,12 +2,9 @@ import re
 import sys
 
 # this script should be run from the root project directory with:
-# `make benchmark 2>&1 | python Tests/MongoSwiftBenchmarks/benchmark.py`
-# the test results go to stderr so the 2>&1 is to redirect stderr to stdout.
-# output = sys.stdin.read()
-# results = filter(lambda x: "Median time" in x or "Score" in x, output.split('\n'))
-
-results = ["Results for for -[MultiDocumentBenchmarks testFindManyAndEmptyCursor]: median time 0.022 seconds, score 705.7451 MB/s"]
+# `make benchmark | python Tests/MongoSwiftBenchmarks/benchmark.py`
+output = sys.stdin.read()
+results = filter(lambda x: "median time" in x, output.split('\n'))
 
 benchmarks = {}
 for r in results:
@@ -15,11 +12,7 @@ for r in results:
 	name = match.group("name")
 	time = match.group("seconds")
 	score = match.group("score")
-	print name
-	print time
-	print score
-	#avg = re.search(r"average: .*?,", r).group(0)[9:-1]
-	#benchmarks[name] = float(avg)
+	benchmarks[name] = {"time": float(time), "score": float(score)}
 
 print benchmarks
 

--- a/Tests/MongoSwiftBenchmarks/benchmark.py
+++ b/Tests/MongoSwiftBenchmarks/benchmark.py
@@ -1,17 +1,25 @@
 import re
 import sys
 
-# this should be run from the root project directory with:
+# this script should be run from the root project directory with:
 # `make benchmark 2>&1 | python Tests/MongoSwiftBenchmarks/benchmark.py`
 # the test results go to stderr so the 2>&1 is to redirect stderr to stdout.
-output = sys.stdin.read()
-results = filter(lambda x: "measured" in x, output.split('\n'))
+# output = sys.stdin.read()
+# results = filter(lambda x: "Median time" in x or "Score" in x, output.split('\n'))
+
+results = ["Results for for -[MultiDocumentBenchmarks testFindManyAndEmptyCursor]: median time 0.022 seconds, score 705.7451 MB/s"]
 
 benchmarks = {}
 for r in results:
-	name = re.search(r"\[.*?\]", r).group(0)[22:-1]
-	avg = re.search(r"average: .*?,", r).group(0)[9:-1]
-	benchmarks[name] = float(avg)
+	match = re.search(r"\[.*\ (?P<name>.*)]: median time (?P<seconds>.*) seconds, score (?P<score>.*) ", r)
+	name = match.group("name")
+	time = match.group("seconds")
+	score = match.group("score")
+	print name
+	print time
+	print score
+	#avg = re.search(r"average: .*?,", r).group(0)[9:-1]
+	#benchmarks[name] = float(avg)
 
 print benchmarks
 


### PR DESCRIPTION
This adds an extension to `XCTestCase` to provide custom time measurement code. The time is calculated by taking the difference in system uptime (the same way as in the built-in `measure` functionality.)

While by default benchmarks will now use 100 iterations, I have adjusted the number  in various cases better match the spec requirements that:
- iterations should loop for at least 1 minute cumulative execution time
- iterations should stop after 100 iterations or 5 minutes cumulative execution time, whichever is shorter

Note that this makes the total benchmark execution time far longer, as there are now 13 benchmarks each running for a minimum of 1 minute. 

This also adds a python script to read benchmark output from stdin and store it in a dictionary like this:
`{'testRunCommand': {'score': 0.236, 'time': 0.677}, 'testDeepDecoding': {'score': 11.6672, 'time': 1.683}, ...}`

Where the time is median time for the task and the "score" is task size in MB / median time. 

Right now that is just printed out at the end, TBD how exactly we need to structure/provide info for plotting to Evergreen. 