### PR TITLE
Fix mutation bug with `Document.merge`

### DIFF
--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -200,7 +200,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         }
 
         set(newValue) {
-            self.checkIsUniquelyReferenced()
+            self.copyStorageIfRequired()
 
             guard let value = newValue else {
                 if !bson_append_null(self.data, key, Int32(key.count)) {
@@ -245,7 +245,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
     /// Appends the key/value pairs from the provided `doc` to this `Document`. 
     public mutating func merge(_ doc: Document) throws {
-        self.checkIsUniquelyReferenced()
+        self.copyStorageIfRequired()
         if !bson_concat(self.data, doc.data) {
             throw MongoError.bsonEncodeError(message: "Failed to merge \(doc) with \(self)")
         }
@@ -261,7 +261,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
     ///  doc2["b"] = 2
     /// Therefore, this function should be called just before we are about to
     /// modify a document - either by setting a value or merging in another doc.
-    private mutating func checkIsUniquelyReferenced() {
+    private mutating func copyStorageIfRequired() {
         if !isKnownUniquelyReferenced(&self.storage) {
             self.storage = DocumentStorage(fromPointer: self.data)
         }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -200,17 +200,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         }
 
         set(newValue) {
-            // this happens if someone has copied the document and modifies it.
-            // for example:
-            //  let doc1: Document = ["a": 1]
-            //  var doc2 = doc1
-            //  doc2["b"] = 2
-            // to provide value semantics, i.e. prevent changes to doc2 from
-            // modifying doc1, we make a copy of the bson_t and let the
-            // copy/copies of the document keep the original
-            if !isKnownUniquelyReferenced(&self.storage) {
-                self.storage = DocumentStorage(fromPointer: self.data)
-            }
+            self.checkIsUniquelyReferenced()
 
             guard let value = newValue else {
                 if !bson_append_null(self.data, key, Int32(key.count)) {
@@ -255,8 +245,25 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
     /// Appends the key/value pairs from the provided `doc` to this `Document`. 
     public mutating func merge(_ doc: Document) throws {
+        self.checkIsUniquelyReferenced()
         if !bson_concat(self.data, doc.data) {
             throw MongoError.bsonEncodeError(message: "Failed to merge \(doc) with \(self)")
+        }
+    }
+
+    /// Checks if the document is uniquely referenced. If not, makes a copy
+    /// of the underlying `bson_t` and lets the copy/copies keep the original.
+    /// This allows us to provide value semantics for `Document`s. 
+    /// This happens if someone copies a document and modifies it.
+    /// For example: 
+    ///  let doc1: Document = ["a": 1]
+    ///  var doc2 = doc1
+    ///  doc2["b"] = 2
+    /// Therefore, this function should be called just before we are about to
+    /// modify a document - either by setting a value or merging in another doc.
+    private mutating func checkIsUniquelyReferenced() {
+        if !isKnownUniquelyReferenced(&self.storage) {
+            self.storage = DocumentStorage(fromPointer: self.data)
         }
     }
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -290,8 +290,15 @@ final class DocumentTests: XCTestCase {
     }
 
     func testMerge() throws {
+        // test documents are merged correctly
         var doc1: Document = ["a": 1]
         try doc1.merge(["b": 2])
         expect(doc1).to(equal(["a": 1, "b": 2]))
+
+        // ensure merging into a copy doesn't modify original
+        var doc2 = doc1
+        try doc2.merge(["c": 3])
+        expect(doc1).to(equal(["a": 1, "b": 2]))
+        expect(doc2).to(equal(["a": 1, "b": 2, "c": 3]))
     }
 }


### PR DESCRIPTION
We want copy-on-write behavior for `Document`s, and we implemented this already for when values are set by using `isKnownUniquelyReferenced` on the backing `DocumentStorage`. 

However, I forgot to add the same check for this new mutating function, `merge`, which can lead to some unexpected behavior like this:

```swift
let a: Document = ["x": 1]
var b = a
try b.merge(["y": 2])
// a is now  ["x": 1, "y": 2]
```

This fixes that issue by performing the same `isKnownUniquelyReferenced` check before merging in a new document. 