### PR TITLE
Add support for SDAM monitoring

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -42,7 +42,7 @@ public struct ServerDescription {
     /// The hostname or IP and the port number that the client connects to. Note that this is not the
     /// server's ismaster.me field, in the case that the server reports an address different from the 
     /// address the client uses.
-    let connectionId: ConnectionId = ConnectionId()
+    let connectionId: ConnectionId
 
     /// The last error related to this server.
     let error: MongoError? = nil
@@ -122,7 +122,7 @@ public struct TopologyDescription {
     let maxElectionId: ObjectId? = nil
 
     /// The servers comprising this topology. By default, a single server at localhost:270107.
-    let servers: [ServerDescription] = [ServerDescription()]
+    let servers: [ServerDescription] = [ServerDescription(connectionId: ConnectionId())]
 
     /// For single-threaded clients, indicates whether the topology must be re-scanned.
     let stale: Bool = false

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -13,7 +13,7 @@ public protocol MongoEvent {
 
 /// A protocol for monitoring events to implement, indicating that they can be initialized from an OpaquePointer
 /// to the corresponding libmongoc type.
-internal protocol InitializableFromOpaquePointer {
+private protocol InitializableFromOpaquePointer {
     /// Initializes the event from an OpaquePointer.
     init(_ event: OpaquePointer)
 }
@@ -46,9 +46,8 @@ public struct CommandStartedEvent: MongoEvent, InitializableFromOpaquePointer {
     /// The connection id for the command.
     let connectionId: ConnectionId
 
-    /// An internal initializer for creating a CommandStartedEvent from an OpaquePointer to a
-    /// mongoc_apm_command_started_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a CommandStartedEvent from an OpaquePointer to a mongoc_apm_command_started_t
+    fileprivate init(_ event: OpaquePointer) {
         let commandData = UnsafeMutablePointer(mutating: mongoc_apm_command_started_get_command(event)!)
         self.command = Document(fromPointer: commandData)
         self.databaseName = String(cString: mongoc_apm_command_started_get_database_name(event))
@@ -87,8 +86,8 @@ public struct CommandSucceededEvent: MongoEvent, InitializableFromOpaquePointer 
     /// The connection id for the command.
     let connectionId: ConnectionId
 
-    /// An internal initializer for creating a CommandSucceededEvent from a mongoc_apm_command_succeeded_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a CommandSucceededEvent from an OpaquePointer to a mongoc_apm_command_succeeded_t
+    fileprivate init(_ event: OpaquePointer) {
         self.duration = mongoc_apm_command_succeeded_get_duration(event)
         let replyData = UnsafeMutablePointer(mutating: mongoc_apm_command_succeeded_get_reply(event)!)
         self.reply = Document(fromPointer: replyData)
@@ -127,8 +126,8 @@ public struct CommandFailedEvent: MongoEvent, InitializableFromOpaquePointer {
     /// The connection id for the command.
     let connectionId: ConnectionId
 
-    /// An internal initializer for creating a CommandFailedEvent from a mongoc_apm_command_failed_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a CommandFailedEvent from an OpaquePointer to a mongoc_apm_command_failed_t
+    fileprivate init(_ event: OpaquePointer) {
         self.duration = mongoc_apm_command_failed_get_duration(event)
         self.commandName = String(cString: mongoc_apm_command_failed_get_command_name(event))
         var error = bson_error_t()
@@ -160,12 +159,12 @@ public struct ServerDescriptionChangedEvent: MongoEvent, InitializableFromOpaque
     /// The new server description.
     let newDescription: ServerDescription
 
-    /// Creates a ServerDescription from an OpaquePointer to a mongoc_server_description_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a ServerDescriptionChangedEvent from an OpaquePointer to a mongoc_server_changed_t
+    fileprivate init(_ event: OpaquePointer) {
         self.connectionId = ConnectionId(mongoc_apm_server_changed_get_host(event))
         var oid = bson_oid_t()
         mongoc_apm_server_changed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(from: oid)
+        self.topologyId = ObjectId(fromPointer: &oid)
         self.previousDescription = ServerDescription(mongoc_apm_server_changed_get_previous_description(event))
         self.newDescription = ServerDescription(mongoc_apm_server_changed_get_new_description(event))
     }
@@ -185,12 +184,12 @@ public struct ServerOpeningEvent: MongoEvent, InitializableFromOpaquePointer {
     /// A unique identifier for the topology.
     let topologyId: ObjectId
 
-    /// Creates a ServerOpeningEvent from an OpaquePointer to a mongoc_apm_server_opening_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a ServerOpeningEvent from an OpaquePointer to a mongoc_apm_server_opening_t
+    fileprivate init(_ event: OpaquePointer) {
         self.connectionId = ConnectionId(mongoc_apm_server_opening_get_host(event))
         var oid = bson_oid_t()
         mongoc_apm_server_opening_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(from: oid)
+        self.topologyId = ObjectId(fromPointer: &oid)
     }
 }
 
@@ -208,12 +207,12 @@ public struct ServerClosedEvent: MongoEvent, InitializableFromOpaquePointer {
     /// A unique identifier for the topology.
     let topologyId: ObjectId
 
-    /// Creates a TopologyClosedEvent from an OpaquePointer to a mongoc_apm_topology_closed_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a TopologyClosedEvent from an OpaquePointer to a mongoc_apm_topology_closed_t
+    fileprivate init(_ event: OpaquePointer) {
         self.connectionId = ConnectionId(mongoc_apm_server_closed_get_host(event))
         var oid = bson_oid_t()
         mongoc_apm_server_closed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(from: oid)
+        self.topologyId = ObjectId(fromPointer: &oid)
     }
 }
 
@@ -234,11 +233,11 @@ public struct TopologyDescriptionChangedEvent: MongoEvent, InitializableFromOpaq
     /// The new topology description.
     let newDescription: TopologyDescription
 
-    /// Creates a TopologyDescriptionChangedEvent from an OpaquePointer to a mongoc_apm_topology_changed_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a TopologyDescriptionChangedEvent from an OpaquePointer to a mongoc_apm_topology_changed_t
+    fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
         mongoc_apm_topology_changed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(from: oid)
+        self.topologyId = ObjectId(fromPointer: &oid)
         self.previousDescription = TopologyDescription(mongoc_apm_topology_changed_get_previous_description(event))
         self.newDescription = TopologyDescription(mongoc_apm_topology_changed_get_new_description(event))
     }
@@ -255,11 +254,11 @@ public struct TopologyOpeningEvent: MongoEvent, InitializableFromOpaquePointer {
     /// A unique identifier for the topology.
     let topologyId: ObjectId
 
-    /// Creates a TopologyOpeningEvent from an OpaquePointer to a mongoc_apm_topology_opening_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a TopologyOpeningEvent from an OpaquePointer to a mongoc_apm_topology_opening_t
+    fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
         mongoc_apm_topology_opening_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(from: oid)
+        self.topologyId = ObjectId(fromPointer: &oid)
     }
 }
 
@@ -274,11 +273,11 @@ public struct TopologyClosedEvent: MongoEvent, InitializableFromOpaquePointer {
     /// A unique identifier for the topology.
     let topologyId: ObjectId
 
-    /// Creates a TopologyClosedEvent from an OpaquePointer to a mongoc_apm_topology_closed_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a TopologyClosedEvent from an OpaquePointer to a mongoc_apm_topology_closed_t
+    fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
         mongoc_apm_topology_closed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(from: oid)
+        self.topologyId = ObjectId(fromPointer: &oid)
     }
 }
 
@@ -294,8 +293,8 @@ public struct ServerHeartbeatStartedEvent: MongoEvent, InitializableFromOpaquePo
     /// The connection ID (host/port pair) of the server.
     let connectionId: ConnectionId
 
-    /// Creates a ServerHeartbeatStartedEvent from an OpaquePointer to a mongoc_apm_server_heartbeat_started_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a ServerHeartbeatStartedEvent from an OpaquePointer to a mongoc_apm_server_heartbeat_started_t
+    fileprivate init(_ event: OpaquePointer) {
         self.connectionId = ConnectionId(mongoc_apm_server_heartbeat_started_get_host(event))
     }
 }
@@ -317,8 +316,8 @@ public struct ServerHeartbeatSucceededEvent: MongoEvent, InitializableFromOpaque
     /// The connection ID (host/port pair) of the server.
     let connectionId: ConnectionId
 
-    /// Creates a ServerHeartbeatSucceededEvent from an OpaquePointer to a mongoc_apm_server_heartbeat_succeeded_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a ServerHeartbeatSucceededEvent from an OpaquePointer to a mongoc_apm_server_heartbeat_succeeded_t
+    fileprivate init(_ event: OpaquePointer) {
         self.duration = mongoc_apm_server_heartbeat_succeeded_get_duration(event)
         let replyData = UnsafeMutablePointer(mutating: mongoc_apm_server_heartbeat_succeeded_get_reply(event)!)
         self.reply = Document(fromPointer: replyData)
@@ -343,8 +342,8 @@ public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePoi
     /// The connection ID (host/port pair) of the server.
     let connectionId: ConnectionId
 
-    /// Creates a ServerHeartbeatFailedEvent from an OpaquePointer to a mongoc_apm_server_heartbeat_failed_t
-    internal init(_ event: OpaquePointer) {
+    /// Initializes a ServerHeartbeatFailedEvent from an OpaquePointer to a mongoc_apm_server_heartbeat_failed_t
+    fileprivate init(_ event: OpaquePointer) {
         self.duration = mongoc_apm_server_heartbeat_failed_get_duration(event)
         var error = bson_error_t()
         mongoc_apm_server_heartbeat_failed_get_error(event, &error)
@@ -358,70 +357,69 @@ public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePoi
 /// them to the `NotificationCenter` that was by the user, or `NotificationCenter.default`
 /// if none was specified.
 
-/// An internal callback that will be set for "command started" events if the user enables command monitoring.
-internal func commandStarted(_event: OpaquePointer?) {
+/// A callback that will be set for "command started" events if the user enables command monitoring.
+private func commandStarted(_event: OpaquePointer?) {
     postNotification(type: CommandStartedEvent.self, _event: _event, contextFunc: mongoc_apm_command_started_get_context)
 }
 
-/// An internal callback that will be set for "command succeeded" events if the user enables command monitoring.
-internal func commandSucceeded(_event: OpaquePointer?) {
+/// A callback that will be set for "command succeeded" events if the user enables command monitoring.
+private func commandSucceeded(_event: OpaquePointer?) {
     postNotification(type: CommandSucceededEvent.self, _event: _event, contextFunc: mongoc_apm_command_succeeded_get_context)
 }
 
-/// An internal callback that will be set for "command failed" events if the user enables command monitoring.
-internal func commandFailed(_event: OpaquePointer?) {
+/// A callback that will be set for "command failed" events if the user enables command monitoring.
+private func commandFailed(_event: OpaquePointer?) {
     postNotification(type: CommandFailedEvent.self, _event: _event, contextFunc: mongoc_apm_command_failed_get_context)
 }
 
-/// An internal callback that will be set for "server description changed" events if the user enables server monitoring.
-internal func serverDescriptionChanged(_event: OpaquePointer?) {
+/// A callback that will be set for "server description changed" events if the user enables server monitoring.
+private func serverDescriptionChanged(_event: OpaquePointer?) {
     postNotification(type: ServerDescriptionChangedEvent.self, _event: _event, contextFunc: mongoc_apm_server_changed_get_context)
 }
 
-/// An internal callback that will be set for "server opening" events if the user enables server monitoring.
-internal func serverOpening(_event: OpaquePointer?) {
+/// A callback that will be set for "server opening" events if the user enables server monitoring.
+private func serverOpening(_event: OpaquePointer?) {
     postNotification(type: ServerOpeningEvent.self, _event: _event, contextFunc: mongoc_apm_server_opening_get_context)
 }
 
-/// An internal callback that will be set for "server closed" events if the user enables server monitoring.
-internal func serverClosed(_event: OpaquePointer?) {
+/// A callback that will be set for "server closed" events if the user enables server monitoring.
+private func serverClosed(_event: OpaquePointer?) {
     postNotification(type: ServerClosedEvent.self, _event: _event, contextFunc: mongoc_apm_server_closed_get_context)
 }
 
-/// An internal callback that will be set for "topology description changed" events if the user enables server
-/// monitoring.
-internal func topologyDescriptionChanged(_event: OpaquePointer?) {
+/// A callback that will be set for "topology description changed" events if the user enables server monitoring.
+private func topologyDescriptionChanged(_event: OpaquePointer?) {
     postNotification(type: TopologyDescriptionChangedEvent.self, _event: _event, contextFunc: mongoc_apm_topology_changed_get_context)
 }
 
-/// An internal callback that will be set for "topology opening" events if the user enables server monitoring.
-internal func topologyOpening(_event: OpaquePointer?) {
+/// A callback that will be set for "topology opening" events if the user enables server monitoring.
+private func topologyOpening(_event: OpaquePointer?) {
     postNotification(type: TopologyOpeningEvent.self, _event: _event, contextFunc: mongoc_apm_topology_opening_get_context)
 }
 
-/// An internal callback that will be set for "topology closed" events if the user enables server monitoring.
-internal func topologyClosed(_event: OpaquePointer?) {
+/// A callback that will be set for "topology closed" events if the user enables server monitoring.
+private func topologyClosed(_event: OpaquePointer?) {
     postNotification(type: TopologyClosedEvent.self, _event: _event, contextFunc: mongoc_apm_topology_closed_get_context)
 }
 
-/// An internal callback that will be set for "server heartbeat started" events if the user enables server monitoring.
-internal func serverHeartbeatStarted(_event: OpaquePointer?) {
+/// A callback that will be set for "server heartbeat started" events if the user enables server monitoring.
+private func serverHeartbeatStarted(_event: OpaquePointer?) {
     postNotification(type: ServerHeartbeatStartedEvent.self, _event: _event, contextFunc: mongoc_apm_server_heartbeat_started_get_context)
 }
 
-/// An internal callback that will be set for "server heartbeat succeeded" events if the user enables server monitoring.
-internal func serverHeartbeatSucceeded(_event: OpaquePointer?) {
+/// A callback that will be set for "server heartbeat succeeded" events if the user enables server monitoring.
+private func serverHeartbeatSucceeded(_event: OpaquePointer?) {
     postNotification(type: ServerHeartbeatSucceededEvent.self, _event: _event, contextFunc: mongoc_apm_server_heartbeat_succeeded_get_context)
 }
 
-/// An internal callback that will be set for "server heartbeat failed" events if the user enables server monitoring.
-internal func serverHeartbeatFailed(_event: OpaquePointer?) {
+/// A callback that will be set for "server heartbeat failed" events if the user enables server monitoring.
+private func serverHeartbeatFailed(_event: OpaquePointer?) {
     postNotification(type: ServerHeartbeatFailedEvent.self, _event: _event, contextFunc: mongoc_apm_server_heartbeat_failed_get_context)
 }
 
 /// Posts a Notification with the specified name, containing an event of type T generated using the provided _event 
 /// and context function.
-internal func postNotification<T: MongoEvent>(type: T.Type, _event: OpaquePointer?,
+private func postNotification<T: MongoEvent>(type: T.Type, _event: OpaquePointer?,
                                             contextFunc: (OpaquePointer) -> UnsafeMutableRawPointer!) where T: InitializableFromOpaquePointer {
     guard let event = _event else {
         preconditionFailure("Missing event pointer for \(type)")
@@ -492,14 +490,26 @@ extension MongoClient {
         mongoc_apm_callbacks_destroy(callbacks)
     }
 
-    /// Disables all notification types for this client. Notifications can be reenabled by calling enableMonitoring.
+    /*  
+     *  Disables monitoring for this MongoClient. Notifications can be reenabled using MongoClient.enableMonitoring.
+     */
     public func disableMonitoring() {
         self.monitoringEventTypes = nil
         self.notificationCenter = nil
     }
 
-    /// Enables monitoring for this client for the event type specified, or both types if neither is specified. 
-    /// Sets the destination NotificationCenter to that provided, or the default if one is not specified.
+    /*
+     *  Enables monitoring for this MongoClient for the event type specified, or both types if neither is specified.
+     *  Sets the destination NotificationCenter to the one provided, or the application's default NotificationCenter
+     *  if one is not specified.
+     *
+     *  - Parameters:
+     *      - forEvents:   A MongoEventType? to enable monitoring for, defaulting to nil. If unspecified, monitoring
+     *                     will be enabled for both .commandMonitoring and .serverMonitoring events.
+            - usingCenter: A NotificationCenter that event notifications should be posted to, defaulting to the default
+                           NotificationCenter for the application.
+     *
+     */
     public func enableMonitoring(forEvents eventType: MongoEventType? = nil,
                                 usingCenter center: NotificationCenter = NotificationCenter.default) {
         if let type = eventType {

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -38,62 +38,61 @@ public enum ServerType: String {
 
 /// A struct describing a mongod or mongos process.
 public struct ServerDescription {
-
     /// The hostname or IP and the port number that the client connects to. Note that this is not the
     /// server's ismaster.me field, in the case that the server reports an address different from the 
     /// address the client uses.
     let connectionId: ConnectionId
 
     /// The last error related to this server.
-    let error: MongoError? = nil
+    let error: MongoError? = nil // currently we will never set this
 
     /// The duration of the server's last ismaster call.
-    let roundTripTime: Int64? = nil
+    var roundTripTime: Int64?
 
     /// The "lastWriteDate" from the server's most recent ismaster response.
-    let lastWriteDate: Date? = nil
+    var lastWriteDate: Date?
 
     /// The last opTime reported by the server. Only mongos and shard servers 
     /// record this field when monitoring config servers as replica sets.
-    let opTime: ObjectId? = nil
+    var opTime: ObjectId?
 
     /// The type of this server.
-    let type: ServerType = .unknown
+    var type: ServerType = .unknown
 
     /// The wire protocol version range supported by the server.
-    let minWireVersion: Int32 = 0
-    let maxWireVersion: Int32 = 0
+    var minWireVersion: Int32 = 0
+    var maxWireVersion: Int32 = 0
 
     /// The hostname or IP and the port number that this server was configured with in the replica set.
-    let me: ConnectionId? = nil
+    var me: ConnectionId?
 
     /// Hosts, arbiters, passives: sets of addresses. This server's opinion of the replica set's members, if any.
-    let hosts: [ConnectionId] = []
-    let arbiters: [ConnectionId] = []
+    var hosts: [ConnectionId] = []
+    var arbiters: [ConnectionId] = []
     /// "Passives" are priority-zero replica set members that cannot become primary. 
     /// The client treats them precisely the same as other members.
-    let passives: [ConnectionId] = []
+    var passives: [ConnectionId] = []
 
     /// Tags for this server.
-    let tags: [String: String] = [:]
+    var tags: [String: String] = [:]
 
     /// The replica set name.
-    let setName: String? = nil
+    var setName: String?
 
     /// The replica set version.
-    let setVersion: Int64? = nil
+    var setVersion: Int64?
 
     /// The election ID where this server was elected, if this is a replica set member that believes it is primary.
-    let electionId: ObjectId? = nil
+    var electionId: ObjectId?
 
     /// This server's opinion of who the primary is. 
-    let primary: ConnectionId? = nil
+    var primary: ConnectionId?
 
     /// When this server was last checked.
-    let lastUpdateTime: Date? = nil
+    let lastUpdateTime: Date? = nil // currently we will never set this
 
     /// The logicalSessionTimeoutMinutes value for this server.
-    let logicalSessionTimeoutMinutes: Int64? = nil
+    var logicalSessionTimeoutMinutes: Int64?
 }
 
 /// The possible types for a topology. The raw values correspond to the values libmongoc uses. 
@@ -113,27 +112,27 @@ public struct TopologyDescription {
     let type: TopologyType
 
     /// The replica set name. 
-    let setName: String? = nil
+    var setName: String?
 
     /// The largest setVersion ever reported by a primary.
-    let maxSetVersion: Int64? = nil
+    var maxSetVersion: Int64?
 
     /// The largest electionId ever reported by a primary.
-    let maxElectionId: ObjectId? = nil
+    var maxElectionId: ObjectId?
 
     /// The servers comprising this topology. By default, a single server at localhost:270107.
-    let servers: [ServerDescription] = [ServerDescription(connectionId: ConnectionId())]
+    var servers: [ServerDescription] = [ServerDescription(connectionId: ConnectionId())]
 
     /// For single-threaded clients, indicates whether the topology must be re-scanned.
-    let stale: Bool = false
+    let stale: Bool = false // currently we will never set this
 
     /// Exists if any server's wire protocol version range is incompatible with the client's.
-    let compatibilityError: MongoError? = nil
+    let compatibilityError: MongoError? = nil // currently we will never set this
 
     /// The logicalSessionTimeoutMinutes value for this topology. This value is the minimum
     /// of the logicalSessionTimeoutMinutes values across all the servers in `servers`, 
     /// or nil if any of them are nil.
-    let logicalSessionTimeoutMinutes: Int64? = nil
+    var logicalSessionTimeoutMinutes: Int64?
 
     /// Determines if the topology has a readable server available.
     // (this function should take in an optional ReadPreference, but we have yet to implement that type.) 

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -1,260 +1,32 @@
 import Foundation
 import libmongoc
 
-/// A struct representing a server connection, consisting of a host and port.
-public struct ConnectionId: Equatable {
-    let host: String
-    let port: UInt16
+/// A protocol for monitoring events to implement, specifying their type and name.
+public protocol MongoEvent {
+    /// The MongoEventType corresponding to the event. This event will be posted if 
+    /// monitoring is enabled for its eventType.
+    static var eventType: MongoEventType { get }
 
-    internal init(_ hostList: UnsafePointer<mongoc_host_list_t>) {
-        var hostData = hostList.pointee
-        self.host = withUnsafeBytes(of: &hostData.host) { (rawPtr) -> String in
-            let ptr = rawPtr.baseAddress!.assumingMemoryBound(to: CChar.self)
-            return String(cString: ptr)
-        }
-        self.port = hostData.port
-    }
-
-    internal init(_ hostAndPort: String) {
-        let parts = hostAndPort.split(separator: ":")
-        self.host = String(parts[0])
-        self.port = UInt16(parts[1])!
-    }
-
-    /// Initializes a ConnectionId at localhost:27017, the default host/port.
-    internal init() {
-        self.host = "localhost"
-        self.port = 27017
-    }
-
-    public static func ==(lhs: ConnectionId, rhs: ConnectionId) -> Bool {
-        return lhs.host == rhs.host && rhs.port == lhs.port
-    }
-}
-
-/// The possible types for a server. The raw values correspond to the values libmongoc uses. 
-/// (We don't use these strings directly because Swift convention is to use lowercase enums.)
-public enum ServerType: String {
-    case standalone = "Standalone"
-    case mongos = "Mongos"
-    case possiblePrimary = "PossiblePrimary"
-    case rsPrimary = "RSPrimary"
-    case rsSecondary = "RSSecondary"
-    case rsArbiter = "RSArbiter"
-    case rsOther = "RSOther"
-    case rsGhost = "RSGhost"
-    case unknown = "Unknown"
-}
-
-/// A struct describing a mongod or mongos process.
-public struct ServerDescription {
-    /// The hostname or IP and the port number that the client connects to. Note that this is not the
-    /// server's ismaster.me field, in the case that the server reports an address different from the 
-    /// address the client uses.
-    let connectionId: ConnectionId
-
-    /// The last error related to this server.
-    let error: MongoError? = nil // currently we will never set this
-
-    /// The duration of the server's last ismaster call.
-    var roundTripTime: Int64?
-
-    /// The "lastWriteDate" from the server's most recent ismaster response.
-    var lastWriteDate: Date?
-
-    /// The last opTime reported by the server. Only mongos and shard servers 
-    /// record this field when monitoring config servers as replica sets.
-    var opTime: ObjectId?
-
-    /// The type of this server.
-    var type: ServerType = .unknown
-
-    /// The wire protocol version range supported by the server.
-    var minWireVersion: Int32 = 0
-    var maxWireVersion: Int32 = 0
-
-    /// The hostname or IP and the port number that this server was configured with in the replica set.
-    var me: ConnectionId?
-
-    /// Hosts, arbiters, passives: sets of addresses. This server's opinion of the replica set's members, if any.
-    var hosts: [ConnectionId] = []
-    var arbiters: [ConnectionId] = []
-    /// "Passives" are priority-zero replica set members that cannot become primary. 
-    /// The client treats them precisely the same as other members.
-    var passives: [ConnectionId] = []
-
-    /// Tags for this server.
-    var tags: [String: String] = [:]
-
-    /// The replica set name.
-    var setName: String?
-
-    /// The replica set version.
-    var setVersion: Int64?
-
-    /// The election ID where this server was elected, if this is a replica set member that believes it is primary.
-    var electionId: ObjectId?
-
-    /// This server's opinion of who the primary is. 
-    var primary: ConnectionId?
-
-    /// When this server was last checked.
-    let lastUpdateTime: Date? = nil // currently, this will never be set
-
-    /// The logicalSessionTimeoutMinutes value for this server.
-    var logicalSessionTimeoutMinutes: Int64?
-
-    /// An internal initializer to create a `ServerDescription` with just a ConnectionId.
-    internal init(connectionId: ConnectionId) {
-        self.connectionId = connectionId
-    }
-
-    /// An internal function to handle parsing isMaster and setting ServerDescription attributes appropriately.
-    internal mutating func parseIsMaster(_ isMaster: Document) {
-        if let lastWrite = isMaster["lastWrite"] as? Document {
-            self.lastWriteDate = lastWrite["lastWriteDate"] as? Date
-            self.opTime = lastWrite["opTime"] as? ObjectId
-        }
-
-        if let minVersion = isMaster["minWireVersion"] as? Int32 {
-            self.minWireVersion = minVersion
-        }
-
-        if let maxVersion = isMaster["maxWireVersion"] as? Int32 {
-            self.maxWireVersion = maxVersion
-        }
-
-        if let me = isMaster["me"] as? String {
-            self.me = ConnectionId(me)
-        }
-
-        if let hosts = isMaster["hosts"] as? [String] {
-            self.hosts = hosts.map { ConnectionId($0) }
-        }
-
-        if let passives = isMaster["passives"] as? [String] {
-            self.passives = passives.map { ConnectionId($0) }
-        }
-
-        if let arbiters = isMaster["arbiters"] as? [String] {
-            self.arbiters = arbiters.map { ConnectionId($0) }
-        }
-
-        if let tags = isMaster["tags"] as? Document {
-            for (k, v) in tags {
-                self.tags[k] = v as? String
-            }
-        }
-
-        self.setName = isMaster["setName"] as? String
-        self.setVersion = isMaster["setVersion"] as? Int64
-        self.electionId = isMaster["electionId"] as? ObjectId
-
-        if let primary = isMaster["primary"] as? String {
-            self.primary = ConnectionId(primary)
-        }
-
-        self.logicalSessionTimeoutMinutes = isMaster["logicalSessionTimeoutMinutes"] as? Int64
-
-    }
-
-    /// An internal initializer to create a `ServerDescription` from an OpaquePointer to a
-    /// mongoc_server_description_t.
-    internal init(_ description: OpaquePointer) {
-        self.connectionId = ConnectionId(mongoc_server_description_host(description))
-        self.roundTripTime = mongoc_server_description_round_trip_time(description)
-
-        let isMasterData =  UnsafeMutablePointer(mutating: mongoc_server_description_ismaster(description)!)
-        let isMaster = Document(fromPointer: isMasterData)
-        self.parseIsMaster(isMaster)
-
-        let serverType = String(cString: mongoc_server_description_type(description))
-        self.type = ServerType(rawValue: serverType)!
-    }
-}
-
-/// The possible types for a topology. The raw values correspond to the values libmongoc uses. 
-/// (We don't use these strings directly because Swift convention is to use lowercase for enums.)
-public enum TopologyType: String {
-    case single = "Single"
-    case replicaSetNoPrimary = "ReplicaSetNoPrimary"
-    case replicaSetWithPrimary = "ReplicaSetWithPrimary"
-    case sharded = "Sharded"
-    case unknown = "Unknown"
-}
-
-/// A struct describing the state of a MongoDB deployment: its type (standalone, replica set, or sharded), 
-/// which servers are up, what type of servers they are, which is primary, and so on.
-public struct TopologyDescription {
-    /// The type of this topology. 
-    let type: TopologyType
-
-    /// The replica set name. 
-    var setName: String? { return self.servers[0].setName }
-
-    /// The largest setVersion ever reported by a primary.
-    var maxSetVersion: Int64?
-
-    /// The largest electionId ever reported by a primary.
-    var maxElectionId: ObjectId?
-
-    /// The servers comprising this topology. By default, a single server at localhost:270107.
-    var servers: [ServerDescription] = [ServerDescription(connectionId: ConnectionId())]
-
-    /// For single-threaded clients, indicates whether the topology must be re-scanned.
-    let stale: Bool = false // currently, this will never be set
-
-    /// Exists if any server's wire protocol version range is incompatible with the client's.
-    let compatibilityError: MongoError? = nil // currently, this will never be set
-
-    /// The logicalSessionTimeoutMinutes value for this topology. This value is the minimum
-    /// of the logicalSessionTimeoutMinutes values across all the servers in `servers`, 
-    /// or nil if any of them are nil.
-    var logicalSessionTimeoutMinutes: Int64? {
-        let timeoutValues = self.servers.map { $0.logicalSessionTimeoutMinutes }
-        if timeoutValues.contains (where: { $0 == nil }) {
-            return nil
-        } else {
-            return timeoutValues.map { $0! }.min()
-        }
-    }
-
-    /// Determines if the topology has a readable server available.
-    // (this function should take in an optional ReadPreference, but we have yet to implement that type.) 
-    func hasReadableServer() -> Bool {
-        return [.single, .replicaSetWithPrimary, .sharded].contains(self.type)
-    }
-
-    /// Determines if the topology has a writable server available.
-    func hasWritableServer() -> Bool {
-        return [.single, .replicaSetWithPrimary].contains(self.type)
-    }
-
-    /// An internal initializer to create a `TopologyDescription` from an OpaquePointer
-    /// to a mongoc_server_description_t
-    internal init(_ description: OpaquePointer) {
-
-        let topologyType = String(cString: mongoc_topology_description_type(description))
-        self.type = TopologyType(rawValue: topologyType)!
-
-        var size = size_t()
-        let serverData = mongoc_topology_description_get_servers(description, &size)
-        let buffer = UnsafeBufferPointer(start: serverData, count: size)
-        if size > 0 {
-            self.servers = Array(buffer).map { ServerDescription($0!) }
-        }
-    }
+    /// The name this event will be posted under.
+    static var eventName: Notification.Name { get }
 }
 
 /// A protocol for monitoring events to implement, indicating that they can be initialized from an OpaquePointer
 /// to the corresponding libmongoc type.
-internal protocol Event {
+internal protocol InitializableFromOpaquePointer {
+    /// Initializes the event from an OpaquePointer.
     init(_ event: OpaquePointer)
 }
 
 /// An event published when a command starts. The event is stored under the key `event`
 /// in the `userInfo` property of `Notification`s posted under the name .commandStarted.
-public struct CommandStartedEvent: Event {
+public struct CommandStartedEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .commandMonitoring }
+
+    /// The name this event will be posted under.
+    public static var eventName: Notification.Name { return .commandStarted }
+
     /// The command.
     let command: Document
 
@@ -289,7 +61,13 @@ public struct CommandStartedEvent: Event {
 
 /// An event published when a command succeeds. The event is stored under the key `event`
 /// in the `userInfo` property of `Notification`s posted under the name .commandSucceeded.
-public struct CommandSucceededEvent: Event {
+public struct CommandSucceededEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .commandMonitoring }
+
+    /// The name this event will be posted under.
+    public static var eventName: Notification.Name { return .commandSucceeded }
+
     /// The execution time of the event, in microseconds.
     let duration: Int64
 
@@ -323,7 +101,12 @@ public struct CommandSucceededEvent: Event {
 
 /// An event published when a command fails. The event is stored under the key `event`
 /// in the `userInfo` property of `Notification`s posted under the name .commandFailed.
-public struct CommandFailedEvent: Event {
+public struct CommandFailedEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .commandMonitoring }
+
+    /// The name this event will be posted under.
+    public static var eventName: Notification.Name { return .commandFailed }
 
     /// The execution time of the event, in microseconds.
     let duration: Int64
@@ -358,7 +141,13 @@ public struct CommandFailedEvent: Event {
 }
 
 /// Published when a server description changes. This does NOT include changes to the server's roundTripTime property.
-public struct ServerDescriptionChangedEvent: Event {
+public struct ServerDescriptionChangedEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under. 
+    public static var eventName: Notification.Name { return .serverDescriptionChanged }
+
     /// The connection ID (host/port pair) of the server.
     let connectionId: ConnectionId
 
@@ -383,7 +172,13 @@ public struct ServerDescriptionChangedEvent: Event {
 }
 
 /// Published when a server is initialized.
-public struct ServerOpeningEvent: Event {
+public struct ServerOpeningEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under. 
+    public static var eventName: Notification.Name { return .serverOpening }
+
     /// The connection ID (host/port pair) of the server.
     let connectionId: ConnectionId
 
@@ -400,7 +195,13 @@ public struct ServerOpeningEvent: Event {
 }
 
 /// Published when a server is closed.
-public struct ServerClosedEvent: Event {
+public struct ServerClosedEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under. 
+    public static var eventName: Notification.Name { return .serverClosed }
+
     /// The connection ID (host/port pair) of the server.
     let connectionId: ConnectionId
 
@@ -417,7 +218,13 @@ public struct ServerClosedEvent: Event {
 }
 
 /// Published when a topology description changes.
-public struct TopologyDescriptionChangedEvent: Event {
+public struct TopologyDescriptionChangedEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under. 
+    public static var eventName: Notification.Name { return .topologyDescriptionChanged }
+
     /// A unique identifier for the topology.
     let topologyId: ObjectId
 
@@ -438,7 +245,13 @@ public struct TopologyDescriptionChangedEvent: Event {
 }
 
 /// Published when a topology is initialized.
-public struct TopologyOpeningEvent: Event {
+public struct TopologyOpeningEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under. 
+    public static var eventName: Notification.Name { return .topologyOpening }
+
     /// A unique identifier for the topology.
     let topologyId: ObjectId
 
@@ -451,7 +264,13 @@ public struct TopologyOpeningEvent: Event {
 }
 
 /// Published when a topology is closed.
-public struct TopologyClosedEvent: Event {
+public struct TopologyClosedEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under.
+    public static var eventName: Notification.Name { return .topologyClosed }
+
     /// A unique identifier for the topology.
     let topologyId: ObjectId
 
@@ -465,7 +284,13 @@ public struct TopologyClosedEvent: Event {
 
 /// Published when the server monitor’s ismaster command is started - immediately before
 /// the ismaster command is serialized into raw BSON and written to the socket.
-public struct ServerHeartbeatStartedEvent: Event {
+public struct ServerHeartbeatStartedEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under.
+    public static var eventName: Notification.Name { return .serverHeartbeatStarted }
+
     /// The connection ID (host/port pair) of the server.
     let connectionId: ConnectionId
 
@@ -476,7 +301,13 @@ public struct ServerHeartbeatStartedEvent: Event {
 }
 
 /// Published when the server monitor’s ismaster succeeds.
-public struct ServerHeartbeatSucceededEvent: Event {
+public struct ServerHeartbeatSucceededEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under.
+    public static var eventName: Notification.Name { return .serverHeartbeatSucceeded }
+
     /// The execution time of the event, in microseconds.
     let duration: Int64
 
@@ -496,7 +327,13 @@ public struct ServerHeartbeatSucceededEvent: Event {
 }
 
 /// Published when the server monitor’s ismaster fails, either with an “ok: 0” or a socket exception.
-public struct ServerHeartbeatFailedEvent: Event {
+public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePointer {
+    /// The type of this event.
+    public static var eventType: MongoEventType { return .serverMonitoring }
+
+    /// The name this event will be posted under. 
+    public static var eventName: Notification.Name { return .serverHeartbeatFailed }
+
     /// The execution time of the event, in microseconds.
     let duration: Int64
 
@@ -523,95 +360,84 @@ public struct ServerHeartbeatFailedEvent: Event {
 
 /// An internal callback that will be set for "command started" events if the user enables command monitoring.
 internal func commandStarted(_event: OpaquePointer?) {
-    postNotification(type: CommandStartedEvent.self, name: .commandStarted,
-                    _event: _event, contextFunc: mongoc_apm_command_started_get_context)
+    postNotification(type: CommandStartedEvent.self, _event: _event, contextFunc: mongoc_apm_command_started_get_context)
 }
 
 /// An internal callback that will be set for "command succeeded" events if the user enables command monitoring.
 internal func commandSucceeded(_event: OpaquePointer?) {
-    postNotification(type: CommandSucceededEvent.self, name: .commandSucceeded,
-                    _event: _event, contextFunc: mongoc_apm_command_succeeded_get_context)
+    postNotification(type: CommandSucceededEvent.self, _event: _event, contextFunc: mongoc_apm_command_succeeded_get_context)
 }
 
 /// An internal callback that will be set for "command failed" events if the user enables command monitoring.
 internal func commandFailed(_event: OpaquePointer?) {
-    postNotification(type: CommandFailedEvent.self, name: .commandFailed,
-                    _event: _event, contextFunc: mongoc_apm_command_failed_get_context)
+    postNotification(type: CommandFailedEvent.self, _event: _event, contextFunc: mongoc_apm_command_failed_get_context)
 }
 
 /// An internal callback that will be set for "server description changed" events if the user enables server monitoring.
 internal func serverDescriptionChanged(_event: OpaquePointer?) {
-    postNotification(type: ServerDescriptionChangedEvent.self, name: .serverDescriptionChanged,
-                    _event: _event, contextFunc: mongoc_apm_server_changed_get_context)
+    postNotification(type: ServerDescriptionChangedEvent.self, _event: _event, contextFunc: mongoc_apm_server_changed_get_context)
 }
 
 /// An internal callback that will be set for "server opening" events if the user enables server monitoring.
 internal func serverOpening(_event: OpaquePointer?) {
-    postNotification(type: ServerOpeningEvent.self, name: .serverOpening,
-                    _event: _event, contextFunc: mongoc_apm_server_opening_get_context)
+    postNotification(type: ServerOpeningEvent.self, _event: _event, contextFunc: mongoc_apm_server_opening_get_context)
 }
 
 /// An internal callback that will be set for "server closed" events if the user enables server monitoring.
 internal func serverClosed(_event: OpaquePointer?) {
-    postNotification(type: ServerClosedEvent.self, name: .serverClosed,
-                    _event: _event, contextFunc: mongoc_apm_server_closed_get_context)
+    postNotification(type: ServerClosedEvent.self, _event: _event, contextFunc: mongoc_apm_server_closed_get_context)
 }
 
 /// An internal callback that will be set for "topology description changed" events if the user enables server
 /// monitoring.
 internal func topologyDescriptionChanged(_event: OpaquePointer?) {
-    postNotification(type: TopologyDescriptionChangedEvent.self, name: .topologyDescriptionChanged,
-                    _event: _event, contextFunc: mongoc_apm_topology_changed_get_context)
+    postNotification(type: TopologyDescriptionChangedEvent.self, _event: _event, contextFunc: mongoc_apm_topology_changed_get_context)
 }
 
 /// An internal callback that will be set for "topology opening" events if the user enables server monitoring.
 internal func topologyOpening(_event: OpaquePointer?) {
-    postNotification(type: TopologyOpeningEvent.self, name: .topologyOpening,
-                _event: _event, contextFunc: mongoc_apm_topology_opening_get_context)
+    postNotification(type: TopologyOpeningEvent.self, _event: _event, contextFunc: mongoc_apm_topology_opening_get_context)
 }
 
 /// An internal callback that will be set for "topology closed" events if the user enables server monitoring.
 internal func topologyClosed(_event: OpaquePointer?) {
-    postNotification(type: TopologyClosedEvent.self, name: .topologyClosed,
-                    _event: _event, contextFunc: mongoc_apm_topology_closed_get_context)
+    postNotification(type: TopologyClosedEvent.self, _event: _event, contextFunc: mongoc_apm_topology_closed_get_context)
 }
 
 /// An internal callback that will be set for "server heartbeat started" events if the user enables server monitoring.
 internal func serverHeartbeatStarted(_event: OpaquePointer?) {
-    postNotification(type: ServerHeartbeatStartedEvent.self, name: .serverHeartbeatStarted,
-                    _event: _event, contextFunc: mongoc_apm_server_heartbeat_started_get_context)
+    postNotification(type: ServerHeartbeatStartedEvent.self, _event: _event, contextFunc: mongoc_apm_server_heartbeat_started_get_context)
 }
 
 /// An internal callback that will be set for "server heartbeat succeeded" events if the user enables server monitoring.
 internal func serverHeartbeatSucceeded(_event: OpaquePointer?) {
-    postNotification(type: ServerHeartbeatSucceededEvent.self, name: .serverHeartbeatSucceeded,
-                    _event: _event, contextFunc: mongoc_apm_server_heartbeat_succeeded_get_context)
+    postNotification(type: ServerHeartbeatSucceededEvent.self, _event: _event, contextFunc: mongoc_apm_server_heartbeat_succeeded_get_context)
 }
 
 /// An internal callback that will be set for "server heartbeat failed" events if the user enables server monitoring.
 internal func serverHeartbeatFailed(_event: OpaquePointer?) {
-    postNotification(type: ServerHeartbeatFailedEvent.self, name: .serverHeartbeatFailed,
-                    _event: _event, contextFunc: mongoc_apm_server_heartbeat_failed_get_context)
+    postNotification(type: ServerHeartbeatFailedEvent.self, _event: _event, contextFunc: mongoc_apm_server_heartbeat_failed_get_context)
 }
 
 /// Posts a Notification with the specified name, containing an event of type T generated using the provided _event 
 /// and context function.
-internal func postNotification<T: Event>(type: T.Type, name: Notification.Name, _event: OpaquePointer?,
-                                         contextFunc: (OpaquePointer) -> UnsafeMutableRawPointer!) {
+internal func postNotification<T: MongoEvent>(type: T.Type, _event: OpaquePointer?,
+                                            contextFunc: (OpaquePointer) -> UnsafeMutableRawPointer!) where T: InitializableFromOpaquePointer {
     guard let event = _event else {
         preconditionFailure("Missing event pointer for \(type)")
     }
-    let eventStruct = type.init(event)
-    let notification = Notification(name: name, userInfo: ["event": eventStruct])
     guard let context = contextFunc(event) else {
         preconditionFailure("Missing context for \(type)")
     }
 
     let client = Unmanaged<MongoClient>.fromOpaque(context).takeUnretainedValue()
 
-    // If client.notificationCenter is set, then notifications are enabled
-    if let center = client.notificationCenter {
-        center.post(notification)
+    if let center = client.notificationCenter, let enabledTypes = client.monitoringEventTypes {
+        if enabledTypes.contains(type.eventType) {
+            let eventStruct = type.init(event)
+            let notification = Notification(name: type.eventName, userInfo: ["event": eventStruct])
+            center.post(notification)
+        }
     }
 }
 
@@ -634,67 +460,53 @@ extension Notification.Name {
 
 /// The two categories of events. One or both can be enabled for a MongoClient.
 public enum MongoEventType {
-    // CommandStartedEvent, CommandSucceededEvent, CommandFailedEvent
+    // Encompasses events named .commandStarted, .commandSucceeded, .commandFailed events
     case commandMonitoring
-    // ServerChangedEvent, ServerOpeningEvent, ServerClosedEvent,
-    // TopologyChangedEvent, TopologyOpeningEvent, TopologyClosedEvewnt,
-    // ServerHeartbeatStartedEvent, ServerHeartbeatClosedEvent, ServerHeartbeatFailedEvent
+    // Encompasses events named .serverChanged, .serverOpening, .serverClosed,
+    // .topologyChangedEvent, .topologyOpening, .topologyClosed,
+    // .serverHeartbeatStarted, .serverHeartbeatClosed, .serverHeartbeatFailed
     case serverMonitoring
 }
 
 /// An extension of MongoClient to add monitoring capability for commands and server discovery and monitoring.
 extension MongoClient {
-    /*
-     *  Initializes monitoring for this client, meaning notifications about command and
-     *  server discovering and monitoring events will be posted to the supplied
-     *  NotificationCenter - or if one is not provided, the default NotificationCenter.
-     *  If no specific event types are provided, all events will be posted.
-     *
-     *  Whatever set of events are selected in the first call to this function will remain
-     *  the monitored events for this client for its lifetime, persisting across any
-     *  number of calls to enableMonitoring and disableMonitoring. The NotificationCenter
-     *  may be changed in future calls to reenableMonitoring.
-     */
-    public func initializeMonitoring(forEvents type: MongoEventType?,
-                                     usingCenter center: NotificationCenter = NotificationCenter.default) throws {
-
-        if self.notificationCenter != nil || self.callbacksSet {
-            throw MongoError.commandError(message: "Monitoring already initialized for this client; " +
-                "reenable it or change the NotificationCenter with reenableMonitoring()")
-        }
-
+    /// Internal function to install all monitoring callbacks for tbis client. This is used if the MongoClient
+    /// is initialized with eventMonitoring = true
+    internal func initializeMonitoring() {
         let callbacks = mongoc_apm_callbacks_new()
-
-        if type == nil || type == .commandMonitoring {
-            mongoc_apm_set_command_started_cb(callbacks, commandStarted)
-            mongoc_apm_set_command_succeeded_cb(callbacks, commandSucceeded)
-            mongoc_apm_set_command_failed_cb(callbacks, commandFailed)
-        }
-        if type == nil || type == .serverMonitoring {
-            mongoc_apm_set_server_changed_cb(callbacks, serverDescriptionChanged)
-            mongoc_apm_set_server_opening_cb(callbacks, serverOpening)
-            mongoc_apm_set_server_closed_cb(callbacks, serverClosed)
-            mongoc_apm_set_topology_changed_cb(callbacks, topologyDescriptionChanged)
-            mongoc_apm_set_topology_opening_cb(callbacks, topologyOpening)
-            mongoc_apm_set_topology_closed_cb(callbacks, topologyClosed)
-            mongoc_apm_set_server_heartbeat_started_cb(callbacks, serverHeartbeatStarted)
-            mongoc_apm_set_server_heartbeat_succeeded_cb(callbacks, serverHeartbeatSucceeded)
-            mongoc_apm_set_server_heartbeat_failed_cb(callbacks, serverHeartbeatFailed)
-        }
-        self.notificationCenter = center
+        mongoc_apm_set_command_started_cb(callbacks, commandStarted)
+        mongoc_apm_set_command_succeeded_cb(callbacks, commandSucceeded)
+        mongoc_apm_set_command_failed_cb(callbacks, commandFailed)
+        mongoc_apm_set_server_changed_cb(callbacks, serverDescriptionChanged)
+        mongoc_apm_set_server_opening_cb(callbacks, serverOpening)
+        mongoc_apm_set_server_closed_cb(callbacks, serverClosed)
+        mongoc_apm_set_topology_changed_cb(callbacks, topologyDescriptionChanged)
+        mongoc_apm_set_topology_opening_cb(callbacks, topologyOpening)
+        mongoc_apm_set_topology_closed_cb(callbacks, topologyClosed)
+        mongoc_apm_set_server_heartbeat_started_cb(callbacks, serverHeartbeatStarted)
+        mongoc_apm_set_server_heartbeat_succeeded_cb(callbacks, serverHeartbeatSucceeded)
+        mongoc_apm_set_server_heartbeat_failed_cb(callbacks, serverHeartbeatFailed)
+        // we can pass this as unretained because the callbacks are stored on the mongoc_client_t, so
+        // if the callback is being executed, the client must still be valid
         mongoc_client_set_apm_callbacks(self._client, callbacks, Unmanaged.passUnretained(self).toOpaque())
-        self.callbacksSet = true
         mongoc_apm_callbacks_destroy(callbacks)
     }
 
-    /// Disables all notification types for this client. Notifications can be reenabled by calling reenableMonitoring.
+    /// Disables all notification types for this client. Notifications can be reenabled by calling enableMonitoring.
     public func disableMonitoring() {
+        self.monitoringEventTypes = nil
         self.notificationCenter = nil
     }
 
-    /// Reenables monitoring for this client for the event types specified in a previous call to initializeMonitoring,
-    // setting the destination NotificationCenter to that provided, or the default if one is not specified.
-    public func reenableMonitoring(usingCenter center: NotificationCenter = NotificationCenter.default) {
+    /// Enables monitoring for this client for the event type specified, or both types if neither is specified. 
+    /// Sets the destination NotificationCenter to that provided, or the default if one is not specified.
+    public func enableMonitoring(forEvents eventType: MongoEventType? = nil,
+                                usingCenter center: NotificationCenter = NotificationCenter.default) {
+        if let type = eventType {
+            self.monitoringEventTypes = [type]
+        } else {
+            self.monitoringEventTypes = [.commandMonitoring, .serverMonitoring]
+        }
         self.notificationCenter = center
     }
 }

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -2,7 +2,7 @@ import Foundation
 import libmongoc
 
 /// A struct representing a server connection, consisting of a host and port.
-public struct ConnectionId {
+public struct ConnectionId: Equatable {
     let host: String
     let port: UInt16
 
@@ -25,6 +25,10 @@ public struct ConnectionId {
     internal init() {
         self.host = "localhost"
         self.port = 27017
+    }
+
+    public static func ==(lhs: ConnectionId, rhs: ConnectionId) -> Bool {
+        return lhs.host == rhs.host && rhs.port == lhs.port
     }
 }
 
@@ -238,13 +242,6 @@ public struct TopologyDescription {
         let buffer = UnsafeBufferPointer(start: serverData, count: size)
         if size > 0 {
             self.servers = Array(buffer).map { ServerDescription($0!) }
-        }
-
-        let timeoutValues = self.servers.map { $0.logicalSessionTimeoutMinutes }
-        if timeoutValues.contains (where: { $0 == nil }) {
-            self.logicalSessionTimeoutMinutes = nil
-        } else {
-            self.logicalSessionTimeoutMinutes = timeoutValues.map { $0! }.min()
         }
     }
 }

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -14,6 +14,133 @@ public struct ConnectionId {
         }
         self.port = hostData.port
     }
+
+    /// Initializes a ConnectionId at localhost:27017, the default host/port.
+    internal init() {
+        self.host = "localhost"
+        self.port = 27017
+    }
+}
+
+/// The possible types for a server. The raw values correspond to the values libmongoc uses. 
+/// (We don't use these strings directly because Swift convention is to use lowercase for enums.)
+public enum ServerType: String {
+    case standalone = "Standalone"
+    case mongos = "Mongos"
+    case possiblePrimary = "PossiblePrimary"
+    case rsPrimary = "RSPrimary"
+    case rsSecondary = "RSSecondary"
+    case rsArbiter = "RSArbiter"
+    case rsOther = "RSOther"
+    case rsGhost = "RSGhost"
+    case unknown = "Unknown"
+}
+
+/// A struct describing a mongod or mongos process.
+public struct ServerDescription {
+
+    /// The hostname or IP and the port number that the client connects to. Note that this is not the
+    /// server's ismaster.me field, in the case that the server reports an address different from the 
+    /// address the client uses.
+    let connectionId: ConnectionId = ConnectionId()
+
+    /// The last error related to this server.
+    let error: MongoError? = nil
+
+    /// The duration of the server's last ismaster call.
+    let roundTripTime: Int64? = nil
+
+    /// The "lastWriteDate" from the server's most recent ismaster response.
+    let lastWriteDate: Date? = nil
+
+    /// The last opTime reported by the server. Only mongos and shard servers 
+    /// record this field when monitoring config servers as replica sets.
+    let opTime: ObjectId? = nil
+
+    /// The type of this server.
+    let type: ServerType = .unknown
+
+    /// The wire protocol version range supported by the server.
+    let minWireVersion: Int32 = 0
+    let maxWireVersion: Int32 = 0
+
+    /// The hostname or IP and the port number that this server was configured with in the replica set.
+    let me: ConnectionId? = nil
+
+    /// Hosts, arbiters, passives: sets of addresses. This server's opinion of the replica set's members, if any.
+    let hosts: [ConnectionId] = []
+    let arbiters: [ConnectionId] = []
+    /// "Passives" are priority-zero replica set members that cannot become primary. 
+    /// The client treats them precisely the same as other members.
+    let passives: [ConnectionId] = []
+
+    /// Tags for this server.
+    let tags: [String: String] = [:]
+
+    /// The replica set name.
+    let setName: String? = nil
+
+    /// The replica set version.
+    let setVersion: Int64? = nil
+
+    /// The election ID where this server was elected, if this is a replica set member that believes it is primary.
+    let electionId: ObjectId? = nil
+
+    /// This server's opinion of who the primary is. 
+    let primary: ConnectionId? = nil
+
+    /// When this server was last checked.
+    let lastUpdateTime: Date? = nil
+
+    /// The logicalSessionTimeoutMinutes value for this server.
+    let logicalSessionTimeoutMinutes: Int64? = nil
+}
+
+/// The possible types for a topology. The raw values correspond to the values libmongoc uses. 
+/// (We don't use these strings directly because Swift convention is to use lowercase for enums.)
+public enum TopologyType: String {
+    case single = "Single"
+    case replicaSetNoPrimary = "ReplicaSetNoPrimary"
+    case replicaSetWithPrimary = "ReplicaSetWithPrimary"
+    case sharded = "Sharded"
+    case unknown = "Unknown"
+}
+
+/// A struct describing the state of a MongoDB deployment: its type (standalone, replica set, or sharded), 
+/// which servers are up, what type of servers they are, which is primary, and so on.
+public struct TopologyDescription {
+    /// The type of this topology. 
+    let type: TopologyType
+
+    /// The replica set name. 
+    let setName: String? = nil
+
+    /// The largest setVersion ever reported by a primary.
+    let maxSetVersion: Int64? = nil
+
+    /// The largest electionId ever reported by a primary.
+    let maxElectionId: ObjectId? = nil
+
+    /// The servers comprising this topology. By default, a single server at localhost:270107.
+    let servers: [ServerDescription] = [ServerDescription()]
+
+    /// For single-threaded clients, indicates whether the topology must be re-scanned.
+    let stale: Bool = false
+
+    /// Exists if any server's wire protocol version range is incompatible with the client's.
+    let compatibilityError: MongoError? = nil
+
+    /// The logicalSessionTimeoutMinutes value for this topology. This value is the minimum
+    /// of the logicalSessionTimeoutMinutes values across all the servers in `servers`, 
+    /// or nil if any of them are nil.
+    let logicalSessionTimeoutMinutes: Int64? = nil
+
+    /// Determines if the topology has a readable server available.
+    // (this function should take in an optional ReadPreference, but we have yet to implement that type.) 
+    func hasReadableServer() -> Bool { return true }
+
+    /// Determines if the topology has a writable server available.
+    func hasWritableServer() -> Bool { return true }
 }
 
 /// An event published when a command starts. The event is stored under the key `event`
@@ -120,9 +247,100 @@ public struct CommandFailedEvent {
     }
 }
 
-/// An internal callback that will be set for "command started" events if the user
-/// enables those notifications. This function generates a new `Notification` and posts
-/// it to the NotificationCenter specified when calling `MongoClient.enableCommandMonitoring`.
+/// Published when a server description changes. This does NOT include changes to the server's roundTripTime property.
+public struct ServerDescriptionChangedEvent {
+    /// The connection ID (host/port pair) of the server.
+    let connectionId: ConnectionId
+
+    /// A unique identifier for the topology.
+    let topologyId: ObjectId
+
+    /// The previous server description.
+    let previousDescription: ServerDescription
+
+    /// The new server description.
+    let newDescription: ServerDescription
+}
+
+/// Published when a server is initialized.
+public struct ServerOpeningEvent {
+    /// The connection ID (host/port pair) of the server.
+    let connectionId: ConnectionId
+
+    /// A unique identifier for the topology.
+    let topologyId: ObjectId
+}
+
+/// Published when a server is closed.
+public struct ServerClosedEvent {
+    /// The connection ID (host/port pair) of the server.
+    let connectionId: ConnectionId
+
+    /// A unique identifier for the topology.
+    let topologyId: ObjectId
+}
+
+/// Published when a topology description changes.
+public struct TopologyDescriptionChangedEvent {
+    /// A unique identifier for the topology.
+    let topologyId: ObjectId
+
+    /// The old topology description.
+    let previousDescription: TopologyDescription
+
+    /// The new topology description.
+    let newDescription: TopologyDescription
+}
+
+/// Published when a topology is initialized.
+public struct TopologyOpeningEvent {
+    /// A unique identifier for the topology.
+    let topologyId: ObjectId
+}
+
+/// Published when a topology is closed.
+public struct TopologyClosedEvent {
+    /// A unique identifier for the topology.
+    let topologyId: ObjectId
+}
+
+/// Published when the server monitor’s ismaster command is started - immediately before
+/// the ismaster command is serialized into raw BSON and written to the socket.
+public struct ServerHeartbeatStartedEvent {
+    /// The connection ID (host/port pair) of the server.
+    let connectionId: ConnectionId
+}
+
+/// Published when the server monitor’s ismaster succeeds.
+public struct ServerHeartbeatSucceededEvent {
+    /// The execution time of the event, in microseconds.
+    let duration: Int64
+
+    /// The command reply.
+    let reply: Document
+
+    /// The connection ID (host/port pair) of the server.
+    let connectionId: ConnectionId
+}
+
+/// Published when the server monitor’s ismaster fails, either with an “ok: 0” or a socket exception.
+public struct ServerHearbeatFailedEvent {
+    /// The execution time of the event, in microseconds.
+    let duration: Int64
+
+    /// The failure. 
+    let failure: MongoError
+
+    /// The connection ID (host/port pair) of the server.
+    let connectionId: ConnectionId
+}
+
+/// Callbacks that will be set for events with the corresponding names if the user enables 
+/// notifications for those events. These functions generate new `Notification`s and post 
+/// them to the `NotificationCenter` that was specified when calling `MongoClient.enableMonitoring`
+/// (or `NotificationCenter.default` if none was specified.)
+
+/// An internal callback that will be set for "command started" events if the user enables notifications for them.
 internal func commandStarted(_event: OpaquePointer?) {
     guard let event = _event else {
         preconditionFailure("Missing event pointer for CommandStartedEvent")
@@ -136,9 +354,7 @@ internal func commandStarted(_event: OpaquePointer?) {
     center.post(notification)
 }
 
-/// An internal callback that will be set for "command succeeded" events if the user
-/// enables those notifications. This function generates a new `Notification` and posts
-/// it to the NotificationCenter specified when calling `MongoClient.enableCommandMonitoring`.
+/// An internal callback that will be set for "command succeeded" events if the user enables notifications for them.
 internal func commandSucceeded(_event: OpaquePointer?) {
     guard let event = _event else {
         preconditionFailure("Missing event pointer for CommandSucceededEvent")
@@ -152,9 +368,7 @@ internal func commandSucceeded(_event: OpaquePointer?) {
     center.post(notification)
 }
 
-/// An internal callback that will be set for "command failed" events if the user
-/// enables those notifications. This function generates a new `Notification` and posts
-/// it to the NotificationCenter specified when calling `MongoClient.enableCommandMonitoring`.
+/// An internal callback that will be set for "command failed" events if the user enables notifications for them.
 internal func commandFailed(_event: OpaquePointer?) {
     guard let event = _event else {
         preconditionFailure("Missing event pointer for CommandFailedEvent")
@@ -168,6 +382,38 @@ internal func commandFailed(_event: OpaquePointer?) {
     center.post(notification)
 }
 
+/// An internal callback that will be set for "server description changed" events if the user enables notifications
+/// for them.
+internal func serverDescriptionChanged(_event: OpaquePointer?) { }
+
+/// An internal callback that will be set for "server opening" events if the user enables notifications for them.
+internal func serverOpening(_event: OpaquePointer?) { }
+
+/// An internal callback that will be set for "server closed" events if the user enables notifications for them.
+internal func serverClosed(_event: OpaquePointer?) { }
+
+/// An internal callback that will be set for "topology description changed" events if the user enables notifications
+/// for them.
+internal func topologyDescriptionChanged(_event: OpaquePointer?) { }
+
+/// An internal callback that will be set for "topology opening" events if the user enables notifications for them.
+internal func topologyOpening(_event: OpaquePointer?) { }
+
+/// An internal callback that will be set for "topology closed" events if the user enables notifications for them.
+internal func topologyClosed(_event: OpaquePointer?) { }
+
+/// An internal callback that will be set for "server heartbeat started" events if the user enables notifications
+/// for them.
+internal func ServerHeartbeatStarted(_event: OpaquePointer?) { }
+
+/// An internal callback that will be set for "server heartbeat succeeded" events if the user enables notifications
+/// for them.
+internal func serverHeartbeatSucceeded(_event: OpaquePointer?) { }
+
+/// An internal callback that will be set for "server heartbeat failed" events if the user enables notifications 
+/// for them.
+internal func serverHeartbeatFailed(_event: OpaquePointer?) { }
+
 /// Extend Notification.Name to have class properties corresponding to each type
 /// of event. This allows creating notifications and observers using the same ".x" names
 /// as those passed into `enableNotifications`.
@@ -175,6 +421,15 @@ extension Notification.Name {
     static let commandStarted = Notification.Name(MongoEvent.commandStarted.rawValue)
     static let commandSucceeded = Notification.Name(MongoEvent.commandSucceeded.rawValue)
     static let commandFailed = Notification.Name(MongoEvent.commandFailed.rawValue)
+    static let serverDescriptionChanged = Notification.Name(MongoEvent.serverDescriptionChanged.rawValue)
+    static let serverOpening = Notification.Name(MongoEvent.serverOpening.rawValue)
+    static let serverClosed = Notification.Name(MongoEvent.serverClosed.rawValue)
+    static let topologyDescriptionChanged = Notification.Name(MongoEvent.topologyDescriptionChanged.rawValue)
+    static let topologyOpening = Notification.Name(MongoEvent.topologyOpening.rawValue)
+    static let topologyClosed = Notification.Name(MongoEvent.topologyClosed.rawValue)
+    static let serverHeartbeatStarted = Notification.Name(MongoEvent.serverHeartbeatStarted.rawValue)
+    static let serverHeartbeatSucceeded = Notification.Name(MongoEvent.serverHeartbeatSucceeded.rawValue)
+    static let serverHeartbeatFailed = Notification.Name(MongoEvent.serverHeartbeatFailed.rawValue)
 }
 
 /// An enumeration of the events that notifications can be enabled for.
@@ -182,26 +437,34 @@ public enum MongoEvent: String {
     case commandStarted
     case commandSucceeded
     case commandFailed
+    case serverDescriptionChanged
+    case serverOpening
+    case serverClosed
+    case topologyDescriptionChanged
+    case topologyOpening
+    case topologyClosed
+    case serverHeartbeatStarted
+    case serverHeartbeatSucceeded
+    case serverHeartbeatFailed
 }
 
-/// An extension of MongoClient to add command monitoring and
-/// server discovery and monitoring capabilities.
+/// An extension of MongoClient to add monitoring capability for commands and server discovery and monitoring.
 extension MongoClient {
     /*
-     *  Enables command monitoring for this client, meaning notifications
-     *  about command events will be posted to the supplied NotificationCenter -
-     *  or if one is not provided, the default NotificationCenter.
+     *  Enables monitoring for this client, meaning notifications about command and 
+     *  server discovering and monitoring events will be posted to the supplied
+     *  NotificationCenter - or if one is not provided, the default NotificationCenter.
      *  If no specific event types are provided, all events will be posted.
      *  Notifications can only be enabled for a single NotificationCenter at a time.
      *
      *  Calling this function will reset all previously enabled events - i.e.
      *  calling
-     *      client.enableNotifications(forEvents: [.commandStarted])
-     *      client.enableNotifications(forEvents: [.commandSucceeded])
+     *      client.enableMonitoring(forEvents: [.commandStarted])
+     *      client.enableMonitoring(forEvents: [.commandSucceeded])
      *
      *  will result in only posting notifications for .commandSucceeded events.
      */
-    public func enableCommandMonitoring(
+    public func enableMonitoring(
         forEvents events: [MongoEvent] = [.commandStarted, .commandSucceeded, .commandFailed],
         usingCenter center: NotificationCenter = NotificationCenter.default) {
         let callbacks = mongoc_apm_callbacks_new()
@@ -213,6 +476,8 @@ extension MongoClient {
                 mongoc_apm_set_command_succeeded_cb(callbacks, commandSucceeded)
             case .commandFailed:
                 mongoc_apm_set_command_failed_cb(callbacks, commandFailed)
+            default:
+                continue
             }
         }
         self.notificationCenter = center
@@ -221,7 +486,7 @@ extension MongoClient {
     }
 
     /// Disables all notification types for this client.
-    public func disableCommandMonitoring() {
+    public func disableMonitoring() {
         mongoc_client_set_apm_callbacks(self._client, nil, nil)
         self.notificationCenter = nil
     }

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -275,7 +275,7 @@ internal struct DBPointer: BsonValue {
 
         let dbRef: Document = [
             "$ref": String(cString: collectionP),
-            "$id": ObjectId(from: oidP)
+            "$id": ObjectId(fromPointer: oidP)
         ]
 
         return dbRef
@@ -452,32 +452,39 @@ struct MinKey: BsonValue, Equatable {
     static func == (lhs: MinKey, rhs: MinKey) -> Bool { return true }
 }
 
-/// A class to represent the BSON ObjectId type
-class ObjectId: BsonValue, Equatable, CustomStringConvertible {
+/// A struct to represent the BSON ObjectId type
+struct ObjectId: BsonValue, Equatable, CustomStringConvertible {
     public var bsonType: BsonType { return .objectId }
-    private var oid: bson_oid_t
+    var oid: String
 
+    /// Initializes a new ObjectId
     init() {
-        self.oid = bson_oid_t()
-        bson_oid_init(&self.oid, nil)
+        var oid_t = bson_oid_t()
+        bson_oid_init(&oid_t, nil)
+        self.init(fromPointer: &oid_t)
     }
 
-    internal init(from: UnsafePointer<bson_oid_t>) {
-        self.oid = bson_oid_t()
-        bson_oid_copy(from, &self.oid)
+    /// Initializes an ObjectId from a string
+    init(fromString oid: String) {
+        self.oid = oid
     }
 
-    internal init(from: bson_oid_t) {
-        self.oid = from
-    }
-
-    init(from: String) {
-        self.oid = bson_oid_t()
-        bson_oid_init_from_string(&self.oid, from)
+    /// Initializes an ObjectId from an UnsafePointer<bson_oid_t> by copying the data
+    /// from it to a string
+    internal init(fromPointer oid_t: UnsafePointer<bson_oid_t>) {
+        var str = Data(count: 25)
+        self.oid = str.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Int8>) in
+            bson_oid_to_string(oid_t, bytes)
+            return String(cString: bytes)
+        }
     }
 
     public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
-        if !bson_append_oid(data, key, Int32(key.count), &self.oid) {
+        // create a new bson_oid_t with self.oid
+        var oid = bson_oid_t()
+        bson_oid_init_from_string(&oid, self.oid)
+        // encode the bson_oid_t to the bson_t
+        if !bson_append_oid(data, key, Int32(key.count), &oid) {
             throw bsonEncodeError(value: self, forKey: key)
         }
     }
@@ -486,19 +493,15 @@ class ObjectId: BsonValue, Equatable, CustomStringConvertible {
         guard let oid = bson_iter_oid(&iter) else {
             preconditionFailure("Failed to retrieve ObjectID value")
         }
-        return ObjectId(from: oid)
+        return ObjectId(fromPointer: oid)
     }
 
     public var description: String {
-        var str = Data(count: 25)
-        return str.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Int8>) in
-            bson_oid_to_string(&self.oid, bytes)
-            return String(cString: bytes)
-        }
+        return self.oid
     }
 
     static func == (lhs: ObjectId, rhs: ObjectId) -> Bool {
-        return lhs.description == rhs.description
+        return lhs.oid == rhs.oid
     }
 
 }

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -467,6 +467,10 @@ class ObjectId: BsonValue, Equatable, CustomStringConvertible {
         bson_oid_copy(from, &self.oid)
     }
 
+    internal init(from: bson_oid_t) {
+        self.oid = from
+    }
+
     init(from: String) {
         self.oid = bson_oid_t()
         bson_oid_init_from_string(&self.oid, from)

--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -33,10 +33,11 @@ public struct ListDatabasesOptions: BsonEncodable {
 public class MongoClient {
     internal var _client = OpaquePointer(bitPattern: 1)
 
-    /// If command monitoring is enabled, stores the NotificationCenter events are posted to.
-    /// We store it so we know it will remain reference-counted for as long as monitoring is enabled,
-    /// because the callbacks we set rely on its existence.
+    /// If command and/or server monitoring is enabled, stores the NotificationCenter events are posted to.
     internal var notificationCenter: NotificationCenter?
+
+    /// Indicates whether we have already set callbacks for this client. Defaults to false.
+    internal var callbacksSet = false
 
     /**
      * Create a new client connection to a MongoDB server

--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -1,13 +1,23 @@
 import Foundation
 import libmongoc
 
-public struct ClientOptions {
+public struct ClientOptions: BsonEncodable {
     /// Determines whether the client should retry supported write operations
     let retryWrites: Bool?
 
+    /// Indicates whether this client should be set up to enable monitoring 
+    /// command and server discovery and monitoring events.
+    let eventMonitoring: Bool
+
     /// Convenience initializer allowing retryWrites to be omitted or optional
-    public init(retryWrites: Bool? = nil) {
+    public init(retryWrites: Bool? = nil, eventMonitoring: Bool = false) {
         self.retryWrites = retryWrites
+        self.eventMonitoring = eventMonitoring
+    }
+
+    /// Custom `encode`, because we don't want to actually send the `eventMonitoring` option
+    public func encode(to encoder: BsonEncoder) throws {
+        try encoder.encode(retryWrites, forKey: "retryWrites")
     }
 }
 
@@ -36,8 +46,8 @@ public class MongoClient {
     /// If command and/or server monitoring is enabled, stores the NotificationCenter events are posted to.
     internal var notificationCenter: NotificationCenter?
 
-    /// Indicates whether we have already set callbacks for this client. Defaults to false.
-    internal var callbacksSet = false
+    /// If command and/or server monitoring is enabled, indicates what event types notifications will be posted for. 
+    internal var monitoringEventTypes: [MongoEventType]?
 
     /**
      * Create a new client connection to a MongoDB server
@@ -55,6 +65,11 @@ public class MongoClient {
         self._client = mongoc_client_new_from_uri(uri)
         if self._client == nil {
             throw MongoError.invalidClient()
+        }
+
+        // if the user passed in this option, set up all the monitoring callbacks 
+        if let opts = options, opts.eventMonitoring {
+            self.initializeMonitoring()
         }
     }
 

--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -96,7 +96,7 @@ public class MongoClient {
         }
 
         // this is defined in the APM extension to Client
-        self.disableCommandMonitoring()
+        self.disableMonitoring()
 
         mongoc_client_destroy(client)
         self._client = nil

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -1,0 +1,244 @@
+import Foundation
+import libmongoc
+
+/// A struct representing a server connection, consisting of a host and port.
+public struct ConnectionId: Equatable {
+    let host: String
+    let port: UInt16
+
+    /// Initializes a ConnectionId from an UnsafePointer to a mongoc_host_list_t. 
+    internal init(_ hostList: UnsafePointer<mongoc_host_list_t>) {
+        var hostData = hostList.pointee
+        self.host = withUnsafeBytes(of: &hostData.host) { (rawPtr) -> String in
+            let ptr = rawPtr.baseAddress!.assumingMemoryBound(to: CChar.self)
+            return String(cString: ptr)
+        }
+        self.port = hostData.port
+    }
+
+    /// Initializes a ConnectionId, using the default localhost:27017 if a host/port is not provided.
+    internal init(_ hostAndPort: String = "localhost:27017") {
+        let parts = hostAndPort.split(separator: ":")
+        self.host = String(parts[0])
+        self.port = UInt16(parts[1])!
+    }
+
+    /// ConnectionIds are equal if their hosts and ports match.
+    public static func == (lhs: ConnectionId, rhs: ConnectionId) -> Bool {
+        return lhs.host == rhs.host && rhs.port == lhs.port
+    }
+}
+
+/// The possible types for a server. The raw values correspond to the values libmongoc uses. 
+/// (We don't use these strings directly because Swift convention is to use lowercase enums.)
+public enum ServerType: String {
+    case standalone = "Standalone"
+    case mongos = "Mongos"
+    case possiblePrimary = "PossiblePrimary"
+    case rsPrimary = "RSPrimary"
+    case rsSecondary = "RSSecondary"
+    case rsArbiter = "RSArbiter"
+    case rsOther = "RSOther"
+    case rsGhost = "RSGhost"
+    case unknown = "Unknown"
+}
+
+/// A struct describing a mongod or mongos process.
+public struct ServerDescription {
+    /// The hostname or IP and the port number that the client connects to. Note that this is not the
+    /// server's ismaster.me field, in the case that the server reports an address different from the 
+    /// address the client uses.
+    let connectionId: ConnectionId
+
+    /// The last error related to this server.
+    let error: MongoError? = nil // currently we will never set this
+
+    /// The duration of the server's last ismaster call.
+    var roundTripTime: Int64?
+
+    /// The "lastWriteDate" from the server's most recent ismaster response.
+    var lastWriteDate: Date?
+
+    /// The last opTime reported by the server. Only mongos and shard servers 
+    /// record this field when monitoring config servers as replica sets.
+    var opTime: ObjectId?
+
+    /// The type of this server.
+    var type: ServerType = .unknown
+
+    /// The wire protocol version range supported by the server.
+    var minWireVersion: Int32 = 0
+    var maxWireVersion: Int32 = 0
+
+    /// The hostname or IP and the port number that this server was configured with in the replica set.
+    var me: ConnectionId?
+
+    /// Hosts, arbiters, passives: sets of addresses. This server's opinion of the replica set's members, if any.
+    var hosts: [ConnectionId] = []
+    var arbiters: [ConnectionId] = []
+    /// "Passives" are priority-zero replica set members that cannot become primary. 
+    /// The client treats them precisely the same as other members.
+    var passives: [ConnectionId] = []
+
+    /// Tags for this server.
+    var tags: [String: String] = [:]
+
+    /// The replica set name.
+    var setName: String?
+
+    /// The replica set version.
+    var setVersion: Int64?
+
+    /// The election ID where this server was elected, if this is a replica set member that believes it is primary.
+    var electionId: ObjectId?
+
+    /// This server's opinion of who the primary is. 
+    var primary: ConnectionId?
+
+    /// When this server was last checked.
+    let lastUpdateTime: Date? = nil // currently, this will never be set
+
+    /// The logicalSessionTimeoutMinutes value for this server.
+    var logicalSessionTimeoutMinutes: Int64?
+
+    /// An internal initializer to create a `ServerDescription` with just a ConnectionId.
+    internal init(connectionId: ConnectionId) {
+        self.connectionId = connectionId
+    }
+
+    /// An internal function to handle parsing isMaster and setting ServerDescription attributes appropriately.
+    internal mutating func parseIsMaster(_ isMaster: Document) {
+        if let lastWrite = isMaster["lastWrite"] as? Document {
+            self.lastWriteDate = lastWrite["lastWriteDate"] as? Date
+            self.opTime = lastWrite["opTime"] as? ObjectId
+        }
+
+        if let minVersion = isMaster["minWireVersion"] as? Int32 {
+            self.minWireVersion = minVersion
+        }
+
+        if let maxVersion = isMaster["maxWireVersion"] as? Int32 {
+            self.maxWireVersion = maxVersion
+        }
+
+        if let me = isMaster["me"] as? String {
+            self.me = ConnectionId(me)
+        }
+
+        if let hosts = isMaster["hosts"] as? [String] {
+            self.hosts = hosts.map { ConnectionId($0) }
+        }
+
+        if let passives = isMaster["passives"] as? [String] {
+            self.passives = passives.map { ConnectionId($0) }
+        }
+
+        if let arbiters = isMaster["arbiters"] as? [String] {
+            self.arbiters = arbiters.map { ConnectionId($0) }
+        }
+
+        if let tags = isMaster["tags"] as? Document {
+            for (k, v) in tags {
+                self.tags[k] = v as? String
+            }
+        }
+
+        self.setName = isMaster["setName"] as? String
+        self.setVersion = isMaster["setVersion"] as? Int64
+        self.electionId = isMaster["electionId"] as? ObjectId
+
+        if let primary = isMaster["primary"] as? String {
+            self.primary = ConnectionId(primary)
+        }
+
+        self.logicalSessionTimeoutMinutes = isMaster["logicalSessionTimeoutMinutes"] as? Int64
+
+    }
+
+    /// An internal initializer to create a `ServerDescription` from an OpaquePointer to a
+    /// mongoc_server_description_t.
+    internal init(_ description: OpaquePointer) {
+        self.connectionId = ConnectionId(mongoc_server_description_host(description))
+        self.roundTripTime = mongoc_server_description_round_trip_time(description)
+
+        let isMasterData =  UnsafeMutablePointer(mutating: mongoc_server_description_ismaster(description)!)
+        let isMaster = Document(fromPointer: isMasterData)
+        self.parseIsMaster(isMaster)
+
+        let serverType = String(cString: mongoc_server_description_type(description))
+        self.type = ServerType(rawValue: serverType)!
+    }
+}
+
+/// The possible types for a topology. The raw values correspond to the values libmongoc uses. 
+/// (We don't use these strings directly because Swift convention is to use lowercase for enums.)
+public enum TopologyType: String {
+    case single = "Single"
+    case replicaSetNoPrimary = "ReplicaSetNoPrimary"
+    case replicaSetWithPrimary = "ReplicaSetWithPrimary"
+    case sharded = "Sharded"
+    case unknown = "Unknown"
+}
+
+/// A struct describing the state of a MongoDB deployment: its type (standalone, replica set, or sharded), 
+/// which servers are up, what type of servers they are, which is primary, and so on.
+public struct TopologyDescription {
+    /// The type of this topology. 
+    let type: TopologyType
+
+    /// The replica set name. 
+    var setName: String? { return self.servers[0].setName }
+
+    /// The largest setVersion ever reported by a primary.
+    var maxSetVersion: Int64?
+
+    /// The largest electionId ever reported by a primary.
+    var maxElectionId: ObjectId?
+
+    /// The servers comprising this topology. By default, a single server at localhost:270107.
+    var servers: [ServerDescription] = [ServerDescription(connectionId: ConnectionId())]
+
+    /// For single-threaded clients, indicates whether the topology must be re-scanned.
+    let stale: Bool = false // currently, this will never be set
+
+    /// Exists if any server's wire protocol version range is incompatible with the client's.
+    let compatibilityError: MongoError? = nil // currently, this will never be set
+
+    /// The logicalSessionTimeoutMinutes value for this topology. This value is the minimum
+    /// of the logicalSessionTimeoutMinutes values across all the servers in `servers`, 
+    /// or nil if any of them are nil.
+    var logicalSessionTimeoutMinutes: Int64? {
+        let timeoutValues = self.servers.map { $0.logicalSessionTimeoutMinutes }
+        if timeoutValues.contains (where: { $0 == nil }) {
+            return nil
+        } else {
+            return timeoutValues.map { $0! }.min()
+        }
+    }
+
+    /// Determines if the topology has a readable server available.
+    // (this function should take in an optional ReadPreference, but we have yet to implement that type.) 
+    func hasReadableServer() -> Bool {
+        return [.single, .replicaSetWithPrimary, .sharded].contains(self.type)
+    }
+
+    /// Determines if the topology has a writable server available.
+    func hasWritableServer() -> Bool {
+        return [.single, .replicaSetWithPrimary].contains(self.type)
+    }
+
+    /// An internal initializer to create a `TopologyDescription` from an OpaquePointer
+    /// to a mongoc_server_description_t
+    internal init(_ description: OpaquePointer) {
+
+        let topologyType = String(cString: mongoc_topology_description_type(description))
+        self.type = TopologyType(rawValue: topologyType)!
+
+        var size = size_t()
+        let serverData = mongoc_topology_description_get_servers(description, &size)
+        let buffer = UnsafeBufferPointer(start: serverData, count: size)
+        if size > 0 {
+            self.servers = Array(buffer).map { ServerDescription($0!) }
+        }
+    }
+}

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -22,7 +22,7 @@ final class CommandMonitoringTests: XCTestCase {
 
     func testCommandMonitoring() throws {
         let client = try MongoClient()
-        client.enableMonitoring(forEvents: [.commandStarted, .commandSucceeded, .commandFailed])
+        try client.initializeMonitoring(forEvents: .commandMonitoring)
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: cmPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             // read in the file data and parse into a struct
@@ -85,8 +85,7 @@ final class CommandMonitoringTests: XCTestCase {
         let db = try client.db("commandTest")
         let collection = try db.createCollection("coll1")
         let customCenter = NotificationCenter()
-        client.enableMonitoring(forEvents: [.commandStarted, .commandSucceeded, .commandFailed],
-                                usingCenter: customCenter)
+        try client.initializeMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)
         var eventCount = 0
         let observer = customCenter.addObserver(forName: nil, object: nil, queue: nil) { (_) in
             eventCount += 1

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -22,7 +22,7 @@ final class CommandMonitoringTests: XCTestCase {
 
     func testCommandMonitoring() throws {
         let client = try MongoClient()
-        client.enableCommandMonitoring()
+        client.enableMonitoring(forEvents: [.commandStarted, .commandSucceeded, .commandFailed])
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: cmPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             // read in the file data and parse into a struct
@@ -85,7 +85,8 @@ final class CommandMonitoringTests: XCTestCase {
         let db = try client.db("commandTest")
         let collection = try db.createCollection("coll1")
         let customCenter = NotificationCenter()
-        client.enableCommandMonitoring(usingCenter: customCenter)
+        client.enableMonitoring(forEvents: [.commandStarted, .commandSucceeded, .commandFailed],
+                                usingCenter: customCenter)
         var eventCount = 0
         let observer = customCenter.addObserver(forName: nil, object: nil, queue: nil) { (_) in
             eventCount += 1

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -21,8 +21,8 @@ final class CommandMonitoringTests: XCTestCase {
     }
 
     func testCommandMonitoring() throws {
-        let client = try MongoClient()
-        try client.initializeMonitoring(forEvents: .commandMonitoring)
+        let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
+        try client.enableMonitoring(forEvents: .commandMonitoring)
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: cmPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             // read in the file data and parse into a struct
@@ -81,11 +81,11 @@ final class CommandMonitoringTests: XCTestCase {
     }
 
     func testAlternateNotificationCenters() throws {
-        let client = try MongoClient()
+        let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         let db = try client.db("commandTest")
         let collection = try db.createCollection("coll1")
         let customCenter = NotificationCenter()
-        try client.initializeMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)
+        try client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)
         var eventCount = 0
         let observer = customCenter.addObserver(forName: nil, object: nil, queue: nil) { (_) in
             eventCount += 1

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -22,7 +22,7 @@ final class CommandMonitoringTests: XCTestCase {
 
     func testCommandMonitoring() throws {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
-        try client.enableMonitoring(forEvents: .commandMonitoring)
+        client.enableMonitoring(forEvents: .commandMonitoring)
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: cmPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             // read in the file data and parse into a struct
@@ -85,7 +85,7 @@ final class CommandMonitoringTests: XCTestCase {
         let db = try client.db("commandTest")
         let collection = try db.createCollection("coll1")
         let customCenter = NotificationCenter()
-        try client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)
+        client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)
         var eventCount = 0
         let observer = customCenter.addObserver(forName: nil, object: nil, queue: nil) { (_) in
             eventCount += 1

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -105,7 +105,7 @@ final class DocumentTests: XCTestCase {
             "timestamp": Timestamp(timestamp: 5, inc: 10),
             "nestedarray": [[1, 2], [Int32(3), Int32(4)]] as [[Int32]],
             "nesteddoc": ["a": 1, "b": 2, "c": false, "d": [3, 4]] as Document,
-            "oid": ObjectId(from: "507f1f77bcf86cd799439011"),
+            "oid": ObjectId(fromString: "507f1f77bcf86cd799439011"),
             "regex": regex,
             "array1": [1, 2],
             "array2": ["string1", "string2"],
@@ -139,7 +139,7 @@ final class DocumentTests: XCTestCase {
         expect(doc["maxkey"] as? MaxKey).to(beAnInstanceOf(MaxKey.self))
         expect(doc["date"] as? Date).to(equal(Date(timeIntervalSince1970: 5000)))
         expect(doc["timestamp"] as? Timestamp).to(equal(Timestamp(timestamp: 5, inc: 10)))
-        expect(doc["oid"] as? ObjectId).to(equal(ObjectId(from: "507f1f77bcf86cd799439011")))
+        expect(doc["oid"] as? ObjectId).to(equal(ObjectId(fromString: "507f1f77bcf86cd799439011")))
 
         let regexReturned = doc["regex"] as? NSRegularExpression
         expect(regexReturned?.pattern).to(equal("^abc"))

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -26,14 +26,14 @@ final class SDAMTests: XCTestCase {
     // Basic test based on the "standalone" spec test for SDAM monitoring:
     // https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/tests/monitoring/standalone.json
     func testMonitoring() throws {
-        let client = try MongoClient()
-        try client.initializeMonitoring(forEvents: .serverMonitoring)
+        let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
+        client.enableMonitoring(forEvents: .serverMonitoring)
 
         let center = NotificationCenter.default
-        var receivedEvents = [Event]()
+        var receivedEvents = [MongoEvent]()
 
         let observer = center.addObserver(forName: nil, object: nil, queue: nil) { (notif) in
-            guard let event = notif.userInfo?["event"] as? Event else {
+            guard let event = notif.userInfo?["event"] as? MongoEvent else {
                 XCTFail("Notification \(notif) did not contain an event")
                 return
             }

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -3,13 +3,28 @@ import Foundation
 import Nimble
 import XCTest
 
-final class SDAMMonitoringTests: XCTestCase {
+final class SDAMTests: XCTestCase {
 
     override func setUp() {
         self.continueAfterFailure = false
     }
 
-    // Basic test based on the "standalone" spec test for SDAM monitoring
+    func checkEmptyLists(_ desc: ServerDescription) {
+        expect(desc.arbiters).to(haveCount(0))
+        expect(desc.hosts).to(haveCount(0))
+        expect(desc.passives).to(haveCount(0))
+    }
+
+    func checkUnknownServerType(_ desc: ServerDescription) {
+        expect(desc.type).to(equal(ServerType.unknown))
+    }
+
+    func checkDefaultHostPort(_ desc: ServerDescription) {
+        expect(desc.connectionId).to(equal(ConnectionId("localhost:27017")))
+    }
+
+    // Basic test based on the "standalone" spec test for SDAM monitoring:
+    // https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/tests/monitoring/standalone.json
     func testMonitoring() throws {
         let client = try MongoClient()
         try client.initializeMonitoring(forEvents: .serverMonitoring)
@@ -29,7 +44,6 @@ final class SDAMMonitoringTests: XCTestCase {
                 receivedEvents.append(event)
             }
         }
-
         // do some basic operations
         let db = try client.db("testing")
         _ = try db.createCollection("testColl")
@@ -37,11 +51,57 @@ final class SDAMMonitoringTests: XCTestCase {
 
         center.removeObserver(observer)
 
+        // check event count and that events are of the expected types
         expect(receivedEvents.count).to(equal(5))
         expect(receivedEvents[0]).to(beAnInstanceOf(TopologyOpeningEvent.self))
         expect(receivedEvents[1]).to(beAnInstanceOf(TopologyDescriptionChangedEvent.self))
         expect(receivedEvents[2]).to(beAnInstanceOf(ServerOpeningEvent.self))
         expect(receivedEvents[3]).to(beAnInstanceOf(ServerDescriptionChangedEvent.self))
         expect(receivedEvents[4]).to(beAnInstanceOf(TopologyDescriptionChangedEvent.self))
+
+        // verify that data in ServerDescription and TopologyDescription looks reasonable
+        let event0 = receivedEvents[0] as! TopologyOpeningEvent
+        expect(event0.topologyId).toNot(beNil())
+
+        let event1 = receivedEvents[1] as! TopologyDescriptionChangedEvent
+        expect(event1.topologyId).to(equal(event0.topologyId))
+        expect(event1.previousDescription.type).to(equal(TopologyType.unknown))
+        expect(event1.newDescription.type).to(equal(TopologyType.single))
+        let server0 = event1.newDescription.servers[0]
+
+        checkDefaultHostPort(server0)
+        expect(server0.type).to(equal(ServerType.unknown))
+        checkEmptyLists(server0)
+
+        let event2 = receivedEvents[2] as! ServerOpeningEvent
+        expect(event2.topologyId).to(equal(event1.topologyId))
+        expect(event2.connectionId).to(equal(ConnectionId("localhost:27017")))
+
+        let event3 = receivedEvents[3] as! ServerDescriptionChangedEvent
+        expect(event3.topologyId).to(equal(event2.topologyId))
+        let prevServer = event3.previousDescription
+        checkDefaultHostPort(prevServer)
+        checkEmptyLists(prevServer)
+        checkUnknownServerType(prevServer)
+
+        let newServer = event3.newDescription
+        checkDefaultHostPort(newServer)
+        checkEmptyLists(newServer)
+        expect(newServer.type).to(equal(ServerType.standalone))
+
+        let event4 = receivedEvents[4] as! TopologyDescriptionChangedEvent
+        expect(event4.topologyId).to(equal(event3.topologyId))
+        let prevTopology = event4.previousDescription
+        expect(prevTopology.type).to(equal(TopologyType.single))
+        expect(prevTopology.servers).to(haveCount(1))
+        checkDefaultHostPort(prevTopology.servers[0])
+        checkUnknownServerType(prevTopology.servers[0])
+        checkEmptyLists(prevTopology.servers[0])
+
+        let newTopology = event4.newDescription
+        expect(newTopology.type).to(equal(TopologyType.single))
+        checkDefaultHostPort(newTopology.servers[0])
+        expect(newTopology.servers[0].type).to(equal(ServerType.standalone))
+        checkEmptyLists(newTopology.servers[0])
     }
 }

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -1,0 +1,25 @@
+@testable import MongoSwift
+import Foundation
+import Nimble
+import XCTest
+
+final class SDAMMonitoringTests: XCTestCase {
+
+	func testMonitoring() throws {
+		let client = try MongoClient()
+		client.enableMonitoring(forEvents: [.serverDescriptionChanged, .serverOpening, .serverClosed, .topologyDescriptionChanged,
+										.topologyOpening, .topologyClosed, .serverHeartbeatStarted, .serverHeartbeatSucceeded, .serverHeartbeatFailed])
+
+		let center = NotificationCenter.default
+
+		let observer = center.addObserver(forName: nil, object: nil, queue: nil) { (notif) in
+			print("NOTIF: \(notif)")
+        }
+
+        let db = try client.db("testing")
+        let coll = try db.createCollection("testColl")
+        _ = try coll.insertOne(["x": 1])
+
+        try db.drop()
+	}
+}


### PR DESCRIPTION
Still TBD exactly what we want the API for enabling and disabling monitoring to look like. I've included what I think is at least a clearer interface than having `enableMonitoring` behave differently depending on if it's been called already, but as we talked about yesterday, it's not really clear why someone would want to be switching monitoring on and off repeatedly. anyway, while we figure that out there is a lot else here to review.

I've added a basic test based on [this](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/tests/monitoring/standalone.json) spec test. basically checking that the events come in the correct order and contain the values/descriptions we expect. I think the rest of the tests would require a mock server, or support for our running tests with something other than a standalone mongod, so 
I am not sure how far down that rabbit hole we want to go. 


