### PR TITLE
SWIFT-114 Use a BsonValue? rather than Any for UpdateResult.upsertedId

### DIFF
--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -365,7 +365,7 @@ public struct UpdateResult {
     public let modifiedCount: Int
 
     /// The identifier of the inserted document if an upsert took place.
-    public let upsertedId: Any
+    public let upsertedId: BsonValue?
 
     /// Given a server response to an update command, creates a corresponding
     /// `UpdateResult`. If the `from` Document does not have `matchedCount` and
@@ -377,7 +377,7 @@ public struct UpdateResult {
          }
          self.matchedCount = matched
          self.modifiedCount = modified
-         self.upsertedId = from["upsertedId"] as Any
+         self.upsertedId = from["upsertedId"]
     }
 }
 


### PR DESCRIPTION
`upsertedId`, if present, will always be a BSON type, so we should use `BsonValue?` rather than `Any`. 