### PR TITLE
SWIFT-29 Implement ReadConcern type

### DIFF
--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -60,11 +60,13 @@ public class MongoClient {
     /// If command and/or server monitoring is enabled, indicates what event types notifications will be posted for.
     internal var monitoringEventTypes: [MongoEventType]?
 
-    /// The read concern set on this client.
-    public var readConcern: ReadConcern {
+    /// The read concern set on this client, or nil if one is not set.
+    public var readConcern: ReadConcern? {
         // per libmongoc docs, we don't need to handle freeing this ourselves
         let readConcern = mongoc_client_get_read_concern(self._client)
-        return ReadConcern(readConcern)
+        let rcObj = ReadConcern(readConcern)
+        if rcObj.isDefault { return nil }
+        return rcObj
     }
 
     /**

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -490,11 +490,13 @@ public class MongoCollection {
         return String(cString: mongoc_collection_get_name(self._collection))
     }
 
-    /// The readConcern set on this collection.
-    public var readConcern: ReadConcern {
+    /// The readConcern set on this collection, or nil if one is not set.
+    public var readConcern: ReadConcern? {
         // per libmongoc docs, we don't need to handle freeing this ourselves
         let readConcern = mongoc_collection_get_read_concern(self._collection)
-        return ReadConcern(readConcern)
+        let rcObj = ReadConcern(readConcern)
+        if rcObj.isDefault { return nil }
+        return rcObj
     }
 
     /**

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -116,11 +116,13 @@ public class MongoDatabase {
         return String(cString: mongoc_database_get_name(self._database))
     }
 
-    /// The readConcern set on this database.
-    public var readConcern: ReadConcern {
+    /// The readConcern set on this database, or nil if one is not set.
+    public var readConcern: ReadConcern? {
         // per libmongoc docs, we don't need to handle freeing this ourselves
         let readConcern = mongoc_database_get_read_concern(self._database)
-        return ReadConcern(readConcern)
+        let rcObj = ReadConcern(readConcern)
+        if rcObj.isDefault { return nil }
+        return rcObj
     }
 
     /**

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -11,6 +11,7 @@ public enum MongoError {
     case bsonParseError(domain: UInt32, code: UInt32, message: String)
     case bsonEncodeError(message: String)
     case typeError(message: String)
+    case readConcernError(message: String)
 }
 
 extension MongoError: LocalizedError {

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -1,0 +1,90 @@
+import libmongoc
+
+/// An enumeration of possible ReadConcern levels.
+public enum ReadConcernLevel: String {
+    case local
+    case available
+    case majority
+    case linearizable
+    case snapshot
+}
+
+/// A class to represent a MongoDB read concern.
+public class ReadConcern {
+
+    /// A pointer to a mongoc_read_concern_t
+    internal var _readConcern: OpaquePointer?
+
+    /// The level of this readConcern, or nil if the level is not set.
+    public var level: String? {
+        guard let level = mongoc_read_concern_get_level(self._readConcern) else {
+            return nil
+        }
+        return String(cString: level)
+    }
+
+    /// Initialize a new ReadConcern from a ReadConcernLevel.
+    public convenience init(_ level: ReadConcernLevel) throws {
+        try self.init(level.rawValue)
+    }
+
+    /// Initialize a new ReadConcern from a String corresponding to a read concern level.
+    public init(_ level: String) throws {
+        self._readConcern = mongoc_read_concern_new()
+        if !mongoc_read_concern_set_level(self._readConcern, level) {
+            throw MongoError.readConcernError(message: "Failed to set read concern level to '\(level)'")
+        }
+    }
+
+    /// Initialize a new empty ReadConcern.
+    public init() {
+        self._readConcern = mongoc_read_concern_new()
+    }
+
+    /// Initialize a new ReadConcern from a Document.
+    public convenience init(_ doc: Document) throws {
+        if let level = doc["level"] as? String {
+            try self.init(level)
+        } else {
+            self.init()
+        }
+    }
+
+    /// Initializes a new ReadConcern by copying a mongoc_read_concern_t.
+    /// The caller is responsible for freeing the original mongoc_read_concern_t.
+    internal init(_ readConcern: OpaquePointer?) {
+        self._readConcern = mongoc_read_concern_copy(readConcern)
+    }
+
+    /// Appends this readConcern to a Document.
+    internal func append(to doc: Document) throws {
+        if !mongoc_read_concern_append(self._readConcern, doc.data) {
+            throw MongoError.readConcernError(message: "Error appending readconcern to document \(doc)")
+        }
+    }
+
+    /// Since we have to follow certain rules about whether to include or omit a ReadConcern,
+    /// this function handles obeying those, factoring in the ReadConcern, if any, for
+    /// whatever object is calling this function. It returns a final options Document for the
+    /// calling function to use, or nil if the Document ends up being empty.
+    internal static func append(_ readConcern: ReadConcern?, to opts: Document?, callerRC: ReadConcern) throws -> Document? {
+        // if the user didn't specify a readConcern, then we just want to use
+        // whatever the default is for the caller. 
+        guard let rc = readConcern else { return opts }
+
+        // the caller is using the server's default RC and we are also using default, don't append anything
+        if callerRC.level == nil && rc.level == nil { return opts }
+
+        // otherwise other us or the caller is using a non-default, so we need to append it
+        let output = opts ?? Document() // create base opts if they don't exist
+        try rc.append(to: output)
+        return output
+    }
+
+    deinit {
+        guard let readConcern = self._readConcern else { return }
+        mongoc_read_concern_destroy(readConcern)
+        self._readConcern = nil
+    }
+
+}

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -10,7 +10,7 @@ public enum ReadConcernLevel: String {
 }
 
 /// A class to represent a MongoDB read concern.
-public class ReadConcern {
+public class ReadConcern: Equatable, CustomStringConvertible {
 
     /// A pointer to a mongoc_read_concern_t
     internal var _readConcern: OpaquePointer?
@@ -21,6 +21,16 @@ public class ReadConcern {
             return nil
         }
         return String(cString: level)
+    }
+
+    private var asDocument: Document {
+        let doc = Document()
+        try? self.append(to: doc)
+        return doc
+    }
+
+    public var description: String {
+        return self.asDocument.description
     }
 
     /// Initialize a new ReadConcern from a ReadConcernLevel.
@@ -75,10 +85,14 @@ public class ReadConcern {
         // the caller is using the server's default RC and we are also using default, don't append anything
         if callerRC.level == nil && rc.level == nil { return opts }
 
-        // otherwise other us or the caller is using a non-default, so we need to append it
+        // otherwise either us or the caller is using a non-default, so we need to append it
         let output = opts ?? Document() // create base opts if they don't exist
         try rc.append(to: output)
         return output
+    }
+
+    public static func == (lhs: ReadConcern, rhs: ReadConcern) -> Bool {
+        return lhs.level == rhs.level
     }
 
     deinit {

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -67,7 +67,7 @@ public class ReadConcern: Equatable, CustomStringConvertible {
     }
 
     /// Appends this readConcern to a Document.
-    internal func append(to doc: Document) throws {
+    private func append(to doc: Document) throws {
         if !mongoc_read_concern_append(self._readConcern, doc.data) {
             throw MongoError.readConcernError(message: "Error appending readconcern to document \(doc)")
         }

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -33,6 +33,10 @@ public class ReadConcern: Equatable, CustomStringConvertible {
         return self.asDocument.description
     }
 
+    public var isDefault: Bool {
+        return mongoc_read_concern_is_default(self._readConcern)
+    }
+
     /// Initialize a new ReadConcern from a ReadConcernLevel.
     public convenience init(_ level: ReadConcernLevel) {
         self.init(level.rawValue)
@@ -80,13 +84,13 @@ public class ReadConcern: Equatable, CustomStringConvertible {
     /// this function handles obeying those, factoring in the ReadConcern, if any, for
     /// whatever object is calling this function. It returns a final options Document for the
     /// calling function to use, or nil if the Document ends up being empty.
-    internal static func append(_ readConcern: ReadConcern?, to opts: Document?, callerRC: ReadConcern) throws -> Document? {
+    internal static func append(_ readConcern: ReadConcern?, to opts: Document?, callerRC: ReadConcern?) throws -> Document? {
         // if the user didn't specify a readConcern, then we just want to use
         // whatever the default is for the caller. 
         guard let rc = readConcern else { return opts }
 
-        // the caller is using the server's default RC and we are also using default, don't append anything
-        if callerRC.level == nil && rc.level == nil { return opts }
+        // the caller is using the server's default RC and we are also using default, so don't append anything
+        if (callerRC == nil || callerRC?.level == nil) && rc.level == nil { return opts }
 
         // otherwise either us or the caller is using a non-default, so we need to append it
         let output = opts ?? Document() // create base opts if they don't exist

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -34,16 +34,14 @@ public class ReadConcern: Equatable, CustomStringConvertible {
     }
 
     /// Initialize a new ReadConcern from a ReadConcernLevel.
-    public convenience init(_ level: ReadConcernLevel) throws {
-        try self.init(level.rawValue)
+    public convenience init(_ level: ReadConcernLevel) {
+        self.init(level.rawValue)
     }
 
     /// Initialize a new ReadConcern from a String corresponding to a read concern level.
-    public init(_ level: String) throws {
+    public init(_ level: String) {
         self._readConcern = mongoc_read_concern_new()
-        if !mongoc_read_concern_set_level(self._readConcern, level) {
-            throw MongoError.readConcernError(message: "Failed to set read concern level to '\(level)'")
-        }
+        mongoc_read_concern_set_level(self._readConcern, level)
     }
 
     /// Initialize a new empty ReadConcern.
@@ -52,12 +50,17 @@ public class ReadConcern: Equatable, CustomStringConvertible {
     }
 
     /// Initialize a new ReadConcern from a Document.
-    public convenience init(_ doc: Document) throws {
+    public convenience init(_ doc: Document) {
         if let level = doc["level"] as? String {
-            try self.init(level)
+            self.init(level)
         } else {
             self.init()
         }
+    }
+
+    /// Initializes a new ReadConcern by copying an existing ReadConcern.
+    public init(from: ReadConcern) {
+        self._readConcern = mongoc_read_concern_copy(from._readConcern)
     }
 
     /// Initializes a new ReadConcern by copying a mongoc_read_concern_t.

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -90,7 +90,7 @@ public class ReadConcern: Equatable, CustomStringConvertible {
         guard let rc = readConcern else { return opts }
 
         // the caller is using the server's default RC and we are also using default, so don't append anything
-        if (callerRC == nil || callerRC?.level == nil) && rc.level == nil { return opts }
+        if callerRC?.level == nil && rc.level == nil { return opts }
 
         // otherwise either us or the caller is using a non-default, so we need to append it
         let output = opts ?? Document() // create base opts if they don't exist

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -1,0 +1,218 @@
+@testable import MongoSwift
+import Nimble
+import XCTest
+
+import libmongoc
+
+final class ReadWriteConcernTests: XCTestCase {
+	static var allTests: [(String, (ReadWriteConcernTests) -> () throws -> Void)] {
+        return [
+        	("testReadConcernType", testReadConcernType),
+            ("testClientReadConcern", testClientReadConcern),
+            ("testDatabaseReadConcern", testDatabaseReadConcern),
+            ("testOperationReadConcerns", testOperationReadConcerns)
+        ]
+    }
+
+    override func setUp() {
+    	self.continueAfterFailure = false
+    }
+
+    func testReadConcernType() throws {
+    	// check that setting readConcern level to all valid inputs doesn't throw
+    	expect(try ReadConcern(.local)).toNot(throwError())
+    	expect(try ReadConcern(.majority)).toNot(throwError())
+    	expect(try ReadConcern(.available)).toNot(throwError())
+    	expect(try ReadConcern(.linearizable)).toNot(throwError())
+    	expect(try ReadConcern(.snapshot)).toNot(throwError())
+
+    	expect(try ReadConcern("local")).toNot(throwError())
+    	expect(try ReadConcern("majority")).toNot(throwError())
+    	expect(try ReadConcern("available")).toNot(throwError())
+    	expect(try ReadConcern("linearizable")).toNot(throwError())
+    	expect(try ReadConcern("snapshot")).toNot(throwError())
+
+    	// check level var works as expected
+    	let rc = try ReadConcern(.majority)
+    	expect(rc.level).to(equal("majority"))
+
+    }
+
+    func testClientReadConcern() throws {
+    	// create a client with no options and check its RC
+    	let client1 = try MongoClient()
+    	// expect the readConcern property to exist with a nil level
+    	expect(client1.readConcern.level).to(beNil())
+
+    	// expect that a DB created from this client inherits its unset RC 
+    	let db1 = try client1.db("test")
+    	expect(db1.readConcern.level).to(beNil())
+
+    	// expect that a DB created from this client can override the client's unset RC
+    	let db2 = try client1.db("test", options: DatabaseOptions(readConcern: try ReadConcern(.majority)))
+    	expect(db2.readConcern.level).to(equal("majority"))
+
+    	client1.close()
+
+    	// create a client with local read concern and check its RC
+    	let client2 = try MongoClient(options: ClientOptions(readConcern: try ReadConcern(.local)))
+    	// although local is default, if it is explicitly provided it should be set
+    	expect(client2.readConcern.level).to(equal("local"))
+
+    	// expect that a DB created from this client inherits its local RC 
+    	let db3 = try client2.db("test")
+    	expect(db3.readConcern.level).to(equal("local"))
+
+    	// expect that a DB created from this client can override the client's local RC
+    	let db4 = try client2.db("test", options: DatabaseOptions(readConcern: try ReadConcern(.majority)))
+    	expect(db4.readConcern.level).to(equal("majority"))
+
+    	client2.close()
+
+    	// create a client with majority read concern and check its RC
+    	let client3 = try MongoClient(options: ClientOptions(readConcern: try ReadConcern(.majority)))
+    	expect(client3.readConcern.level).to(equal("majority"))
+
+    	// expect that a DB created from this client can override the client's majority RC with an unset one
+    	let db5 = try client3.db("test", options: DatabaseOptions(readConcern: ReadConcern()))
+    	expect(db5.readConcern.level).to(beNil())
+
+    	client3.close()
+    }
+
+    func testDatabaseReadConcern() throws {
+    	let client = try MongoClient()
+
+    	let db1 = try client.db("test")
+    	defer { do { try db1.drop() } catch {} }
+
+    	// expect that a collection created from a DB with unset RC also has unset RC
+    	var coll1 = try db1.createCollection("coll1")
+    	expect(coll1.readConcern.level).to(beNil())
+
+    	// expect that a collection retrieved from a DB with unset RC also has unset RC
+    	coll1 = try db1.collection("coll1")
+    	expect(coll1.readConcern.level).to(beNil())
+
+    	// expect that a collection created from a DB with unset RC can override the DB's RC
+    	var coll2 = try db1.createCollection("coll2", options: CreateCollectionOptions(readConcern: try ReadConcern(.local)))
+    	expect(coll2.readConcern.level).to(equal("local"))
+
+    	// expect that a collection retrieved from a DB with unset RC can override the DB's RC
+    	coll2 = try db1.collection("coll2", options: CollectionOptions(readConcern: try ReadConcern(.local)))
+    	expect(coll2.readConcern.level).to(equal("local"))
+
+    	try db1.drop()
+
+    	let db2 = try client.db("test", options: DatabaseOptions(readConcern: try ReadConcern(.local)))
+    	defer { do { try db2.drop() } catch {} }
+
+    	// expect that a collection created from a DB with local RC also has local RC
+    	var coll3 = try db2.createCollection("coll3")
+    	expect(coll3.readConcern.level).to(equal("local"))
+
+    	// expect that a collection retrieved from a DB with local RC also has local RC
+    	coll3 = try db2.collection("coll3")
+    	expect(coll3.readConcern.level).to(equal("local"))
+
+    	// expect that a collection created from a DB with local RC can override the DB's RC
+    	var coll4 = try db2.createCollection("coll4", options: CreateCollectionOptions(readConcern: try ReadConcern(.majority)))
+    	expect(coll4.readConcern.level).to(equal("majority"))
+
+ 		// expect that a collection retrieved from a DB with local RC can override the DB's RC
+ 		coll4 = try db2.collection("coll4", options: CollectionOptions(readConcern: try ReadConcern(.majority)))
+    	expect(coll4.readConcern.level).to(equal("majority"))
+    }
+
+    func testOperationReadConcerns() throws {
+    	// setup a collection 
+    	let client = try MongoClient()
+    	let db = try client.db("test")
+    	defer { do { try db.drop() } catch {} }
+    	let coll = try db.createCollection("coll1")
+
+    	let command: Document = ["count": "coll1"]
+
+    	// run command with a valid readConcern
+    	let options1 = RunCommandOptions(readConcern: try ReadConcern(.local))
+    	let res1 = try db.runCommand(command, options: options1)
+        expect(res1["ok"] as? Double).to(equal(1.0))
+
+        // run command with an empty readConcern
+        let options2 = RunCommandOptions(readConcern: ReadConcern())
+        let res2 = try db.runCommand(command, options: options2)
+        expect(res2["ok"] as? Double).to(equal(1.0))
+
+        // running command with an invalid RC level should throw
+        let options3 = RunCommandOptions(readConcern: try ReadConcern("blah"))
+        expect(try db.runCommand(command, options: options3)).to(throwError())
+
+        // try various command + read concern pairs to make sure they work
+        expect(try coll.find(options: FindOptions(readConcern: try ReadConcern(.local)))).toNot(throwError())
+
+        expect(try coll.aggregate([["$project": ["a": 1] as Document]],
+        	options: AggregateOptions(readConcern: try ReadConcern(.majority)))).toNot(throwError())
+
+        expect(try coll.count(options: CountOptions(readConcern: try ReadConcern(.majority)))).toNot(throwError())
+
+        expect(try coll.distinct(fieldName: "a",
+        	options: DistinctOptions(readConcern: try ReadConcern(.local)))).toNot(throwError())
+    }
+
+    func testConnectionStrings() throws {
+    	let csPath = "\(self.getSpecsPath())/read-write-concern/tests/connection-string"
+    	let testFiles = try FileManager.default.contentsOfDirectory(atPath: csPath).filter { $0.hasSuffix(".json") }
+    	for filename in testFiles {
+    		let testFilePath = URL(fileURLWithPath: "\(csPath)/\(filename)")
+            let asDocument = try Document(fromJSONFile: testFilePath)
+            let tests: [Document] = try asDocument.get("tests")
+            for test in tests {
+	            let description: String = try test.get("description")
+                if description == "wtimeoutMS as an invalid number" { continue }
+	            let uri: String = try test.get("uri")
+	            let valid: Bool = try test.get("valid")
+	            if valid {
+                    let client = try MongoClient(connectionString: uri)
+                    if let readConcern = test["readConcern"] as? Document, readConcern != [:] {
+                        expect(readConcern["level"] as? String).to(equal(client.readConcern.level))
+                    } else if let writeConcern = test["writeConcern"] as? Document {
+                        // TODO SWIFT-30: verify the writeconcern matches that on the client
+                    }
+	            } else {
+	            	expect(try MongoClient(connectionString: uri)).to(throwError())
+	            }
+            }
+    	}
+    }
+
+    func testDocuments() throws {
+        let encoder = BsonEncoder()
+        let docsPath = "\(self.getSpecsPath())/read-write-concern/tests/document"
+        let testFiles = try FileManager.default.contentsOfDirectory(atPath: docsPath).filter { $0.hasSuffix(".json") }
+        for filename in testFiles {
+            let testFilePath = URL(fileURLWithPath: "\(docsPath)/\(filename)")
+            let asDocument = try Document(fromJSONFile: testFilePath)
+            let tests: [Document] = try asDocument.get("tests")
+            for test in tests {
+                let description: String = try test.get("description")
+                if description == "WTimeoutMS as an invalid number" { continue }
+                let valid: Bool = try test.get("valid")
+                if let rcToUse = test["readConcern"] as? Document {
+                    let rc = try ReadConcern(rcToUse)
+                    let opts = try ReadConcern.append(rc, to: Document(), callerRC: ReadConcern())
+                    let rcToSend = test["readConcernDocument"] as? Document
+                    // if expected is empty, make sure actual is
+                    if rcToSend == [:] {
+                        expect(opts).to(equal([:] as Document))
+                    // otherwise check that documents match
+                    } else {
+                        expect(opts).to(equal(["readConcern": rcToSend] as Document))
+                    }
+
+                } else if let wcToUse = test["writeConcern"] as? Document {
+                    // TODO SWIFT-30: encode the write concern and confirm it matches the expected one
+                }
+            }
+        }
+    }
+}

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -5,9 +5,9 @@ import XCTest
 import libmongoc
 
 final class ReadWriteConcernTests: XCTestCase {
-	static var allTests: [(String, (ReadWriteConcernTests) -> () throws -> Void)] {
+    static var allTests: [(String, (ReadWriteConcernTests) -> () throws -> Void)] {
         return [
-        	("testReadConcernType", testReadConcernType),
+            ("testReadConcernType", testReadConcernType),
             ("testClientReadConcern", testClientReadConcern),
             ("testDatabaseReadConcern", testDatabaseReadConcern),
             ("testOperationReadConcerns", testOperationReadConcerns)
@@ -15,127 +15,126 @@ final class ReadWriteConcernTests: XCTestCase {
     }
 
     override func setUp() {
-    	self.continueAfterFailure = false
+        self.continueAfterFailure = false
     }
 
     func testReadConcernType() throws {
-    	// check that setting readConcern level to all valid inputs doesn't throw
-    	expect(try ReadConcern(.local)).toNot(throwError())
-    	expect(try ReadConcern(.majority)).toNot(throwError())
-    	expect(try ReadConcern(.available)).toNot(throwError())
-    	expect(try ReadConcern(.linearizable)).toNot(throwError())
-    	expect(try ReadConcern(.snapshot)).toNot(throwError())
+        // check level var works as expected
+        let rc = ReadConcern(.majority)
+        expect(rc.level).to(equal("majority"))
 
-    	expect(try ReadConcern("local")).toNot(throwError())
-    	expect(try ReadConcern("majority")).toNot(throwError())
-    	expect(try ReadConcern("available")).toNot(throwError())
-    	expect(try ReadConcern("linearizable")).toNot(throwError())
-    	expect(try ReadConcern("snapshot")).toNot(throwError())
+        // test copy init
+        let rc2 = ReadConcern(from: rc)
+        expect(rc2.level).to(equal("majority"))
 
-    	// check level var works as expected
-    	let rc = try ReadConcern(.majority)
-    	expect(rc.level).to(equal("majority"))
+        // test empty init
+        let rc3 = ReadConcern()
+        expect(rc3.level).to(beNil())
+
+        // test init from doc
+        let rc4 = ReadConcern(["level": "majority"])
+        expect(rc4.level).to(equal("majority"))
 
     }
 
     func testClientReadConcern() throws {
-    	// create a client with no options and check its RC
-    	let client1 = try MongoClient()
-    	// expect the readConcern property to exist with a nil level
-    	expect(client1.readConcern.level).to(beNil())
+        // create a client with no options and check its RC
+        let client1 = try MongoClient()
+        // expect the readConcern property to exist with a nil level
+        expect(client1.readConcern.level).to(beNil())
 
-    	// expect that a DB created from this client inherits its unset RC 
-    	let db1 = try client1.db("test")
-    	expect(db1.readConcern.level).to(beNil())
+        // expect that a DB created from this client inherits its unset RC 
+        let db1 = try client1.db("test")
+        expect(db1.readConcern.level).to(beNil())
 
-    	// expect that a DB created from this client can override the client's unset RC
-    	let db2 = try client1.db("test", options: DatabaseOptions(readConcern: try ReadConcern(.majority)))
-    	expect(db2.readConcern.level).to(equal("majority"))
+        // expect that a DB created from this client can override the client's unset RC
+        let db2 = try client1.db("test", options: DatabaseOptions(readConcern: ReadConcern(.majority)))
+        expect(db2.readConcern.level).to(equal("majority"))
 
-    	client1.close()
+        client1.close()
 
-    	// create a client with local read concern and check its RC
-    	let client2 = try MongoClient(options: ClientOptions(readConcern: try ReadConcern(.local)))
-    	// although local is default, if it is explicitly provided it should be set
-    	expect(client2.readConcern.level).to(equal("local"))
+        // create a client with local read concern and check its RC
+        let client2 = try MongoClient(options: ClientOptions(readConcern: ReadConcern(.local)))
+        // although local is default, if it is explicitly provided it should be set
+        expect(client2.readConcern.level).to(equal("local"))
 
-    	// expect that a DB created from this client inherits its local RC 
-    	let db3 = try client2.db("test")
-    	expect(db3.readConcern.level).to(equal("local"))
+        // expect that a DB created from this client inherits its local RC 
+        let db3 = try client2.db("test")
+        expect(db3.readConcern.level).to(equal("local"))
 
-    	// expect that a DB created from this client can override the client's local RC
-    	let db4 = try client2.db("test", options: DatabaseOptions(readConcern: try ReadConcern(.majority)))
-    	expect(db4.readConcern.level).to(equal("majority"))
+        // expect that a DB created from this client can override the client's local RC
+        let db4 = try client2.db("test", options: DatabaseOptions(readConcern: ReadConcern(.majority)))
+        expect(db4.readConcern.level).to(equal("majority"))
 
-    	client2.close()
+        client2.close()
 
-    	// create a client with majority read concern and check its RC
-    	let client3 = try MongoClient(options: ClientOptions(readConcern: try ReadConcern(.majority)))
-    	expect(client3.readConcern.level).to(equal("majority"))
+        // create a client with majority read concern and check its RC
+        let client3 = try MongoClient(options: ClientOptions(readConcern: ReadConcern(.majority)))
+        expect(client3.readConcern.level).to(equal("majority"))
 
-    	// expect that a DB created from this client can override the client's majority RC with an unset one
-    	let db5 = try client3.db("test", options: DatabaseOptions(readConcern: ReadConcern()))
-    	expect(db5.readConcern.level).to(beNil())
+        // expect that a DB created from this client can override the client's majority RC with an unset one
+        let db5 = try client3.db("test", options: DatabaseOptions(readConcern: ReadConcern()))
+        expect(db5.readConcern.level).to(beNil())
 
-    	client3.close()
+        client3.close()
     }
 
     func testDatabaseReadConcern() throws {
-    	let client = try MongoClient()
+        let client = try MongoClient()
 
-    	let db1 = try client.db("test")
-    	defer { do { try db1.drop() } catch {} }
+        let db1 = try client.db("test")
+        defer {try? db1.drop() }
 
-    	// expect that a collection created from a DB with unset RC also has unset RC
-    	var coll1 = try db1.createCollection("coll1")
-    	expect(coll1.readConcern.level).to(beNil())
+        // expect that a collection created from a DB with unset RC also has unset RC
+        var coll1 = try db1.createCollection("coll1")
+        expect(coll1.readConcern.level).to(beNil())
 
-    	// expect that a collection retrieved from a DB with unset RC also has unset RC
-    	coll1 = try db1.collection("coll1")
-    	expect(coll1.readConcern.level).to(beNil())
+        // expect that a collection retrieved from a DB with unset RC also has unset RC
+        coll1 = try db1.collection("coll1")
+        expect(coll1.readConcern.level).to(beNil())
 
-    	// expect that a collection created from a DB with unset RC can override the DB's RC
-    	var coll2 = try db1.createCollection("coll2", options: CreateCollectionOptions(readConcern: try ReadConcern(.local)))
-    	expect(coll2.readConcern.level).to(equal("local"))
+        // expect that a collection created from a DB with unset RC can override the DB's RC
+        var coll2 = try db1.createCollection("coll2", options: CreateCollectionOptions(readConcern: ReadConcern(.local)))
+        expect(coll2.readConcern.level).to(equal("local"))
 
-    	// expect that a collection retrieved from a DB with unset RC can override the DB's RC
-    	coll2 = try db1.collection("coll2", options: CollectionOptions(readConcern: try ReadConcern(.local)))
-    	expect(coll2.readConcern.level).to(equal("local"))
+        // expect that a collection retrieved from a DB with unset RC can override the DB's RC
+        coll2 = try db1.collection("coll2", options: CollectionOptions(readConcern: ReadConcern(.local)))
+        expect(coll2.readConcern.level).to(equal("local"))
 
-    	try db1.drop()
+        try db1.drop()
 
-    	let db2 = try client.db("test", options: DatabaseOptions(readConcern: try ReadConcern(.local)))
-    	defer { do { try db2.drop() } catch {} }
+        let db2 = try client.db("test", options: DatabaseOptions(readConcern: ReadConcern(.local)))
+        defer { try? db2.drop() }
 
-    	// expect that a collection created from a DB with local RC also has local RC
-    	var coll3 = try db2.createCollection("coll3")
-    	expect(coll3.readConcern.level).to(equal("local"))
+        // expect that a collection created from a DB with local RC also has local RC
+        var coll3 = try db2.createCollection("coll3")
+        expect(coll3.readConcern.level).to(equal("local"))
 
-    	// expect that a collection retrieved from a DB with local RC also has local RC
-    	coll3 = try db2.collection("coll3")
-    	expect(coll3.readConcern.level).to(equal("local"))
+        // expect that a collection retrieved from a DB with local RC also has local RC
+        coll3 = try db2.collection("coll3")
+        expect(coll3.readConcern.level).to(equal("local"))
 
-    	// expect that a collection created from a DB with local RC can override the DB's RC
-    	var coll4 = try db2.createCollection("coll4", options: CreateCollectionOptions(readConcern: try ReadConcern(.majority)))
-    	expect(coll4.readConcern.level).to(equal("majority"))
+        // expect that a collection created from a DB with local RC can override the DB's RC
+        var coll4 = try db2.createCollection("coll4", options: CreateCollectionOptions(readConcern: ReadConcern(.majority)))
+        expect(coll4.readConcern.level).to(equal("majority"))
 
- 		// expect that a collection retrieved from a DB with local RC can override the DB's RC
- 		coll4 = try db2.collection("coll4", options: CollectionOptions(readConcern: try ReadConcern(.majority)))
-    	expect(coll4.readConcern.level).to(equal("majority"))
+        // expect that a collection retrieved from a DB with local RC can override the DB's RC
+        coll4 = try db2.collection("coll4", options: CollectionOptions(readConcern: ReadConcern(.majority)))
+        expect(coll4.readConcern.level).to(equal("majority"))
     }
 
     func testOperationReadConcerns() throws {
-    	// setup a collection 
-    	let client = try MongoClient()
-    	let db = try client.db("test")
-    	defer { do { try db.drop() } catch {} }
-    	let coll = try db.createCollection("coll1")
+        // setup a collection 
+        let client = try MongoClient()
+        let db = try client.db("test")
+        defer { try? db.drop() }
+        let coll = try db.createCollection("coll1")
 
-    	let command: Document = ["count": "coll1"]
+        let command: Document = ["count": "coll1"]
 
-    	// run command with a valid readConcern
-    	let options1 = RunCommandOptions(readConcern: try ReadConcern(.local))
-    	let res1 = try db.runCommand(command, options: options1)
+        // run command with a valid readConcern
+        let options1 = RunCommandOptions(readConcern: ReadConcern(.local))
+        let res1 = try db.runCommand(command, options: options1)
         expect(res1["ok"] as? Double).to(equal(1.0))
 
         // run command with an empty readConcern
@@ -144,47 +143,47 @@ final class ReadWriteConcernTests: XCTestCase {
         expect(res2["ok"] as? Double).to(equal(1.0))
 
         // running command with an invalid RC level should throw
-        let options3 = RunCommandOptions(readConcern: try ReadConcern("blah"))
+        let options3 = RunCommandOptions(readConcern: ReadConcern("blah"))
         expect(try db.runCommand(command, options: options3)).to(throwError())
 
         // try various command + read concern pairs to make sure they work
-        expect(try coll.find(options: FindOptions(readConcern: try ReadConcern(.local)))).toNot(throwError())
+        expect(try coll.find(options: FindOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
 
         expect(try coll.aggregate([["$project": ["a": 1] as Document]],
-        	options: AggregateOptions(readConcern: try ReadConcern(.majority)))).toNot(throwError())
+            options: AggregateOptions(readConcern: ReadConcern(.majority)))).toNot(throwError())
 
-        expect(try coll.count(options: CountOptions(readConcern: try ReadConcern(.majority)))).toNot(throwError())
+        expect(try coll.count(options: CountOptions(readConcern: ReadConcern(.majority)))).toNot(throwError())
 
         expect(try coll.distinct(fieldName: "a",
-        	options: DistinctOptions(readConcern: try ReadConcern(.local)))).toNot(throwError())
+            options: DistinctOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
     }
 
     func testConnectionStrings() throws {
-    	let csPath = "\(self.getSpecsPath())/read-write-concern/tests/connection-string"
-    	let testFiles = try FileManager.default.contentsOfDirectory(atPath: csPath).filter { $0.hasSuffix(".json") }
-    	for filename in testFiles {
-    		let testFilePath = URL(fileURLWithPath: "\(csPath)/\(filename)")
+        let csPath = "\(self.getSpecsPath())/read-write-concern/tests/connection-string"
+        let testFiles = try FileManager.default.contentsOfDirectory(atPath: csPath).filter { $0.hasSuffix(".json") }
+        for filename in testFiles {
+            let testFilePath = URL(fileURLWithPath: "\(csPath)/\(filename)")
             let asDocument = try Document(fromJSONFile: testFilePath)
             let tests: [Document] = try asDocument.get("tests")
             for test in tests {
-	            let description: String = try test.get("description")
+                let description: String = try test.get("description")
                 // skipping because C driver does not comply with these; see CDRIVER-2621
                 if description.lowercased().contains("wtimeoutms") { continue }
-	            let uri: String = try test.get("uri")
-	            let valid: Bool = try test.get("valid")
-	            if valid {
+                let uri: String = try test.get("uri")
+                let valid: Bool = try test.get("valid")
+                if valid {
                     let client = try MongoClient(connectionString: uri)
                     if let readConcern = test["readConcern"] as? Document {
-                        let rc = try ReadConcern(readConcern)
+                        let rc = ReadConcern(readConcern)
                          expect(client.readConcern).to(equal(rc))
                     } else if let writeConcern = test["writeConcern"] as? Document {
                         // TODO SWIFT-30: verify the writeconcern matches that on the client
                     }
-	            } else {
-	            	expect(try MongoClient(connectionString: uri)).to(throwError())
-	            }
+                } else {
+                    expect(try MongoClient(connectionString: uri)).to(throwError())
+                }
             }
-    	}
+        }
     }
 
     func testDocuments() throws {
@@ -201,8 +200,8 @@ final class ReadWriteConcernTests: XCTestCase {
                 if ["WTimeoutMS as an invalid number", "W as an invalid number"].contains(description) { continue }
                 let valid: Bool = try test.get("valid")
                 if let rcToUse = test["readConcern"] as? Document {
-                    let rc = try ReadConcern(rcToUse)
-                    let rcToSend = try ReadConcern(test["readConcernDocument"] as! Document)
+                    let rc = ReadConcern(rcToUse)
+                    let rcToSend = ReadConcern(test["readConcernDocument"] as! Document)
                     expect(rcToSend).to(equal(rc))
                 } else if let wcToUse = test["writeConcern"] as? Document {
                     // TODO SWIFT-30: encode the write concern and confirm it matches the expected one

--- a/Tests/Specs/read-write-concern/read-write-concern.rst
+++ b/Tests/Specs/read-write-concern/read-write-concern.rst
@@ -1,0 +1,499 @@
+.. role:: javascript(code)
+  :language: javascript
+
+======================
+Read and Write Concern
+======================
+
+:Spec: 135
+:Title: Read and Write Concern
+:Authors: Craig Wilson
+:Advisors: Jesse Davis, Hannes Magnusson, Anna Herlihy
+:Status: Approved
+:Type: Standards
+:Server Versions: 2.4+
+:Last Modified: December 18, 2017
+:Version: 1.5
+
+.. contents::
+
+--------
+
+Abstract
+========
+
+A driver must support configuring and sending read concern and write concerns
+to a server. This specification defines the API drivers must implement as well as how that API is translated into messages for communication with the server.
+
+META
+====
+
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in `RFC 2119 <https://www.ietf.org/rfc/rfc2119.txt>`_.
+
+Terminology
+===========
+
+MaxWireVersion
+    The ``maxWireVersion`` value reported by the ``ismaster`` command.
+Server Selection
+    The process of selecting a server to read or write from. See https://github.com/mongodb/specifications/tree/master/source/server-selection.
+
+Specification
+=============
+
+
+This specification includes guidance for implementing `Read Concern`_ and `Write Concern`_ in a driver. It does not define how read and write concern behave or are implemented on the server.
+
+------------
+Read Concern
+------------
+
+For naming and deviation guidance, see the `CRUD specification <https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#naming>`_. Defined below are the constructs for drivers.
+
+.. code:: typescript
+
+  enum ReadConcernLevel {
+      /**
+       * This is rendered as "local" (lower-case) on the wire.
+       */
+      local,
+
+      /**
+       * This is rendered as "majority" (lower-case) on the wire.
+       */
+      majority,
+
+      /**
+       * This is rendered as "linearizable" (lower-case) on the wire.
+       */
+      linearizable
+
+      /**
+       * This is rendered as "available" (lower-case) on the wire.
+       */
+      available
+  }
+
+  class ReadConcern {
+    /**
+     * The level of the read concern.
+     */
+    level: Optional<ReadConcernLevel | String>
+  }
+
+The read concern option is available for the following operations: 
+
+- ``find`` command
+- ``aggregate`` command
+- ``distinct`` command
+- ``count`` command
+- ``parallelCollectionScan`` command
+- ``geoNear`` command
+- ``geoSearch`` command
+- ``mapReduce`` command with {out : inline} output option
+
+``aggregate`` command with $out and ``mapReduce`` command with "out" set to anything other than "inline" do not support readConcern.
+
+Unknown Levels and Additional Options for String Based ReadConcerns
+-------------------------------------------------------------------
+
+For forward compatibility, a driver MUST NOT raise an error when a user provides an unknown ``level`` or additional options. The driver relies on the server to validate levels and other contents of the read concern.
+
+
+Server’s Default Read Concern
+-----------------------------
+
+When a ``ReadConcern`` is created but no values are specified, it should be considered the server’s default ``ReadConcern``.
+
+:javascript:`readConcern: { }` is not the same as  :javascript:`readConcern: { level=“local” }`. The former is the server’s default ``ReadConcern`` while the latter is the user explicitly specifying a ``ReadConcern`` with a ``level`` of “local”.
+
+
+On the Wire
+-----------
+
+Read Commands
+~~~~~~~~~~~~~
+
+Read commands that support ``ReadConcern`` take a named parameter spelled (case-sensitively) ``readConcern``. See command documentation for further examples. 
+
+When a user has not specified a ``ReadConcern`` or has specified the server’s default ``ReadConcern``, drivers MUST omit the ``readConcern`` parameter when sending the command.
+
+
+.. note::
+    While the default ``ReadConcern`` MUST be omitted, an explicitly specified ``ReadConcern`` of :javascript:`readConcern: { level: “local” }` MUST NOT be omitted.
+
+
+Generic Command Method
+~~~~~~~~~~~~~~~~~~~~~~
+
+If your driver offers a generic ``RunCommand`` method on your ``database`` object, ``ReadConcern`` MUST NOT be applied automatically to any command. A user wishing to use a ``ReadConcern`` in a generic command must supply it manually.
+
+
+Errors
+~~~~~~
+
+``ReadConcern`` errors from a server MUST NOT be handled by a driver. There is nothing a driver can do about them and any such errors will get propagated to the user via normal error handling.
+
+
+Location Specification
+----------------------
+
+Via Code
+~~~~~~~~
+
+``ReadConcern`` SHOULD be specifiable at the ``Client``, ``Database``, and ``Collection`` levels. Unless specified, the value MUST be inherited from its parent and SHOULD NOT be modifiable on an existing ``Client``, ``Database``, and ``Collection``. In addition, a driver MAY allow it to be specified on a per-operation basis in accordance with the CRUD specification. 
+
+For example:
+
+.. code:: typescript
+
+    var client = new MongoClient({ readConcern: { level: "local" } });
+
+    // db1's readConcern level is "local".
+    var db1 = client.getDatabase("db1");
+
+    // col1's readConcern level is "local"
+    var col1 = db1.getCollection("col_name");
+
+    // db2's readConcern level is "majority".
+    var db2 = client.getDatabase("db_name", { readConcern: { level: "majority" } });
+
+    // col2's readConcern level is "majority"
+    var col2 = db2.getCollection("col_name");
+
+    // col3's readConcern level is the server’s default read concern
+    var col3 = db2.getCollection("col_name", { readConcern: { } });
+
+
+Via Connection String
+~~~~~~~~~~~~~~~~~~~~~
+
+Options
+    * ``readConcernLevel`` - defines the level for the read concern.
+
+For example:
+
+.. code:: 
+
+    mongodb://server:27017/db?readConcernLevel=majority
+
+Errors
+------
+
+MaxWireVersion < 4
+    Only the server’s default ``ReadConcern`` is support by ``MaxWireVersion`` < 4. When using other ``readConcernLevels`` with clients reporting ``MaxWireVersion`` < 4, the driver MUST raise an error. This check MUST happen after server selection has occurred in the case of mixed version clusters. It is up to users to appropriately define a ``ReadPreference`` such that intermittent errors do not occur.
+
+.. note::
+
+   ``ReadConcern`` is only supported for commands.
+
+-------------
+Write Concern
+-------------
+
+For naming and deviation guidance, see the `CRUD specification <https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#naming>`_. Below are defined the constructs for drivers.
+
+.. code:: typescript
+  
+  class WriteConcern {
+    /**
+     * If true, wait for the the write operation to get committed to the journal. When unspecified, a driver
+     * MUST NOT send "j".
+     *
+     * @see http://docs.mongodb.org/manual/core/write-concern/#journaled
+     */
+    journal: Optional<Boolean>,
+
+    /**
+     * When an integer, specifies the number of nodes that should acknowledge the write      
+     * and MUST be greater than or equal to 0.
+     * When a string, indicates tags. "majority" is defined, but users 
+     * could specify other custom error modes.
+     * When not specified, a driver MUST NOT send "w".
+     */
+    w: Optional<Int32 | String>,
+
+    /**
+     * If the write concern is not satisfied within the specified timeout (in milliseconds), 
+     * the operation will return an error.
+     * The value MUST be greater than or equal to 0.
+     * When not specified, a driver should not send "wtimeout".
+     *
+     * @see http://docs.mongodb.org/manual/core/write-concern/#timeouts
+     */
+    wtimeoutMS: Optional<Int64>
+  }
+
+
+FSync
+-----
+
+FSync SHOULD be considered deprecated.  Those drivers supporting the deprecated ``fsync`` option SHOULD treat ``fsync`` identically to ``journal`` in terms of consistency with ``w`` and whether a ``WriteConcern`` that specifies ``fsync`` is acknowledged or unacknowledged.
+
+
+Server’s Default WriteConcern
+-----------------------------
+
+When a ``WriteConcern`` is created but no values are specified, it should be considered the server’s default ``WriteConcern``.
+
+The server has a settings field called ``getLastErrorDefaults`` which allows a user to customize the default behavior of a ``WriteConcern``. Because of this, :javascript:`writeConcern: { }` is not the same as :javascript:`writeConcern: {w: 1}`. Sending :javascript:`{w:1}` overrides that default. As another example, :javascript:`writeConcern: { }` is not the same as :javascript:`writeConcern: {journal: false}`.
+    
+
+Inconsistent WriteConcern
+-------------------------
+
+Drivers SHOULD raise an error when an inconsistent ``WriteConcern`` is specified. The following is an exhaustive list of inconsistent ``WriteConcerns``:
+
+.. code:: typescript
+
+   writeConcern = { w: 0, journal: true };
+
+If, for the sake of backwards compatibility, the driver allows inconsistent write concerns where ``w`` equals 0 but ``journal`` is set to ``true``, the driver MUST treat it as an ``Acknowledged WriteConcern``.
+
+
+Unacknowledged WriteConcern
+---------------------------
+
+An ``Unacknowledged WriteConcern`` is when (``w`` equals 0) AND (``journal`` is not set or is ``false``). 
+
+These criteria indicates that the user does not care about errors from the server.
+
+Examples:
+
+.. code:: typescript
+
+   writeConcern = { w: 0 }; // Unacknowledged
+   writeConcern = { w: 0, journal: false }; // Unacknowledged
+   writeConcern = { w: 0, wtimeoutMS: 100 }; // Unacknowledged 
+
+
+On the Wire
+-----------
+
+OP_INSERT, OP_DELETE, OP_UPDATE
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``WriteConcern`` is implemented by sending the ``getLastError``(GLE) command directly after the operation. Drivers SHOULD piggy-back the GLE onto the same buffer as the operation. Regardless, GLE MUST be sent on the same connection as the initial write operation.
+
+When a user has not specified a ``WriteConcern`` or has specified the server’s default ``WriteConcern``, drivers MUST send the GLE command without arguments. For example: :javascript:`{ getLastError: 1 }`
+
+Drivers MUST NOT send a GLE for an ``Unacknowledged WriteConcern``. In this instance, the server will not send a reply.
+
+See the ``getLastError`` command documentation for other formatting.
+
+
+Write Commands
+~~~~~~~~~~~~~~
+
+The ``insert``, ``delete``, and ``update`` commands take a named parameter, ``writeConcern``. See the command documentation for further examples.
+
+When a user has not specified a ``WriteConcern`` or has specified the server’s default ``WriteConcern``, drivers MUST omit the ``writeConcern`` parameter from the command.
+
+All other ``WriteConcerns``, including the ``Unacknowledged WriteConcern``, MUST be sent with the ``writeConcern`` parameter.
+
+.. note::
+    Drivers MAY use ``OP_INSERT``, ``OP_UPDATE``, and ``OP_DELETE`` when an ``Unacknowledged WriteConcern`` is used.
+
+Generic Command Method
+~~~~~~~~~~~~~~~~~~~~~~
+
+If your driver offers a generic ``RunCommand`` method on your ``database`` object, ``WriteConcern`` MUST NOT be applied automatically to any command. A user wishing to use a ``WriteConcern`` in a generic command must manually include it in the command document passed to the method.
+
+The generic command method MUST NOT check the user's command document for a ``WriteConcern`` nor check whether the server is new enough to support a write concern for the command. The method simply sends the user's command to the server as-is.
+
+Find And Modify
+~~~~~~~~~~~~~~~
+
+The ``findAndModify`` command takes a named parameter, ``writeConcern``. See command documentation for further examples.
+
+If writeConcern is specified for the Collection, ``writeConcern`` MUST be omitted when sending ``findAndModify`` with MaxWireVersion < 4.
+
+If the findAndModify helper accepts writeConcern as a parameter, the driver MUST raise an error with MaxWireVersion < 4.
+
+.. note ::
+    Driver documentation SHOULD include a warning in their server 3.2 compatible releases that an elevated ``WriteConcern`` may cause performance degradation when using ``findAndModify``. This is because ``findAndModify`` will now be honoring a potentially high latency setting where it did not before.
+
+Other commands that write
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Command helper methods for commands that write, other than those discussed above,
+MAY accept a write concern or write concern options in their parameter list.
+If the helper accepts a write concern, the driver MUST error if the selected server's MaxWireVersion < 5 and a
+write concern has explicitly been specified.
+
+Helper methods that apply the write concern inherited from the Collection or Database, SHOULD check whether the
+selected server's MaxWireVersion >= 5 and if so, include the inherited write concern in the command on the wire.
+If the selected server's MaxWireVersion < 5, these methods SHOULD silently omit the write concern from the command
+on the wire.
+
+These commands that write are:
+  * ``aggregate`` with ``$out``
+  * ``copydb``
+  * ``create``
+  * ``createIndexes``
+  * ``drop``
+  * ``dropDatabase``
+  * ``dropIndexes``
+  * ``mapReduce`` with ``$out``
+  * ``clone``
+  * ``cloneCollection``
+  * ``cloneCollectionAsCapped``
+  * ``collMod``
+  * ``convertToCapped``
+  * ``renameCollection``
+
+Errors
+~~~~~~
+
+Server errors associated with ``WriteConcern`` return successful responses with a ``writeConcernError`` field indicating the issue. For example,
+
+.. code:: typescript
+
+    rs0:PRIMARY> db.runCommand({insert: "foo", documents: [{x:1}], writeConcern: { w: "blah"}})
+    {
+        "ok" : 1,
+        "n" : 1,
+        "lastOp" : Timestamp(1441992923, 1),
+        "electionId" : ObjectId("55f30e4cffffffffffffffff"),
+        "writeConcernError" : {
+            "code" : 79,
+            "errmsg" : "No write concern mode named 'blah' found in replica set configuration"
+        }
+    }
+
+Drivers SHOULD parse server replies for a "writeConcernError" field and report the error
+only in the command-specific helper methods for commands that write, from the list above.
+For example, helper methods for "findAndModify" or "aggregate" SHOULD parse the server reply
+for "writeConcernError".
+
+Drivers SHOULD report writeConcernErrors however they report other server errors:
+by raising an exception, returning "false", or another idiom that is consistent with other server errors.
+
+Drivers SHOULD NOT parse server replies for "writeConcernError" in generic command methods.
+
+(Reporting of writeConcernErrors is more complex for bulk operations,
+see the Bulk API Spec.)
+
+Location Specification
+----------------------
+
+Via Code
+~~~~~~~~
+
+``WriteConcern`` SHOULD be specifiable at the ``Client``, ``Database``, and ``Collection`` levels. Unless specified, the value MUST be inherited from its parent and SHOULD NOT be modifiable on an existing ``Client``, ``Database``, and ``Collection``. In addition, a driver MAY allow it to be specified on a per-operation basis in accordance with the CRUD specification.
+
+For example:
+
+.. code:: typescript
+
+    var client = new MongoClient({ writeConcern: { w: 2 } });
+
+    // db1's writeConcern is {w: 2}.
+    var db1 = client.getDatabase("db1");
+
+    // col1's writeConcern is {w: 2}.
+    var col1 = db1.getCollection("col_name");
+
+    // db2's writeConcern is {journal: true}.
+    var db2 = client.getDatabase("db_name", { writeConcern: { journal: true } });
+
+    // col2's writeConcern {journal: true}.
+    var col2 = db2.getCollection("col_name");
+
+    // col3's writeConcern is the server’s default write concern.
+    var col3 = db2.getCollection("col_name", { writeConcern: { } });
+
+    // Override col3's writeConcern.
+    col3.drop({ writeConcern: { w: 3 } });
+
+
+Via Connection String
+~~~~~~~~~~~~~~~~~~~~~
+
+Options
+    * ``w`` - corresponds to ``w`` in the class definition.
+    * ``journal`` - corresponds to ``journal`` in the class definition.
+    * ``wtimeoutMS`` - corresponds to ``wtimeoutMS`` in the class definition.
+
+For example:
+
+.. code:: 
+
+    mongodb://server:27017/db?w=3
+
+    mongodb://server:27017/db?journal=true
+
+    mongodb://server:27017/db?wtimeoutMS=1000
+
+    mongodb://server:27017/db?w=majority&wtimeoutMS=1000
+
+
+
+Backwards Compatibility
+=======================
+
+There should be no backwards compatibility concerns. This specification merely deals with how to specify read and write concerns.
+
+Test Plan
+=========
+
+Yaml tests are located here: https://github.com/mongodb/specifications/tree/master/source/read-write-concern/tests
+
+Below are English descriptions of other items that should be tested:
+
+-----------
+ReadConcern
+-----------
+
+1. Commands supporting a read concern MUST raise an error when MaxWireVersion is less than 4 and a non-default, non-local read concern is specified.
+2. Commands supporting a read concern MUST NOT send the default read concern to the server.
+3. Commands supporting a read concern MUST send any non-default read concern to the server.
+
+------------
+WriteConcern
+------------
+
+1. Commands supporting a write concern MUST NOT send the default write concern to the server.
+2. Commands supporting a write concern MUST send any non-default acknowledged write concern to the server, either in the command or as a getLastError.
+3. On ServerVersion less than 2.6, drivers MUST NOT send a getLastError command for an Unacknowledged write concern.
+4. FindAndModify helper methods MUST NOT send a write concern when the MaxWireVersion is less than 4.
+5. Helper methods for other commands that write MUST NOT send a write concern when the MaxWireVersion is less than 5.
+
+Reference Implementation
+========================
+
+These are currently under construction.
+
+
+Q & A
+=====
+
+Q: Why is specifying a non-default ``ReadConcern`` for servers < 3.2 an error while a non-default write concern gets ignored in ``findAndModify``?
+  ``findAndModify`` is an existing command and since ``WriteConcern`` may be defined globally, anyone using ``findAndModify`` in their applications with a non-default ``WriteConcern`` defined globally would have all their ``findAndModify`` operations fail.
+
+Q: Why does a driver send :javascript:`{ readConcern: { level: “local” } }` to the server when that is the server’s default?
+  First, to mirror how ``WriteConcern`` already works, ``ReadConcern() does not equal ReadConcern(level=local)`` in the same way that ``WriteConcern() does not equal WriteConcern(w=1)``. This is true for ``WriteConcern`` because the server’s default could be set differently. While this setting does not currently exist for ``ReadConcern``, it is a possible eventuality and it costs a driver nothing to be prepared for it.
+  Second, it makes sense that if a user doesn’t specify a ``ReadConcern``, we don’t send one and if a user does specify a ``ReadConcern``, we do send one. If the user specifies level=”local”, for instance, we send it.
+
+Version History
+===============
+
+  - 2015-10-16: ReadConcern of local is no longer allowed to be used when talking with MaxWireVersion < 4.
+  - 2016-05-20: Added note about helpers for commands that write accepting a writeConcern parameter.
+  - 2016-06-17: Added "linearizable" to ReadConcern levels.
+  - 2016-07-15: Command-specific helper methods for commands that write SHOULD check the server's MaxWireVersion
+    and decide whether to send writeConcern.
+    Advise drivers to parse server replies for writeConcernError
+    and raise an exception if found,
+    only in command-specific helper methods that take a writeConcern parameter,
+    not in generic command methods.
+    Don't mention obscure commands with no helpers.
+  - 2016-08-06: Further clarify that command-specific helper methods for commands that write
+    take write concern options in their parameter lists, and relax from SHOULD to MAY.
+  - 2017-03-13: reIndex silently ignores writeConcern in MongoDB 3.4 and returns
+    an error if writeConcern is included with MongoDB 3.5+. See
+    `SERVER-27891 <https://jira.mongodb.org/browse/SERVER-27891>`_.
+  - 2017-11-17 : Added list of commands that support readConcern 
+  - 2017-12-18 : Added "available" to Readconcern level. 

--- a/Tests/Specs/read-write-concern/tests/README.rst
+++ b/Tests/Specs/read-write-concern/tests/README.rst
@@ -1,0 +1,67 @@
+=======================
+Connection String Tests
+=======================
+
+The YAML and JSON files in this directory tree are platform-independent tests
+that drivers can use to prove their conformance to the Read and Write Concern 
+specification.
+
+Version
+-------
+
+Files in the "specifications" repository have no version scheme. They are not
+tied to a MongoDB server version, and it is our intention that each
+specification moves from "draft" to "final" with no further versions; it is
+superseded by a future spec, not revised.
+
+However, implementers must have stable sets of tests to target. As test files
+evolve they will be occasionally tagged like "uri-tests-tests-2015-07-16", until
+the spec is final.
+
+Format
+------
+
+Connection String
+~~~~~~~~~~~~~~~~~
+
+These tests are designed to exercise the connection string parsing related
+to read concern and write concern.
+
+Each YAML file contains an object with a single ``tests`` key. This key is an
+array of test case objects, each of which have the following keys:
+
+- ``description``: A string describing the test.
+- ``uri``: A string containing the URI to be parsed.
+- ``valid:``: a boolean indicating if parsing the uri should result in an error.
+- ``writeConcern:`` A document indicating the expected write concern.
+- ``readConcern:`` A document indicating the expected read concern.
+
+If a test case includes a null value for one of these keys, or if the key is missing,
+no assertion is necessary. This both simplifies parsing of the test files and allows flexibility
+for drivers that might substitute default values *during* parsing.
+
+Document
+~~~~~~~~
+
+These tests are designed to ensure compliance with the spec in relation to what should be 
+sent to the server.
+
+Each YAML file contains an object with a single ``tests`` key. This key is an
+array of test case objects, each of which have the following keys:
+
+- ``description``: A string describing the test.
+- ``valid:``: a boolean indicating if the write concern created from the document is valid.
+- ``writeConcern:`` A document indicating the write concern to use.
+- ``writeConcernDocument:`` A document indicating the write concern to be sent to the server.
+- ``readConcern:`` A document indicating the read concern to use.
+- ``readConcernDocument:`` A document indicating the read concern to be sent to the server.
+- ``isServerDefault:`` Indicates whether the read or write concern is considered the server's default.
+- ``isAcknowledged:`` Indicates if the write concern should be considered acknowledged.
+
+Use as unit tests
+=================
+
+Testing whether a URI is valid or not should simply be a matter of checking
+whether URI parsing raises an error or exception.
+Testing for emitted warnings may require more legwork (e.g. configuring a log
+handler and watching for output).

--- a/Tests/Specs/read-write-concern/tests/connection-string/read-concern.json
+++ b/Tests/Specs/read-write-concern/tests/connection-string/read-concern.json
@@ -1,0 +1,29 @@
+{
+  "tests": [
+    {
+      "description": "Default",
+      "uri": "mongodb://localhost/",
+      "valid": true,
+      "warning": false,
+      "readConcern": {}
+    },
+    {
+      "description": "local specified",
+      "uri": "mongodb://localhost/?readConcernLevel=local",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "local"
+      }
+    },
+    {
+      "description": "majority specified",
+      "uri": "mongodb://localhost/?readConcernLevel=majority",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "majority"
+      }
+    }
+  ]
+}

--- a/Tests/Specs/read-write-concern/tests/connection-string/write-concern.json
+++ b/Tests/Specs/read-write-concern/tests/connection-string/write-concern.json
@@ -1,0 +1,118 @@
+{
+  "tests": [
+    {
+      "description": "Default",
+      "uri": "mongodb://localhost/",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {}
+    },
+    {
+      "description": "w as a valid number",
+      "uri": "mongodb://localhost/?w=1",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 1
+      }
+    },
+    {
+      "description": "w as an invalid number",
+      "uri": "mongodb://localhost/?w=-2",
+      "valid": false,
+      "warning": null
+    },
+    {
+      "description": "w as a string",
+      "uri": "mongodb://localhost/?w=majority",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": "majority"
+      }
+    },
+    {
+      "description": "wtimeoutMS as a valid number",
+      "uri": "mongodb://localhost/?wtimeoutMS=500",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "wtimeoutMS": 500
+      }
+    },
+    {
+      "description": "wtimeoutMS as an invalid number",
+      "uri": "mongodb://localhost/?wtimeoutMS=-500",
+      "valid": false,
+      "warning": null
+    },
+    {
+      "description": "journal as false",
+      "uri": "mongodb://localhost/?journal=false",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "journal": false
+      }
+    },
+    {
+      "description": "journal as true",
+      "uri": "mongodb://localhost/?journal=true",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "journal": true
+      }
+    },
+    {
+      "description": "All options combined",
+      "uri": "mongodb://localhost/?w=3&wtimeoutMS=500&journal=true",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 3,
+        "wtimeoutMS": 500,
+        "journal": true
+      }
+    },
+    {
+      "description": "Unacknowledged with w",
+      "uri": "mongodb://localhost/?w=0",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 0
+      }
+    },
+    {
+      "description": "Unacknowledged with w and journal",
+      "uri": "mongodb://localhost/?w=0&journal=false",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 0,
+        "journal": false
+      }
+    },
+    {
+      "description": "Unacknowledged with w and wtimeoutMS",
+      "uri": "mongodb://localhost/?w=0&wtimeoutMS=500",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 0,
+        "wtimeoutMS": 500
+      }
+    },
+    {
+      "description": "Acknowledged with w as 0 and journal true",
+      "uri": "mongodb://localhost/?w=0&journal=true",
+      "valid": false,
+      "warning": false,
+      "writeConcern": {
+        "w": 0,
+        "journal": true
+      }
+    }
+  ]
+}

--- a/Tests/Specs/read-write-concern/tests/document/read-concern.json
+++ b/Tests/Specs/read-write-concern/tests/document/read-concern.json
@@ -1,0 +1,33 @@
+{
+  "tests": [
+    {
+      "description": "Default",
+      "valid": true,
+      "readConcern": {},
+      "readConcernDocument": {},
+      "isServerDefault": true
+    },
+    {
+      "description": "Majority",
+      "valid": true,
+      "readConcern": {
+        "level": "majority"
+      },
+      "readConcernDocument": {
+        "level": "majority"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Local",
+      "valid": true,
+      "readConcern": {
+        "level": "local"
+      },
+      "readConcernDocument": {
+        "level": "local"
+      },
+      "isServerDefault": false
+    }
+  ]
+}

--- a/Tests/Specs/read-write-concern/tests/document/write-concern.json
+++ b/Tests/Specs/read-write-concern/tests/document/write-concern.json
@@ -1,0 +1,174 @@
+{
+  "tests": [
+    {
+      "description": "Default",
+      "valid": true,
+      "writeConcern": {},
+      "writeConcernDocument": {},
+      "isServerDefault": true,
+      "isAcknowledged": true
+    },
+    {
+      "description": "W as a number",
+      "valid": true,
+      "writeConcern": {
+        "w": 3
+      },
+      "writeConcernDocument": {
+        "w": 3
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "W as an invalid number",
+      "valid": false,
+      "writeConcern": {
+        "w": -3
+      },
+      "writeConcernDocument": null,
+      "isServerDefault": null,
+      "isAcknowledged": null
+    },
+    {
+      "description": "W as majority",
+      "valid": true,
+      "writeConcern": {
+        "w": "majority"
+      },
+      "writeConcernDocument": {
+        "w": "majority"
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "W as a custom string",
+      "valid": true,
+      "writeConcern": {
+        "w": "my_mode"
+      },
+      "writeConcernDocument": {
+        "w": "my_mode"
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "WTimeoutMS",
+      "valid": true,
+      "writeConcern": {
+        "wtimeoutMS": 1000
+      },
+      "writeConcernDocument": {
+        "wtimeout": 1000
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "WTimeoutMS as an invalid number",
+      "valid": false,
+      "writeConcern": {
+        "wtimeoutMS": -1000
+      },
+      "writeConcernDocument": null,
+      "isServerDefault": null,
+      "isAcknowledged": null
+    },
+    {
+      "description": "Journal as true",
+      "valid": true,
+      "writeConcern": {
+        "journal": true
+      },
+      "writeConcernDocument": {
+        "j": true
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "Journal as false",
+      "valid": true,
+      "writeConcern": {
+        "journal": false
+      },
+      "writeConcernDocument": {
+        "j": false
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "Unacknowledged with only w",
+      "valid": true,
+      "writeConcern": {
+        "w": 0
+      },
+      "writeConcernDocument": {
+        "w": 0
+      },
+      "isServerDefault": false,
+      "isAcknowledged": false
+    },
+    {
+      "description": "Unacknowledged with wtimeoutMS",
+      "valid": true,
+      "writeConcern": {
+        "w": 0,
+        "wtimeoutMS": 500
+      },
+      "writeConcernDocument": {
+        "w": 0,
+        "wtimeout": 500
+      },
+      "isServerDefault": false,
+      "isAcknowledged": false
+    },
+    {
+      "description": "Unacknowledged with journal",
+      "valid": true,
+      "writeConcern": {
+        "w": 0,
+        "journal": false
+      },
+      "writeConcernDocument": {
+        "w": 0,
+        "j": false
+      },
+      "isServerDefault": false,
+      "isAcknowledged": false
+    },
+    {
+      "description": "W is 0 with journal true",
+      "valid": false,
+      "writeConcern": {
+        "w": 0,
+        "journal": true
+      },
+      "writeConcernDocument": {
+        "w": 0,
+        "j": true
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "Everything",
+      "valid": true,
+      "writeConcern": {
+        "w": 3,
+        "wtimeoutMS": 1000,
+        "journal": true
+      },
+      "writeConcernDocument": {
+        "w": 3,
+        "wtimeout": 1000,
+        "j": true
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    }
+  ]
+}


### PR DESCRIPTION
- Implement `ReadConcern` type wrapping a `mongoc_read_concern_t`
- Allow `ReadConcern` to be specified when creating a `MongoClient`, `MongoDatabase`, or `MongoCollection` and for commands that support it 
- Add a new `skipFields` property to the `BsonEncodable` protocol allowing user to specify field names that should be omitted when using the default `encode(to encoder: BsonEncoder)` implementation. This is useful since we want to append `ReadConcern`s to options documents differently than the other fields.
