### PR TITLE
SWIFT-143: ReadPreference option for core classes and operations

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -13,7 +13,8 @@ extension MongoCollection {
      */
     public func find(_ filter: Document = [:], options: FindOptions? = nil) throws -> MongoCursor<CollectionType> {
         let opts = try BsonEncoder().encode(options)
-        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts?.data, nil) else {
+        let rp = options?.readPreference?._readPreference
+        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts?.data, rp) else {
             throw MongoError.invalidResponse()
         }
         guard let client = self._client else {
@@ -33,9 +34,10 @@ extension MongoCollection {
      */
     public func aggregate(_ pipeline: [Document], options: AggregateOptions? = nil) throws -> MongoCursor<Document> {
         let opts = try BsonEncoder().encode(options)
+        let rp = options?.readPreference?._readPreference
         let pipeline: Document = ["pipeline": pipeline]
         guard let cursor = mongoc_collection_aggregate(
-            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts?.data, nil) else {
+            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts?.data, rp) else {
             throw MongoError.invalidResponse()
         }
         guard let client = self._client else {
@@ -55,11 +57,12 @@ extension MongoCollection {
      */
     public func count(_ filter: Document = [:], options: CountOptions? = nil) throws -> Int {
         let opts = try BsonEncoder().encode(options)
+        let rp = options?.readPreference?._readPreference
         var error = bson_error_t()
         // because we already encode skip and limit in the options,
         // pass in 0s so we don't get duplicate parameter errors.
         let count = mongoc_collection_count_with_opts(
-            self._collection, MONGOC_QUERY_NONE, filter.data, 0, 0, opts?.data, nil, &error)
+            self._collection, MONGOC_QUERY_NONE, filter.data, 0, 0, opts?.data, rp, &error)
 
         if count == -1 { throw MongoError.commandError(message: toErrorString(error)) }
 
@@ -90,10 +93,11 @@ extension MongoCollection {
         ]
 
         let opts = try BsonEncoder().encode(options)
+        let rp = options?.readPreference?._readPreference
         let reply = Document()
         var error = bson_error_t()
         if !mongoc_collection_read_command_with_opts(
-            self._collection, command.data, nil, opts?.data, reply.data, &error) {
+            self._collection, command.data, rp, opts?.data, reply.data, &error) {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
@@ -164,13 +168,17 @@ public struct AggregateOptions: Encodable {
     /// A `ReadConcern` to use in read stages of this operation.
     public let readConcern: ReadConcern?
 
+    /// A ReadPreference to use for this operation.
+    public let readPreference: ReadPreference?
+
     /// A `WriteConcern` to use in `$out` stages of this operation.
     public let writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(allowDiskUse: Bool? = nil, batchSize: Int32? = nil, bypassDocumentValidation: Bool? = nil,
                 collation: Document? = nil, comment: String? = nil, hint: Hint? = nil, maxTimeMS: Int64? = nil,
-                readConcern: ReadConcern? = nil, writeConcern: WriteConcern? = nil) {
+                readConcern: ReadConcern? = nil, readPreference: ReadPreference? = nil,
+                writeConcern: WriteConcern? = nil) {
         self.allowDiskUse = allowDiskUse
         self.batchSize = batchSize
         self.bypassDocumentValidation = bypassDocumentValidation
@@ -179,7 +187,13 @@ public struct AggregateOptions: Encodable {
         self.hint = hint
         self.maxTimeMS = maxTimeMS
         self.readConcern = readConcern
+        self.readPreference = readPreference
         self.writeConcern = writeConcern
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case allowDiskUse, batchSize, bypassDocumentValidation, collation, maxTimeMS, comment, hint, readConcern,
+            writeConcern
     }
 }
 
@@ -203,15 +217,23 @@ public struct CountOptions: Encodable {
     /// A ReadConcern to use for this operation. 
     public let readConcern: ReadConcern?
 
+    /// A ReadPreference to use for this operation.
+    public let readPreference: ReadPreference?
+
     /// Convenience initializer allowing any/all parameters to be optional
     public init(collation: Document? = nil, hint: Hint? = nil, limit: Int64? = nil, maxTimeMS: Int64? = nil,
-                readConcern: ReadConcern? = nil, skip: Int64? = nil) {
+                readConcern: ReadConcern? = nil, readPreference: ReadPreference? = nil, skip: Int64? = nil) {
         self.collation = collation
         self.hint = hint
         self.limit = limit
         self.maxTimeMS = maxTimeMS
         self.readConcern = readConcern
+        self.readPreference = readPreference
         self.skip = skip
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case collation, hint, limit, maxTimeMS, readConcern, skip
     }
 }
 
@@ -226,11 +248,20 @@ public struct DistinctOptions: Encodable {
     /// A ReadConcern to use for this operation. 
     public let readConcern: ReadConcern?
 
+    /// A ReadPreference to use for this operation.
+    public let readPreference: ReadPreference?
+
     /// Convenience initializer allowing any/all parameters to be optional
-    public init(collation: Document? = nil, maxTimeMS: Int64? = nil, readConcern: ReadConcern? = nil) {
+    public init(collation: Document? = nil, maxTimeMS: Int64? = nil, readConcern: ReadConcern? = nil,
+                readPreference: ReadPreference? = nil) {
         self.collation = collation
         self.maxTimeMS = maxTimeMS
         self.readConcern = readConcern
+        self.readPreference = readPreference
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case collation, maxTimeMS, readConcern
     }
 }
 
@@ -333,13 +364,16 @@ public struct FindOptions: Encodable {
     /// A ReadConcern to use for this operation. 
     public let readConcern: ReadConcern?
 
+    /// A ReadPreference to use for this operation.
+    public let readPreference: ReadPreference?
+
     /// Convenience initializer allowing any/all parameters to be optional
     public init(allowPartialResults: Bool? = nil, batchSize: Int32? = nil, collation: Document? = nil,
                 comment: String? = nil, cursorType: CursorType? = nil, hint: Hint? = nil, limit: Int64? = nil,
                 max: Document? = nil, maxAwaitTimeMS: Int64? = nil, maxScan: Int64? = nil, maxTimeMS: Int64? = nil,
                 min: Document? = nil, noCursorTimeout: Bool? = nil, projection: Document? = nil,
-                readConcern: ReadConcern? = nil, returnKey: Bool? = nil, showRecordId: Bool? = nil, skip: Int64? = nil,
-                sort: Document? = nil) {
+                readConcern: ReadConcern? = nil, readPreference: ReadPreference? = nil, returnKey: Bool? = nil,
+                showRecordId: Bool? = nil, skip: Int64? = nil, sort: Document? = nil) {
         self.allowPartialResults = allowPartialResults
         self.batchSize = batchSize
         self.collation = collation
@@ -358,6 +392,7 @@ public struct FindOptions: Encodable {
         self.noCursorTimeout = noCursorTimeout
         self.projection = projection
         self.readConcern = readConcern
+        self.readPreference = readPreference
         self.returnKey = returnKey
         self.showRecordId = showRecordId
         self.skip = skip

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -29,6 +29,11 @@ public class MongoCollection<T: Codable> {
         return rcObj
     }
 
+    /// The `ReadPreference` set on this collection
+    public var readPreference: ReadPreference? {
+        return ReadPreference(from: mongoc_collection_get_read_prefs(self._collection))
+    }
+
     /// The `WriteConcern` set on this collection, or nil if one is not set.
     public var writeConcern: WriteConcern? {
         // per libmongoc docs, we don't need to handle freeing this ourselves

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -110,13 +110,19 @@ public struct CollectionOptions {
     /// the collection will inherit the database's read concern.
     public let readConcern: ReadConcern?
 
+    /// A read preference to set on the returned collection. If one is not
+    /// specified, the collection will inherit the database's read preference.
+    public let readPreference: ReadPreference?
+
     /// A write concern to set on the returned collection. If one is not specified,
     /// the collection will inherit the database's write concern.
     public let writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all arguments to be omitted or optional
-    public init(readConcern: ReadConcern? = nil, writeConcern: WriteConcern? = nil) {
+    public init(readConcern: ReadConcern? = nil, readPreference: ReadPreference? = nil,
+                writeConcern: WriteConcern? = nil) {
         self.readConcern = readConcern
+        self.readPreference = readPreference
         self.writeConcern = writeConcern
     }
 }
@@ -138,6 +144,11 @@ public class MongoDatabase {
         let rcObj = ReadConcern(from: readConcern)
         if rcObj.isDefault { return nil }
         return rcObj
+    }
+
+    /// The `ReadPreference` set on this database
+    public var readPreference: ReadPreference? {
+        return ReadPreference(from: mongoc_collection_get_read_prefs(self._database))
     }
 
     /// The `WriteConcern` set on this database, or `nil` if one is not set.
@@ -203,6 +214,10 @@ public class MongoDatabase {
 
         if let rc = options?.readConcern {
             mongoc_collection_set_read_concern(collection, rc._readConcern)
+        }
+
+        if let rp = options?.readPreference {
+            mongoc_collection_set_read_prefs(collection, rp._readPreference)
         }
 
         if let wc = options?.writeConcern {


### PR DESCRIPTION
https://jira.mongodb.org/browse/SWIFT-143

I believe this covers all of the relevant helper methods currently in the driver:

 * `MongoDatabase.runCommand()`
 * `MongoCollection.aggregate()`
 * `MongoCollection.count()`
 * `MongoCollection.distinct()`
 * `MongoCollection.find()`

Per the database, collection, and index enumeration specs, those operations must be executed on a primary server (unless connected to a secondary in standalone mode). In any event, they do not use a read preference.