### PR TITLE
SWIFT-73 Add @discardableResult to non-void functions with negligible return values

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "21f4fed2052cea480f5f1d2044d45aa25fdfb988",
-          "version": "7.1.1"
+          "revision": "8023e3980d91b470ad073d6da843b73f2eeb1844",
+          "version": "7.1.2"
         }
       },
       {

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -701,6 +701,7 @@ public class MongoCollection<T: Codable> {
      * - Returns: The optional result of attempting to perform the insert. If the `WriteConcern`
      *            is unacknowledged, `nil` is returned.
      */
+    @discardableResult
     public func insertOne(_ value: CollectionType, options: InsertOneOptions? = nil) throws -> InsertOneResult? {
         let encoder = BsonEncoder()
         let document = try encoder.encode(value)
@@ -726,6 +727,7 @@ public class MongoCollection<T: Codable> {
      * - Returns: The optional result of attempting to performing the insert. If the write concern
      *            is unacknowledged, nil is returned
      */
+    @discardableResult
     public func insertMany(_ values: [CollectionType], options: InsertManyOptions? = nil) throws -> InsertManyResult? {
         let encoder = BsonEncoder()
         let documents = try values.map { try encoder.encode($0) }
@@ -754,6 +756,7 @@ public class MongoCollection<T: Codable> {
      * - Returns: The optional result of attempting to replace a document. If the `WriteConcern`
      *            is unacknowledged, `nil` is returned.
      */
+    @discardableResult
     public func replaceOne(filter: Document, replacement: CollectionType, options: ReplaceOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
         let replacementDoc = try encoder.encode(replacement)
@@ -778,6 +781,7 @@ public class MongoCollection<T: Codable> {
      * - Returns: The optional result of attempting to update a document. If the `WriteConcern` is
      *            unacknowledged, `nil` is returned.
      */
+    @discardableResult
     public func updateOne(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
@@ -801,6 +805,7 @@ public class MongoCollection<T: Codable> {
      * - Returns: The optional result of attempting to update multiple documents. If the write
      *            concern is unacknowledged, nil is returned
      */
+    @discardableResult
     public func updateMany(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
@@ -823,6 +828,7 @@ public class MongoCollection<T: Codable> {
      * - Returns: The optional result of performing the deletion. If the `WriteConcern` is
      *            unacknowledged, `nil` is returned.
      */
+    @discardableResult
     public func deleteOne(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
@@ -845,6 +851,7 @@ public class MongoCollection<T: Codable> {
      * - Returns: The optional result of performing the deletion. If the `WriteConcern` is
      *            unacknowledged, `nil` is returned.
      */
+    @discardableResult
     public func deleteMany(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
         let encoder = BsonEncoder()
         let opts = try encoder.encode(options)
@@ -865,6 +872,7 @@ public class MongoCollection<T: Codable> {
      *
      * - Returns: The name of the created index.
      */
+    @discardableResult
     public func createIndex(_ forModel: IndexModel) throws -> String {
         return try createIndexes([forModel])[0]
     }
@@ -878,6 +886,7 @@ public class MongoCollection<T: Codable> {
      *
      * - Returns: The name of the created index
      */
+    @discardableResult
     public func createIndex(_ keys: Document, options: IndexOptions? = nil) throws -> String {
         return try createIndex(IndexModel(keys: keys, options: options))
     }
@@ -890,6 +899,7 @@ public class MongoCollection<T: Codable> {
      *
      * - Returns: An `[String]` containing the names of all the indexes that were created.
      */
+    @discardableResult
     public func createIndexes(_ forModels: [IndexModel]) throws -> [String] {
         let collName = String(cString: mongoc_collection_get_name(self._collection))
         let encoder = BsonEncoder()
@@ -938,6 +948,7 @@ public class MongoCollection<T: Codable> {
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
+    @discardableResult
     public func dropIndex(_ keys: Document, options: IndexOptions? = nil) throws -> Document {
         return try dropIndex(IndexModel(keys: keys, options: options))
     }
@@ -950,6 +961,7 @@ public class MongoCollection<T: Codable> {
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
+    @discardableResult
     public func dropIndex(_ model: IndexModel) throws -> Document {
         return try _dropIndexes(keys: model.keys)
     }
@@ -959,6 +971,7 @@ public class MongoCollection<T: Codable> {
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
+    @discardableResult
     public func dropIndexes() throws -> Document {
         return try _dropIndexes()
     }

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -274,6 +274,7 @@ public class MongoDatabase {
      *
      * - Returns: a `Document` containing the server response for the command
      */
+    @discardableResult
     public func runCommand(_ command: Document, options: RunCommandOptions? = nil) throws -> Document {
         let encoder = BsonEncoder()
         let opts = try ReadConcern.append(options?.readConcern, to: try encoder.encode(options), callerRC: self.readConcern)

--- a/Tests/MongoSwiftBenchmarks/DocumentBenchmarks.swift
+++ b/Tests/MongoSwiftBenchmarks/DocumentBenchmarks.swift
@@ -29,7 +29,7 @@ final class SingleDocumentBenchmarks: XCTestCase {
         // reading (and discarding) the result each time.
         let result = try measureOp({
             for _ in 1...10000 {
-                _ = try db.runCommand(command)
+                try db.runCommand(command)
             }
         })
 
@@ -50,7 +50,7 @@ final class SingleDocumentBenchmarks: XCTestCase {
             toInsert.append(document)
         }
 
-        _ = try collection.insertMany(toInsert)
+        try collection.insertMany(toInsert)
 
         // make sure the documents were actually inserted
         expect(try collection.count([:])).to(equal(10000))
@@ -89,7 +89,7 @@ final class SingleDocumentBenchmarks: XCTestCase {
             // leave it to the driver or database. Repeat this `numDocs` times.
             results.append(try measureTime({
                 for doc in documents {
-                    _ = try collection.insertOne(doc)
+                    try collection.insertOne(doc)
                 }
             }))
 
@@ -121,7 +121,7 @@ public class MultiDocumentBenchmarks: XCTestCase {
         let (db, collection) = try setup()
         let jsonString = try String(contentsOf: tweetFile, encoding: .utf8)
         for _ in 1...10000 {
-            _ = try collection.insertOne(try Document(fromJSON: jsonString))
+            try collection.insertOne(try Document(fromJSON: jsonString))
         }
 
         // make sure the documents were actually inserted
@@ -155,7 +155,7 @@ public class MultiDocumentBenchmarks: XCTestCase {
             // Do an ordered 'insert_many' with `numDocs` copies of the document.
             // DO NOT manually add an _id field; leave it to the driver or database.
             results.append(try measureTime({
-                _ = try collection.insertMany(documents)
+                try collection.insertMany(documents)
             }))
 
             // make sure the documents were actually inserted

--- a/Tests/MongoSwiftTests/CollectionTests.swift
+++ b/Tests/MongoSwiftTests/CollectionTests.swift
@@ -55,7 +55,7 @@ final class CollectionTests: XCTestCase {
                 return
             }
             coll = try client.db("collectionTest").createCollection("coll1")
-            _ = try coll.insertMany([doc1, doc2])
+            try coll.insertMany([doc1, doc2])
         } catch {
             XCTFail("Setup failed: \(error)")
         }
@@ -288,9 +288,9 @@ final class CollectionTests: XCTestCase {
         let db = try client.db("codable")
         defer { try? db.drop() }
         let coll1 = try db.createCollection("coll1", withType: Basic.self)
-        _ = try coll1.insertOne(Basic(x: 1, y: "hi"))
-        _ = try coll1.insertMany([Basic(x: 2, y: "hello"), Basic(x: 3, y: "blah")])
-        _ = try coll1.replaceOne(filter: ["x": 2], replacement: Basic(x: 4, y: "hi"))
+        try coll1.insertOne(Basic(x: 1, y: "hi"))
+        try coll1.insertMany([Basic(x: 2, y: "hello"), Basic(x: 3, y: "blah")])
+        try coll1.replaceOne(filter: ["x": 2], replacement: Basic(x: 4, y: "hi"))
         expect(try coll1.count()).to(equal(3))
 
         for doc in try coll1.find() {

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -55,7 +55,7 @@ final class CommandMonitoringTests: XCTestCase {
                 let db = try client.db(testFile.databaseName)
                 try db.drop() // In case last test run failed, drop to clear out DB
                 let collection = try db.createCollection(testFile.collectionName)
-                _ = try collection.insertMany(testFile.data)
+                try collection.insertMany(testFile.data)
 
                 // 2. Add an observer that looks for all events
                 var expectedEvents = test.expectations
@@ -95,7 +95,7 @@ final class CommandMonitoringTests: XCTestCase {
             eventCount += 1
         }
 
-        _ = try collection.insertOne(["x": 1])
+        try collection.insertOne(["x": 1])
         expect(eventCount).to(beGreaterThan(0))
         customCenter.removeObserver(observer)
 
@@ -161,9 +161,9 @@ private struct CMTest {
         case "count":
             do { _ = try collection.count(filter ?? [:]) } catch { }
         case "deleteMany":
-            do { _ = try collection.deleteMany(filter ?? [:]) } catch { }
+            do { try collection.deleteMany(filter ?? [:]) } catch { }
         case "deleteOne":
-            do { _ = try collection.deleteOne(filter ?? [:]) } catch { }
+            do { try collection.deleteOne(filter ?? [:]) } catch { }
 
         case "find":
             // TODO SWIFT-63: use "hint" if provided
@@ -193,20 +193,20 @@ private struct CMTest {
         case "insertMany":
             let documents: [Document] = try self.args.get("documents")
             let options = InsertManyOptions(ordered: self.args["ordered"] as? Bool)
-            do { _ = try collection.insertMany(documents, options: options) } catch { }
+            do { try collection.insertMany(documents, options: options) } catch { }
 
         case "insertOne":
             let document: Document = try self.args.get("document")
-            do { _ = try collection.insertOne(document) } catch { }
+            do { try collection.insertOne(document) } catch { }
 
         case "updateMany":
             let update: Document = try self.args.get("update")
-            do { _ = try collection.updateMany(filter: filter ?? [:], update: update) } catch { }
+            do { try collection.updateMany(filter: filter ?? [:], update: update) } catch { }
 
         case "updateOne":
             let update: Document = try self.args.get("update")
             let options = UpdateOptions(upsert: self.args["upsert"] as? Bool)
-            do { _ = try collection.updateOne(filter: filter ?? [:], update: update, options: options) } catch { }
+            do { try collection.updateOne(filter: filter ?? [:], update: update, options: options) } catch { }
 
         default:
             XCTFail("Unrecognized operation name \(self.operationName)")

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -66,7 +66,7 @@ final class CrudTests: XCTestCase {
                 // 4) verify that expected data is present
                 // 5) drop the collection to clean up
                 let collection = try db.collection("\(file.name)+\(i)")
-                _ = try collection.insertMany(file.data)
+                try collection.insertMany(file.data)
                 try test.execute(usingCollection: collection)
                 try test.verifyData(testCollection: collection, db: db)
                 try collection.drop()


### PR DESCRIPTION
cc @jsflax

The compiler generates a warning if you don't assign the return value of a non-void function to something. Adding the `@discardableResult` attribute tells the compiler to ignore that. [docs on Swift attributes](https://docs.swift.org/swift-book/ReferenceManual/Attributes.html)

This is useful in cases where a user may not care about the results, and saves them having to assign the return values to `_`. You can see several examples of this in the tests I modified. 

Let me know if you think I missed any methods that have negligible results, or if you think we should still be forcing users to acknowledge the return values of any of the methods I modified. 