### PR TITLE
SWIFT-106 Enable deleteOne-collation and deleteMany-collation CRUD tests

### DIFF
--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -13,10 +13,7 @@ private var skippedFiles = [
     "findOneAndReplace",
     "findOneAndUpdate-arrayFilters",
     "findOneAndUpdate-collation",
-    "findOneAndUpdate",
-    // TODO: once CDRIVER-2527 changes available, stop skipping these 
-    "deleteMany-collation",
-    "deleteOne-collation"
+    "findOneAndUpdate"
 ]
 
 internal extension Document {


### PR DESCRIPTION
We skipped the delete + collation tests before because of [CDRIVER-2527](https://jira.mongodb.org/browse/CDRIVER-2527). A fix was included in libmongoc 1.10, so we no longer need to skip them. 