### PR TITLE
SWIFT-30 Implement WriteConcern type

### DIFF
--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -14,11 +14,17 @@ public struct ClientOptions: Encodable {
     /// the server's default read concern will be used.
     let readConcern: ReadConcern?
 
+    /// Specifies a WriteConcern to use for the client. If one is not specified,
+    /// the server's default write concern will be used.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing any/all to be omitted or optional
-    public init(eventMonitoring: Bool = false, readConcern: ReadConcern? = nil, retryWrites: Bool? = nil) {
+    public init(eventMonitoring: Bool = false, readConcern: ReadConcern? = nil, retryWrites: Bool? = nil,
+                writeConcern: WriteConcern? = nil) {
         self.retryWrites = retryWrites
         self.eventMonitoring = eventMonitoring
         self.readConcern = readConcern
+        self.writeConcern = writeConcern
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -50,6 +56,15 @@ public struct DatabaseOptions {
     /// A read concern to set on the retrieved database. If one is not specified,
     /// the database will inherit the client's read concern. 
     let readConcern: ReadConcern?
+
+    /// A write concern to set on the retrieved database. If one is not specified,
+    /// the database will inherit the client's write concern.
+    let writeConcern: WriteConcern?
+
+    public init(readConcern: ReadConcern? = nil, writeConcern: WriteConcern? = nil) {
+        self.readConcern = readConcern
+        self.writeConcern = writeConcern
+    }
 }
 
 /// A MongoDB Client.
@@ -69,6 +84,15 @@ public class MongoClient {
         let rcObj = ReadConcern(readConcern)
         if rcObj.isDefault { return nil }
         return rcObj
+    }
+
+    /// The write concern set on this client, or nil if one is not set.
+    public var writeConcern: WriteConcern? {
+        // per libmongoc docs, we don't need to handle freeing this ourselves
+        let writeConcern = mongoc_client_get_write_concern(self._client)
+        let wcObj = WriteConcern(writeConcern)
+        if wcObj.isDefault { return nil }
+        return wcObj
     }
 
     /**
@@ -94,6 +118,11 @@ public class MongoClient {
         // if a readConcern is provided, set it on the client
         if let rc = options?.readConcern {
             mongoc_client_set_read_concern(self._client, rc._readConcern)
+        }
+
+        // if a writeConcern is provided, set it on the client
+        if let wc = options?.writeConcern {
+            mongoc_client_set_write_concern(self._client, wc._writeConcern)
         }
 
         if options?.eventMonitoring == true { self.initializeMonitoring() }
@@ -177,6 +206,10 @@ public class MongoClient {
 
         if let rc = options?.readConcern {
             mongoc_database_set_read_concern(db, rc._readConcern)
+        }
+
+        if let wc = options?.writeConcern {
+            mongoc_database_set_write_concern(db, wc._writeConcern)
         }
 
         return MongoDatabase(fromDatabase: db, withClient: self)

--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -61,6 +61,7 @@ public struct DatabaseOptions {
     /// the database will inherit the client's write concern.
     let writeConcern: WriteConcern?
 
+    /// Convenience initializer allowing any/all arguments to be omitted or optional
     public init(readConcern: ReadConcern? = nil, writeConcern: WriteConcern? = nil) {
         self.readConcern = readConcern
         self.writeConcern = writeConcern

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -26,13 +26,16 @@ public struct AggregateOptions: Encodable {
     /// The index to use for the aggregation. The hint does not apply to $lookup and $graphLookup stages.
     // let hint: Optional<(String | Document)>
 
-    /// A `ReadConcern` to use for this operation. 
+    /// A `ReadConcern` to use in read stages of this operation.
     let readConcern: ReadConcern?
+
+    /// A `WriteConcern` to use in `$out` stages of this operation.
+    let writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(allowDiskUse: Bool? = nil, batchSize: Int32? = nil, bypassDocumentValidation: Bool? = nil,
                 collation: Document? = nil, comment: String? = nil, maxTimeMS: Int64? = nil,
-                readConcern: ReadConcern? = nil) {
+                readConcern: ReadConcern? = nil, writeConcern: WriteConcern? = nil) {
         self.allowDiskUse = allowDiskUse
         self.batchSize = batchSize
         self.bypassDocumentValidation = bypassDocumentValidation
@@ -40,9 +43,10 @@ public struct AggregateOptions: Encodable {
         self.comment = comment
         self.maxTimeMS = maxTimeMS
         self.readConcern = readConcern
+        self.writeConcern = writeConcern
     }
 
-    // Encode everything except readConcern
+    // Encode everything except readConcern and writeConcern
     private enum CodingKeys: String, CodingKey {
         case allowDiskUse, batchSize, bypassDocumentValidation,
             collation, maxTimeMS, comment
@@ -242,9 +246,18 @@ public struct InsertOneOptions: Encodable {
     /// If true, allows the write to opt-out of document level validation.
     public let bypassDocumentValidation: Bool?
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing bypassDocumentValidation to be omitted or optional
-    public init(bypassDocumentValidation: Bool? = nil) {
+    public init(bypassDocumentValidation: Bool? = nil, writeConcern: WriteConcern? = nil) {
         self.bypassDocumentValidation = bypassDocumentValidation
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case bypassDocumentValidation
     }
 }
 
@@ -258,10 +271,19 @@ public struct InsertManyOptions: Encodable {
     /// Defaults to true.
     public var ordered: Bool = true
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing any/all parameters to be omitted or optional
-    public init(bypassDocumentValidation: Bool? = nil, ordered: Bool? = true) {
+    public init(bypassDocumentValidation: Bool? = nil, ordered: Bool? = true, writeConcern: WriteConcern? = nil) {
         self.bypassDocumentValidation = bypassDocumentValidation
         if let o = ordered { self.ordered = o }
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case bypassDocumentValidation, ordered
     }
 }
 
@@ -279,13 +301,22 @@ public struct UpdateOptions: Encodable {
     /// When true, creates a new document if no document matches the query.
     public let upsert: Bool?
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing any/all parameters to be optional
     public init(arrayFilters: [Document]? = nil, bypassDocumentValidation: Bool? = nil, collation: Document? = nil,
-                upsert: Bool? = nil) {
+                upsert: Bool? = nil, writeConcern: WriteConcern? = nil) {
         self.arrayFilters = arrayFilters
         self.bypassDocumentValidation = bypassDocumentValidation
         self.collation = collation
         self.upsert = upsert
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case arrayFilters, bypassDocumentValidation, collation, upsert
     }
 }
 
@@ -300,11 +331,21 @@ public struct ReplaceOptions: Encodable {
     /// When true, creates a new document if no document matches the query.
     public let upsert: Bool?
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(bypassDocumentValidation: Bool? = nil, collation: Document? = nil, upsert: Bool? = nil) {
+    public init(bypassDocumentValidation: Bool? = nil, collation: Document? = nil, upsert: Bool? = nil,
+                writeConcern: WriteConcern? = nil) {
         self.bypassDocumentValidation = bypassDocumentValidation
         self.collation = collation
         self.upsert = upsert
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case bypassDocumentValidation, collation, upsert
     }
 }
 
@@ -313,9 +354,18 @@ public struct DeleteOptions: Encodable {
     /// Specifies a collation.
     public let collation: Document?
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
      /// Convenience initializer allowing collation to be omitted or optional
-    public init(collation: Document? = nil) {
+    public init(collation: Document? = nil, writeConcern: WriteConcern? = nil) {
         self.collation = collation
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case collation
     }
 }
 
@@ -519,7 +569,17 @@ public struct IndexOptions: Encodable {
     }
 }
 
-/// A MongoDB collection.
+public struct CreateIndexOptions {
+    /// An optional WriteConcern to use for the command
+    let writeConcern: WriteConcern?
+}
+
+public struct DropIndexOptions {
+    /// An optional WriteConcern to use for the command
+    let writeConcern: WriteConcern?
+}
+
+/// A MongoDB Collection
 public class MongoCollection<T: Codable> {
     private var _collection: OpaquePointer?
     private var _client: MongoClient?
@@ -546,6 +606,15 @@ public class MongoCollection<T: Codable> {
         let rcObj = ReadConcern(readConcern)
         if rcObj.isDefault { return nil }
         return rcObj
+    }
+
+    /// The `WriteConcern` set on this collection, or nil if one is not set.
+    public var writeConcern: WriteConcern? {
+        // per libmongoc docs, we don't need to handle freeing this ourselves
+        let writeConcern = mongoc_collection_get_write_concern(self._collection)
+        let wcObj = WriteConcern(writeConcern)
+        if wcObj.isDefault { return nil }
+        return wcObj
     }
 
     /// Initializes a new `MongoCollection` instance, not meant to be instantiated directly
@@ -604,10 +673,11 @@ public class MongoCollection<T: Codable> {
      */
     public func aggregate(_ pipeline: [Document], options: AggregateOptions? = nil) throws -> MongoCursor<Document> {
         let encoder = BsonEncoder()
-        let opts = try ReadConcern.append(options?.readConcern, to: try encoder.encode(options), callerRC: self.readConcern)
+        let withRC = try ReadConcern.append(options?.readConcern, to: try encoder.encode(options), callerRC: self.readConcern)
+        let withWC = try WriteConcern.append(options?.writeConcern, to: withRC, callerWC: self.writeConcern)
         let pipeline: Document = ["pipeline": pipeline]
         guard let cursor = mongoc_collection_aggregate(
-            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts?.data, nil) else {
+            self._collection, MONGOC_QUERY_NONE, pipeline.data, withWC?.data, nil) else {
             throw MongoError.invalidResponse()
         }
         guard let client = self._client else {
@@ -707,7 +777,7 @@ public class MongoCollection<T: Codable> {
         if document["_id"] == nil {
             try ObjectId().encode(to: document.data, forKey: "_id")
         }
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         var error = bson_error_t()
         if !mongoc_collection_insert_one(self._collection, document.data, opts?.data, nil, &error) {
             throw MongoError.commandError(message: toErrorString(error))
@@ -728,12 +798,14 @@ public class MongoCollection<T: Codable> {
      */
     public func insertMany(_ values: [CollectionType], options: InsertManyOptions? = nil) throws -> InsertManyResult? {
         let encoder = BsonEncoder()
+
         let documents = try values.map { try encoder.encode($0) }
         for doc in documents where doc["_id"] == nil {
             try ObjectId().encode(to: doc.data, forKey: "_id")
         }
         var docPointers = documents.map { UnsafePointer($0.data) }
-        let opts = try encoder.encode(options)
+
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_insert_many(
@@ -757,7 +829,7 @@ public class MongoCollection<T: Codable> {
     public func replaceOne(filter: Document, replacement: CollectionType, options: ReplaceOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
         let replacementDoc = try encoder.encode(replacement)
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_replace_one(
@@ -780,7 +852,7 @@ public class MongoCollection<T: Codable> {
      */
     public func updateOne(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_update_one(
@@ -803,7 +875,7 @@ public class MongoCollection<T: Codable> {
      */
     public func updateMany(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_update_many(
@@ -825,7 +897,7 @@ public class MongoCollection<T: Codable> {
      */
     public func deleteOne(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_delete_one(
@@ -847,7 +919,7 @@ public class MongoCollection<T: Codable> {
      */
     public func deleteMany(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_delete_many(
@@ -862,11 +934,12 @@ public class MongoCollection<T: Codable> {
      *
      * - Parameters:
      *   - model: An `IndexModel` representing the keys and options for the index
+     *   - writeConcern: Optional WriteConcern to use for the command
      *
      * - Returns: The name of the created index.
      */
-    public func createIndex(_ forModel: IndexModel) throws -> String {
-        return try createIndexes([forModel])[0]
+    public func createIndex(_ forModel: IndexModel, options: CreateIndexOptions? = nil) throws -> String {
+        return try createIndexes([forModel], options: options)[0]
     }
 
     /**
@@ -875,11 +948,13 @@ public class MongoCollection<T: Codable> {
      * - Parameters:
      *   - keys: a `Document` specifing the keys for the index
      *   - options: Optional `IndexOptions` to use for the index
+     *   - writeConcern: Optional `WriteConcern` to use for the command
      *
      * - Returns: The name of the created index
      */
-    public func createIndex(_ keys: Document, options: IndexOptions? = nil) throws -> String {
-        return try createIndex(IndexModel(keys: keys, options: options))
+    public func createIndex(_ keys: Document, options: IndexOptions? = nil,
+                            commandOptions: CreateIndexOptions? = nil) throws -> String {
+        return try createIndex(IndexModel(keys: keys, options: options), options: commandOptions)
     }
 
     /**
@@ -887,10 +962,11 @@ public class MongoCollection<T: Codable> {
      *
      * - Parameters:
      *   - models: An `[IndexModel]` specifying the indexes to create
+     *   - writeConcern: Optional `WriteConcern` to use for the command
      *
      * - Returns: An `[String]` containing the names of all the indexes that were created.
      */
-    public func createIndexes(_ forModels: [IndexModel]) throws -> [String] {
+    public func createIndexes(_ forModels: [IndexModel], options: CreateIndexOptions? = nil) throws -> [String] {
         let collName = String(cString: mongoc_collection_get_name(self._collection))
         let encoder = BsonEncoder()
         var indexData = [Document]()
@@ -908,7 +984,8 @@ public class MongoCollection<T: Codable> {
         ]
 
         var error = bson_error_t()
-        if !mongoc_collection_write_command_with_opts(self._collection, command.data, nil, nil, &error) {
+        let opts = try WriteConcern.append(options?.writeConcern, to: nil, callerWC: self.writeConcern)
+        if !mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, nil, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
@@ -920,11 +997,13 @@ public class MongoCollection<T: Codable> {
      *
      * - Parameters:
      *   - name: The name of the index to drop
+     *   - writeConcern: An optional WriteConcern to use for the command
      *
      */
-    public func dropIndex(_ name: String) throws {
+    public func dropIndex(_ name: String, options: DropIndexOptions? = nil) throws {
         var error = bson_error_t()
-        if !mongoc_collection_drop_index(self._collection, name, &error) {
+        let opts = try WriteConcern.append(options?.writeConcern, to: nil, callerWC: self.writeConcern)
+        if !mongoc_collection_drop_index_with_opts(self._collection, name, opts?.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
     }
@@ -935,43 +1014,49 @@ public class MongoCollection<T: Codable> {
      * - Parameters:
      *   - keys: a `Document` containing the keys for the index to drop
      *   - options: Optional `IndexOptions` the dropped index should match
+     *   - writeConcern: An optional `WriteConcern` to use for the command
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
-    public func dropIndex(_ keys: Document, options: IndexOptions? = nil) throws -> Document {
-        return try dropIndex(IndexModel(keys: keys, options: options))
+    public func dropIndex(_ keys: Document, options: IndexOptions? = nil,
+                            commandOptions: DropIndexOptions? = nil) throws -> Document {
+        return try dropIndex(IndexModel(keys: keys, options: options), options: commandOptions)
     }
 
     /**
      * Attempts to drop a single index from the collection given an `IndexModel` describing it.
      *
      * - Parameters:
-     *   - model: The model describing the index to drop
+     *   - model: An `IndexModel` describing the index to drop
+     *   - writeConcern: An optional `WriteConcern` to use for the command
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
-    public func dropIndex(_ model: IndexModel) throws -> Document {
-        return try _dropIndexes(keys: model.keys)
+    public func dropIndex(_ model: IndexModel, options: DropIndexOptions? = nil) throws -> Document {
+        return try _dropIndexes(keys: model.keys, options: options)
     }
 
     /**
      * Drops all indexes in the collection.
+     * 
+     * - Parameters:
+    *   - writeConcern: An optional `WriteConcern` to use for the command
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
-    public func dropIndexes() throws -> Document {
-        return try _dropIndexes()
+    public func dropIndexes(options: DropIndexOptions? = nil) throws -> Document {
+        return try _dropIndexes(options: options)
     }
 
-    private func _dropIndexes(keys: Document? = nil) throws -> Document {
+    private func _dropIndexes(keys: Document? = nil, options: DropIndexOptions? = nil) throws -> Document {
         let collName = String(cString: mongoc_collection_get_name(self._collection))
         let command: Document = ["dropIndexes": collName, "index": keys ?? "*"]
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_write_command_with_opts(self._collection, command.data, nil, reply.data, &error) {
+        let opts = try WriteConcern.append(options?.writeConcern, to: nil, callerWC: self.writeConcern)
+        if !mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
-
         return reply
     }
 

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -581,7 +581,7 @@ public struct DropIndexOptions {
     let writeConcern: WriteConcern?
 }
 
-/// A MongoDB Collection
+/// A MongoDB collection.
 public class MongoCollection<T: Codable> {
     private var _collection: OpaquePointer?
     private var _client: MongoClient?

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -569,13 +569,15 @@ public struct IndexOptions: Encodable {
     }
 }
 
+/// Options to use when creating a new index on a `MongoCollection`.
 public struct CreateIndexOptions {
-    /// An optional WriteConcern to use for the command
+    /// An optional `WriteConcern` to use for the command
     let writeConcern: WriteConcern?
 }
 
+/// Options to use when dropping an index from a `MongoCollection`.
 public struct DropIndexOptions {
-    /// An optional WriteConcern to use for the command
+    /// An optional `WriteConcern` to use for the command
     let writeConcern: WriteConcern?
 }
 

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -130,12 +130,11 @@ public struct CollectionOptions {
     /// the collection will inherit the database's write concern.
     let writeConcern: WriteConcern?
 
+    /// Convenience initializer allowing any/all arguments to be omitted or optional
     public init(readConcern: ReadConcern? = nil, writeConcern: WriteConcern? = nil) {
         self.readConcern = readConcern
         self.writeConcern = writeConcern
     }
-
-    public var skipFields: [String] { return ["readConcern", "writeConcern"] }
 }
 
 /// A MongoDB Database

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -23,6 +23,7 @@ public enum MongoError {
     case typeError(message: String)
     /// Thrown when there is an error involving a `ReadConcern`. 
     case readConcernError(message: String)
+    /// Thrown when there is an error involving a `WriteConcern`. 
     case writeConcernError(message: String)
 }
 

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -23,6 +23,7 @@ public enum MongoError {
     case typeError(message: String)
     /// Thrown when there is an error involving a `ReadConcern`. 
     case readConcernError(message: String)
+    case writeConcernError(message: String)
 }
 
 /// An extension of `MongoError` to support printing out descriptive error messages.
@@ -32,7 +33,8 @@ extension MongoError: LocalizedError {
         case let .invalidUri(message), let .invalidCursor(message),
             let .invalidCollection(message), let .commandError(message),
             let .bsonParseError(_, _, message), let .bsonEncodeError(message),
-            let .typeError(message):
+            let .typeError(message), let .readConcernError(message),
+            let .writeConcernError(message):
             return message
         default:
             return nil

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -115,5 +115,134 @@ public class ReadConcern: Equatable, CustomStringConvertible {
         mongoc_read_concern_destroy(readConcern)
         self._readConcern = nil
     }
+}
 
+/// A class to represent a MongoDB write concern.
+public class WriteConcern: Equatable, CustomStringConvertible {
+
+    /// A pointer to a mongoc_write_concern_t
+    internal var _writeConcern: OpaquePointer?
+
+    // Indicates whether to wait for the write operation to get committed to the journal.
+    public var journal: Bool? {
+        return mongoc_write_concern_get_journal(self._writeConcern)
+    }
+
+    // Specifies the number of nodes that should acknowledge the write.
+    // MUST be greater than or equal to 0. Only one of this and wTags may be set.
+    public var w: Int32? {
+        return mongoc_write_concern_get_w(self._writeConcern)
+    }
+
+    // Indicates a tag for nodes that should acknowledge the write. Only one of this and w may be set.
+    public var wTag: String? {
+        guard let wTag = mongoc_write_concern_get_wtag(self._writeConcern) else { return nil }
+        return String(cString: wTag)
+    }
+
+    /// If the write concern is not satisfied within this timeout (in milliseconds),
+    /// the operation will return an error. The value MUST be greater than or equal to 0.
+    public var wtimeoutMS: Int32? {
+        return mongoc_write_concern_get_wtimeout(self._writeConcern)
+    }
+
+    /// Indicates whether this is an acknowledged write concern.
+    public var isAcknowledged: Bool {
+        return mongoc_write_concern_is_acknowledged(self._writeConcern)
+    }
+
+    /// Indicates whether this is the default write concern.
+    public var isDefault: Bool {
+        return mongoc_write_concern_is_default(self._writeConcern)
+    }
+
+    /// Indicates whether the combination of values set on this WriteConcern is valid.
+    public var isValid: Bool {
+        return mongoc_write_concern_is_valid(self._writeConcern)
+    }
+
+    private var asDocument: Document {
+        let doc = Document()
+        try? self.append(to: doc)
+        return doc
+    }
+
+    public var description: String {
+        return self.asDocument.description
+    }
+
+    /// Initializes a new, empty WriteConcern
+    public init() {
+        self._writeConcern = mongoc_write_concern_new()
+    }
+
+    /// Initializes a WriteConcern. Only one of w and wTag should be provided.
+    public init(journal: Bool? = nil, w: Int32? = nil, wTag: String? = nil, wtimeoutMS: Int32? = nil) {
+        self._writeConcern = mongoc_write_concern_new()
+        self.setJournal(journal)
+        self.setW(w)
+        self.setWTag(wTag)
+        self.setWTimeoutMS(wtimeoutMS)
+    }
+
+    /// Initializes a new WriteConcern by copying a mongoc_write_concern_t.
+    /// The caller is responsible for freeing the original mongoc_write_concern_t.
+    internal init(_ writeConcern: OpaquePointer?) {
+        self._writeConcern = mongoc_write_concern_copy(writeConcern)
+    }
+
+    /// Sets the journal value on this writeConcern
+    private func setJournal(_ journal: Bool?) {
+        if let journal = journal { mongoc_write_concern_set_journal(self._writeConcern, journal) }
+    }
+
+    /// Sets the wTag value on this writeConcern
+    private func setWTag(_ wTag: String?) {
+        if let wTag = wTag { mongoc_write_concern_set_wtag(self._writeConcern, wTag) }
+    }
+
+    /// Sets the wtimeoutMS value on this writeConcern
+    private func setWTimeoutMS(_ wtimeoutMS: Int32?) {
+        if let wtimeoutMS = wtimeoutMS { mongoc_write_concern_set_wtimeout(self._writeConcern, wtimeoutMS) }
+    }
+
+    /// Sets the w value on this writeConcern
+    private func setW(_ w: Int32?) {
+        if let w = w { mongoc_write_concern_set_w(self._writeConcern, w) }
+    }
+
+    /// Appends this writeConcern to a Document.
+    private func append(to doc: Document) throws {
+        if !mongoc_write_concern_append(self._writeConcern, doc.data) {
+            throw MongoError.writeConcernError(message: "Error appending WriteConcern to document \(doc)")
+        }
+    }
+
+    /// Since we have to follow certain rules about whether to include or omit a WriteConcern,
+    /// this function handles obeying those, factoring in the WriteConcern, if any, for
+    /// whatever object is calling this function. It returns a final options Document for the
+    /// calling function to use, or nil if the Document ends up being empty.
+    internal static func append(_ writeConcern: WriteConcern?, to opts: Document?, callerWC: WriteConcern?) throws -> Document? {
+        // if the user didn't specify a writeConcern, then we just want to use
+        // whatever the default is for the caller.
+        guard let wc = writeConcern else { return opts }
+
+        // the caller is using the server's default WC and we are also using default, don't append anything
+        if callerWC == nil && wc.isDefault { return opts }
+
+        // otherwise either us or the caller is using a non-default, so we need to append it
+        let output = opts ?? Document() // create base opts if they don't exist
+        try wc.append(to: output)
+        return output
+    }
+
+    public static func == (lhs: WriteConcern, rhs: WriteConcern) -> Bool {
+        return lhs.asDocument == rhs.asDocument
+    }
+
+    deinit {
+        guard let writeConcern = self._writeConcern else { return }
+        mongoc_write_concern_destroy(writeConcern)
+        self._writeConcern = nil
+    }
 }

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -176,39 +176,20 @@ public class WriteConcern: Equatable, CustomStringConvertible {
         self._writeConcern = mongoc_write_concern_new()
     }
 
-    /// Initializes a WriteConcern. Only one of w and wTag should be provided.
+    /// Initializes a WriteConcern. Only one of `w` and `wTag` should be provided. If both are supplied,
+    /// `wTag` will be used.
     public init(journal: Bool? = nil, w: Int32? = nil, wTag: String? = nil, wtimeoutMS: Int32? = nil) {
         self._writeConcern = mongoc_write_concern_new()
-        self.setJournal(journal)
-        self.setW(w)
-        self.setWTag(wTag)
-        self.setWTimeoutMS(wtimeoutMS)
+        if let journal = journal { mongoc_write_concern_set_journal(self._writeConcern, journal) }
+        if let w = w { mongoc_write_concern_set_w(self._writeConcern, w) }
+        if let wTag = wTag { mongoc_write_concern_set_wtag(self._writeConcern, wTag) }
+        if let wtimeoutMS = wtimeoutMS { mongoc_write_concern_set_wtimeout(self._writeConcern, wtimeoutMS) }
     }
 
     /// Initializes a new WriteConcern by copying a mongoc_write_concern_t.
     /// The caller is responsible for freeing the original mongoc_write_concern_t.
     internal init(_ writeConcern: OpaquePointer?) {
         self._writeConcern = mongoc_write_concern_copy(writeConcern)
-    }
-
-    /// Sets the journal value on this writeConcern
-    private func setJournal(_ journal: Bool?) {
-        if let journal = journal { mongoc_write_concern_set_journal(self._writeConcern, journal) }
-    }
-
-    /// Sets the wTag value on this writeConcern
-    private func setWTag(_ wTag: String?) {
-        if let wTag = wTag { mongoc_write_concern_set_wtag(self._writeConcern, wTag) }
-    }
-
-    /// Sets the wtimeoutMS value on this writeConcern
-    private func setWTimeoutMS(_ wtimeoutMS: Int32?) {
-        if let wtimeoutMS = wtimeoutMS { mongoc_write_concern_set_wtimeout(self._writeConcern, wtimeoutMS) }
-    }
-
-    /// Sets the w value on this writeConcern
-    private func setW(_ w: Int32?) {
-        if let w = w { mongoc_write_concern_set_w(self._writeConcern, w) }
     }
 
     /// Appends this writeConcern to a Document.

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -123,18 +123,18 @@ public class WriteConcern: Equatable, CustomStringConvertible {
     /// A pointer to a mongoc_write_concern_t
     internal var _writeConcern: OpaquePointer?
 
-    // Indicates whether to wait for the write operation to get committed to the journal.
+    /// Indicates whether to wait for the write operation to get committed to the journal.
     public var journal: Bool? {
         return mongoc_write_concern_get_journal(self._writeConcern)
     }
 
-    // Specifies the number of nodes that should acknowledge the write.
-    // MUST be greater than or equal to 0. Only one of this and wTags may be set.
+    /// Specifies the number of nodes that should acknowledge the write.
+    /// MUST be greater than or equal to 0. Only one of this and wTags may be set.
     public var w: Int32? {
         return mongoc_write_concern_get_w(self._writeConcern)
     }
 
-    // Indicates a tag for nodes that should acknowledge the write. Only one of this and w may be set.
+    /// Indicates a tag for nodes that should acknowledge the write. Only one of this and w may be set.
     public var wTag: String? {
         guard let wTag = mongoc_write_concern_get_wtag(self._writeConcern) else { return nil }
         return String(cString: wTag)

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -84,87 +84,92 @@ final class ReadWriteConcernTests: XCTestCase {
     }
 
     func testClientReadConcern() throws {
-        // create a client with no options and check its RC
-        let client1 = try MongoClient()
-        // expect the readConcern property to exist with a nil level
-        expect(client1.readConcern).to(beNil())
 
-        // expect that a DB created from this client inherits its unset RC 
-        let db1 = try client1.db("test")
-        expect(db1.readConcern).to(beNil())
+        let majority = ReadConcern(.majority)
 
-        // expect that a DB created from this client can override the client's unset RC
-        let db2 = try client1.db("test", options: DatabaseOptions(readConcern: ReadConcern(.majority)))
-        expect(db2.readConcern?.level).to(equal("majority"))
+        // test behavior of a client with initialized with no RC
+        do {
+            let client = try MongoClient()
+            // expect the readConcern property to exist with a nil level
+            expect(client.readConcern).to(beNil())
 
-        client1.close()
+            // expect that a DB created from this client inherits its unset RC 
+            let db1 = try client.db("test")
+            expect(db1.readConcern).to(beNil())
 
-        // create a client with local read concern and check its RC
-        let client2 = try MongoClient(options: ClientOptions(readConcern: ReadConcern(.local)))
-        // although local is default, if it is explicitly provided it should be set
-        expect(client2.readConcern?.level).to(equal("local"))
+            // expect that a DB created from this client can override the client's unset RC
+            let db2 = try client.db("test", options: DatabaseOptions(readConcern: majority))
+            expect(db2.readConcern?.level).to(equal("majority"))
+        }
 
-        // expect that a DB created from this client inherits its local RC 
-        let db3 = try client2.db("test")
-        expect(db3.readConcern?.level).to(equal("local"))
+        // test behavior of a client initialized with local RC
+        do {
+            let client = try MongoClient(options: ClientOptions(readConcern: ReadConcern(.local)))
+            // although local is default, if it is explicitly provided it should be set
+            expect(client.readConcern?.level).to(equal("local"))
 
-        // expect that a DB created from this client can override the client's local RC
-        let db4 = try client2.db("test", options: DatabaseOptions(readConcern: ReadConcern(.majority)))
-        expect(db4.readConcern?.level).to(equal("majority"))
+            // expect that a DB created from this client inherits its local RC 
+            let db1 = try client.db("test")
+            expect(db1.readConcern?.level).to(equal("local"))
 
-        client2.close()
+            // expect that a DB created from this client can override the client's local RC
+            let db2 = try client.db("test", options: DatabaseOptions(readConcern: majority))
+            expect(db2.readConcern?.level).to(equal("majority"))
+        }
 
-        // create a client with majority read concern and check its RC
-        let client3 = try MongoClient(options: ClientOptions(readConcern: ReadConcern(.majority)))
-        expect(client3.readConcern?.level).to(equal("majority"))
+        // test behavior of a client initialized with majority RC
+        do {
+            let client = try MongoClient(options: ClientOptions(readConcern: majority))
+            expect(client.readConcern?.level).to(equal("majority"))
 
-        // expect that a DB created from this client can override the client's majority RC with an unset one
-        let db5 = try client3.db("test", options: DatabaseOptions(readConcern: ReadConcern()))
-        expect(db5.readConcern).to(beNil())
-
-        client3.close()
+            // expect that a DB created from this client can override the client's majority RC with an unset one
+            let db = try client.db("test", options: DatabaseOptions(readConcern: ReadConcern()))
+            expect(db.readConcern).to(beNil())
+        }
     }
 
     func testClientWriteConcern() throws {
-        // create a client with no options and check its RC
-        let client1 = try MongoClient()
-        // expect the readConcern property to exist and be default
-        expect(client1.writeConcern).to(beNil())
+        let w2 = WriteConcern(w: 2)
 
-        // expect that a DB created from this client inherits its default WC
-        let db1 = try client1.db("test")
-        expect(db1.writeConcern).to(beNil())
+        // test behavior of a client with initialized with no WC
+        do {
+            let client1 = try MongoClient()
+            // expect the readConcern property to exist and be default
+            expect(client1.writeConcern).to(beNil())
 
-        // expect that a DB created from this client can override the client's default WC
-        let db2 = try client1.db("test", options: DatabaseOptions(writeConcern: WriteConcern(w: 2)))
-        expect(db2.writeConcern?.w).to(equal(2))
+            // expect that a DB created from this client inherits its default WC
+            let db1 = try client1.db("test")
+            expect(db1.writeConcern).to(beNil())
 
-        client1.close()
+            // expect that a DB created from this client can override the client's default WC
+            let db2 = try client1.db("test", options: DatabaseOptions(writeConcern: w2))
+            expect(db2.writeConcern?.w).to(equal(2))
+        }
 
-        // create a client with w: 1 and check its WC
-        let client2 = try MongoClient(options: ClientOptions(writeConcern: WriteConcern(w: 1)))
-        // although w:1 is default, if it is explicitly provided it should be set
-        expect(client2.writeConcern?.w).to(equal(1))
+        // test behavior of a client with w: 1
+        do {
+            let client2 = try MongoClient(options: ClientOptions(writeConcern: WriteConcern(w: 1)))
+            // although w:1 is default, if it is explicitly provided it should be set
+            expect(client2.writeConcern?.w).to(equal(1))
 
-        // expect that a DB created from this client inherits its WC
-        let db3 = try client2.db("test")
-        expect(db3.writeConcern?.w).to(equal(1))
+            // expect that a DB created from this client inherits its WC
+            let db3 = try client2.db("test")
+            expect(db3.writeConcern?.w).to(equal(1))
 
-        // expect that a DB created from this client can override the client's WC
-        let db4 = try client2.db("test", options: DatabaseOptions(writeConcern: WriteConcern(w: 2)))
-        expect(db4.writeConcern?.w).to(equal(2))
+            // expect that a DB created from this client can override the client's WC
+            let db4 = try client2.db("test", options: DatabaseOptions(writeConcern: w2))
+            expect(db4.writeConcern?.w).to(equal(2))
+        }
 
-        client2.close()
+        // test behavior of a client with w: 2
+        do {
+            let client3 = try MongoClient(options: ClientOptions(writeConcern: w2))
+            expect(client3.writeConcern?.w).to(equal(2))
 
-        // create a client with w:2 and check its WC
-        let client3 = try MongoClient(options: ClientOptions(writeConcern: WriteConcern(w: 2)))
-        expect(client3.writeConcern?.w).to(equal(2))
-
-        // expect that a DB created from this client can override the client's WC with an unset one
-        let db5 = try client3.db("test", options: DatabaseOptions(writeConcern: WriteConcern()))
-        expect(db5.writeConcern).to(beNil())
-
-        client3.close()
+            // expect that a DB created from this client can override the client's WC with an unset one
+            let db5 = try client3.db("test", options: DatabaseOptions(writeConcern: WriteConcern()))
+            expect(db5.writeConcern).to(beNil())
+        }
     }
 
     func testDatabaseReadConcern() throws {

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -2,15 +2,49 @@
 import Nimble
 import XCTest
 
-import libmongoc
+extension WriteConcern {
+    /// Initialize a new ReadConcern from a Document.
+    fileprivate convenience init(_ doc: Document) {
+        let wtag = doc["w"] as? String
+        let w = doc["w"] as? Int
+
+        // can be stored under either "j" or "journal"
+        var jToUse: Bool? = nil
+        if let j = doc["journal"] as? Bool {
+            jToUse = j
+        } else if let j = doc["j"] as? Bool {
+            jToUse = j
+        }
+
+        // can be stored under either "wtimeout" or "wtimeoutMS"
+        var wtToUse: Int32? = nil
+        if let wt = doc["wtimeoutMS"] as? Int {
+            wtToUse = Int32(wt)
+        } else if let wt = doc["wtimeout"] as? Int {
+            wtToUse = Int32(wt)
+        }
+
+        if wtag != nil {
+            self.init(journal: jToUse, wTag: wtag, wtimeoutMS: wtToUse)
+        } else {
+            self.init(journal: jToUse, w: w != nil ? Int32(w!) : nil, wtimeoutMS: wtToUse)
+        }
+    }
+}
 
 final class ReadWriteConcernTests: XCTestCase {
     static var allTests: [(String, (ReadWriteConcernTests) -> () throws -> Void)] {
         return [
             ("testReadConcernType", testReadConcernType),
+            ("testWriteConcernType", testWriteConcernType),
             ("testClientReadConcern", testClientReadConcern),
+            ("testClientWriteConcern", testClientWriteConcern),
             ("testDatabaseReadConcern", testDatabaseReadConcern),
-            ("testOperationReadConcerns", testOperationReadConcerns)
+            ("testDatabaseWriteConcern", testDatabaseWriteConcern),
+            ("testOperationReadConcerns", testOperationReadConcerns),
+            ("testOperationWriteConcerns", testOperationReadConcerns),
+            ("testConnectionStrings", testConnectionStrings),
+            ("testDocuments", testDocuments)
         ]
     }
 
@@ -35,6 +69,18 @@ final class ReadWriteConcernTests: XCTestCase {
         let rc4 = ReadConcern(["level": "majority"])
         expect(rc4.level).to(equal("majority"))
 
+    }
+
+    func testWriteConcernType() throws {
+        // try creating write concerns with various valid options
+        expect(WriteConcern(w: 0).isValid).to(beTrue())
+        expect(WriteConcern(w: 3).isValid).to(beTrue())
+        expect(WriteConcern(journal: true, w: 1).isValid).to(beTrue())
+        expect(WriteConcern(w: 0, wtimeoutMS: 1000).isValid).to(beTrue())
+        expect(WriteConcern(wTag: "hi").isValid).to(beTrue())
+
+        // verify that this combination is considered invalid
+        expect(WriteConcern(journal: true, w: 0).isValid).to(beFalse())
     }
 
     func testClientReadConcern() throws {
@@ -79,11 +125,53 @@ final class ReadWriteConcernTests: XCTestCase {
         client3.close()
     }
 
+    func testClientWriteConcern() throws {
+        // create a client with no options and check its RC
+        let client1 = try MongoClient()
+        // expect the readConcern property to exist and be default
+        expect(client1.writeConcern).to(beNil())
+
+        // expect that a DB created from this client inherits its default WC
+        let db1 = try client1.db("test")
+        expect(db1.writeConcern).to(beNil())
+
+        // expect that a DB created from this client can override the client's default WC
+        let db2 = try client1.db("test", options: DatabaseOptions(writeConcern: WriteConcern(w: 2)))
+        expect(db2.writeConcern?.w).to(equal(2))
+
+        client1.close()
+
+        // create a client with w: 1 and check its WC
+        let client2 = try MongoClient(options: ClientOptions(writeConcern: WriteConcern(w: 1)))
+        // although w:1 is default, if it is explicitly provided it should be set
+        expect(client2.writeConcern?.w).to(equal(1))
+
+        // expect that a DB created from this client inherits its WC
+        let db3 = try client2.db("test")
+        expect(db3.writeConcern?.w).to(equal(1))
+
+        // expect that a DB created from this client can override the client's WC
+        let db4 = try client2.db("test", options: DatabaseOptions(writeConcern: WriteConcern(w: 2)))
+        expect(db4.writeConcern?.w).to(equal(2))
+
+        client2.close()
+
+        // create a client with w:2 and check its WC
+        let client3 = try MongoClient(options: ClientOptions(writeConcern: WriteConcern(w: 2)))
+        expect(client3.writeConcern?.w).to(equal(2))
+
+        // expect that a DB created from this client can override the client's WC with an unset one
+        let db5 = try client3.db("test", options: DatabaseOptions(writeConcern: WriteConcern()))
+        expect(db5.writeConcern).to(beNil())
+
+        client3.close()
+    }
+
     func testDatabaseReadConcern() throws {
         let client = try MongoClient()
 
         let db1 = try client.db("test")
-        defer {try? db1.drop() }
+        defer { try? db1.drop() }
 
         // expect that a collection created from a DB with unset RC also has unset RC
         var coll1 = try db1.createCollection("coll1")
@@ -123,6 +211,50 @@ final class ReadWriteConcernTests: XCTestCase {
         expect(coll4.readConcern?.level).to(equal("majority"))
     }
 
+    func testDatabaseWriteConcern() throws {
+        let client = try MongoClient()
+
+        let db1 = try client.db("test")
+        defer { try? db1.drop() }
+
+        // expect that a collection created from a DB with default WC also has default WC
+        var coll1 = try db1.createCollection("coll1")
+        expect(coll1.writeConcern).to(beNil())
+
+        // expect that a collection retrieved from a DB with default WC also has default WC
+        coll1 = try db1.collection("coll1")
+        expect(coll1.writeConcern).to(beNil())
+
+        // expect that a collection created from a DB with default WC can override the DB's WC
+        var coll2 = try db1.createCollection("coll2", options: CreateCollectionOptions(writeConcern: WriteConcern(w: 1)))
+        expect(coll2.writeConcern?.w).to(equal(1))
+
+        // expect that a collection retrieved from a DB with default WC can override the DB's WC
+        coll2 = try db1.collection("coll2", options: CollectionOptions(writeConcern: WriteConcern(w: 1)))
+        expect(coll2.writeConcern?.w).to(equal(1))
+
+        try db1.drop()
+
+        let db2 = try client.db("test", options: DatabaseOptions(writeConcern: WriteConcern(w: 1)))
+        defer { try? db2.drop() }
+
+        // expect that a collection created from a DB with w:1 also has w:1
+        var coll3 = try db2.createCollection("coll3")
+        expect(coll3.writeConcern?.w).to(equal(1))
+
+        // expect that a collection retrieved from a DB with w:1 also has w:1
+        coll3 = try db2.collection("coll3")
+        expect(coll3.writeConcern?.w).to(equal(1))
+
+        // expect that a collection created from a DB with w:1 can override the DB's WC
+        var coll4 = try db2.createCollection("coll4", options: CreateCollectionOptions(writeConcern: WriteConcern(w: 2)))
+        expect(coll4.writeConcern?.w).to(equal(2))
+
+        // expect that a collection retrieved from a DB with w:1 can override the DB's WC
+        coll4 = try db2.collection("coll4", options: CollectionOptions(writeConcern: WriteConcern(w: 2)))
+        expect(coll4.writeConcern?.w).to(equal(2))
+    }
+
     func testOperationReadConcerns() throws {
         // setup a collection 
         let client = try MongoClient()
@@ -158,6 +290,67 @@ final class ReadWriteConcernTests: XCTestCase {
             options: DistinctOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
     }
 
+    func testOperationWriteConcerns() throws {
+        let client = try MongoClient()
+        let db = try client.db("test")
+        defer { try? db.drop() }
+
+        var counter = 0
+        func nextDoc() -> Document {
+            defer { counter += 1 }
+            return ["x": counter]
+        }
+
+        let coll = try db.createCollection("coll1")
+        let wc1 = WriteConcern(w: 1)
+        let wc2 =  WriteConcern()
+        let wc3 = WriteConcern(journal: true)
+
+        let command: Document = ["insert": "coll1", "documents": [nextDoc()] as [Document]]
+
+        // run command with a valid writeConcern
+        let options1 = RunCommandOptions(writeConcern: wc1)
+        let res1 = try db.runCommand(command, options: options1)
+        expect(res1["ok"] as? Double).to(equal(1.0))
+
+        // run command with an empty writeConcern
+        let options2 = RunCommandOptions(writeConcern: wc2)
+        let res2 = try db.runCommand(command, options: options2)
+        expect(res2["ok"] as? Double).to(equal(1.0))
+
+        expect(try coll.insertOne(nextDoc(), options: InsertOneOptions(writeConcern: wc1))).toNot(throwError())
+        expect(try coll.insertOne(nextDoc(), options: InsertOneOptions(writeConcern: wc3))).toNot(throwError())
+
+        expect(try coll.insertMany([nextDoc(), nextDoc()], options: InsertManyOptions(writeConcern: wc1))).toNot(throwError())
+        expect(try coll.insertMany([nextDoc(), nextDoc()], options: InsertManyOptions(writeConcern: wc3))).toNot(throwError())
+
+        expect(try coll.updateOne(filter: ["x": 1], update: ["$set": nextDoc()], options: UpdateOptions(writeConcern: wc2))).toNot(throwError())
+        expect(try coll.updateOne(filter: ["x": 2], update: ["$set": nextDoc()], options: UpdateOptions(writeConcern: wc3))).toNot(throwError())
+
+        expect(try coll.updateMany(filter: ["x": 3], update: ["$set": nextDoc()], options: UpdateOptions(writeConcern: wc2))).toNot(throwError())
+        expect(try coll.updateMany(filter: ["x": 4], update: ["$set": nextDoc()], options: UpdateOptions(writeConcern: wc3))).toNot(throwError())
+
+        let coll2 = try db.createCollection("coll2")
+        defer { try? coll2.drop() }
+        let pipeline: [Document] = [["$out": "test.coll2"]]
+        expect(try coll.aggregate(pipeline, options: AggregateOptions(writeConcern: wc1))).toNot(throwError())
+
+        expect(try coll.replaceOne(filter: ["x": 5], replacement: nextDoc(), options: ReplaceOptions(writeConcern: wc1))).toNot(throwError())
+        expect(try coll.replaceOne(filter: ["x": 6], replacement: nextDoc(), options: ReplaceOptions(writeConcern: wc3))).toNot(throwError())
+
+        expect(try coll.deleteOne(["x": 7], options: DeleteOptions(writeConcern: wc1))).toNot(throwError())
+        expect(try coll.deleteOne(["x": 8], options: DeleteOptions(writeConcern: wc3))).toNot(throwError())
+
+        expect(try coll.deleteMany(["x": 9], options: DeleteOptions(writeConcern: wc1))).toNot(throwError())
+        expect(try coll.deleteMany(["x": 10], options: DeleteOptions(writeConcern: wc3))).toNot(throwError())
+
+        expect(try coll.createIndex(["x": 1], commandOptions: CreateIndexOptions(writeConcern: wc1))).toNot(throwError())
+        expect(try coll.createIndexes([IndexModel(keys: ["x": -1])], options: CreateIndexOptions(writeConcern: wc3))).toNot(throwError())
+
+        expect(try coll.dropIndex(["x": 1], commandOptions: DropIndexOptions(writeConcern: wc1))).toNot(throwError())
+        expect(try coll.dropIndexes(options: DropIndexOptions(writeConcern: wc3))).toNot(throwError())
+    }
+
     func testConnectionStrings() throws {
         let csPath = "\(self.getSpecsPath())/read-write-concern/tests/connection-string"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: csPath).filter { $0.hasSuffix(".json") }
@@ -181,7 +374,12 @@ final class ReadWriteConcernTests: XCTestCase {
                             expect(client.readConcern).to(equal(rc))
                         }
                     } else if let writeConcern = test["writeConcern"] as? Document {
-                        // TODO SWIFT-30: verify the writeconcern matches that on the client
+                        let wc = WriteConcern(writeConcern)
+                        if wc.isDefault {
+                            expect(client.writeConcern).to(beNil())
+                        } else {
+                            expect(client.writeConcern).to(equal(wc))
+                        }
                     }
                 } else {
                     expect(try MongoClient(connectionString: uri)).to(throwError())
@@ -207,7 +405,13 @@ final class ReadWriteConcernTests: XCTestCase {
                     let rcToSend = ReadConcern(test["readConcernDocument"] as! Document)
                     expect(rcToSend).to(equal(rc))
                 } else if let wcToUse = test["writeConcern"] as? Document {
-                    // TODO SWIFT-30: encode the write concern and confirm it matches the expected one
+                    if valid {
+                        let wc = WriteConcern(wcToUse)
+                        let wcToSend = WriteConcern(test["writeConcernDocument"] as! Document)
+                        expect(wcToSend).to(equal(wc))
+                    } else {
+                        expect(WriteConcern(wcToUse).isValid).to(beFalse())
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is on top of the `ReadConcern` implementation so I don't expect you to review it til that's merged in, but just moving this into review for the sake of our tracking where I'm at work-wise. 

Anyway, pretty straightforward, this adds a `WriteConcern` type and adds support for specifying WC at the client, database, collection, and operation level.