### PR TITLE
SWIFT-70 Make OpaquePointers to libmongoc types optional to prevent freeing unset values

### DIFF
--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -41,7 +41,7 @@ public struct ListDatabasesOptions: BsonEncodable {
 
 // A MongoDB Client
 public class MongoClient {
-    internal var _client = OpaquePointer(bitPattern: 1)
+    internal var _client: OpaquePointer?
 
     /// If command and/or server monitoring is enabled, stores the NotificationCenter events are posted to.
     internal var notificationCenter: NotificationCenter?
@@ -75,7 +75,7 @@ public class MongoClient {
 
     /**
      * Create a new client from an existing `mongoc_client_t`.
-     * Do not use this initialier unless you know what you are doing.
+     * Do not use this initializer unless you know what you are doing.
      *
      * - Parameters:
      *   - fromPointer: the `mongoc_client_t` to store and use internally

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -456,7 +456,7 @@ public struct IndexOptions: BsonEncodable {
 
 // A MongoDB Collection
 public class MongoCollection {
-    private var _collection = OpaquePointer(bitPattern: 1)
+    private var _collection: OpaquePointer?
     private var _client: MongoClient?
 
     /// The name of this collection.
@@ -476,13 +476,12 @@ public class MongoCollection {
         Deinitializes a MongoCollection, cleaning up the internal mongoc_collection_t
      */
     deinit {
+        self._client = nil
         guard let collection = self._collection else {
             return
         }
-
         mongoc_collection_destroy(collection)
         self._collection = nil
-        self._client = nil
     }
 
     /**

--- a/Sources/MongoSwift/Cursor.swift
+++ b/Sources/MongoSwift/Cursor.swift
@@ -2,7 +2,7 @@ import libmongoc
 
 // A Cursor
 public class MongoCursor: Sequence, IteratorProtocol {
-    private var _cursor = OpaquePointer(bitPattern: 1)
+    private var _cursor: OpaquePointer?
     private var _client: MongoClient?
 
     /**
@@ -24,13 +24,12 @@ public class MongoCursor: Sequence, IteratorProtocol {
      * Close the cursor
      */
     public func close() {
+        self._client = nil
         guard let cursor = self._cursor else {
             return
         }
-
         mongoc_cursor_destroy(cursor)
         self._cursor = nil
-        self._client = nil
     }
 
     /**

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -88,7 +88,7 @@ public struct CreateCollectionOptions: BsonEncodable {
 
 // A MongoDB Database
 public class MongoDatabase {
-    private var _database = OpaquePointer(bitPattern: 1)
+    private var _database: OpaquePointer?
     private var _client: MongoClient?
 
     /// The name of this database.
@@ -108,10 +108,10 @@ public class MongoDatabase {
      * Deinitializes a MongoDatabase, cleaning up the internal mongoc_database_t
      */
     deinit {
+        self._client = nil
         guard let database = self._database else { return }
         mongoc_database_destroy(database)
         self._database = nil
-        self._client = nil
     }
 
     /**

--- a/Tests/MongoSwiftTests/ClientTests.swift
+++ b/Tests/MongoSwiftTests/ClientTests.swift
@@ -7,7 +7,8 @@ final class ClientTests: XCTestCase {
     static var allTests: [(String, (ClientTests) -> () throws -> Void)] {
         return [
             ("testListDatabases", testListDatabases),
-            ("testOpaqueInitialization", testOpaqueInitialization)
+            ("testOpaqueInitialization", testOpaqueInitialization),
+            ("testFailedClientInitialization", testFailedClientInitialization)
         ]
     }
 
@@ -37,5 +38,10 @@ final class ClientTests: XCTestCase {
         let docs = Array(findResult)
         expect(docs[0]["test"] as? Int).to(equal(42))
         try db.drop()
+    }
+
+    func testFailedClientInitialization() {
+        // check that we fail gracefully with an error if passing in an invalid URI
+        expect(try MongoClient(connectionString: "abcd")).to(throwError())
     }
 }


### PR DESCRIPTION
While the pointers were already technically optional because we created them using [`init?(bitPattern: Int)`](https://developer.apple.com/documentation/swift/opaquepointer/1688016-init), initializing with `bitPattern: 1` never fails. This meant that in cases where assigning a real pointer failed for whatever reason, we would try to free a value at `0x0000000000000001`, causing libmongoc to crash. 

This change makes it so that if we fail to set the pointer to a real value, we won't try to free it.

 I also moved the nil-ing out of `self._client`s to the top of each `deinit` so we do it even if we return early because the main pointer is nil. though actually I'm not sure if we even really need to nil out the client at all - shouldn't ARC take care of it and know whether to call `MongoClient.deinit` or not? 