### PR TITLE
SWIFT-30 Implement WriteConcern type 

### DIFF
--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -26,13 +26,16 @@ public struct AggregateOptions: Encodable {
     /// The index to use for the aggregation. The hint does not apply to $lookup and $graphLookup stages.
     // let hint: Optional<(String | Document)>
 
-    /// A `ReadConcern` to use for this operation. 
+    /// A `ReadConcern` to use in read stages of this operation.
     public let readConcern: ReadConcern?
+
+    /// A `WriteConcern` to use in `$out` stages of this operation.
+    let writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(allowDiskUse: Bool? = nil, batchSize: Int32? = nil, bypassDocumentValidation: Bool? = nil,
                 collation: Document? = nil, comment: String? = nil, maxTimeMS: Int64? = nil,
-                readConcern: ReadConcern? = nil) {
+                readConcern: ReadConcern? = nil, writeConcern: WriteConcern? = nil) {
         self.allowDiskUse = allowDiskUse
         self.batchSize = batchSize
         self.bypassDocumentValidation = bypassDocumentValidation
@@ -40,6 +43,7 @@ public struct AggregateOptions: Encodable {
         self.comment = comment
         self.maxTimeMS = maxTimeMS
         self.readConcern = readConcern
+        self.writeConcern = writeConcern
     }
 }
 
@@ -220,9 +224,18 @@ public struct InsertOneOptions: Encodable {
     /// If true, allows the write to opt-out of document level validation.
     public let bypassDocumentValidation: Bool?
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing bypassDocumentValidation to be omitted or optional
-    public init(bypassDocumentValidation: Bool? = nil) {
+    public init(bypassDocumentValidation: Bool? = nil, writeConcern: WriteConcern? = nil) {
         self.bypassDocumentValidation = bypassDocumentValidation
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case bypassDocumentValidation
     }
 }
 
@@ -236,10 +249,19 @@ public struct InsertManyOptions: Encodable {
     /// Defaults to true.
     public var ordered: Bool = true
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing any/all parameters to be omitted or optional
-    public init(bypassDocumentValidation: Bool? = nil, ordered: Bool? = true) {
+    public init(bypassDocumentValidation: Bool? = nil, ordered: Bool? = true, writeConcern: WriteConcern? = nil) {
         self.bypassDocumentValidation = bypassDocumentValidation
         if let o = ordered { self.ordered = o }
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case bypassDocumentValidation, ordered
     }
 }
 
@@ -257,13 +279,22 @@ public struct UpdateOptions: Encodable {
     /// When true, creates a new document if no document matches the query.
     public let upsert: Bool?
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing any/all parameters to be optional
     public init(arrayFilters: [Document]? = nil, bypassDocumentValidation: Bool? = nil, collation: Document? = nil,
-                upsert: Bool? = nil) {
+                upsert: Bool? = nil, writeConcern: WriteConcern? = nil) {
         self.arrayFilters = arrayFilters
         self.bypassDocumentValidation = bypassDocumentValidation
         self.collation = collation
         self.upsert = upsert
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case arrayFilters, bypassDocumentValidation, collation, upsert
     }
 }
 
@@ -278,11 +309,21 @@ public struct ReplaceOptions: Encodable {
     /// When true, creates a new document if no document matches the query.
     public let upsert: Bool?
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(bypassDocumentValidation: Bool? = nil, collation: Document? = nil, upsert: Bool? = nil) {
+    public init(bypassDocumentValidation: Bool? = nil, collation: Document? = nil, upsert: Bool? = nil,
+                writeConcern: WriteConcern? = nil) {
         self.bypassDocumentValidation = bypassDocumentValidation
         self.collation = collation
         self.upsert = upsert
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case bypassDocumentValidation, collation, upsert
     }
 }
 
@@ -291,9 +332,18 @@ public struct DeleteOptions: Encodable {
     /// Specifies a collation.
     public let collation: Document?
 
+    /// An optional WriteConcern to use for the command.
+    let writeConcern: WriteConcern?
+
      /// Convenience initializer allowing collation to be omitted or optional
-    public init(collation: Document? = nil) {
+    public init(collation: Document? = nil, writeConcern: WriteConcern? = nil) {
         self.collation = collation
+        self.writeConcern = writeConcern
+    }
+
+    // Encode everything except writeConcern
+    private enum CodingKeys: String, CodingKey {
+        case collation
     }
 }
 
@@ -497,6 +547,18 @@ public struct IndexOptions: Encodable {
     }
 }
 
+/// Options to use when creating a new index on a `MongoCollection`.
+public struct CreateIndexOptions {
+    /// An optional `WriteConcern` to use for the command
+    let writeConcern: WriteConcern?
+}
+
+/// Options to use when dropping an index from a `MongoCollection`.
+public struct DropIndexOptions {
+    /// An optional `WriteConcern` to use for the command
+    let writeConcern: WriteConcern?
+}
+
 /// A MongoDB collection.
 public class MongoCollection<T: Codable> {
     private var _collection: OpaquePointer?
@@ -524,6 +586,15 @@ public class MongoCollection<T: Codable> {
         let rcObj = ReadConcern(from: readConcern)
         if rcObj.isDefault { return nil }
         return rcObj
+    }
+
+    /// The `WriteConcern` set on this collection, or nil if one is not set.
+    public var writeConcern: WriteConcern? {
+        // per libmongoc docs, we don't need to handle freeing this ourselves
+        let writeConcern = mongoc_collection_get_write_concern(self._collection)
+        let wcObj = WriteConcern(writeConcern)
+        if wcObj.isDefault { return nil }
+        return wcObj
     }
 
     /// Initializes a new `MongoCollection` instance, not meant to be instantiated directly
@@ -583,7 +654,7 @@ public class MongoCollection<T: Codable> {
         let opts = try BsonEncoder().encode(options)
         let pipeline: Document = ["pipeline": pipeline]
         guard let cursor = mongoc_collection_aggregate(
-            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts?.data, nil) else {
+            self._collection, MONGOC_QUERY_NONE, pipeline.data, withWC?.data, nil) else {
             throw MongoError.invalidResponse()
         }
         guard let client = self._client else {
@@ -682,7 +753,7 @@ public class MongoCollection<T: Codable> {
         if document["_id"] == nil {
             try ObjectId().encode(to: document.data, forKey: "_id")
         }
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         var error = bson_error_t()
         if !mongoc_collection_insert_one(self._collection, document.data, opts?.data, nil, &error) {
             throw MongoError.commandError(message: toErrorString(error))
@@ -704,12 +775,14 @@ public class MongoCollection<T: Codable> {
     @discardableResult
     public func insertMany(_ values: [CollectionType], options: InsertManyOptions? = nil) throws -> InsertManyResult? {
         let encoder = BsonEncoder()
+
         let documents = try values.map { try encoder.encode($0) }
         for doc in documents where doc["_id"] == nil {
             try ObjectId().encode(to: doc.data, forKey: "_id")
         }
         var docPointers = documents.map { UnsafePointer($0.data) }
-        let opts = try encoder.encode(options)
+
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_insert_many(
@@ -734,7 +807,7 @@ public class MongoCollection<T: Codable> {
     public func replaceOne(filter: Document, replacement: CollectionType, options: ReplaceOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
         let replacementDoc = try encoder.encode(replacement)
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_replace_one(
@@ -758,7 +831,7 @@ public class MongoCollection<T: Codable> {
     @discardableResult
     public func updateOne(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_update_one(
@@ -782,7 +855,7 @@ public class MongoCollection<T: Codable> {
     @discardableResult
     public func updateMany(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_update_many(
@@ -805,7 +878,7 @@ public class MongoCollection<T: Codable> {
     @discardableResult
     public func deleteOne(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_delete_one(
@@ -828,7 +901,7 @@ public class MongoCollection<T: Codable> {
     @discardableResult
     public func deleteMany(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
         let encoder = BsonEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try WriteConcern.append(options?.writeConcern, to: try encoder.encode(options), callerWC: self.writeConcern)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_delete_many(
@@ -843,12 +916,13 @@ public class MongoCollection<T: Codable> {
      *
      * - Parameters:
      *   - model: An `IndexModel` representing the keys and options for the index
+     *   - writeConcern: Optional WriteConcern to use for the command
      *
      * - Returns: The name of the created index.
      */
     @discardableResult
-    public func createIndex(_ forModel: IndexModel) throws -> String {
-        return try createIndexes([forModel])[0]
+    public func createIndex(_ forModel: IndexModel, options: CreateIndexOptions? = nil) throws -> String {
+        return try createIndexes([forModel], options: options)[0]
     }
 
     /**
@@ -857,12 +931,14 @@ public class MongoCollection<T: Codable> {
      * - Parameters:
      *   - keys: a `Document` specifing the keys for the index
      *   - options: Optional `IndexOptions` to use for the index
+     *   - writeConcern: Optional `WriteConcern` to use for the command
      *
      * - Returns: The name of the created index
      */
     @discardableResult
-    public func createIndex(_ keys: Document, options: IndexOptions? = nil) throws -> String {
-        return try createIndex(IndexModel(keys: keys, options: options))
+    public func createIndex(_ keys: Document, options: IndexOptions? = nil,
+                            commandOptions: CreateIndexOptions? = nil) throws -> String {
+        return try createIndex(IndexModel(keys: keys, options: options), options: commandOptions)
     }
 
     /**
@@ -870,11 +946,12 @@ public class MongoCollection<T: Codable> {
      *
      * - Parameters:
      *   - models: An `[IndexModel]` specifying the indexes to create
+     *   - writeConcern: Optional `WriteConcern` to use for the command
      *
      * - Returns: An `[String]` containing the names of all the indexes that were created.
      */
     @discardableResult
-    public func createIndexes(_ forModels: [IndexModel]) throws -> [String] {
+    public func createIndexes(_ forModels: [IndexModel], options: CreateIndexOptions? = nil) throws -> [String] {
         let collName = String(cString: mongoc_collection_get_name(self._collection))
         let encoder = BsonEncoder()
         var indexData = [Document]()
@@ -892,7 +969,8 @@ public class MongoCollection<T: Codable> {
         ]
 
         var error = bson_error_t()
-        if !mongoc_collection_write_command_with_opts(self._collection, command.data, nil, nil, &error) {
+        let opts = try WriteConcern.append(options?.writeConcern, to: nil, callerWC: self.writeConcern)
+        if !mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, nil, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
@@ -904,11 +982,13 @@ public class MongoCollection<T: Codable> {
      *
      * - Parameters:
      *   - name: The name of the index to drop
+     *   - writeConcern: An optional WriteConcern to use for the command
      *
      */
-    public func dropIndex(_ name: String) throws {
+    public func dropIndex(_ name: String, options: DropIndexOptions? = nil) throws {
         var error = bson_error_t()
-        if !mongoc_collection_drop_index(self._collection, name, &error) {
+        let opts = try WriteConcern.append(options?.writeConcern, to: nil, callerWC: self.writeConcern)
+        if !mongoc_collection_drop_index_with_opts(self._collection, name, opts?.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
     }
@@ -919,46 +999,52 @@ public class MongoCollection<T: Codable> {
      * - Parameters:
      *   - keys: a `Document` containing the keys for the index to drop
      *   - options: Optional `IndexOptions` the dropped index should match
+     *   - writeConcern: An optional `WriteConcern` to use for the command
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
     @discardableResult
-    public func dropIndex(_ keys: Document, options: IndexOptions? = nil) throws -> Document {
-        return try dropIndex(IndexModel(keys: keys, options: options))
+    public func dropIndex(_ keys: Document, options: IndexOptions? = nil,
+                            commandOptions: DropIndexOptions? = nil) throws -> Document {
+        return try dropIndex(IndexModel(keys: keys, options: options), options: commandOptions)
     }
 
     /**
      * Attempts to drop a single index from the collection given an `IndexModel` describing it.
      *
      * - Parameters:
-     *   - model: The model describing the index to drop
+     *   - model: An `IndexModel` describing the index to drop
+     *   - writeConcern: An optional `WriteConcern` to use for the command
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
     @discardableResult
-    public func dropIndex(_ model: IndexModel) throws -> Document {
-        return try _dropIndexes(keys: model.keys)
+    public func dropIndex(_ model: IndexModel, options: DropIndexOptions? = nil) throws -> Document {
+        return try _dropIndexes(keys: model.keys, options: options)
     }
 
     /**
      * Drops all indexes in the collection.
+     * 
+     * - Parameters:
+    *   - writeConcern: An optional `WriteConcern` to use for the command
      *
      * - Returns: a `Document` containing the server's response to the command.
      */
     @discardableResult
-    public func dropIndexes() throws -> Document {
-        return try _dropIndexes()
+    public func dropIndexes(options: DropIndexOptions? = nil) throws -> Document {
+        return try _dropIndexes(options: options)
     }
 
-    private func _dropIndexes(keys: Document? = nil) throws -> Document {
+    private func _dropIndexes(keys: Document? = nil, options: DropIndexOptions? = nil) throws -> Document {
         let collName = String(cString: mongoc_collection_get_name(self._collection))
         let command: Document = ["dropIndexes": collName, "index": keys ?? "*"]
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_write_command_with_opts(self._collection, command.data, nil, reply.data, &error) {
+        let opts = try WriteConcern.append(options?.writeConcern, to: nil, callerWC: self.writeConcern)
+        if !mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
-
         return reply
     }
 

--- a/Sources/MongoSwift/Collection.swift
+++ b/Sources/MongoSwift/Collection.swift
@@ -805,7 +805,8 @@ public class MongoCollection<T: Codable> {
      */
     @discardableResult
     public func updateOne(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
-        let opts = try BsonEncoder().encode(options)
+        let encoder = BsonEncoder()
+        let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_update_one(
@@ -828,7 +829,8 @@ public class MongoCollection<T: Codable> {
      */
     @discardableResult
     public func updateMany(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
-        let opts = try BsonEncoder().encode(options)
+        let encoder = BsonEncoder()
+        let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_update_many(
@@ -850,7 +852,8 @@ public class MongoCollection<T: Codable> {
      */
     @discardableResult
     public func deleteOne(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
-        let opts = try BsonEncoder().encode(options)
+        let encoder = BsonEncoder()
+        let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_delete_one(
@@ -872,7 +875,8 @@ public class MongoCollection<T: Codable> {
      */
     @discardableResult
     public func deleteMany(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
-        let opts = try BsonEncoder().encode(options)
+        let encoder = BsonEncoder()
+        let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_delete_many(

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -312,7 +312,7 @@ public class MongoDatabase {
         let opts = try BsonEncoder().encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_database_command_with_opts(self._database, command.data, nil, withWC?.data, reply.data, &error) {
+        if !mongoc_database_command_with_opts(self._database, command.data, nil, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return reply

--- a/Sources/MongoSwift/Database.swift
+++ b/Sources/MongoSwift/Database.swift
@@ -8,10 +8,15 @@ public struct RunCommandOptions: Encodable {
     /// An optional `ReadConcern` to use for this operation
     public let readConcern: ReadConcern?
 
+    /// An optional WriteConcern to use for this operation
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing session to be omitted or optional
-    public init(readConcern: ReadConcern? = nil, session: ClientSession? = nil) {
+    public init(readConcern: ReadConcern? = nil, session: ClientSession? = nil,
+                writeConcern: WriteConcern? = nil) {
         self.readConcern = readConcern
         self.session = session
+        self.writeConcern = writeConcern
     }
 }
 
@@ -77,12 +82,16 @@ public struct CreateCollectionOptions: Encodable {
     /// the database's read concern.
     public let readConcern: ReadConcern?
 
+    /// A write concern to set on the returned collection. If one is not specified, it will inherit
+    /// the database's write concern.
+    let writeConcern: WriteConcern?
+
     /// Convenience initializer allowing any/all parameters to be omitted or optional
     public init(autoIndexId: Bool? = nil, capped: Bool? = nil, collation: Document? = nil,
                 indexOptionDefaults: Document? = nil, max: Int64? = nil, readConcern: ReadConcern? = nil,
                 session: ClientSession? = nil, size: Int64? = nil, storageEngine: Document? = nil,
                 validationAction: String? = nil, validationLevel: String? = nil, validator: Document? = nil,
-                viewOn: String? = nil) {
+                viewOn: String? = nil, writeConcern: WriteConcern? = nil) {
         self.autoIndexId = autoIndexId
         self.capped = capped
         self.collation = collation
@@ -96,10 +105,11 @@ public struct CreateCollectionOptions: Encodable {
         self.validationLevel = validationLevel
         self.validator = validator
         self.viewOn = viewOn
+        self.writeConcern = writeConcern
     }
 
-    // Encode everything except `readConcern`. We skip it because we don't actually
-    // send it with the initial command, we just set it on the collection after its creation.
+    // Encode everything except `readConcern` and 'writeConcern`. We skip them because we don't actually
+    // send them with the initial command, we just set them on the collection after its creation.
     private enum CodingKeys: String, CodingKey {
         case autoIndexId, capped, collation, indexOptionDefaults, max, session,
             size, storageEngine, validationAction, validationLevel, validator, viewOn
@@ -111,6 +121,16 @@ public struct CollectionOptions {
     /// A read concern to set on the returned collection. If one is not specified,
     /// the collection will inherit the database's read concern.
     public let readConcern: ReadConcern?
+
+    /// A write concern to set on the returned collection. If one is not specified,
+    /// the collection will inherit the database's write concern.
+    public let writeConcern: WriteConcern?
+
+    /// Convenience initializer allowing any/all arguments to be omitted or optional
+    public init(readConcern: ReadConcern? = nil, writeConcern: WriteConcern? = nil) {
+        self.readConcern = readConcern
+        self.writeConcern = writeConcern
+    }
 }
 
 /// A MongoDB Database
@@ -130,6 +150,15 @@ public class MongoDatabase {
         let rcObj = ReadConcern(from: readConcern)
         if rcObj.isDefault { return nil }
         return rcObj
+    }
+
+    /// The `WriteConcern` set on this database, or `nil` if one is not set.
+    public var writeConcern: WriteConcern? {
+        // per libmongoc docs, we don't need to handle freeing this ourselves
+        let writeConcern = mongoc_database_get_write_concern(self._database)
+        let wcObj = WriteConcern(writeConcern)
+        if wcObj.isDefault { return nil }
+        return wcObj
     }
 
     /// Initializes a new `MongoDatabase` instance, not meant to be instantiated directly.
@@ -188,6 +217,10 @@ public class MongoDatabase {
             mongoc_collection_set_read_concern(collection, rc._readConcern)
         }
 
+        if let wc = options?.writeConcern {
+            mongoc_collection_set_write_concern(collection, wc._writeConcern)
+        }
+
         guard let client = self._client else {
             throw MongoError.invalidClient()
         }
@@ -234,6 +267,10 @@ public class MongoDatabase {
             mongoc_collection_set_read_concern(collection, rc._readConcern)
         }
 
+        if let wc = options?.writeConcern {
+            mongoc_collection_set_write_concern(collection, wc._writeConcern)
+        }
+
         guard let client = self._client else {
             throw MongoError.invalidClient()
         }
@@ -275,7 +312,7 @@ public class MongoDatabase {
         let opts = try BsonEncoder().encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_database_command_with_opts(self._database, command.data, nil, opts?.data, reply.data, &error) {
+        if !mongoc_database_command_with_opts(self._database, command.data, nil, withWC?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return reply

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -23,6 +23,8 @@ public enum MongoError {
     case typeError(message: String)
     /// Thrown when there is an error involving a `ReadConcern`. 
     case readConcernError(message: String)
+    /// Thrown when there is an error involving a `WriteConcern`. 
+    case writeConcernError(message: String)
 }
 
 /// An extension of `MongoError` to support printing out descriptive error messages.
@@ -32,7 +34,8 @@ extension MongoError: LocalizedError {
         case let .invalidUri(message), let .invalidCursor(message),
             let .invalidCollection(message), let .commandError(message),
             let .bsonParseError(_, _, message), let .bsonEncodeError(message),
-            let .typeError(message):
+            let .typeError(message), let .readConcernError(message),
+            let .writeConcernError(message):
             return message
         default:
             return nil

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -121,7 +121,7 @@ public class WriteConcern: Codable {
     internal var _writeConcern: OpaquePointer?
 
     /// An option to request acknowledgement that the write operation has propagated to specified mongod instances.
-    public enum W: Codable , Equatable {
+    public enum W: Codable, Equatable {
         /// Specifies the number of nodes that should acknowledge the write. MUST be greater than or equal to 0.
         case number(Int32)
         /// Indicates a tag for nodes that should acknowledge the write. 

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -93,7 +93,117 @@ public class ReadConcern: Codable {
         mongoc_read_concern_destroy(readConcern)
         self._readConcern = nil
     }
+}
 
+/// A class to represent a MongoDB write concern.
+public class WriteConcern: Equatable, CustomStringConvertible {
+
+    /// A pointer to a mongoc_write_concern_t
+    internal var _writeConcern: OpaquePointer?
+
+    /// Indicates whether to wait for the write operation to get committed to the journal.
+    public var journal: Bool? {
+        return mongoc_write_concern_get_journal(self._writeConcern)
+    }
+
+    /// Specifies the number of nodes that should acknowledge the write.
+    /// MUST be greater than or equal to 0. Only one of this and wTags may be set.
+    public var w: Int32? {
+        return mongoc_write_concern_get_w(self._writeConcern)
+    }
+
+    /// Indicates a tag for nodes that should acknowledge the write. Only one of this and w may be set.
+    public var wTag: String? {
+        guard let wTag = mongoc_write_concern_get_wtag(self._writeConcern) else { return nil }
+        return String(cString: wTag)
+    }
+
+    /// If the write concern is not satisfied within this timeout (in milliseconds),
+    /// the operation will return an error. The value MUST be greater than or equal to 0.
+    public var wtimeoutMS: Int32? {
+        return mongoc_write_concern_get_wtimeout(self._writeConcern)
+    }
+
+    /// Indicates whether this is an acknowledged write concern.
+    public var isAcknowledged: Bool {
+        return mongoc_write_concern_is_acknowledged(self._writeConcern)
+    }
+
+    /// Indicates whether this is the default write concern.
+    public var isDefault: Bool {
+        return mongoc_write_concern_is_default(self._writeConcern)
+    }
+
+    /// Indicates whether the combination of values set on this WriteConcern is valid.
+    public var isValid: Bool {
+        return mongoc_write_concern_is_valid(self._writeConcern)
+    }
+
+    private var asDocument: Document {
+        let doc = Document()
+        try? self.append(to: doc)
+        return doc
+    }
+
+    public var description: String {
+        return self.asDocument.description
+    }
+
+    /// Initializes a new, empty WriteConcern
+    public init() {
+        self._writeConcern = mongoc_write_concern_new()
+    }
+
+    /// Initializes a WriteConcern. Only one of `w` and `wTag` should be provided. If both are supplied,
+    /// `wTag` will be used.
+    public init(journal: Bool? = nil, w: Int32? = nil, wTag: String? = nil, wtimeoutMS: Int32? = nil) {
+        self._writeConcern = mongoc_write_concern_new()
+        if let journal = journal { mongoc_write_concern_set_journal(self._writeConcern, journal) }
+        if let w = w { mongoc_write_concern_set_w(self._writeConcern, w) }
+        if let wTag = wTag { mongoc_write_concern_set_wtag(self._writeConcern, wTag) }
+        if let wtimeoutMS = wtimeoutMS { mongoc_write_concern_set_wtimeout(self._writeConcern, wtimeoutMS) }
+    }
+
+    /// Initializes a new WriteConcern by copying a mongoc_write_concern_t.
+    /// The caller is responsible for freeing the original mongoc_write_concern_t.
+    internal init(_ writeConcern: OpaquePointer?) {
+        self._writeConcern = mongoc_write_concern_copy(writeConcern)
+    }
+
+    /// Appends this writeConcern to a Document.
+    private func append(to doc: Document) throws {
+        if !mongoc_write_concern_append(self._writeConcern, doc.data) {
+            throw MongoError.writeConcernError(message: "Error appending WriteConcern to document \(doc)")
+        }
+    }
+
+    /// Since we have to follow certain rules about whether to include or omit a WriteConcern,
+    /// this function handles obeying those, factoring in the WriteConcern, if any, for
+    /// whatever object is calling this function. It returns a final options Document for the
+    /// calling function to use, or nil if the Document ends up being empty.
+    internal static func append(_ writeConcern: WriteConcern?, to opts: Document?, callerWC: WriteConcern?) throws -> Document? {
+        // if the user didn't specify a writeConcern, then we just want to use
+        // whatever the default is for the caller.
+        guard let wc = writeConcern else { return opts }
+
+        // the caller is using the server's default WC and we are also using default, don't append anything
+        if callerWC == nil && wc.isDefault { return opts }
+
+        // otherwise either us or the caller is using a non-default, so we need to append it
+        let output = opts ?? Document() // create base opts if they don't exist
+        try wc.append(to: output)
+        return output
+    }
+
+    public static func == (lhs: WriteConcern, rhs: WriteConcern) -> Bool {
+        return lhs.asDocument == rhs.asDocument
+    }
+
+    deinit {
+        guard let writeConcern = self._writeConcern else { return }
+        mongoc_write_concern_destroy(writeConcern)
+        self._writeConcern = nil
+    }
 }
 
 /// An extension of `ReadConcern` to make it `CustomStringConvertible`.

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -95,117 +95,6 @@ public class ReadConcern: Codable {
     }
 }
 
-/// A class to represent a MongoDB write concern.
-public class WriteConcern: Equatable, CustomStringConvertible {
-
-    /// A pointer to a mongoc_write_concern_t
-    internal var _writeConcern: OpaquePointer?
-
-    /// Indicates whether to wait for the write operation to get committed to the journal.
-    public var journal: Bool? {
-        return mongoc_write_concern_get_journal(self._writeConcern)
-    }
-
-    /// Specifies the number of nodes that should acknowledge the write.
-    /// MUST be greater than or equal to 0. Only one of this and wTags may be set.
-    public var w: Int32? {
-        return mongoc_write_concern_get_w(self._writeConcern)
-    }
-
-    /// Indicates a tag for nodes that should acknowledge the write. Only one of this and w may be set.
-    public var wTag: String? {
-        guard let wTag = mongoc_write_concern_get_wtag(self._writeConcern) else { return nil }
-        return String(cString: wTag)
-    }
-
-    /// If the write concern is not satisfied within this timeout (in milliseconds),
-    /// the operation will return an error. The value MUST be greater than or equal to 0.
-    public var wtimeoutMS: Int32? {
-        return mongoc_write_concern_get_wtimeout(self._writeConcern)
-    }
-
-    /// Indicates whether this is an acknowledged write concern.
-    public var isAcknowledged: Bool {
-        return mongoc_write_concern_is_acknowledged(self._writeConcern)
-    }
-
-    /// Indicates whether this is the default write concern.
-    public var isDefault: Bool {
-        return mongoc_write_concern_is_default(self._writeConcern)
-    }
-
-    /// Indicates whether the combination of values set on this WriteConcern is valid.
-    public var isValid: Bool {
-        return mongoc_write_concern_is_valid(self._writeConcern)
-    }
-
-    private var asDocument: Document {
-        let doc = Document()
-        try? self.append(to: doc)
-        return doc
-    }
-
-    public var description: String {
-        return self.asDocument.description
-    }
-
-    /// Initializes a new, empty WriteConcern
-    public init() {
-        self._writeConcern = mongoc_write_concern_new()
-    }
-
-    /// Initializes a WriteConcern. Only one of `w` and `wTag` should be provided. If both are supplied,
-    /// `wTag` will be used.
-    public init(journal: Bool? = nil, w: Int32? = nil, wTag: String? = nil, wtimeoutMS: Int32? = nil) {
-        self._writeConcern = mongoc_write_concern_new()
-        if let journal = journal { mongoc_write_concern_set_journal(self._writeConcern, journal) }
-        if let w = w { mongoc_write_concern_set_w(self._writeConcern, w) }
-        if let wTag = wTag { mongoc_write_concern_set_wtag(self._writeConcern, wTag) }
-        if let wtimeoutMS = wtimeoutMS { mongoc_write_concern_set_wtimeout(self._writeConcern, wtimeoutMS) }
-    }
-
-    /// Initializes a new WriteConcern by copying a mongoc_write_concern_t.
-    /// The caller is responsible for freeing the original mongoc_write_concern_t.
-    internal init(_ writeConcern: OpaquePointer?) {
-        self._writeConcern = mongoc_write_concern_copy(writeConcern)
-    }
-
-    /// Appends this writeConcern to a Document.
-    private func append(to doc: Document) throws {
-        if !mongoc_write_concern_append(self._writeConcern, doc.data) {
-            throw MongoError.writeConcernError(message: "Error appending WriteConcern to document \(doc)")
-        }
-    }
-
-    /// Since we have to follow certain rules about whether to include or omit a WriteConcern,
-    /// this function handles obeying those, factoring in the WriteConcern, if any, for
-    /// whatever object is calling this function. It returns a final options Document for the
-    /// calling function to use, or nil if the Document ends up being empty.
-    internal static func append(_ writeConcern: WriteConcern?, to opts: Document?, callerWC: WriteConcern?) throws -> Document? {
-        // if the user didn't specify a writeConcern, then we just want to use
-        // whatever the default is for the caller.
-        guard let wc = writeConcern else { return opts }
-
-        // the caller is using the server's default WC and we are also using default, don't append anything
-        if callerWC == nil && wc.isDefault { return opts }
-
-        // otherwise either us or the caller is using a non-default, so we need to append it
-        let output = opts ?? Document() // create base opts if they don't exist
-        try wc.append(to: output)
-        return output
-    }
-
-    public static func == (lhs: WriteConcern, rhs: WriteConcern) -> Bool {
-        return lhs.asDocument == rhs.asDocument
-    }
-
-    deinit {
-        guard let writeConcern = self._writeConcern else { return }
-        mongoc_write_concern_destroy(writeConcern)
-        self._writeConcern = nil
-    }
-}
-
 /// An extension of `ReadConcern` to make it `CustomStringConvertible`.
 extension ReadConcern: CustomStringConvertible {
     /// An extended JSON description of this `ReadConcern`, or the
@@ -222,5 +111,168 @@ extension ReadConcern: CustomStringConvertible {
 extension ReadConcern: Equatable {
     public static func == (lhs: ReadConcern, rhs: ReadConcern) -> Bool {
         return lhs.level == rhs.level
+    }
+}
+
+/// A class to represent a MongoDB write concern.
+public class WriteConcern: Codable {
+
+    /// A pointer to a mongoc_write_concern_t
+    internal var _writeConcern: OpaquePointer?
+
+    /// An option to request acknowledgement that the write operation has propagated to specified mongod instances.
+    public enum W: Codable , Equatable{
+        /// Specifies the number of nodes that should acknowledge the write. MUST be greater than or equal to 0.
+        case number(Int32)
+        /// Indicates a tag for nodes that should acknowledge the write. 
+        case tag(String)
+        /// Specifies that a majoirty of nodes should acknowledge the write.
+        case majority
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let wTag = try? container.decode(String.self) {
+                self = .tag(wTag)
+            } else {
+                let wNumber = try container.decode(Int32.self)
+                if wNumber == MONGOC_WRITE_CONCERN_W_MAJORITY {
+                    self = .majority
+                } else {
+                    self = .number(wNumber)
+                }
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case let .number(wNumber):
+                try container.encode(wNumber)
+            case let .tag(wTag):
+                try container.encode(wTag)
+            case .majority:
+                try container.encode("majority")
+            }
+        }
+
+        public static func == (lhs: W, rhs: W) -> Bool {
+            switch (lhs, rhs) {
+            case let (.number(lNum), .number(rNum)):
+                return lNum == rNum
+            case let (.tag(lTag), .tag(rTag)):
+                return lTag == rTag
+            case (.majority, .majority):
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    /// Indicates the `W` value for this `WriteConcern`.
+    public var w: W {
+        if let wTag = mongoc_write_concern_get_wtag(self._writeConcern) {
+            return .tag(String(cString: wTag))
+        }
+        let number = mongoc_write_concern_get_w(self._writeConcern)
+        if number == MONGOC_WRITE_CONCERN_W_MAJORITY { return .majority }
+        return .number(number)
+    }
+
+    /// Indicates whether to wait for the write operation to get committed to the journal.
+    public var journal: Bool? {
+        return mongoc_write_concern_get_journal(self._writeConcern)
+    }
+
+    /// If the write concern is not satisfied within this timeout (in milliseconds),
+    /// the operation will return an error. The value MUST be greater than or equal to 0.
+    public var wtimeoutMS: Int32? {
+        return mongoc_write_concern_get_wtimeout(self._writeConcern)
+    }
+
+    /// Indicates whether vbnm this is an acknowledged write concern.
+    public var isAcknowledged: Bool {
+        return mongoc_write_concern_is_acknowledged(self._writeConcern)
+    }
+
+    /// Indicates whether this is the default write concern.
+    public var isDefault: Bool {
+        return mongoc_write_concern_is_default(self._writeConcern)
+    }
+
+    /// Indicates whether the combination of values set on this `WriteConcern` is valid.
+    public var isValid: Bool {
+        return mongoc_write_concern_is_valid(self._writeConcern)
+    }
+
+    /// Initializes a new, empty `WriteConcern`.
+    public init() {
+        self._writeConcern = mongoc_write_concern_new()
+    }
+
+    /// Initializes a new `WriteConcern`.
+    public init(journal: Bool? = nil, w: W? = nil, wtimeoutMS: Int32? = nil) {
+        self._writeConcern = mongoc_write_concern_new()
+        if let journal = journal { mongoc_write_concern_set_journal(self._writeConcern, journal) }
+        if let wtimeoutMS = wtimeoutMS { mongoc_write_concern_set_wtimeout(self._writeConcern, wtimeoutMS) }
+
+        if let w = w {
+            switch w {
+            case let .number(wNumber):
+                mongoc_write_concern_set_w(self._writeConcern, wNumber) 
+            case let .tag(wTag):
+                mongoc_write_concern_set_wtag(self._writeConcern, wTag)
+            case .majority:
+                mongoc_write_concern_set_w(self._writeConcern, MONGOC_WRITE_CONCERN_W_MAJORITY)
+            }
+        }
+    }
+
+    /// Initializes a new `WriteConcern` by copying a `mongoc_write_concern_t`.
+    /// The caller is responsible for freeing the original `mongoc_write_concern_t`.
+    internal init(_ writeConcern: OpaquePointer?) {
+        self._writeConcern = mongoc_write_concern_copy(writeConcern)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case w, j, wtimeout
+    }
+
+    public required convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let w = try container.decodeIfPresent(W.self, forKey: .w)
+        let journal = try container.decodeIfPresent(Bool.self, forKey: .j)
+        let wtimeoutMS = try container.decodeIfPresent(Int32.self, forKey: .wtimeout)
+        self.init(journal: journal, w: w, wtimeoutMS: wtimeoutMS)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.w, forKey: .w)
+        try container.encodeIfPresent(self.journal, forKey: .j)
+        try container.encodeIfPresent(self.wtimeoutMS, forKey: .wtimeout)
+    }
+
+    deinit {
+        guard let writeConcern = self._writeConcern else { return }
+        mongoc_write_concern_destroy(writeConcern)
+        self._writeConcern = nil
+    }
+}
+
+/// An extension of `WriteConcern` to make it `CustomStringConvertible`.
+extension WriteConcern: CustomStringConvertible {
+    public var description: String {
+        if let encoded = try? BsonEncoder().encode(self).description {
+            return encoded
+        }
+        return ""
+    }
+}
+
+/// An extension of `WriteConcern` to make it `Equatable`.
+extension WriteConcern: Equatable {
+    public static func == (lhs: WriteConcern, rhs: WriteConcern) -> Bool {
+        return lhs.description == rhs.description
     }
 }

--- a/Sources/MongoSwift/ReadWriteConcern.swift
+++ b/Sources/MongoSwift/ReadWriteConcern.swift
@@ -121,7 +121,7 @@ public class WriteConcern: Codable {
     internal var _writeConcern: OpaquePointer?
 
     /// An option to request acknowledgement that the write operation has propagated to specified mongod instances.
-    public enum W: Codable , Equatable{
+    public enum W: Codable , Equatable {
         /// Specifies the number of nodes that should acknowledge the write. MUST be greater than or equal to 0.
         case number(Int32)
         /// Indicates a tag for nodes that should acknowledge the write. 

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -1,7 +1,6 @@
 @testable import MongoSwift
 import Nimble
 import XCTest
-import libmongoc
 
 extension WriteConcern {
     /// Initialize a new ReadConcern from a Document.


### PR DESCRIPTION
Main changes since the last time you looked at this @mbroadst -
- no more manually appending `WriteConcern`s
- `WriteConcern` now `Codable`
- I switched `w` to an `enum` to better reflect the three different options for `w` values: tag, number, and "majority"