### PR TITLE
SWIFT-108 Refactor how ReadConcerns are encoded

### DIFF
--- a/Sources/MongoSwift/Client.swift
+++ b/Sources/MongoSwift/Client.swift
@@ -12,7 +12,7 @@ public struct ClientOptions: Encodable {
 
     /// Specifies a ReadConcern to use for the client. If one is not specified,
     /// the server's default read concern will be used.
-    let readConcern: ReadConcern?
+    public let readConcern: ReadConcern?
 
     /// Convenience initializer allowing any/all to be omitted or optional
     public init(eventMonitoring: Bool = false, readConcern: ReadConcern? = nil, retryWrites: Bool? = nil) {
@@ -49,7 +49,7 @@ public struct ListDatabasesOptions: Encodable {
 public struct DatabaseOptions {
     /// A read concern to set on the retrieved database. If one is not specified,
     /// the database will inherit the client's read concern. 
-    let readConcern: ReadConcern?
+    public let readConcern: ReadConcern?
 }
 
 /// A MongoDB Client.
@@ -66,7 +66,7 @@ public class MongoClient {
     public var readConcern: ReadConcern? {
         // per libmongoc docs, we don't need to handle freeing this ourselves
         let readConcern = mongoc_client_get_read_concern(self._client)
-        let rcObj = ReadConcern(readConcern)
+        let rcObj = ReadConcern(from: readConcern)
         if rcObj.isDefault { return nil }
         return rcObj
     }


### PR DESCRIPTION
Ugh... more things that should be public but weren't. I think we should enable [this linter rule](https://github.com/realm/SwiftLint/blob/master/Rules.md#explicit-acl) requiring explicit access control levels? We have a bunch of minor linter violations I have been meaning to address anyway so I just opened [SWIFT-115](https://jira.mongodb.org/browse/SWIFT-115) to deal with that. 

Anyway, this gets rid of the special logic for encoding `ReadConcern`s as libmongoc will already take care of that for us, and makes `ReadConcern` `Codable` so we can encode it with the rest of the options. 

Also did some refactoring of `ReadConcern` to pull out a couple of the protocols into extensions. unfortunately we can't do this with `Codable` because `required init`s for classes have to be in the class definition.