### PR TITLE
Prevent a fatal error when encoding an Int too large for an Int32

### DIFF
--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -374,7 +374,11 @@ extension Double: BsonValue {
 extension Int: BsonValue {
     public var bsonType: BsonType { return .int32 }
     public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
-        if !bson_append_int32(data, key, Int32(key.count), Int32(self)) {
+        guard let int32 = Int32(exactly: self) else {
+            throw MongoError.bsonEncodeError(message:
+                "`Int` value \(self) does not fit in an `Int32`. Use an `Int64` instead")
+        }
+        if !bson_append_int32(data, key, Int32(key.count), int32) {
             throw bsonEncodeError(value: self, forKey: key)
         }
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -222,7 +222,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
             do {
                 try value.encode(to: self.data, forKey: key)
             } catch {
-                preconditionFailure("Failed to set the value for key \(key) to \(value)")
+                preconditionFailure("Failed to set the value for key \(key) to \(value): \(error)")
             }
 
         }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -208,6 +208,13 @@ final class DocumentTests: XCTestCase {
         XCTAssertNotEqual(doc1, doc2)
     }
 
+    func testInvalidInt() {
+        let doc1 = Document()
+        let v = Int(Int32.max) + 1
+        expect(try v.encode(to: doc1.data, forKey: "x")).to(throwError())
+
+    }
+
     // swiftlint:disable:next cyclomatic_complexity
     func testBSONCorpus() throws {
         let SKIPPED_CORPUS_TESTS = [


### PR DESCRIPTION
Rather than assuming the value will fit, this checks if it will first and throws an error if not.