### PR TITLE
SWIFT-77 Rewrite BsonEncoder to conform to Encoder protocol 

### DIFF
--- a/Sources/MongoSwift/BSON/BsonDecoder.swift
+++ b/Sources/MongoSwift/BSON/BsonDecoder.swift
@@ -539,7 +539,7 @@ extension _BsonDecoder: SingleValueDecodingContainer {
     public func decode(_ type: String.Type) throws -> String { return try decodeBsonType(type) }
 }
 
-private struct _BsonKey: CodingKey {
+internal struct _BsonKey: CodingKey {
     public var stringValue: String
     public var intValue: Int?
 
@@ -558,12 +558,12 @@ private struct _BsonKey: CodingKey {
         self.intValue = intValue
     }
 
-    fileprivate init(index: Int) {
+    internal init(index: Int) {
         self.stringValue = "Index \(index)"
         self.intValue = index
     }
 
-    fileprivate static let `super` = _BsonKey(stringValue: "super")!
+    internal static let `super` = _BsonKey(stringValue: "super")!
 }
 
 private extension DecodingError {
@@ -576,17 +576,11 @@ private extension DecodingError {
         let description = "Expected to find a value that can be represented as a \(expectation), " +
                          "but found value \(String(describing: reality)) of type \(type(of: reality)) instead."
         return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
-
     }
 }
 
 /// This needs to be in this file to access some fileprivate decoder properties
 extension Document: Decodable {
-
-    static let decodeToTypes: [Decodable.Type] = [Double.self, String.self, Binary.self, ObjectId.self,
-                                                    Bool.self, Date.self, RegularExpression.self,
-                                                    CodeWithScope.self, Int.self, Int32.self, Int64.self,
-                                                    Decimal128.self, MinKey.self, MaxKey.self, Document.self]
 
     public init(from decoder: Decoder) throws {
         // if it's a BsonDecoder we should just short-circuit and return the container document

--- a/Sources/MongoSwift/BSON/BsonEncoderNew.swift
+++ b/Sources/MongoSwift/BSON/BsonEncoderNew.swift
@@ -1,0 +1,647 @@
+import Foundation
+import libmongoc
+
+/// `BSONEncoder` facilitates the encoding of `Encodable` values into BSON.
+public class BSONEncoder {
+
+    /// Contextual user-provided information for use during encoding.
+    public var userInfo: [CodingUserInfoKey: Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the encoding hierarchy.
+    fileprivate struct _Options {
+        let userInfo: [CodingUserInfoKey: Any]
+    }
+
+    /// The options set on the top-level encoder.
+    fileprivate var options: _Options {
+        return _Options(userInfo: userInfo)
+    }
+
+    /// Initializes `self`.
+    public init() {}
+
+    /// Encodes the given top-level value and returns its BSON representation.
+    ///
+    /// - parameter value: The value to encode.
+    /// - returns: A new `Document` containing the encoded BSON data.
+    /// - throws: An error if any value throws an error during encoding.
+    public func encode<T: Encodable>(_ value: T) throws -> Document {
+        let encoder = _BSONEncoder(options: self.options)
+        guard let topLevel = try encoder.box(value) else {
+            throw EncodingError.invalidValue(value,
+                EncodingError.Context(codingPath: [],
+                    debugDescription: "Top-level \(T.self) did not encode any values."))
+        }
+
+        guard let dict = topLevel as? MutableDictionary else {
+            throw EncodingError.invalidValue(value,
+                EncodingError.Context(codingPath: [],
+                    debugDescription: "Top-level \(T.self) was not encoded as a complete document."))
+        }
+
+        return dict.asDocument()
+    }
+}
+
+/// A private class to implement the `Encoder` protocol.
+private class _BSONEncoder: Encoder {
+
+    /// The encoder's storage.
+    fileprivate var storage: _BSONEncodingStorage
+
+    /// Options set on the top-level encoder.
+    fileprivate let options: BSONEncoder._Options
+
+    /// The path to the current point in encoding.
+    public var codingPath: [CodingKey]
+
+    /// Contextual user-provided information for use during encoding.
+    public var userInfo: [CodingUserInfoKey: Any] {
+        return self.options.userInfo
+    }
+
+    /// Initializes `self` with the given top-level encoder options.
+    fileprivate init(options: BSONEncoder._Options, codingPath: [CodingKey] = []) {
+        self.options = options
+        self.storage = _BSONEncodingStorage()
+        self.codingPath = codingPath
+    }
+
+    /// Returns whether a new element can be encoded at this coding path.
+    ///
+    /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
+    fileprivate var canEncodeNewValue: Bool {
+        return self.storage.count == self.codingPath.count
+    }
+
+    public func container<Key>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> {
+        // If an existing keyed container was already requested, return that one.
+        let topContainer: MutableDictionary
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushKeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? MutableDictionary else {
+                preconditionFailure(
+                    "Attempt to push new keyed encoding container when already previously encoded at this path.")
+            }
+            topContainer = container
+        }
+        let container = _BSONKeyedEncodingContainer<Key>(
+            referencing: self, codingPath: self.codingPath, wrapping: topContainer)
+        return KeyedEncodingContainer(container)
+    }
+
+    public func unkeyedContainer() -> UnkeyedEncodingContainer {
+        // If an existing unkeyed container was already requested, return that one.
+        let topContainer: MutableArray
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushUnkeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? MutableArray else {
+                preconditionFailure(
+                    "Attempt to push new unkeyed encoding container when already previously encoded at this path.")
+            }
+            topContainer = container
+        }
+
+        return _BSONUnkeyedEncodingContainer(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
+    }
+
+    public func singleValueContainer() -> SingleValueEncodingContainer {
+        return self
+    }
+}
+
+private struct _BSONEncodingStorage {
+
+    /// The container stack.
+    /// Elements may be any BsonValue type.
+    fileprivate var containers: [BsonValue?] = []
+
+    /// Initializes `self` with no containers.
+    fileprivate init() {}
+
+    fileprivate var count: Int {
+        return self.containers.count
+    }
+
+    fileprivate mutating func pushKeyedContainer() -> MutableDictionary {
+        let dictionary = MutableDictionary()
+        self.containers.append(dictionary)
+        return dictionary
+    }
+
+    fileprivate mutating func pushUnkeyedContainer() -> MutableArray {
+        let array = MutableArray()
+        self.containers.append(array)
+        return array
+    }
+
+    fileprivate mutating func push(container: BsonValue?) {
+        self.containers.append(container)
+    }
+
+    fileprivate mutating func popContainer() -> BsonValue? {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        return self.containers.popLast()!
+    }
+}
+
+/// _BsonReferencingEncoder is a special subclass of _BsonEncoder which has its own storage, but references the 
+/// contents of a different encoder. It's used in superEncoder(), which returns a new encoder for encoding a 
+/// superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't 
+// necessarily know when it's done being used (to write to the original container).
+private class _BsonReferencingEncoder: _BSONEncoder {
+
+    /// The type of container we're referencing.
+    private enum Reference {
+        /// Referencing a specific index in an array container.
+        case array(MutableArray, Int)
+
+        /// Referencing a specific key in a dictionary container.
+        case dictionary(MutableDictionary, String)
+    }
+
+    /// The encoder we're referencing.
+    fileprivate let encoder: _BSONEncoder
+
+    /// The container reference itself.
+    private let reference: Reference
+
+    fileprivate init(referencing encoder: _BSONEncoder, at index: Int, wrapping array: MutableArray) {
+        self.encoder = encoder
+        self.reference = .array(array, index)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
+
+        self.codingPath.append(_BsonKey(index: index))
+    }
+
+    /// Initializes `self` by referencing the given dictionary container in the given encoder.
+    fileprivate init(referencing encoder: _BSONEncoder, key: CodingKey, wrapping dictionary: MutableDictionary) {
+        self.encoder = encoder
+        self.reference = .dictionary(dictionary, key.stringValue)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
+
+        self.codingPath.append(key)
+    }
+
+    fileprivate override var canEncodeNewValue: Bool {
+        // With a regular encoder, the storage and coding path grow together.
+        // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
+        // We have to take this into account.
+        return self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1
+    }
+
+    /// Finalizes `self` by writing the contents of our storage to the referenced encoder's storage.
+    deinit {
+        let value: BsonValue?
+        switch self.storage.count {
+        case 0: value = nil
+        case 1: value = self.storage.popContainer()
+        default: fatalError("Referencing encoder deallocated with multiple containers on stack.")
+        }
+
+        switch self.reference {
+        case .array(let array, let index):
+            array.insert(value, at: index)
+
+        case .dictionary(let dictionary, let key):
+            dictionary[key] = value
+        }
+    }
+
+}
+
+/// Extend _BSONEncoder to add methods for "boxing" values.
+extension _BSONEncoder {
+
+    /// Converts a `CodableNumber` to a `BsonValue` type. Throws if `value` cannot be 
+    /// exactly represented by an `Int`, `Int32`, `Int64`, or `Double`. 
+    fileprivate func boxNumber<T: CodableNumber>(_ value: T) throws -> BsonValue {
+        guard let number = value.bsonValue else {
+            throw EncodingError._numberError(at: self.codingPath, value: value)
+        }
+        return number
+    }
+
+    fileprivate func box<T: Encodable>(_ value: T) throws -> BsonValue? {
+
+        // if it's already a BsonValue, just return it, unless if it is an 
+        // array. technically [Any] is a BsonValue, but we can only use this
+        // short-circuiting if all the elements are actually BsonValues.
+        if let bsonValue = value as? BsonValue, !(bsonValue is [Any]) {
+            return bsonValue
+        } else if let bsonArray = value as? [BsonValue?] {
+            return bsonArray
+        }
+
+        // The value should request a container from the _BSONEncoder.
+        let depth = self.storage.count
+        do {
+            try value.encode(to: self)
+        } catch {
+            // If the value pushed a container before throwing, pop it back off to restore state.
+            if self.storage.count > depth { _ = self.storage.popContainer() }
+            throw error
+        }
+
+        // The top container should be a new container.
+        guard self.storage.count > depth else { return nil }
+        return self.storage.popContainer()
+    }
+}
+
+private struct _BSONKeyedEncodingContainer<K: CodingKey> : KeyedEncodingContainerProtocol {
+    typealias Key = K
+
+    /// A reference to the encoder we're writing to.
+    private let encoder: _BSONEncoder
+
+    /// A reference to the container we're writing to.
+    private let container: MutableDictionary
+
+    /// The path of coding keys taken to get to this point in encoding.
+    private(set) public var codingPath: [CodingKey]
+
+    /// Initializes `self` with the given references.
+    fileprivate init(referencing encoder: _BSONEncoder, codingPath: [CodingKey], wrapping container: MutableDictionary) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+        self.container = container
+    }
+
+    public mutating func encodeNil(forKey key: Key) throws { self.container[key.stringValue] = nil }
+    public mutating func encode(_ value: Bool, forKey key: Key) throws { self.container[key.stringValue] = value }
+    public mutating func encode(_ value: Int, forKey key: Key) throws { self.container[key.stringValue] = value }
+    public mutating func encode(_ value: Int8, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
+    public mutating func encode(_ value: Int16, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
+    public mutating func encode(_ value: Int32, forKey key: Key) throws { self.container[key.stringValue] = value }
+    public mutating func encode(_ value: Int64, forKey key: Key) throws { self.container[key.stringValue] = value }
+    public mutating func encode(_ value: UInt, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
+    public mutating func encode(_ value: UInt8, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
+    public mutating func encode(_ value: UInt16, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
+    public mutating func encode(_ value: UInt32, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
+    public mutating func encode(_ value: UInt64, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
+    public mutating func encode(_ value: String, forKey key: Key) throws { self.container[key.stringValue] = value }
+    public mutating func encode(_ value: Float, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
+    public mutating func encode(_ value: Double, forKey key: Key) throws { self.container[key.stringValue] = value }
+
+    private mutating func encodeNumber<T: CodableNumber>(_ value: T, forKey key: Key) throws {
+        // put the key on the codingPath in case the attempt to convert the number fails and we throw
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+        self.container[key.stringValue] = try encoder.boxNumber(value)
+    }
+
+    public mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+        self.container[key.stringValue] = try encoder.box(value)
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        let dictionary = MutableDictionary()
+        self.container[key.stringValue] = dictionary
+
+        self.codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+
+        let container = _BSONKeyedEncodingContainer<NestedKey>(
+            referencing: self.encoder, codingPath: self.codingPath, wrapping: dictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        let array = MutableArray()
+        self.container[key.stringValue] = array
+
+        self.codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+
+        return _BSONUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: array)
+    }
+
+    public mutating func superEncoder() -> Encoder {
+        return _BsonReferencingEncoder(referencing: self.encoder, key: _BsonKey.super, wrapping: self.container)
+
+    }
+
+    public mutating func superEncoder(forKey key: Key) -> Encoder {
+        return _BsonReferencingEncoder(referencing: self.encoder, key: key, wrapping: self.container)
+    }
+}
+
+private struct _BSONUnkeyedEncodingContainer: UnkeyedEncodingContainer {
+
+    /// A reference to the encoder we're writing to.
+    private let encoder: _BSONEncoder
+
+    /// A reference to the container we're writing to.
+    private let container: MutableArray
+
+    /// The path of coding keys taken to get to this point in encoding.
+    private(set) public var codingPath: [CodingKey]
+
+    /// The number of elements encoded into the container.
+    public var count: Int {
+        return self.container.count
+    }
+
+    /// Initializes `self` with the given references.
+    fileprivate init(referencing encoder: _BSONEncoder, codingPath: [CodingKey], wrapping container: MutableArray) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+        self.container = container
+    }
+
+    public mutating func encodeNil() throws { self.container.add(nil) }
+    public mutating func encode(_ value: Bool) throws { self.container.add(value) }
+    public mutating func encode(_ value: Int) throws { self.container.add(value) }
+    public mutating func encode(_ value: Int8) throws { try self.encodeNumber(value) }
+    public mutating func encode(_ value: Int16) throws { try self.encodeNumber(value) }
+    public mutating func encode(_ value: Int32) throws { self.container.add(value) }
+    public mutating func encode(_ value: Int64) throws { self.container.add(value) }
+    public mutating func encode(_ value: UInt) throws { try self.encodeNumber(value) }
+    public mutating func encode(_ value: UInt8) throws { try self.encodeNumber(value) }
+    public mutating func encode(_ value: UInt16) throws { try self.encodeNumber(value) }
+    public mutating func encode(_ value: UInt32) throws { try self.encodeNumber(value) }
+    public mutating func encode(_ value: UInt64) throws { try self.encodeNumber(value) }
+    public mutating func encode(_ value: String) throws { self.container.add(value) }
+    public mutating func encode(_ value: Float) throws { try self.encodeNumber(value) }
+    public mutating func encode(_ value: Double) throws { self.container.add(value) }
+
+    private mutating func encodeNumber<T: CodableNumber>(_ value: T) throws {
+        self.encoder.codingPath.append(_BsonKey(index: self.count))
+        defer { self.encoder.codingPath.removeLast() }
+
+        self.container.add(try encoder.boxNumber(value))
+    }
+
+    public mutating func encode<T: Encodable>(_ value: T) throws {
+        self.encoder.codingPath.append(_BsonKey(index: self.count))
+        defer { self.encoder.codingPath.removeLast() }
+
+        self.container.add(try encoder.box(value))
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+        self.codingPath.append(_BsonKey(index: self.count))
+        defer { self.codingPath.removeLast() }
+
+        let dictionary = MutableDictionary()
+        self.container.add(dictionary)
+
+        let container = _BSONKeyedEncodingContainer<NestedKey>(
+            referencing: self.encoder, codingPath: self.codingPath, wrapping: dictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        self.codingPath.append(_BsonKey(index: self.count))
+        defer { self.codingPath.removeLast() }
+
+        let array = MutableArray()
+        self.container.add(array)
+        return _BSONUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: array)
+    }
+
+    public mutating func superEncoder() -> Encoder {
+         return _BsonReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
+    }
+}
+
+extension _BSONEncoder: SingleValueEncodingContainer {
+
+    private func assertCanEncodeNewValue() {
+        precondition(self.canEncodeNewValue,
+            "Attempt to encode value through single value container when previously value already encoded.")
+    }
+
+    public func encodeNil() throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: nil)
+    }
+
+    public func encode(_ value: Bool) throws { try self.encodeBsonType(value) }
+    public func encode(_ value: Int) throws { try self.encodeBsonType(value) }
+    public func encode(_ value: Int8) throws { try self.encodeNumber(value) }
+    public func encode(_ value: Int16) throws { try self.encodeNumber(value) }
+    public func encode(_ value: Int32) throws { try self.encodeBsonType(value) }
+    public func encode(_ value: Int64) throws { try self.encodeBsonType(value) }
+    public func encode(_ value: UInt) throws { try self.encodeNumber(value) }
+    public func encode(_ value: UInt8) throws { try self.encodeNumber(value) }
+    public func encode(_ value: UInt16) throws { try self.encodeNumber(value) }
+    public func encode(_ value: UInt32) throws { try self.encodeNumber(value) }
+    public func encode(_ value: UInt64) throws { try self.encodeNumber(value) }
+    public func encode(_ value: String) throws { try self.encodeBsonType(value) }
+    public func encode(_ value: Float) throws { try self.encodeNumber(value) }
+    public func encode(_ value: Double) throws { try self.encodeBsonType(value) }
+
+    private func encodeNumber<T: CodableNumber>(_ value: T) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: try self.boxNumber(value))
+    }
+
+    private func encodeBsonType<T: BsonValue>(_ value: T) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: value)
+    }
+
+    public func encode<T: Encodable>(_ value: T) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: try self.box(value))
+    }
+}
+
+/// A private class wrapping a Swift array so we can pass it by reference for 
+/// encoder storage purposes. We use this rather than NSMutableArray because
+/// it allows us to preserve Swift type information. 
+private class MutableArray: BsonValue {
+
+    var bsonType: BsonType { return .array }
+
+    var array = [BsonValue?]()
+
+    fileprivate func add(_ value: BsonValue?) {
+        array.append(value)
+    }
+
+    var count: Int { return array.count }
+
+    /// Converts self to a `Document` where keys "0", "1", etc.
+    /// correspond to array indices. 
+    func asDocument() -> Document {
+        var doc = Document()
+        for (i, v) in array.enumerated() {
+            doc[String(i)] = v
+        }
+        return doc
+    }
+
+    func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
+        try self.array.encode(to: data, forKey: key)
+    }
+
+    static func from(iter: inout bson_iter_t) -> BsonValue {
+        return [BsonValue].from(iter: &iter)
+    }
+
+    func insert(_ value: BsonValue?, at index: Int) {
+        self.array.insert(value, at: index)
+    }
+}
+
+/// A private class wrapping a Swift dictionary so we can pass it by reference
+/// for encoder storage purposes. We use this rather than NSMutableDictionary 
+/// because it allows us to preserve Swift type information.
+private class MutableDictionary: BsonValue {
+
+    var bsonType: BsonType { return .document }
+
+    // rather than using a dictionary, do this so we preserve key orders
+    var keys = [String]()
+    var values = [BsonValue?]()
+
+    subscript(key: String) -> BsonValue? {
+        get {
+            guard let index = keys.index(of: key) else { return nil }
+            return values[index]
+        }
+        set(newValue) {
+            keys.append(key)
+            values.append(newValue)
+        }
+    }
+
+    /// Converts self to a `Document` with equivalent key-value pairs.
+    func asDocument() -> Document {
+        var doc = Document()
+        for i in 0 ..< keys.count {
+            doc[keys[i]] = values[i]
+        }
+        return doc
+    }
+
+    func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
+        try self.asDocument().encode(to: data, forKey: key)
+    }
+
+    static func from(iter: inout bson_iter_t) -> BsonValue {
+        return Document.from(iter: &iter)
+    }
+}
+
+private extension EncodingError {
+    static func _numberError<T: CodableNumber>(at path: [CodingKey], value: T) -> EncodingError {
+        let description = "Value \(String(describing: value)) of type \(type(of: value)) cannot be " +
+                            "exactly represented by a BSON number type (Int, Int32, Int64 or Double)."
+        return .invalidValue(value, Context(codingPath: path, debugDescription: description))
+    }
+}
+
+extension Document: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        if let bsonEncoder = encoder as? _BSONEncoder {
+            bsonEncoder.storage.containers.append(self)
+            return
+        }
+
+        var container = encoder.container(keyedBy: _BsonKey.self)
+        for (k, v) in self {
+            try Document.recursivelyEncodeKeyed(v, forKey: k, to: &container)
+        }
+    }
+
+    private static func recursivelyEncodeKeyed(_ value: BsonValue?, forKey key: String, to container: inout KeyedEncodingContainer<_BsonKey>) throws {
+        let k = _BsonKey(stringValue: key)!
+        switch value {
+        case let val as [BsonValue?]:
+            var nested = container.nestedUnkeyedContainer(forKey: k)
+            for v in val {
+                try Document.recursivelyEncodeUnkeyed(v, to: &nested)
+            }
+        case let val as Binary:
+            try container.encode(val, forKey: k)
+        case let val as Bool:
+            try container.encode(val, forKey: k)
+        case let val as Date:
+            try container.encode(val, forKey: k)
+        case let val as Decimal128:
+            try container.encode(val, forKey: k)
+        case let val as Document:
+            var nested = container.nestedContainer(keyedBy: _BsonKey.self, forKey: k)
+            for (nestedK, nestedV) in val {
+                try Document.recursivelyEncodeKeyed(nestedV, forKey: nestedK, to: &nested)
+            }
+        case let val as Double:
+            try container.encode(val, forKey: k)
+        case let val as Int:
+            try container.encode(val, forKey: k)
+        case let val as Int32:
+            try container.encode(val, forKey: k)
+        case let val as Int64:
+            try container.encode(val, forKey: k)
+        case let val as CodeWithScope:
+            try container.encode(val, forKey: k)
+        case let val as MaxKey:
+            try container.encode(val, forKey: k)
+        case let val as MinKey:
+            try container.encode(val, forKey: k)
+        case let val as ObjectId:
+            try container.encode(val, forKey: k)
+        case let val as String:
+            try container.encode(val, forKey: k)
+        case nil:
+            try container.encodeNil(forKey: k)
+        default:
+            throw MongoError.typeError(message: "Encountered a non-encodable type in a Document: \(type(of: value))")
+        }
+    }
+
+    private static func recursivelyEncodeUnkeyed(_ value: BsonValue?, to container: inout UnkeyedEncodingContainer) throws {
+        switch value {
+        case let val as [BsonValue]:
+            var nested = container.nestedUnkeyedContainer()
+            for v in val {
+                try Document.recursivelyEncodeUnkeyed(v, to: &nested)
+            }
+        case let val as Binary:
+            try container.encode(val)
+        case let val as Bool:
+            try container.encode(val)
+        case let val as Date:
+            try container.encode(val)
+        case let val as Decimal128:
+            try container.encode(val)
+        case let val as Document:
+            var nested = container.nestedContainer(keyedBy: _BsonKey.self)
+            for (nestedK, nestedV) in val {
+                try Document.recursivelyEncodeKeyed(nestedV, forKey: nestedK, to: &nested)
+            }
+        case let val as Double:
+            try container.encode(val)
+        case let val as Int:
+            try container.encode(val)
+        case let val as Int32:
+            try container.encode(val)
+        case let val as Int64:
+            try container.encode(val)
+        case let val as CodeWithScope:
+            try container.encode(val)
+        case let val as MaxKey:
+            try container.encode(val)
+        case let val as MinKey:
+            try container.encode(val)
+        case let val as ObjectId:
+            try container.encode(val)
+        case let val as String:
+            try container.encode(val)
+        case nil:
+             try container.encodeNil()
+        default:
+            throw MongoError.typeError(message: "Encountered a non-encodable type in a Document: \(type(of: value))")
+        }
+    }
+}

--- a/Sources/MongoSwift/BSON/BsonEncoderNew.swift
+++ b/Sources/MongoSwift/BSON/BsonEncoderNew.swift
@@ -43,11 +43,11 @@ public class BSONEncoder {
     }
 }
 
-/// A private class to implement the `Encoder` protocol.
-private class _BSONEncoder: Encoder {
+/// An internal class to implement the `Encoder` protocol.
+internal class _BSONEncoder: Encoder {
 
     /// The encoder's storage.
-    fileprivate var storage: _BSONEncodingStorage
+    internal var storage: _BSONEncodingStorage
 
     /// Options set on the top-level encoder.
     fileprivate let options: BSONEncoder._Options
@@ -114,11 +114,11 @@ private class _BSONEncoder: Encoder {
     }
 }
 
-private struct _BSONEncodingStorage {
+internal struct _BSONEncodingStorage {
 
     /// The container stack.
     /// Elements may be any BsonValue type.
-    fileprivate var containers: [BsonValue?] = []
+    internal var containers: [BsonValue?] = []
 
     /// Initializes `self` with no containers.
     fileprivate init() {}
@@ -538,110 +538,5 @@ private extension EncodingError {
         let description = "Value \(String(describing: value)) of type \(type(of: value)) cannot be " +
                             "exactly represented by a BSON number type (Int, Int32, Int64 or Double)."
         return .invalidValue(value, Context(codingPath: path, debugDescription: description))
-    }
-}
-
-extension Document: Encodable {
-    public func encode(to encoder: Encoder) throws {
-        if let bsonEncoder = encoder as? _BSONEncoder {
-            bsonEncoder.storage.containers.append(self)
-            return
-        }
-
-        var container = encoder.container(keyedBy: _BsonKey.self)
-        for (k, v) in self {
-            try Document.recursivelyEncodeKeyed(v, forKey: k, to: &container)
-        }
-    }
-
-    private static func recursivelyEncodeKeyed(_ value: BsonValue?, forKey key: String, to container: inout KeyedEncodingContainer<_BsonKey>) throws {
-        let k = _BsonKey(stringValue: key)!
-        switch value {
-        case let val as [BsonValue?]:
-            var nested = container.nestedUnkeyedContainer(forKey: k)
-            for v in val {
-                try Document.recursivelyEncodeUnkeyed(v, to: &nested)
-            }
-        case let val as Binary:
-            try container.encode(val, forKey: k)
-        case let val as Bool:
-            try container.encode(val, forKey: k)
-        case let val as Date:
-            try container.encode(val, forKey: k)
-        case let val as Decimal128:
-            try container.encode(val, forKey: k)
-        case let val as Document:
-            var nested = container.nestedContainer(keyedBy: _BsonKey.self, forKey: k)
-            for (nestedK, nestedV) in val {
-                try Document.recursivelyEncodeKeyed(nestedV, forKey: nestedK, to: &nested)
-            }
-        case let val as Double:
-            try container.encode(val, forKey: k)
-        case let val as Int:
-            try container.encode(val, forKey: k)
-        case let val as Int32:
-            try container.encode(val, forKey: k)
-        case let val as Int64:
-            try container.encode(val, forKey: k)
-        case let val as CodeWithScope:
-            try container.encode(val, forKey: k)
-        case let val as MaxKey:
-            try container.encode(val, forKey: k)
-        case let val as MinKey:
-            try container.encode(val, forKey: k)
-        case let val as ObjectId:
-            try container.encode(val, forKey: k)
-        case let val as String:
-            try container.encode(val, forKey: k)
-        case nil:
-            try container.encodeNil(forKey: k)
-        default:
-            throw MongoError.typeError(message: "Encountered a non-encodable type in a Document: \(type(of: value))")
-        }
-    }
-
-    private static func recursivelyEncodeUnkeyed(_ value: BsonValue?, to container: inout UnkeyedEncodingContainer) throws {
-        switch value {
-        case let val as [BsonValue]:
-            var nested = container.nestedUnkeyedContainer()
-            for v in val {
-                try Document.recursivelyEncodeUnkeyed(v, to: &nested)
-            }
-        case let val as Binary:
-            try container.encode(val)
-        case let val as Bool:
-            try container.encode(val)
-        case let val as Date:
-            try container.encode(val)
-        case let val as Decimal128:
-            try container.encode(val)
-        case let val as Document:
-            var nested = container.nestedContainer(keyedBy: _BsonKey.self)
-            for (nestedK, nestedV) in val {
-                try Document.recursivelyEncodeKeyed(nestedV, forKey: nestedK, to: &nested)
-            }
-        case let val as Double:
-            try container.encode(val)
-        case let val as Int:
-            try container.encode(val)
-        case let val as Int32:
-            try container.encode(val)
-        case let val as Int64:
-            try container.encode(val)
-        case let val as CodeWithScope:
-            try container.encode(val)
-        case let val as MaxKey:
-            try container.encode(val)
-        case let val as MinKey:
-            try container.encode(val)
-        case let val as ObjectId:
-            try container.encode(val)
-        case let val as String:
-            try container.encode(val)
-        case nil:
-             try container.encodeNil()
-        default:
-            throw MongoError.typeError(message: "Encountered a non-encodable type in a Document: \(type(of: value))")
-        }
     }
 }

--- a/Sources/MongoSwift/BSON/BsonEncoderNew.swift
+++ b/Sources/MongoSwift/BSON/BsonEncoderNew.swift
@@ -470,16 +470,6 @@ private class MutableArray: BsonValue {
 
     var count: Int { return array.count }
 
-    /// Converts self to a `Document` where keys "0", "1", etc.
-    /// correspond to array indices. 
-    func asDocument() -> Document {
-        var doc = Document()
-        for (i, v) in array.enumerated() {
-            doc[String(i)] = v
-        }
-        return doc
-    }
-
     func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
         try self.array.encode(to: data, forKey: key)
     }

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -423,7 +423,7 @@ extension Int64: BsonValue {
 }
 
 /// A struct to represent the BSON Code and CodeWithScope types.
-public struct CodeWithScope: BsonValue, Codable, Equatable {
+public struct CodeWithScope: BsonValue, Equatable, Codable {
     /// A string containing Javascript code.
     public let code: String
     /// An optional scope `Document` containing a mapping of identifiers to values,

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -159,7 +159,7 @@ extension Array: BsonValue {
 }
 
 /// Subtypes for BSON Binary values.
-public enum BsonSubtype: Int, Decodable {
+public enum BsonSubtype: Int, Codable {
     /// Generic binary subtype
     case binary = 0,
     /// A function
@@ -177,7 +177,7 @@ public enum BsonSubtype: Int, Decodable {
 }
 
 /// A struct to represent the BSON Binary type.
-public struct Binary: BsonValue, Equatable, Decodable {
+public struct Binary: BsonValue, Equatable, Codable {
 
     public var bsonType: BsonType { return .binary }
 
@@ -323,7 +323,7 @@ internal struct DBPointer: BsonValue {
 }
 
 /// A struct to represent the BSON Decimal128 type.
-public struct Decimal128: BsonValue, Equatable, Decodable {
+public struct Decimal128: BsonValue, Equatable, Codable {
     /// This number, represented as a `String`.
     public let data: String
 
@@ -423,7 +423,7 @@ extension Int64: BsonValue {
 }
 
 /// A struct to represent the BSON Code and CodeWithScope types.
-public struct CodeWithScope: BsonValue, Decodable, Equatable {
+public struct CodeWithScope: BsonValue, Codable, Equatable {
     /// A string containing Javascript code.
     public let code: String
     /// An optional scope `Document` containing a mapping of identifiers to values,
@@ -480,7 +480,7 @@ public struct CodeWithScope: BsonValue, Decodable, Equatable {
 }
 
 /// A struct to represent the BSON MaxKey type.
-public struct MaxKey: BsonValue, Equatable, Decodable {
+public struct MaxKey: BsonValue, Equatable, Codable {
     private var maxKey = 1
 
     public var bsonType: BsonType { return .maxKey }
@@ -496,7 +496,7 @@ public struct MaxKey: BsonValue, Equatable, Decodable {
 }
 
 /// A struct to represent the BSON MinKey type.
-public struct MinKey: BsonValue, Equatable, Decodable {
+public struct MinKey: BsonValue, Equatable, Codable {
     private var minKey = 1
 
     public var bsonType: BsonType { return .minKey }
@@ -512,7 +512,7 @@ public struct MinKey: BsonValue, Equatable, Decodable {
 }
 
 /// A struct to represent the BSON ObjectId type.
-public struct ObjectId: BsonValue, Equatable, CustomStringConvertible, Decodable {
+public struct ObjectId: BsonValue, Equatable, CustomStringConvertible, Codable {
 
     public var bsonType: BsonType { return .objectId }
 
@@ -603,7 +603,7 @@ extension NSRegularExpression {
 }
 
 /// A struct to represent a BSON regular expression.
-struct RegularExpression: BsonValue, Equatable, Decodable {
+struct RegularExpression: BsonValue, Equatable, Codable {
 
     public var bsonType: BsonType { return .regularExpression }
 
@@ -716,7 +716,7 @@ internal struct Symbol: BsonValue {
 }
 
 /// A struct to represent the BSON Timestamp type.
-public struct Timestamp: BsonValue, Equatable, Decodable {
+public struct Timestamp: BsonValue, Equatable, Codable {
     public var bsonType: BsonType { return .timestamp }
 
     /// A timestamp representing seconds since the Unix epoch.

--- a/Sources/MongoSwift/BSON/CodableNumber.swift
+++ b/Sources/MongoSwift/BSON/CodableNumber.swift
@@ -2,18 +2,19 @@ import Foundation
 
 /// A protocol for numbers that require encoding/decoding support but are not necessarily BSON types.
 internal protocol CodableNumber {
-    /// Attempts to initialize this type from an analogous BsonValue. Returns nil
+    /// Attempts to initialize this type from an analogous `BsonValue`. Returns `nil`
     /// the `from` value cannot be accurately represented as this type.
     init?(from value: BsonValue)
 
-    /// when we rewrite encoder, will add a `asBsonValue` method here that handles the 
-    /// CodableNumber -> BsonValue conversion
-
-    /// Initializer for creating from Int, Int32, Int64
+    /// Initializer for creating from `Int`, `Int32`, `Int64`
     init?<T: BinaryInteger>(exactly source: T)
 
-    /// Initializer for creating from a Double
+    /// Initializer for creating from a `Double`
     init?(exactly source: Double)
+
+    /// Converts this number to a `BsonValue`. Returns `nil` if it cannot
+    /// be represented exactly. 
+    var bsonValue: BsonValue? { get }
 }
 
 extension CodableNumber {
@@ -32,18 +33,86 @@ extension CodableNumber {
         }
         return nil
     }
+
+    /// By default, just try casting the number to a `BsonValue`. Types
+    /// where that will not work provide their own `asBsonValue` impl. 
+    var bsonValue: BsonValue? {
+        return self as? BsonValue
+    }
 }
 
 extension Int: CodableNumber {}
-extension Int8: CodableNumber {}
-extension Int16: CodableNumber {}
 extension Int32: CodableNumber {}
 extension Int64: CodableNumber {}
-extension UInt8: CodableNumber {}
-extension UInt16: CodableNumber {}
-extension UInt32: CodableNumber {}
-extension UInt64: CodableNumber {}
-extension UInt: CodableNumber {}
+
+extension Int8: CodableNumber {
+    var bsonValue: BsonValue? {
+        // Int8 always fits in an Int32
+        return Int32(exactly: self)
+    }
+}
+
+extension Int16: CodableNumber {
+    var bsonValue: BsonValue? {
+        // Int16 always fits in an Int32
+        return Int32(exactly: self)
+    }
+}
+
+extension UInt8: CodableNumber {
+    var bsonValue: BsonValue? {
+        // UInt8 always fits in an Int32
+        return Int32(exactly: self)
+    }
+}
+
+extension UInt16: CodableNumber {
+    var bsonValue: BsonValue? {
+        // UInt16 always fits in an Int32
+        return Int(exactly: self)
+    }
+}
+
+extension UInt32: CodableNumber {
+    var bsonValue: BsonValue? {
+        // try an Int32 first
+        if let int32 = Int32(exactly: self) { return int32 }
+        // otherwise, will always fit in an Int64
+        return Int64(exactly: self)
+    }
+}
+
+extension UInt64: CodableNumber {
+    var bsonValue: BsonValue? {
+        // try an Int32 first
+        if let int32 = Int32(exactly: self) { return int32 }
+        // then an Int64
+        if let int64 = Int64(exactly: self) { return int64 }
+        // finally try a double
+        if let double = Double(exactly: self) { return double }
+        // we could consider trying a Decimal128 here. However,
+        // it's not clear how we could support decoding something
+        // stored as Decimal128 back to a UInt64 without access
+        // to libbson internals.
+        return nil
+    }
+}
+
+extension UInt: CodableNumber {
+    var bsonValue: BsonValue? {
+        // try an Int32 first
+        if let int32 = Int32(exactly: self) { return int32 }
+        // then an Int64
+        if let int64 = Int64(exactly: self) { return int64 }
+        // finally try a double
+        if let double = Double(exactly: self) { return double }
+        // we could consider trying a Decimal128 here. However,
+        // it's not clear how we could support decoding something
+        // stored as Decimal128 back to a UInt without access 
+        // to libbson internals.
+        return nil
+    }
+}
 
 /// Override the default initializer due to a runtime assertion that fails
 /// when initializing a Double from an Int (possible Swift bug?)
@@ -83,5 +152,10 @@ extension Float: CodableNumber {
             break
         }
         return nil
+    }
+
+    var bsonValue: BsonValue? {
+        // a Float can always be represented as a Double
+        return Double(exactly: self)
     }
 }

--- a/Sources/MongoSwift/BSON/Document+Codable.swift
+++ b/Sources/MongoSwift/BSON/Document+Codable.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+extension Document: Codable {
+	public func encode(to encoder: Encoder) throws {
+		if let bsonEncoder = encoder as? _BSONEncoder {
+			bsonEncoder.storage.containers.append(self)
+			return
+		}
+
+		var container = encoder.container(keyedBy: _BsonKey.self)
+		for (k, v) in self {
+			try Document.recursivelyEncodeKeyed(v, forKey: k, to: &container)
+		}
+	}
+
+	// swiftlint:disable:next cyclomatic_complexity
+	private static func recursivelyEncodeKeyed(_ value: BsonValue?, forKey key: String, to container: inout KeyedEncodingContainer<_BsonKey>) throws {
+		let k = _BsonKey(stringValue: key)!
+		switch value {
+		case let val as Binary:
+			try container.encode(val, forKey: k)
+		case let val as Bool:
+			try container.encode(val, forKey: k)
+		case let val as Date:
+			try container.encode(val, forKey: k)
+		case let val as Decimal128:
+			try container.encode(val, forKey: k)
+		case let val as Double:
+			try container.encode(val, forKey: k)
+		case let val as Int:
+			try container.encode(val, forKey: k)
+		case let val as Int32:
+			try container.encode(val, forKey: k)
+		case let val as Int64:
+			try container.encode(val, forKey: k)
+		case let val as CodeWithScope:
+			try container.encode(val, forKey: k)
+		case let val as MaxKey:
+			try container.encode(val, forKey: k)
+		case let val as MinKey:
+			try container.encode(val, forKey: k)
+		case let val as ObjectId:
+			try container.encode(val, forKey: k)
+		case let val as String:
+			try container.encode(val, forKey: k)
+		case nil:
+			try container.encodeNil(forKey: k)
+		case let val as [BsonValue?]:
+			var nested = container.nestedUnkeyedContainer(forKey: k)
+			for v in val {
+				try Document.recursivelyEncodeUnkeyed(v, to: &nested)
+			}
+		case let val as Document:
+			var nested = container.nestedContainer(keyedBy: _BsonKey.self, forKey: k)
+			for (nestedK, nestedV) in val {
+				try Document.recursivelyEncodeKeyed(nestedV, forKey: nestedK, to: &nested)
+			}
+		default:
+			throw MongoError.typeError(message: "Encountered a non-encodable type in a Document: \(type(of: value))")
+		}
+	}
+
+	// swiftlint:disable:next cyclomatic_complexity
+	private static func recursivelyEncodeUnkeyed(_ value: BsonValue?, to container: inout UnkeyedEncodingContainer) throws {
+		switch value {
+		case let val as Binary:
+			try container.encode(val)
+		case let val as Bool:
+			try container.encode(val)
+		case let val as Date:
+			try container.encode(val)
+		case let val as Decimal128:
+			try container.encode(val)
+		case let val as Double:
+			try container.encode(val)
+		case let val as Int:
+			try container.encode(val)
+		case let val as Int32:
+			try container.encode(val)
+		case let val as Int64:
+			try container.encode(val)
+		case let val as CodeWithScope:
+			try container.encode(val)
+		case let val as MaxKey:
+			try container.encode(val)
+		case let val as MinKey:
+			try container.encode(val)
+		case let val as ObjectId:
+			try container.encode(val)
+		case let val as String:
+			try container.encode(val)
+		case nil:
+			 try container.encodeNil()
+		case let val as [BsonValue]:
+			var nested = container.nestedUnkeyedContainer()
+			for v in val {
+				try Document.recursivelyEncodeUnkeyed(v, to: &nested)
+			}
+		case let val as Document:
+			var nested = container.nestedContainer(keyedBy: _BsonKey.self)
+			for (nestedK, nestedV) in val {
+				try Document.recursivelyEncodeKeyed(nestedV, forKey: nestedK, to: &nested)
+			}
+		default:
+			throw MongoError.typeError(message: "Encountered a non-encodable type in a Document: \(type(of: value))")
+		}
+	}
+
+		public init(from decoder: Decoder) throws {
+		// if it's a BsonDecoder we should just short-circuit and return the container document
+		if let bsonDecoder = decoder as? _BsonDecoder {
+			let topContainer = bsonDecoder.storage.topContainer
+			guard let doc = topContainer as? Document else {
+				throw DecodingError._typeMismatch(at: [], expectation: Document.self, reality: topContainer)
+			}
+			self = doc
+		// Otherwise get a keyed container and decode each key one by one
+		} else {
+			let container = try decoder.container(keyedBy: _BsonKey.self)
+			var output = Document()
+			for key in container.allKeys {
+				let k = key.stringValue
+				output[k] = try Document.recursivelyDecodeKeyed(key: key, container: container)
+			}
+			self = output
+		}
+	}
+
+	/// Switch through all possible BSON types (a document can contain any) and try recursively decoding the value
+	/// stored under `key` as that type from the provided keyed container.
+	// swiftlint:disable:next cyclomatic_complexity
+	private static func recursivelyDecodeKeyed(key: _BsonKey, container: KeyedDecodingContainer<_BsonKey>) throws -> BsonValue {
+		if let value = try? container.decode(Double.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(String.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(Binary.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(ObjectId.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(Bool.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(Date.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(RegularExpression.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(CodeWithScope.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(Int.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(Int32.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(Int64.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(Decimal128.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(MinKey.self, forKey: key) {
+			return value
+		} else if let value = try? container.decode(MaxKey.self, forKey: key) {
+			return value
+		} else if var nested = try? container.nestedUnkeyedContainer(forKey: key) {
+			var res = [BsonValue]()
+			while !nested.isAtEnd {
+				res.append(try recursivelyDecodeUnkeyed(container: &nested))
+			}
+			return res
+		// this will recursively call Document.init(from: decoder Decoder)
+		} else if let value = try? container.decode(Document.self, forKey: key) {
+			return value
+		} else {
+			throw MongoError.typeError(message: "Encountered a value in an keyed container under key \(key.stringValue) that could not be decoded to any BSON type")
+		}
+	}
+
+	/// Switch through all possible BSON types (a document can contain any) and try recursively decoding the next value
+	/// as that type from the provided unkeyed container.
+	private static func recursivelyDecodeUnkeyed(container: inout UnkeyedDecodingContainer) throws -> BsonValue {
+		if let value = try? container.decode(Double.self) {
+			return value
+		} else if let value = try? container.decode(String.self) {
+			return value
+		} else if let value = try? container.decode(Binary.self) {
+			return value
+		} else if let value = try? container.decode(ObjectId.self) {
+			return value
+		} else if let value = try? container.decode(Bool.self) {
+			return value
+		} else if let value = try? container.decode(Date.self) {
+			return value
+		} else if let value = try? container.decode(RegularExpression.self) {
+			return value
+		} else if let value = try? container.decode(CodeWithScope.self) {
+			return value
+		} else if let value = try? container.decode(Int.self) {
+			return value
+		} else if let value = try? container.decode(Int32.self) {
+			return value
+		} else if let value = try? container.decode(Int64.self) {
+			return value
+		} else if let value = try? container.decode(Decimal128.self) {
+			return value
+		} else if let value = try? container.decode(MinKey.self) {
+			return value
+		} else if let value = try? container.decode(MaxKey.self) {
+			return value
+		} else if var nested = try? container.nestedUnkeyedContainer() {
+			var res = [BsonValue]()
+			while !nested.isAtEnd {
+				res.append(try recursivelyDecodeUnkeyed(container: &nested))
+			}
+			return res
+		// this will recursively call Document.init(from: decoder Decoder)
+		} else if let value = try? container.decode(Document.self) {
+			return value
+		} else {
+			throw MongoError.typeError(message: "Encountered a value in an unkeyed container that could not be decoded to any BSON type")
+		}
+	}
+}

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -20,7 +20,15 @@ final class CodecTests: XCTestCase {
         return [
             ("testEncodeStructs", testEncodeStructs),
             ("testEncodeListDatabasesOptions", testEncodeListDatabasesOptions),
-            ("testNilEncodingStrategy", testNilEncodingStrategy)
+            ("testNilEncodingStrategy", testNilEncodingStrategy),
+            ("testStructs", testStructs),
+            ("testOptionals", testOptionals),
+            ("testEncodingNonBsonNumbers", testEncodingNonBsonNumbers),
+            ("testDecodingNonBsonNumbers", testEncodingNonBsonNumbers),
+            ("testBsonNumbers", testEncodingNonBsonNumbers),
+            ("testBsonValues", testBsonValues),
+            ("testDecodeScalars", testDecodeScalars),
+            ("testDocumentIsCodable", testDocumentIsCodable)
         ]
     }
 
@@ -168,6 +176,8 @@ final class CodecTests: XCTestCase {
         let uint: UInt?
         let float: Float?
 
+        static let keys = ["int8", "int16", "uint8", "uint16", "uint32", "uint64", "uint", "float"]
+
         public static func == (lhs: Numbers, rhs: Numbers) -> Bool {
             return lhs.int8 == rhs.int8 && lhs.int16 == rhs.int16 &&
                     lhs.uint8 == rhs.uint8 && lhs.uint16 == rhs.uint16 &&
@@ -211,9 +221,14 @@ final class CodecTests: XCTestCase {
         expect(try encoder.encode(Numbers(uint64: UInt64(Int64.max) + 1))).to(equal(["uint64": 9223372036854775808.0]))
         expect(try encoder.encode(Numbers(uint: UInt(Int64.max) + 1))).to(equal(["uint": 9223372036854775808.0]))
 
-        // check that we fail gracefully with a UInt, UInt64 that can't fit in any type
+        // check that we fail gracefully with a UInt, UInt64 that can't fit in any type.
+        // Swift 4.0 is unable to properly handle these edge cases and returns incorrect
+        // values from `Double(exactly:)`.
+        // 4.1 fixes this -- see https://bugs.swift.org/browse/SR-7056.
+        #if swift(>=4.1)
         expect(try encoder.encode(Numbers(uint64: UInt64.max))).to(throwError())
         expect(try encoder.encode(Numbers(uint: UInt.max))).to(throwError())
+        #endif
     }
 
     /// Test decoding where the requested numeric types are non-BSON
@@ -225,20 +240,27 @@ final class CodecTests: XCTestCase {
         let s = Numbers(int8: 42, int16: 42, uint8: 42, uint16: 42, uint32: 42, uint64: 42, uint: 42, float: 42)
 
         // store all values as Int32s and decode them to their requested types
-        let doc1: Document = ["int8": 42, "int16": 42, "uint8": 42, "uint16": 42,
-                            "uint32": 42, "uint64": 42, "uint": 42, "float": 42]
+        var doc1 = Document()
+        for k in Numbers.keys {
+            doc1[k] = 42
+        }
         let res1 = try decoder.decode(Numbers.self, from: doc1)
         expect(res1).to(equal(s))
 
-        // store all values as Int64s and decode them to their requested types
-        let doc2: Document = ["int8": Int64(42), "int16": Int64(42), "uint8": Int64(42), "uint16": Int64(42),
-                            "uint32": Int64(42), "uint64": Int64(42), "uint": Int64(42), "float": Int64(42)]
+        // store all values as Int64s and decode them to their requested types.
+        var doc2 = Document()
+        for k in Numbers.keys {
+            doc2[k] = Int64(42)
+        }
+
         let res2 = try decoder.decode(Numbers.self, from: doc2)
         expect(res2).to(equal(s))
 
         // store all values as Doubles and decode them to their requested types
-        let doc3: Document = ["int8": Double(42), "int16": Double(42), "uint8": Double(42), "uint16": Double(42),
-                            "uint32": Double(42), "uint64": Double(42), "uint": Double(42), "float": Double(42)]
+        var doc3 = Document()
+        for k in Numbers.keys {
+            doc3[k] = Double(42)
+        }
         let res3 = try decoder.decode(Numbers.self, from: doc3)
         expect(res3).to(equal(s))
 
@@ -334,8 +356,8 @@ final class CodecTests: XCTestCase {
             "int32": 5,
             "int64": 6,
             "dec": ["data": "1.2E+10"] as Document,
-            "minkey": [] as Document,
-            "maxkey": [] as Document,
+            "minkey": ["minKey": 1] as Document,
+            "maxkey": ["maxKey": 1] as Document,
             "regex": ["pattern": "^abc", "options": "imx"] as Document
         ]
 
@@ -495,317 +517,5 @@ final class CodecTests: XCTestCase {
         // again, order gets messed up, so just hard code in the key ordering we get
         let encoded = try String(data: encoder.encode(expected), encoding: .utf8)
         expect(encoded).to(equal("{\"array\":[\"a\",\"b\",\"c\"],\"points\":600,\"doc\":{\"x\":2},\"name\":\"Durian\",\"description\":\"A fruit with a distinctive scent.\"}"))
-    }
-
-    struct Numbers: Decodable, Equatable {
-        let int8: Int8?
-        let int16: Int16?
-        let uint8: UInt8?
-        let uint16: UInt16?
-        let uint32: UInt32?
-        let uint64: UInt64?
-        let uint: UInt?
-        let float: Float?
-
-        static let keys = ["int8", "int16", "uint8", "uint16", "uint32", "uint64", "uint", "float"]
-
-        public static func == (lhs: Numbers, rhs: Numbers) -> Bool {
-            return lhs.int8 == rhs.int8 && lhs.int16 == rhs.int16 &&
-                    lhs.uint8 == rhs.uint8 && lhs.uint16 == rhs.uint16 &&
-                    lhs.uint32 == rhs.uint32 && lhs.uint64 == rhs.uint64 &&
-                    lhs.uint == rhs.uint && lhs.float == rhs.float
-        }
-
-        init(int8: Int8? = nil, int16: Int16? = nil, uint8: UInt8? = nil, uint16: UInt16? = nil,
-             uint32: UInt32? = nil, uint64: UInt64? = nil, uint: UInt? = nil, float: Float? = nil) {
-            self.int8 = int8
-            self.int16 = int16
-            self.uint8 = uint8
-            self.uint16 = uint16
-            self.uint32 = uint32
-            self.uint64 = uint64
-            self.uint = uint
-            self.float = float
-        }
-    }
-
-    /// Test decoding where the requested numeric types are non-BSON
-    /// and require conversions.
-    func testDecodingNonBsonNumbers() throws {
-        let decoder = BsonDecoder()
-
-        // the struct we expect to get back
-        let s = Numbers(int8: 42, int16: 42, uint8: 42, uint16: 42, uint32: 42, uint64: 42, uint: 42, float: 42)
-
-        // store all values as Int32s and decode them to their requested types
-        var doc1 = Document()
-        for k in Numbers.keys {
-            doc1[k] = 42
-        }
-        let res1 = try decoder.decode(Numbers.self, from: doc1)
-        expect(res1).to(equal(s))
-
-        // store all values as Int64s and decode them to their requested types.
-        var doc2 = Document()
-        for k in Numbers.keys {
-            doc2[k] = Int64(42)
-        }
-
-        let res2 = try decoder.decode(Numbers.self, from: doc2)
-        expect(res2).to(equal(s))
-
-        // store all values as Doubles and decode them to their requested types
-        var doc3 = Document()
-        for k in Numbers.keys {
-            doc3[k] = Double(42)
-        }
-        let res3 = try decoder.decode(Numbers.self, from: doc3)
-        expect(res3).to(equal(s))
-
-        // test for each type that we fail gracefully when values cannot be represented because they are out of bounds
-        expect(try decoder.decode(Numbers.self, from: ["int8": Int(Int8.max) + 1])).to(throwError())
-        expect(try decoder.decode(Numbers.self, from: ["int16": Int(Int16.max) + 1])).to(throwError())
-        expect(try decoder.decode(Numbers.self, from: ["uint8": -1])).to(throwError())
-        expect(try decoder.decode(Numbers.self, from: [ "uint16": -1])).to(throwError())
-        expect(try decoder.decode(Numbers.self, from: ["uint32": -1])).to(throwError())
-        expect(try decoder.decode(Numbers.self, from: ["uint64": -1])).to(throwError())
-        expect(try decoder.decode(Numbers.self, from: ["uint": -1])).to(throwError())
-        expect(try decoder.decode(Numbers.self, from: ["float": Double.greatestFiniteMagnitude])).to(throwError())
-    }
-
-     struct BsonNumbers: Decodable, Equatable {
-        let int: Int
-        let int32: Int32
-        let int64: Int64
-        let double: Double
-
-        public static func == (lhs: BsonNumbers, rhs: BsonNumbers) -> Bool {
-            return lhs.int == rhs.int && lhs.int32 == rhs.int32 &&
-                    lhs.int64 == rhs.int64 && lhs.double == rhs.double
-        }
-    }
-
-    /// Test that BSON number types can be decoded from any type they are stored as
-    func testDecodingBsonNumbers() throws {
-        let decoder = BsonDecoder()
-        // the struct we expect to get back
-        let s = BsonNumbers(int: 42, int32: 42, int64: 42, double: 42)
-
-        // store all values as Int32s and decode them to their requested types
-        let doc1: Document = ["int": Int32(42), "int32": Int32(42), "int64": Int32(42), "double": Int32(42)]
-        let res1 = try decoder.decode(BsonNumbers.self, from: doc1)
-        expect(res1).to(equal(s))
-
-        // store all values as Int64s and decode them to their requested types
-        let doc2: Document = ["int": Int64(42), "int32": Int64(42), "int64": Int64(42), "double": Int64(42)]
-        let res2 = try decoder.decode(BsonNumbers.self, from: doc2)
-        expect(res2).to(equal(s))
-
-        // store all values as Doubles and decode them to their requested types
-        let doc3: Document = ["int": Double(42), "int32": Double(42), "int64": Double(42), "double": Double(42)]
-        let res3 = try decoder.decode(BsonNumbers.self, from: doc3)
-        expect(res3).to(equal(s))
-    }
-
-    struct AllBsonTypes: Decodable, Equatable {
-        let double: Double
-        let string: String
-        let doc: Document
-        let arr: [Int]
-        let binary: Binary
-        let oid: ObjectId
-        let bool: Bool
-        let date: Date
-        let code: CodeWithScope
-        let int: Int
-        let ts: Timestamp
-        let int32: Int32
-        let int64: Int64
-        let dec: Decimal128
-        let minkey: MinKey
-        let maxkey: MaxKey
-        let regex: RegularExpression
-
-        public static func == (lhs: AllBsonTypes, rhs: AllBsonTypes) -> Bool {
-            return lhs.double == rhs.double && lhs.string == rhs.string &&
-                    lhs.doc == rhs.doc && lhs.arr == rhs.arr && lhs.binary == rhs.binary &&
-                    lhs.oid == rhs.oid && lhs.bool == rhs.bool && lhs.code == rhs.code &&
-                    lhs.int == rhs.int && lhs.ts == rhs.ts && lhs.int32 == rhs.int32 &&
-                    lhs.int64 == rhs.int64 && lhs.dec == rhs.dec && lhs.minkey == rhs.minkey &&
-                    lhs.maxkey == rhs.maxkey && lhs.regex == rhs.regex && lhs.date == rhs.date
-        }
-    }
-
-    /// Test decoding to all possible BSON types
-    func testDecodeBsonValues() throws {
-
-        // decode from fully de-structured 
-        let doc1: Document = [
-            "double": Double(2),
-            "string": "hi",
-            "doc": ["x": 1] as Document,
-            "arr": [1, 2],
-            "binary": ["subtype": 0, "data": [255, 255]] as Document,
-            "oid": ["oid": "507f1f77bcf86cd799439011"] as Document,
-            "bool": true,
-            "date": 5000,
-            "code": ["code": "hi", "scope": ["x": 1] as Document] as Document,
-            "int": 1,
-            "ts": ["timestamp": 1, "increment": 2] as Document,
-            "int32": 5,
-            "int64": 6,
-            "dec": ["data": "1.2E+10"] as Document,
-            "minkey": ["minKey": 1] as Document,
-            "maxkey": ["maxKey": 1] as Document,
-            "regex": ["pattern": "^abc", "options": "imx"] as Document
-        ]
-
-        let expected = AllBsonTypes(
-                            double: Double(2),
-                            string: "hi",
-                            doc: ["x": 1],
-                            arr: [1, 2],
-                            binary: Binary(base64: "//8=", subtype: .binary),
-                            oid: ObjectId(fromString: "507f1f77bcf86cd799439011"),
-                            bool: true,
-                            date: Date(timeIntervalSinceReferenceDate: 5000),
-                            code: CodeWithScope(code: "hi", scope: ["x": 1]),
-                            int: 1,
-                            ts: Timestamp(timestamp: 1, inc: 2),
-                            int32: 5,
-                            int64: 6,
-                            dec: Decimal128("1.2E+10"),
-                            minkey: MinKey(),
-                            maxkey: MaxKey(),
-                            regex: RegularExpression(pattern: "^abc", options: "imx")
-                        )
-
-        let decoder = BsonDecoder()
-        let res1 = try decoder.decode(AllBsonTypes.self, from: doc1)
-        expect(res1).to(equal(expected))
-
-        let doc2: Document = [
-            "double": Double(2),
-            "string": "hi",
-            "doc": ["x": 1] as Document,
-            "arr": [1, 2],
-            "binary": Binary(base64: "//8=", subtype: .binary),
-            "oid": ObjectId(fromString: "507f1f77bcf86cd799439011"),
-            "bool": true,
-            "date": Date(timeIntervalSinceReferenceDate: 5000),
-            "code": CodeWithScope(code: "hi", scope: ["x": 1]),
-            "int": 1,
-            "ts": Timestamp(timestamp: 1, inc: 2),
-            "int32": 5,
-            "int64": 6,
-            "dec": Decimal128("1.2E+10"),
-            "minkey": MinKey(),
-            "maxkey": MaxKey(),
-            "regex": RegularExpression(pattern: "^abc", options: "imx")
-        ]
-
-        let res2 = try decoder.decode(AllBsonTypes.self, from: doc2)
-        expect(res2).to(equal(expected))
-
-        let base64 = "//8="
-        let extjson = """
-        {
-            "double" : 2.0,
-            "string" : "hi",
-            "doc" : { "x" : 1 },
-            "arr" : [ 1, 2 ],
-            "binary" : { "$binary" : { "base64": "\(base64)", "subType" : "00" } },
-            "oid" : { "$oid" : "507f1f77bcf86cd799439011" },
-            "bool" : true,
-            "date" : { "$date" : "2001-01-01T01:23:20Z" },
-            "code" : { "$code" : "hi", "$scope" : { "x" : 1 } },
-            "int" : 1,
-            "ts" : { "$timestamp" : { "t" : 1, "i" : 2 } },
-            "int32" : 5, "int64" : 6,
-            "dec" : { "$numberDecimal" : "1.2E+10" },
-            "minkey" : { "$minKey" : 1 },
-            "maxkey" : { "$maxKey" : 1 },
-            "regex" : { "$regularExpression" : { "pattern" : "^abc", "options" : "imx" } }
-        }
-        """
-
-        let res3 = try decoder.decode(AllBsonTypes.self, from: extjson)
-        expect(res3).to(equal(expected))
-    }
-
-    /// Test decoding extJSON and JSON for standalone values
-    func testDecodeScalars() throws {
-        let decoder = BsonDecoder()
-
-        expect(try decoder.decode(Int32.self, from: "42")).to(equal(Int32(42)))
-        expect(try decoder.decode(Int32.self, from: "{\"$numberInt\": \"42\"}")).to(equal(Int32(42)))
-
-        let oid = ObjectId(fromString: "507f1f77bcf86cd799439011")
-        expect(try decoder.decode(ObjectId.self, from: "{\"$oid\": \"507f1f77bcf86cd799439011\"}")).to(equal(oid))
-
-        expect(try decoder.decode(String.self, from: "\"somestring\"")).to(equal("somestring"))
-
-        expect(try decoder.decode(Int64.self, from: "42")).to(equal(Int64(42)))
-        expect(try decoder.decode(Int64.self, from: "{\"$numberLong\": \"42\"}")).to(equal(Int64(42)))
-
-        expect(try decoder.decode(Double.self, from: "42.42")).to(equal(42.42))
-        expect(try decoder.decode(Double.self, from: "{\"$numberDouble\": \"42.42\"}")).to(equal(42.42))
-
-        expect(try decoder.decode(Decimal128.self,
-            from: "{\"$numberDecimal\": \"1.2E+10\"}")).to(equal(Decimal128("1.2E+10")))
-
-        let binary = Binary(base64: "//8=", subtype: .binary)
-        expect(try decoder.decode(Binary.self,
-            from: "{\"$binary\" : {\"base64\": \"//8=\", \"subType\" : \"00\"}}")).to(equal(binary))
-
-        expect(try decoder.decode(CodeWithScope.self, from: "{\"code\": \"hi\" }")).to(equal(CodeWithScope(code: "hi")))
-        let cws = CodeWithScope(code: "hi", scope: ["x": 1])
-        expect(try decoder.decode(CodeWithScope.self,
-            from: "{\"code\": \"hi\", \"scope\": {\"x\" : 1} }")).to(equal(cws))
-
-        expect(try decoder.decode(Document.self, from: "{\"x\": 1}")).to(equal(["x": 1]))
-
-        let ts = Timestamp(timestamp: 1, inc: 2)
-        expect(try decoder.decode(Timestamp.self, from: "{ \"$timestamp\" : { \"t\" : 1, \"i\" : 2 } }")).to(equal(ts))
-
-        let regex = RegularExpression(pattern: "^abc", options: "imx")
-        expect(try decoder.decode(RegularExpression.self,
-            from: "{ \"$regularExpression\" : { \"pattern\" :\"^abc\", \"options\" : \"imx\" } }")).to(equal(regex))
-
-        expect(try decoder.decode(MinKey.self, from: "{\"$minKey\": 1}")).to(equal(MinKey()))
-        expect(try decoder.decode(MaxKey.self, from: "{\"$maxKey\": 1}")).to(equal(MaxKey()))
-
-        expect(try decoder.decode(Bool.self, from: "false")).to(beFalse())
-        expect(try decoder.decode(Bool.self, from: "true")).to(beTrue())
-
-        expect(try decoder.decode([Int].self, from: "[1, 2, 3]")).to(equal([1, 2, 3]))
-    }
-
-    // test that Document.init(from decoder: Decoder) works with a non BSON decoder.
-    func testDocumentIsDecodable() throws {
-        // note: instead of doing this, one can and should just initialize a Document with the `init(fromJSON:)`
-        // constructor. this test is to demonstrate that a Document can theoretically be created from any decoder.
-        let decoder = JSONDecoder()
-
-        let json = """
-        {
-            "name": "Durian",
-            "points": 600,
-            "description": "A fruit with a distinctive scent.",
-            "array": ["a", "b", "c"],
-            "doc": { "x" : 2.0 }
-        }
-        """.data(using: .utf8)!
-
-        let expected: Document = [
-            "description": "A fruit with a distinctive scent.",
-            "doc": ["x": 2.0] as Document,
-            "name": "Durian",
-            "array": ["a", "b", "c"],
-            "points": 600.0
-        ]
-
-        let res = try decoder.decode(Document.self, from: json)
-        expect(res).to(equal(expected))
     }
 }

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -60,7 +60,7 @@ final class CodecTests: XCTestCase {
         .to(equal(["session": nil, "filter": nil, "nameOnly": true]))
     }
 
-    struct BasicStruct: Decodable, Equatable {
+    struct BasicStruct: Codable, Equatable {
         let int: Int
         let string: String
 
@@ -69,7 +69,7 @@ final class CodecTests: XCTestCase {
         }
     }
 
-    struct NestedStruct: Decodable, Equatable {
+    struct NestedStruct: Codable, Equatable {
         let s1: BasicStruct
         let s2: BasicStruct
 
@@ -78,7 +78,7 @@ final class CodecTests: XCTestCase {
         }
     }
 
-    struct NestedArray: Decodable, Equatable {
+    struct NestedArray: Codable, Equatable {
         let array: [BasicStruct]
 
         public static func == (lhs: NestedArray, rhs: NestedArray) -> Bool {
@@ -86,7 +86,7 @@ final class CodecTests: XCTestCase {
         }
     }
 
-    struct NestedNestedStruct: Decodable, Equatable {
+    struct NestedNestedStruct: Codable, Equatable {
         let s: NestedStruct
 
         public static func == (lhs: NestedNestedStruct, rhs: NestedNestedStruct) -> Bool {
@@ -94,39 +94,41 @@ final class CodecTests: XCTestCase {
         }
     }
 
-    /// Test decoding a variety of structs containing simple types that have 
+    /// Test encoding/decoding a variety of structs containing simple types that have 
     /// built in Codable support (strings, arrays, ints, and structs composed of them.)
-    func testDecodingStructs() throws {
+    func testStructs() throws {
+        let encoder = BSONEncoder()
         let decoder = BsonDecoder()
 
-        // decode a document to a basic struct
+        // a basic struct 
         let basic1 = BasicStruct(int: 1, string: "hello")
         let basic1Doc: Document = ["int": 1, "string": "hello"]
-        let res1 = try decoder.decode(BasicStruct.self, from: basic1Doc)
-        expect(res1).to(equal(basic1))
+        expect(try encoder.encode(basic1)).to(equal(basic1Doc))
+        expect(try decoder.decode(BasicStruct.self, from: basic1Doc)).to(equal(basic1))
 
-        // decode a document to a struct storing two nested structs as properties
+        // a struct storing two nested structs as properties
         let basic2 = BasicStruct(int: 2, string: "hi")
         let basic2Doc: Document = ["int": 2, "string": "hi"]
 
         let nestedStruct = NestedStruct(s1: basic1, s2: basic2)
         let nestedStructDoc: Document = ["s1": basic1Doc, "s2": basic2Doc]
-        let res2 = try decoder.decode(NestedStruct.self, from: nestedStructDoc)
-        expect(res2).to(equal(nestedStruct))
+        expect(try encoder.encode(nestedStruct)).to(equal(nestedStructDoc))
+        expect(try decoder.decode(NestedStruct.self, from: nestedStructDoc)).to(equal(nestedStruct))
 
-        // decode a document to a struct storing two nested structs in an array
+        // a struct storing two nested structs in an array
         let nestedArray = NestedArray(array: [basic1, basic2])
         let nestedArrayDoc: Document = ["array": [basic1Doc, basic2Doc]]
-        let res3 = try decoder.decode(NestedArray.self, from: nestedArrayDoc)
-        expect(res3).to(equal(nestedArray))
+        expect(try encoder.encode(nestedArray)).to(equal(nestedArrayDoc))
+        expect(try decoder.decode(NestedArray.self, from: nestedArrayDoc)).to(equal(nestedArray))
 
+        // one more level of nesting
         let nestedNested = NestedNestedStruct(s: nestedStruct)
         let nestedNestedDoc: Document = ["s": nestedStructDoc]
-        let res4 = try decoder.decode(NestedNestedStruct.self, from: nestedNestedDoc)
-        expect(res4).to(equal(nestedNested))
+        expect(try encoder.encode(nestedNested)).to(equal(nestedNestedDoc))
+        expect(try decoder.decode(NestedNestedStruct.self, from: nestedNestedDoc)).to(equal(nestedNested))
     }
 
-    struct OptionalsStruct: Decodable, Equatable {
+    struct OptionalsStruct: Codable, Equatable {
         let int: Int?
         let bool: Bool?
         let string: String
@@ -136,23 +138,363 @@ final class CodecTests: XCTestCase {
         }
     }
 
-    /// Test decoding a struct containing optional values. 
-    func testDecodingOptionals() throws {
+    /// Test encoding/decoding a struct containing optional values.
+    func testOptionals() throws {
+        let encoder = BSONEncoder()
         let decoder = BsonDecoder()
 
         let s1 = OptionalsStruct(int: 1, bool: true, string: "hi")
         let s1Doc: Document = ["int": 1, "bool": true, "string": "hi"]
-        let res1 = try decoder.decode(OptionalsStruct.self, from: s1Doc)
-        expect(res1).to(equal(s1))
+        expect(try encoder.encode(s1)).to(equal(s1Doc))
+        expect(try decoder.decode(OptionalsStruct.self, from: s1Doc)).to(equal(s1))
 
         let s2 = OptionalsStruct(int: nil, bool: true, string: "hi")
         let s2Doc1: Document = ["bool": true, "string": "hi"]
-        let res2 = try decoder.decode(OptionalsStruct.self, from: s2Doc1)
-        expect(res2).to(equal(s2))
+        expect(try encoder.encode(s2)).to(equal(s2Doc1))
+        expect(try decoder.decode(OptionalsStruct.self, from: s2Doc1)).to(equal(s2))
 
+        // test with key in doc explicitly set to nil
         let s2Doc2: Document = ["int": nil, "bool": true, "string": "hi"]
-        let res3 = try decoder.decode(OptionalsStruct.self, from: s2Doc2)
-        expect(res3).to(equal(s2))
+        expect(try decoder.decode(OptionalsStruct.self, from: s2Doc2)).to(equal(s2))
+    }
+
+    struct Numbers: Codable, Equatable {
+        let int8: Int8?
+        let int16: Int16?
+        let uint8: UInt8?
+        let uint16: UInt16?
+        let uint32: UInt32?
+        let uint64: UInt64?
+        let uint: UInt?
+        let float: Float?
+
+        public static func == (lhs: Numbers, rhs: Numbers) -> Bool {
+            return lhs.int8 == rhs.int8 && lhs.int16 == rhs.int16 &&
+                    lhs.uint8 == rhs.uint8 && lhs.uint16 == rhs.uint16 &&
+                    lhs.uint32 == rhs.uint32 && lhs.uint64 == rhs.uint64 &&
+                    lhs.uint == rhs.uint && lhs.float == rhs.float
+        }
+
+        init(int8: Int8? = nil, int16: Int16? = nil, uint8: UInt8? = nil, uint16: UInt16? = nil,
+             uint32: UInt32? = nil, uint64: UInt64? = nil, uint: UInt? = nil, float: Float? = nil) {
+            self.int8 = int8
+            self.int16 = int16
+            self.uint8 = uint8
+            self.uint16 = uint16
+            self.uint32 = uint32
+            self.uint64 = uint64
+            self.uint = uint
+            self.float = float
+        }
+    }
+
+    /// Test encoding where the struct's numeric types are non-BSON
+    /// and require conversions.
+    func testEncodingNonBsonNumbers() throws {
+        let encoder = BSONEncoder()
+
+        let s1 = Numbers(int8: 42, int16: 42, uint8: 42, uint16: 42, uint32: 42, uint64: 42, uint: 42, float: 42)
+        // all should be stored as Int32s, except the float should be stored as a double
+        let doc1: Document = ["int8": 42, "int16": 42, "uint8": 42, "uint16": 42,
+                    "uint32": 42, "uint64": 42, "uint": 42, "float": 42.0]
+
+        expect(try encoder.encode(s1)).to(equal(doc1))
+
+        // check that a UInt32 too large for an Int32 gets converted to Int64
+        expect(try encoder.encode(Numbers(uint32: 4294967295))).to(equal(["uint32": Int64(4294967295)]))
+
+        // check that UInt, UInt64 too large for an Int32 gets converted to Int64
+        expect(try encoder.encode(Numbers(uint64: 4294967295))).to(equal(["uint64": Int64(4294967295)]))
+        expect(try encoder.encode(Numbers(uint: 4294967295))).to(equal(["uint": Int64(4294967295)]))
+
+        // check that UInt, UInt64 too large for an Int64 gets converted to Double
+        expect(try encoder.encode(Numbers(uint64: UInt64(Int64.max) + 1))).to(equal(["uint64": 9223372036854775808.0]))
+        expect(try encoder.encode(Numbers(uint: UInt(Int64.max) + 1))).to(equal(["uint": 9223372036854775808.0]))
+
+        // check that we fail gracefully with a UInt, UInt64 that can't fit in any type
+        expect(try encoder.encode(Numbers(uint64: UInt64.max))).to(throwError())
+        expect(try encoder.encode(Numbers(uint: UInt.max))).to(throwError())
+    }
+
+    /// Test decoding where the requested numeric types are non-BSON
+    /// and require conversions.
+    func testDecodingNonBsonNumbers() throws {
+        let decoder = BsonDecoder()
+
+        // the struct we expect to get back
+        let s = Numbers(int8: 42, int16: 42, uint8: 42, uint16: 42, uint32: 42, uint64: 42, uint: 42, float: 42)
+
+        // store all values as Int32s and decode them to their requested types
+        let doc1: Document = ["int8": 42, "int16": 42, "uint8": 42, "uint16": 42,
+                            "uint32": 42, "uint64": 42, "uint": 42, "float": 42]
+        let res1 = try decoder.decode(Numbers.self, from: doc1)
+        expect(res1).to(equal(s))
+
+        // store all values as Int64s and decode them to their requested types
+        let doc2: Document = ["int8": Int64(42), "int16": Int64(42), "uint8": Int64(42), "uint16": Int64(42),
+                            "uint32": Int64(42), "uint64": Int64(42), "uint": Int64(42), "float": Int64(42)]
+        let res2 = try decoder.decode(Numbers.self, from: doc2)
+        expect(res2).to(equal(s))
+
+        // store all values as Doubles and decode them to their requested types
+        let doc3: Document = ["int8": Double(42), "int16": Double(42), "uint8": Double(42), "uint16": Double(42),
+                            "uint32": Double(42), "uint64": Double(42), "uint": Double(42), "float": Double(42)]
+        let res3 = try decoder.decode(Numbers.self, from: doc3)
+        expect(res3).to(equal(s))
+
+        // test for each type that we fail gracefully when values cannot be represented because they are out of bounds
+        expect(try decoder.decode(Numbers.self, from: ["int8": Int(Int8.max) + 1])).to(throwError())
+        expect(try decoder.decode(Numbers.self, from: ["int16": Int(Int16.max) + 1])).to(throwError())
+        expect(try decoder.decode(Numbers.self, from: ["uint8": -1])).to(throwError())
+        expect(try decoder.decode(Numbers.self, from: [ "uint16": -1])).to(throwError())
+        expect(try decoder.decode(Numbers.self, from: ["uint32": -1])).to(throwError())
+        expect(try decoder.decode(Numbers.self, from: ["uint64": -1])).to(throwError())
+        expect(try decoder.decode(Numbers.self, from: ["uint": -1])).to(throwError())
+        expect(try decoder.decode(Numbers.self, from: ["float": Double.greatestFiniteMagnitude])).to(throwError())
+    }
+
+     struct BsonNumbers: Codable, Equatable {
+        let int: Int
+        let int32: Int32
+        let int64: Int64
+        let double: Double
+
+        public static func == (lhs: BsonNumbers, rhs: BsonNumbers) -> Bool {
+            return lhs.int == rhs.int && lhs.int32 == rhs.int32 &&
+                    lhs.int64 == rhs.int64 && lhs.double == rhs.double
+        }
+    }
+
+    /// Test that BSON number types are encoded properly, and can be decoded from any type they are stored as
+    func testBsonNumbers() throws {
+        let encoder = BSONEncoder()
+        let decoder = BsonDecoder()
+        // the struct we expect to get back
+        let s = BsonNumbers(int: 42, int32: 42, int64: 42, double: 42)
+        expect(try encoder.encode(s)).to(equal(["int": Int(42), "int32": Int32(42), "int64": Int64(42), "double": Double(42)]))
+
+        // store all values as Int32s and decode them to their requested types
+        let doc1: Document = ["int": Int32(42), "int32": Int32(42), "int64": Int32(42), "double": Int32(42)]
+        expect(try decoder.decode(BsonNumbers.self, from: doc1)).to(equal(s))
+
+        // store all values as Int64s and decode them to their requested types
+        let doc2: Document = ["int": Int64(42), "int32": Int64(42), "int64": Int64(42), "double": Int64(42)]
+        expect(try decoder.decode(BsonNumbers.self, from: doc2)).to(equal(s))
+
+        // store all values as Doubles and decode them to their requested types
+        let doc3: Document = ["int": Double(42), "int32": Double(42), "int64": Double(42), "double": Double(42)]
+        expect(try decoder.decode(BsonNumbers.self, from: doc3)).to(equal(s))
+    }
+
+    struct AllBsonTypes: Codable, Equatable {
+        let double: Double
+        let string: String
+        let doc: Document
+        let arr: [Int]
+        let binary: Binary
+        let oid: ObjectId
+        let bool: Bool
+        let date: Date
+        let code: CodeWithScope
+        let int: Int
+        let ts: Timestamp
+        let int32: Int32
+        let int64: Int64
+        let dec: Decimal128
+        let minkey: MinKey
+        let maxkey: MaxKey
+        let regex: RegularExpression
+
+        public static func == (lhs: AllBsonTypes, rhs: AllBsonTypes) -> Bool {
+            return lhs.double == rhs.double && lhs.string == rhs.string &&
+                    lhs.doc == rhs.doc && lhs.arr == rhs.arr && lhs.binary == rhs.binary &&
+                    lhs.oid == rhs.oid && lhs.bool == rhs.bool && lhs.code == rhs.code &&
+                    lhs.int == rhs.int && lhs.ts == rhs.ts && lhs.int32 == rhs.int32 &&
+                    lhs.int64 == rhs.int64 && lhs.dec == rhs.dec && lhs.minkey == rhs.minkey &&
+                    lhs.maxkey == rhs.maxkey && lhs.regex == rhs.regex && lhs.date == rhs.date
+        }
+    }
+
+    /// Test decoding/encoding to all possible BSON types
+    func testBsonValues() throws {
+
+        // decode from fully de-structured 
+        let doc1: Document = [
+            "double": Double(2),
+            "string": "hi",
+            "doc": ["x": 1] as Document,
+            "arr": [1, 2],
+            "binary": ["subtype": 0, "data": [255, 255]] as Document,
+            "oid": ["oid": "507f1f77bcf86cd799439011"] as Document,
+            "bool": true,
+            "date": 5000,
+            "code": ["code": "hi", "scope": ["x": 1] as Document] as Document,
+            "int": 1,
+            "ts": ["timestamp": 1, "increment": 2] as Document,
+            "int32": 5,
+            "int64": 6,
+            "dec": ["data": "1.2E+10"] as Document,
+            "minkey": [] as Document,
+            "maxkey": [] as Document,
+            "regex": ["pattern": "^abc", "options": "imx"] as Document
+        ]
+
+        let expected = AllBsonTypes(
+                            double: Double(2),
+                            string: "hi",
+                            doc: ["x": 1],
+                            arr: [1, 2],
+                            binary: Binary(base64: "//8=", subtype: .binary),
+                            oid: ObjectId(fromString: "507f1f77bcf86cd799439011"),
+                            bool: true,
+                            date: Date(timeIntervalSinceReferenceDate: 5000),
+                            code: CodeWithScope(code: "hi", scope: ["x": 1]),
+                            int: 1,
+                            ts: Timestamp(timestamp: 1, inc: 2),
+                            int32: 5,
+                            int64: 6,
+                            dec: Decimal128("1.2E+10"),
+                            minkey: MinKey(),
+                            maxkey: MaxKey(),
+                            regex: RegularExpression(pattern: "^abc", options: "imx")
+                        )
+
+        let decoder = BsonDecoder()
+        let res1 = try decoder.decode(AllBsonTypes.self, from: doc1)
+        expect(res1).to(equal(expected))
+
+        let doc2: Document = [
+            "double": Double(2),
+            "string": "hi",
+            "doc": ["x": 1] as Document,
+            "arr": [1, 2],
+            "binary": Binary(base64: "//8=", subtype: .binary),
+            "oid": ObjectId(fromString: "507f1f77bcf86cd799439011"),
+            "bool": true,
+            "date": Date(timeIntervalSinceReferenceDate: 5000),
+            "code": CodeWithScope(code: "hi", scope: ["x": 1]),
+            "int": 1,
+            "ts": Timestamp(timestamp: 1, inc: 2),
+            "int32": 5,
+            "int64": Int64(6),
+            "dec": Decimal128("1.2E+10"),
+            "minkey": MinKey(),
+            "maxkey": MaxKey(),
+            "regex": RegularExpression(pattern: "^abc", options: "imx")
+        ]
+
+        let res2 = try decoder.decode(AllBsonTypes.self, from: doc2)
+        expect(res2).to(equal(expected))
+
+        let encoder = BSONEncoder()
+        expect(try encoder.encode(expected)).to(equal(doc2))
+
+        let base64 = "//8="
+        let extjson = """
+        {
+            "double" : 2.0,
+            "string" : "hi",
+            "doc" : { "x" : 1 },
+            "arr" : [ 1, 2 ],
+            "binary" : { "$binary" : { "base64": "\(base64)", "subType" : "00" } },
+            "oid" : { "$oid" : "507f1f77bcf86cd799439011" },
+            "bool" : true,
+            "date" : { "$date" : "2001-01-01T01:23:20Z" },
+            "code" : { "$code" : "hi", "$scope" : { "x" : 1 } },
+            "int" : 1,
+            "ts" : { "$timestamp" : { "t" : 1, "i" : 2 } },
+            "int32" : 5, "int64" : 6,
+            "dec" : { "$numberDecimal" : "1.2E+10" },
+            "minkey" : { "$minKey" : 1 },
+            "maxkey" : { "$maxKey" : 1 },
+            "regex" : { "$regularExpression" : { "pattern" : "^abc", "options" : "imx" } }
+        }
+        """
+
+        let res3 = try decoder.decode(AllBsonTypes.self, from: extjson)
+        expect(res3).to(equal(expected))
+    }
+
+    /// Test decoding extJSON and JSON for standalone values
+    func testDecodeScalars() throws {
+        let decoder = BsonDecoder()
+
+        expect(try decoder.decode(Int32.self, from: "42")).to(equal(Int32(42)))
+        expect(try decoder.decode(Int32.self, from: "{\"$numberInt\": \"42\"}")).to(equal(Int32(42)))
+
+        let oid = ObjectId(fromString: "507f1f77bcf86cd799439011")
+        expect(try decoder.decode(ObjectId.self, from: "{\"$oid\": \"507f1f77bcf86cd799439011\"}")).to(equal(oid))
+
+        expect(try decoder.decode(String.self, from: "\"somestring\"")).to(equal("somestring"))
+
+        expect(try decoder.decode(Int64.self, from: "42")).to(equal(Int64(42)))
+        expect(try decoder.decode(Int64.self, from: "{\"$numberLong\": \"42\"}")).to(equal(Int64(42)))
+
+        expect(try decoder.decode(Double.self, from: "42.42")).to(equal(42.42))
+        expect(try decoder.decode(Double.self, from: "{\"$numberDouble\": \"42.42\"}")).to(equal(42.42))
+
+        expect(try decoder.decode(Decimal128.self,
+            from: "{\"$numberDecimal\": \"1.2E+10\"}")).to(equal(Decimal128("1.2E+10")))
+
+        let binary = Binary(base64: "//8=", subtype: .binary)
+        expect(try decoder.decode(Binary.self,
+            from: "{\"$binary\" : {\"base64\": \"//8=\", \"subType\" : \"00\"}}")).to(equal(binary))
+
+        expect(try decoder.decode(CodeWithScope.self, from: "{\"code\": \"hi\" }")).to(equal(CodeWithScope(code: "hi")))
+        let cws = CodeWithScope(code: "hi", scope: ["x": 1])
+        expect(try decoder.decode(CodeWithScope.self,
+            from: "{\"code\": \"hi\", \"scope\": {\"x\" : 1} }")).to(equal(cws))
+
+        expect(try decoder.decode(Document.self, from: "{\"x\": 1}")).to(equal(["x": 1]))
+
+        let ts = Timestamp(timestamp: 1, inc: 2)
+        expect(try decoder.decode(Timestamp.self, from: "{ \"$timestamp\" : { \"t\" : 1, \"i\" : 2 } }")).to(equal(ts))
+
+        let regex = RegularExpression(pattern: "^abc", options: "imx")
+        expect(try decoder.decode(RegularExpression.self,
+            from: "{ \"$regularExpression\" : { \"pattern\" :\"^abc\", \"options\" : \"imx\" } }")).to(equal(regex))
+
+        expect(try decoder.decode(MinKey.self, from: "{\"$minKey\": 1}")).to(equal(MinKey()))
+        expect(try decoder.decode(MaxKey.self, from: "{\"$maxKey\": 1}")).to(equal(MaxKey()))
+
+        expect(try decoder.decode(Bool.self, from: "false")).to(beFalse())
+        expect(try decoder.decode(Bool.self, from: "true")).to(beTrue())
+
+        expect(try decoder.decode([Int].self, from: "[1, 2, 3]")).to(equal([1, 2, 3]))
+    }
+
+    // test that Document.init(from decoder: Decoder) works with a non BSON decoder and that
+    // Document.encode(to encoder: Encoder) works with a non BSON encoder
+    func testDocumentIsCodable() throws {
+        // note: instead of doing this, one can and should just initialize a Document with the `init(fromJSON:)`
+        // constructor, and conver to JSON using the .extendedJSON property. this test is just to demonstrate 
+        // that a Document can theoretically work with any encoder/decoder.
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let json = """
+        {
+            "name": "Durian",
+            "points": 600,
+            "description": "A fruit with a distinctive scent.",
+            "array": ["a", "b", "c"],
+            "doc": { "x" : 2.0 }
+        }
+        """.data(using: .utf8)!
+
+        let expected: Document = [
+            "description": "A fruit with a distinctive scent.",
+            "doc": ["x": 2.0] as Document,
+            "name": "Durian",
+            "array": ["a", "b", "c"],
+            "points": 600.0
+        ]
+
+        expect(try decoder.decode(Document.self, from: json)).to(equal(expected))
+
+        // again, order gets messed up, so just hard code in the key ordering we get
+        let encoded = try String(data: encoder.encode(expected), encoding: .utf8)
+        expect(encoded).to(equal("{\"array\":[\"a\",\"b\",\"c\"],\"points\":600,\"doc\":{\"x\":2},\"name\":\"Durian\",\"description\":\"A fruit with a distinctive scent.\"}"))
     }
 
     struct Numbers: Decodable, Equatable {


### PR DESCRIPTION
This is all on top the `BsonDecoder` PR so hold off on reviewing til that's in.

To make the review process easier for switching to the new encoder, I've written this implementation in its own file and temporarily named it `BSONEncoder`(instead of `BsonEncoder`). The old encoder still exists and all of the options types are encoded with it. 
In a second PR to follow this one, I will remove the old encoder and replace all usages of it with this new one, in the process making all of our options types `Encodable`. 
