### PR TITLE
SWIFT-76 Support using `Codable` types with collections

### DIFF
--- a/Sources/MongoSwift/BSON/BsonDecoder.swift
+++ b/Sources/MongoSwift/BSON/BsonDecoder.swift
@@ -26,6 +26,7 @@ public class BsonDecoder {
     /// - returns: A value of the requested type.
     /// - throws: An error if any value throws an error during decoding.
     public func decode<T: Decodable>(_ type: T.Type, from document: Document) throws -> T {
+        if let doc = document as? T { return doc }
         let _decoder = _BsonDecoder(referencing: document, options: self.options)
         return try type.init(from: _decoder)
     }

--- a/Sources/MongoSwift/BSON/BsonEncoder.swift
+++ b/Sources/MongoSwift/BSON/BsonEncoder.swift
@@ -26,6 +26,8 @@ public class BsonEncoder {
     /// - returns: A new `Document` containing the encoded BSON data.
     /// - throws: An error if any value throws an error during encoding.
     public func encode<T: Encodable>(_ value: T) throws -> Document {
+        if let doc = value as? Document { return doc }
+
         let encoder = _BsonEncoder(options: self.options)
         guard let topLevel = try encoder.box(value) else {
             throw EncodingError.invalidValue(value,

--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -152,7 +152,7 @@ public class MongoClient {
      *
      * - Returns: A `MongoCursor` over `Document`s describing the databases matching provided criteria
      */
-    public func listDatabases(options: ListDatabasesOptions? = nil) throws -> MongoCursor {
+    public func listDatabases(options: ListDatabasesOptions? = nil) throws -> MongoCursor<Document> {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
         guard let cursor = mongoc_client_find_databases_with_opts(self._client, opts?.data) else {

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -520,9 +520,19 @@ public struct IndexOptions: Encodable {
 }
 
 /// A MongoDB collection.
-public class MongoCollection {
+public class MongoCollection<T: Codable> {
     private var _collection: OpaquePointer?
     private var _client: MongoClient?
+
+    /// A `Codable` type associated with this `MongoCollection` instance. 
+    /// This allows `CollectionType` values to be directly inserted into and 
+    /// retrieved from the collection, by encoding/decoding them using the 
+    /// `BsonEncoder` and `BsonDecoder`. 
+    /// This type association only exists in the context of this particular 
+    /// `MongoCollection` instance. It is the responsibility of the user to 
+    /// ensure that any data already stored in the collection was encoded 
+    /// from this same type.
+    public typealias CollectionType = T
 
     /// The name of this collection.
     public var name: String {
@@ -571,7 +581,7 @@ public class MongoCollection {
      *
      * - Returns: A `MongoCursor` over the resulting `Document`s
      */
-    public func find(_ filter: Document = [:], options: FindOptions? = nil) throws -> MongoCursor {
+    public func find(_ filter: Document = [:], options: FindOptions? = nil) throws -> MongoCursor<CollectionType> {
         let encoder = BsonEncoder()
         let opts = try ReadConcern.append(options?.readConcern, to: try encoder.encode(options), callerRC: self.readConcern)
         guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts?.data, nil) else {
@@ -592,7 +602,7 @@ public class MongoCollection {
      *
      * - Returns: A `MongoCursor` over the resulting `Document`s
      */
-    public func aggregate(_ pipeline: [Document], options: AggregateOptions? = nil) throws -> MongoCursor {
+    public func aggregate(_ pipeline: [Document], options: AggregateOptions? = nil) throws -> MongoCursor<CollectionType> {
         let encoder = BsonEncoder()
         let opts = try ReadConcern.append(options?.readConcern, to: try encoder.encode(options), callerRC: self.readConcern)
         let pipeline: Document = ["pipeline": pipeline]
@@ -640,7 +650,7 @@ public class MongoCollection {
      * - Returns: A 'MongoCursor' containing the distinct values for the specified criteria
      */
     public func distinct(fieldName: String, filter: Document = [:],
-                         options: DistinctOptions? = nil) throws -> MongoCursor {
+                         options: DistinctOptions? = nil) throws -> MongoCursor<Document> {
         guard let client = self._client else {
             throw MongoError.invalidClient()
         }
@@ -681,23 +691,24 @@ public class MongoCollection {
     }
 
     /**
-     * Inserts the provided `Document`. If the document is missing an identifier, one will be
+     * Encodes the provided value to BSON and inserts it. If the value is missing an identifier, one will be
      * generated for it.
      *
      * - Parameters:
-     *   - document: The `Document` to insert
+     *   - value: A `CollectionType` value to encode and insert
      *   - options: Optional `InsertOneOptions` to use when executing the command
      *
      * - Returns: The optional result of attempting to perform the insert. If the `WriteConcern`
      *            is unacknowledged, `nil` is returned.
      */
-    public func insertOne(_ document: Document, options: InsertOneOptions? = nil) throws -> InsertOneResult? {
+    public func insertOne(_ value: CollectionType, options: InsertOneOptions? = nil) throws -> InsertOneResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
-        var error = bson_error_t()
+        let document = try encoder.encode(value)
         if document["_id"] == nil {
             try ObjectId().encode(to: document.data, forKey: "_id")
         }
+        let opts = try encoder.encode(options)
+        var error = bson_error_t()
         if !mongoc_collection_insert_one(self._collection, document.data, opts?.data, nil, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
@@ -705,24 +716,24 @@ public class MongoCollection {
     }
 
     /**
-     * Inserts the provided `Document`s. If any documents are missing an identifier,
+     * Encodes the provided values to BSON and inserts them. If any values are missing identifiers,
      * the driver will generate them.
      *
      * - Parameters:
-     *   - documents: The `Document`s to insert
+     *   - documents: The `CollectionType` values to insert
      *   - options: Optional `InsertManyOptions` to use when executing the command
      *
      * - Returns: The optional result of attempting to performing the insert. If the write concern
      *            is unacknowledged, nil is returned
      */
-    public func insertMany(_ documents: [Document], options: InsertManyOptions? = nil) throws -> InsertManyResult? {
+    public func insertMany(_ values: [CollectionType], options: InsertManyOptions? = nil) throws -> InsertManyResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
-
+        let documents = try values.map { try encoder.encode($0) }
         for doc in documents where doc["_id"] == nil {
             try ObjectId().encode(to: doc.data, forKey: "_id")
         }
         var docPointers = documents.map { UnsafePointer($0.data) }
+        let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_insert_many(
@@ -737,19 +748,20 @@ public class MongoCollection {
      *
      * - Parameters:
      *   - filter: A `Document` representing the match criteria
-     *   - replacement: The replacement `Document`
+     *   - replacement: The replacement value, a `CollectionType` value to be encoded and inserted
      *   - options: Optional `ReplaceOptions` to use when executing the command
      *
      * - Returns: The optional result of attempting to replace a document. If the `WriteConcern`
      *            is unacknowledged, `nil` is returned.
      */
-    public func replaceOne(filter: Document, replacement: Document, options: ReplaceOptions? = nil) throws -> UpdateResult? {
+    public func replaceOne(filter: Document, replacement: CollectionType, options: ReplaceOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
+        let replacementDoc = try encoder.encode(replacement)
         let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_replace_one(
-            self._collection, filter.data, replacement.data, opts?.data, reply.data, &error) {
+            self._collection, filter.data, replacementDoc.data, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return UpdateResult(from: reply)
@@ -968,7 +980,7 @@ public class MongoCollection {
      *
      * - Returns: A `MongoCursor` over the index names.
      */
-    public func listIndexes() throws -> MongoCursor {
+    public func listIndexes() throws -> MongoCursor<Document> {
         guard let cursor = mongoc_collection_find_indexes_with_opts(self._collection, nil) else {
             throw MongoError.invalidResponse()
         }

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -602,7 +602,7 @@ public class MongoCollection<T: Codable> {
      *
      * - Returns: A `MongoCursor` over the resulting `Document`s
      */
-    public func aggregate(_ pipeline: [Document], options: AggregateOptions? = nil) throws -> MongoCursor<CollectionType> {
+    public func aggregate(_ pipeline: [Document], options: AggregateOptions? = nil) throws -> MongoCursor<Document> {
         let encoder = BsonEncoder()
         let opts = try ReadConcern.append(options?.readConcern, to: try encoder.encode(options), callerRC: self.readConcern)
         let pipeline: Document = ["pipeline": pipeline]

--- a/Sources/MongoSwift/Cursor.swift
+++ b/Sources/MongoSwift/Cursor.swift
@@ -1,9 +1,10 @@
 import libmongoc
 
 /// A MongoDB cursor.
-public class MongoCursor: Sequence, IteratorProtocol {
+public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
     private var _cursor: OpaquePointer?
     private var _client: MongoClient?
+    private var decodeError: Error?
 
     /// Initializes a new `MongoCursor` instance, not meant to be instantiated directly.
     internal init(fromCursor: OpaquePointer, withClient: MongoClient) {
@@ -30,7 +31,7 @@ public class MongoCursor: Sequence, IteratorProtocol {
     /// which returns `nil` and requires manually checking for an error afterward.
     /// - returns: the next `Document` in this cursor, or `nil` if at the end of the cursor
     /// - throws: an error if one occurs while iterating
-    public func nextOrError() throws -> Document? {
+    public func nextOrError() throws -> T? {
         if let next = self.next() { return next }
         if let error = self.error { throw error }
         return nil
@@ -39,6 +40,7 @@ public class MongoCursor: Sequence, IteratorProtocol {
     /// The error that occurred while iterating this cursor, if one exists. This should be used to check for errors 
     /// after `next()` returns `nil`.
     public var error: Error? {
+        if let err = self.decodeError { return err }
         var error = bson_error_t()
         if mongoc_cursor_error(self._cursor, &error) {
             return MongoError.invalidCursor(message: toErrorString(error))
@@ -48,13 +50,20 @@ public class MongoCursor: Sequence, IteratorProtocol {
 
     /// Returns the next `Document` in this cursor, or nil. Once this function returns `nil`, the caller should use 
     /// the `.error` property to check for errors.
-    public func next() -> Document? {
+    public func next() -> T? {
         let out = UnsafeMutablePointer<UnsafePointer<bson_t>?>.allocate(capacity: 1)
         defer {
             out.deinitialize(count: 1)
             out.deallocate(capacity: 1)
         }
         if !mongoc_cursor_next(self._cursor, out) { return nil }
-        return Document(fromPointer: UnsafeMutablePointer(mutating: out.pointee!))
+        let doc = Document(fromPointer: UnsafeMutablePointer(mutating: out.pointee!))
+
+        do {
+            return try BsonDecoder().decode(T.self, from: doc)
+        } catch {
+            self.decodeError = error
+            return nil
+        }
     }
 }

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -163,10 +163,27 @@ public class MongoDatabase {
      *
      * - Parameters:
      *   - name: the name of the collection to get
+     *   - options: options to set on the returned collection
      *
-     * - Returns: the requested `MongoCollection`
+     * - Returns: the requested `MongoCollection<Document>`
      */
-    public func collection(_ name: String, options: CollectionOptions? = nil) throws -> MongoCollection {
+    public func collection(_ name: String, options: CollectionOptions? = nil) throws -> MongoCollection<Document> {
+        return try self.collection(name, withType: Document.self, options: options)
+    }
+
+    /**
+     * Access a collection within this database, and associates the specified `Codable` type `T` with the 
+     * returned `MongoCollection`. This association only exists in the context of this particular 
+     * `MongoCollection` instance.
+     *
+     * - Parameters:
+     *   - name: the name of the collection to get
+     *   - options: options to set on the returned collection
+     *
+     * - Returns: the requested `MongoCollection<T>`
+     */
+    public func collection<T: Codable>(_ name: String, withType: T.Type,
+                                              options: CollectionOptions? = nil) throws -> MongoCollection<T> {
         guard let collection = mongoc_database_get_collection(self._database, name) else {
             throw MongoError.invalidCollection(message: "Could not get collection '\(name)'")
         }
@@ -188,9 +205,27 @@ public class MongoDatabase {
      *   - name: a `String`, the name of the collection to create
      *   - options: Optional `CreateCollectionOptions` to use for the collection
      *
-     * - Returns: the newly created `MongoCollection`
+     * - Returns: the newly created `MongoCollection<Document>`
      */
-    public func createCollection(_ name: String, options: CreateCollectionOptions? = nil) throws -> MongoCollection {
+    public func createCollection(_ name: String,
+                                 options: CreateCollectionOptions? = nil) throws -> MongoCollection<Document> {
+        return try self.createCollection(name, withType: Document.self, options: options)
+    }
+
+    /**
+     * Creates a collection in this database with the specified options, and associates the 
+     * specified `Codable` type `T` with the returned `MongoCollection`. This association only
+     * exists in the context of this particular `MongoCollection` instance.
+     * 
+     *
+     * - Parameters:
+     *   - name: a `String`, the name of the collection to create
+     *   - options: Optional `CreateCollectionOptions` to use for the collection
+     *
+     * - Returns: the newly created `MongoCollection<T>`
+     */
+    public func createCollection<T: Codable>(_ name: String, withType: T.Type,
+                                             options: CreateCollectionOptions? = nil) throws -> MongoCollection<T> {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
         var error = bson_error_t()
@@ -218,7 +253,7 @@ public class MongoDatabase {
      *
      * - Returns: a `MongoCursor` over an array of collections
      */
-    public func listCollections(options: ListCollectionsOptions? = nil) throws -> MongoCursor {
+    public func listCollections(options: ListCollectionsOptions? = nil) throws -> MongoCursor<Document> {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
         guard let collections = mongoc_database_find_collections_with_opts(self._database, opts?.data) else {

--- a/Tests/MongoSwiftBenchmarks/DocumentBenchmarks.swift
+++ b/Tests/MongoSwiftBenchmarks/DocumentBenchmarks.swift
@@ -12,7 +12,7 @@ let largeSize = 27.31
 
 let commandSize = 0.16
 
-func setup() throws -> (MongoDatabase, MongoCollection) {
+func setup() throws -> (MongoDatabase, MongoCollection<Document>) {
     let db = try MongoClient().db("perftest")
     try db.drop()
     return (db, try db.createCollection("corpus"))

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -153,7 +153,7 @@ private struct CMTest {
     // Wrap each operation in do/catch because we expect some of them to fail.
     // If something fails/succeeds incorrectly, we'll know because the generated
     // events won't match up.
-    func doOperation(withCollection collection: MongoCollection) throws {
+    func doOperation(withCollection collection: MongoCollection<Document>) throws {
         // TODO SWIFT-31: use readPreferences for commands if provided
         let filter = self.args["filter"] as? Document
         switch self.operationName {

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -174,11 +174,11 @@ private class CrudTest {
     }
 
     // Subclasses should implement `execute` according to the particular operation(s) they are for. 
-    func execute(usingCollection coll: MongoCollection) throws { XCTFail("Unimplemented") }
+    func execute(usingCollection coll: MongoCollection<Document>) throws { XCTFail("Unimplemented") }
 
     // If the test has a `collection` field in its `outcome`, verify that the expected
     // data is present. If there is no `collection` field, do nothing. 
-    func verifyData(testCollection coll: MongoCollection, db: MongoDatabase) throws {
+    func verifyData(testCollection coll: MongoCollection<Document>, db: MongoDatabase) throws {
         guard let collection = self.collection else { return } // only  some tests have data to verify
         // if a name is not specified, check the current collection
         var collToCheck = coll
@@ -206,7 +206,7 @@ private class CrudTest {
 
 /// A class for executing `aggregate` tests
 private class AggregateTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let pipeline: [Document] = try self.args.get("pipeline")
         let options = AggregateOptions(batchSize: self.batchSize, collation: self.collation)
         let cursor = try coll.aggregate(pipeline, options: options)
@@ -225,7 +225,7 @@ private class AggregateTest: CrudTest {
 
 /// A class for executing `count` tests
 private class CountTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter: Document = try self.args.get("filter")
         let options = CountOptions(collation: self.collation, limit: self.limit, skip: self.skip)
         let result = try coll.count(filter, options: options)
@@ -235,7 +235,7 @@ private class CountTest: CrudTest {
 
 /// A class for executing `deleteOne` and `deleteMany` tests
 private class DeleteTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter: Document = try self.args.get("filter")
         let options = DeleteOptions(collation: self.collation)
         let result: DeleteResult?
@@ -252,7 +252,7 @@ private class DeleteTest: CrudTest {
 
 /// A class for executing `distinct` tests
 private class DistinctTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter = self.args["filter"] as? Document
         let fieldName: String = try self.args.get("fieldName")
         let options = DistinctOptions(collation: self.collation)
@@ -265,7 +265,7 @@ private class DistinctTest: CrudTest {
 
 /// A class for executing `find` tests
 private class FindTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter: Document = try self.args.get("filter")
         let options = FindOptions(batchSize: batchSize, collation: collation, limit: self.limit,
                                     skip: self.skip, sort: self.sort)
@@ -276,7 +276,7 @@ private class FindTest: CrudTest {
 
 /// A class for executing `insertMany` tests
 private class InsertManyTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let docs: [Document] = try self.args.get("documents")
         let result = try coll.insertMany(docs)
 
@@ -296,7 +296,7 @@ private class InsertManyTest: CrudTest {
 
 /// A Class for executing `insertOne` tests
 private class InsertOneTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let doc: Document = try self.args.get("document")
         let result = try coll.insertOne(doc)
         expect(doc["_id"] as? Int).to(equal(result?.insertedId as? Int))
@@ -305,7 +305,7 @@ private class InsertOneTest: CrudTest {
 
 /// A class for executing `replaceOne` tests
 private class ReplaceOneTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter: Document = try self.args.get("filter")
         let replacement: Document = try self.args.get("replacement")
         let options = ReplaceOptions(collation: self.collation, upsert: self.upsert)
@@ -316,7 +316,7 @@ private class ReplaceOneTest: CrudTest {
 
 /// A class for executing `updateOne` and `updateMany` tests
 private class UpdateTest: CrudTest {
-    override func execute(usingCollection coll: MongoCollection) throws {
+    override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter: Document = try self.args.get("filter")
         let update: Document = try self.args.get("update")
         let arrayFilters = self.args["arrayFilters"] as? [Document]


### PR DESCRIPTION
While we discussed before figuring out some way to do this with protocols or inheritance so that `MongoCollection` wouldn't need to be parameterized by a type, this ended up being so clean and simple that it feels more like the "right" way to do it to me. 

So basically I added support for 
- Inserting `Codable`s with `insertOne` or `insertMany`
- giving a `Codable` as the "replacement" value in `replaceOne`
- getting a `Cursor` over `Codable`s back from `find` 

For some other collection methods, I was unsure how exactly we would want to utilize the `Codable` type. For example, maybe you would want to filter by a `Codable` for `deleteOne`/`deleteMany`. But that might not always be true - those commands support filters that wouldn't necessarily map to the fields in your `Codable` type. 
And for `aggregate`, you're probably doing some kind of transformation on your data, and the type of the output values might not necessarily match the type of the input values, but they could both be `Codable`s.  
So I've left those out for now to just get your feedback on the general approach and those 4 methods, as it seems like we need to think about the API a little bit more for some commands...