### PR TITLE
SWIFT-85: Add a custom RegularExpression type

### DIFF
--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -575,12 +575,12 @@ struct RegularExpression: BsonValue, Equatable {
         guard let pattern = bson_iter_regex(&iter, options) else {
             preconditionFailure("Failed to retrieve regular expression pattern")
         }
-        let patternStr = String(cString: pattern)
+        let patternString = String(cString: pattern)
 
         guard let stringOptions = options.pointee else {
             preconditionFailure("Failed to retrieve regular expression options")
         }
-        let optionsStr = String(cString: stringOptions)
+        let optionsString = String(cString: stringOptions)
 
         return RegularExpression(pattern: patternStr, options: optionsStr)
     }

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -588,7 +588,7 @@ struct RegularExpression: BsonValue, Equatable {
     }
 
     // Creates an NSRegularExpression with the specified pattern and options.
-    public var asNSRegularExpression: NSRegularExpression {
+    public var nsRegularExpression: NSRegularExpression {
         let opts = NSRegularExpression.optionsFromString(self.options)
         do {
             return try NSRegularExpression(pattern: self.pattern, options: opts)

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -549,11 +549,13 @@ struct RegularExpression: BsonValue, Equatable {
     public let pattern: String
     public let options: String
 
+    /// Initializes a new RegularExpression
     public init(pattern: String, options: String) {
         self.pattern = pattern
         self.options = String(options.sorted())
     }
 
+    /// Initializes a new RegularExpression with the pattern and options of the provided NSRegularExpression
     public init(from regex: NSRegularExpression) {
         self.pattern = regex.pattern
         self.options = regex.stringOptions
@@ -582,7 +584,7 @@ struct RegularExpression: BsonValue, Equatable {
         }
         let optionsString = String(cString: stringOptions)
 
-        return RegularExpression(pattern: patternStr, options: optionsStr)
+        return RegularExpression(pattern: patternString, options: optionsString)
     }
 
     // Creates an NSRegularExpression with the specified pattern and options.

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -139,7 +139,7 @@ final class DocumentTests: XCTestCase {
         let regex = doc["regex"] as? RegularExpression
 
         expect(regex).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
-        expect(regex?.asNSRegularExpression).to(equal(try NSRegularExpression(pattern: "^abc", options: NSRegularExpression.optionsFromString("imx"))))
+        expect(regex?.nsRegularExpression).to(equal(try NSRegularExpression(pattern: "^abc", options: NSRegularExpression.optionsFromString("imx"))))
 
         expect(doc["array1"] as? [Int]).to(equal([1, 2]))
         expect(doc["array2"] as? [String]).to(equal(["string1", "string2"]))

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -84,11 +84,6 @@ final class DocumentTests: XCTestCase {
             return
         }
 
-        // Since the NSRegularExpression constructor can throw, create the
-        // regex separately first
-        let opts = NSRegularExpression.optionsFromString("imx")
-        let regex = try NSRegularExpression(pattern: "^abc", options: opts)
-
         // Set up test document values
         let doc: Document = [
             "string": "test string",
@@ -106,7 +101,7 @@ final class DocumentTests: XCTestCase {
             "nestedarray": [[1, 2], [Int32(3), Int32(4)]] as [[Int32]],
             "nesteddoc": ["a": 1, "b": 2, "c": false, "d": [3, 4]] as Document,
             "oid": ObjectId(fromString: "507f1f77bcf86cd799439011"),
-            "regex": regex,
+            "regex": RegularExpression(pattern: "^abc", options: "imx"),
             "array1": [1, 2],
             "array2": ["string1", "string2"],
             "null": nil,
@@ -140,11 +135,7 @@ final class DocumentTests: XCTestCase {
         expect(doc["date"] as? Date).to(equal(Date(timeIntervalSince1970: 5000)))
         expect(doc["timestamp"] as? Timestamp).to(equal(Timestamp(timestamp: 5, inc: 10)))
         expect(doc["oid"] as? ObjectId).to(equal(ObjectId(fromString: "507f1f77bcf86cd799439011")))
-
-        let regexReturned = doc["regex"] as? NSRegularExpression
-        expect(regexReturned?.pattern).to(equal("^abc"))
-        expect(regexReturned?.stringOptions).to(equal("imx"))
-
+        expect(doc["regex"] as? RegularExpression).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
         expect(doc["array1"] as? [Int]).to(equal([1, 2]))
         expect(doc["array2"] as? [String]).to(equal(["string1", "string2"]))
         expect(doc["null"]).to(beNil())

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -135,7 +135,12 @@ final class DocumentTests: XCTestCase {
         expect(doc["date"] as? Date).to(equal(Date(timeIntervalSince1970: 5000)))
         expect(doc["timestamp"] as? Timestamp).to(equal(Timestamp(timestamp: 5, inc: 10)))
         expect(doc["oid"] as? ObjectId).to(equal(ObjectId(fromString: "507f1f77bcf86cd799439011")))
-        expect(doc["regex"] as? RegularExpression).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
+
+        let regex = doc["regex"] as? RegularExpression
+
+        expect(regex).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
+        expect(regex?.asNSRegularExpression).to(equal(try NSRegularExpression(pattern: "^abc", options: NSRegularExpression.optionsFromString("imx"))))
+
         expect(doc["array1"] as? [Int]).to(equal([1, 2]))
         expect(doc["array2"] as? [String]).to(equal(["string1", "string2"]))
         expect(doc["null"]).to(beNil())


### PR DESCRIPTION
As we discussed earlier, this is necessary if we want all BSON types to be `Codable`. 