### PR TITLE
Add a getError method and a way to iterate+throw for cursors

### DIFF
--- a/Tests/MongoSwiftTests/CollectionTests.swift
+++ b/Tests/MongoSwiftTests/CollectionTests.swift
@@ -275,6 +275,6 @@ final class CollectionTests: XCTestCase {
 
         let findResult2 = try coll.find(["cat": "cat"])
         for _ in findResult2 { }
-        expect(findResult2.getError()).to(beNil())
+        expect(findResult2.error).to(beNil())
     }
 }

--- a/Tests/MongoSwiftTests/CollectionTests.swift
+++ b/Tests/MongoSwiftTests/CollectionTests.swift
@@ -268,4 +268,13 @@ final class CollectionTests: XCTestCase {
     func testGetName() {
         expect(self.coll.name).to(equal("coll1"))
     }
+
+    func testCursorIteration() throws {
+        let findResult1 = try coll.find(["cat": "cat"])
+        while let _  = try findResult1.nextOrError() { }
+
+        let findResult2 = try coll.find(["cat": "cat"])
+        for _ in findResult2 { }
+        expect(findResult2.getError()).to(beNil())
+    }
 }


### PR DESCRIPTION
This adds a method to get the error that occured while iterating the cursor, if any. Also adds a `nextOrError` throwing method for iterating the cursor if you don't want to have to remember to check the cursor at the end. this still feels kind of weird so if you have any other ideas let me know... but at least for now this is better than just printing out the error message 