### PR TITLE
SWIFT-146: Implement findAndModify API

### DIFF
--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -19,7 +19,8 @@ extension MongoCollection {
     @discardableResult
     public func findOneAndDelete(_ filter: Document,
                                  options: FindOneAndDeleteOptions? = nil) throws -> CollectionType? {
-        return try self.findAndModify(filter: filter, options: options)
+        let opts = options ?? FindOneAndDeleteOptions()
+        return try self.findAndModify(filter: filter, options: opts)
     }
 
     /**
@@ -73,7 +74,6 @@ extension MongoCollection {
                                options: FindAndModifyOptionsConvertible? = nil) throws -> CollectionType? {
 
         var opts = try options?.asOpts()
-
         if let update = update {
             // if no options were provided but we need to set update, create them
             opts = opts ?? FindAndModifyOptions()
@@ -291,7 +291,7 @@ private class FindAndModifyOptions {
         if let coll = collation { extra["collation"] = coll }
 
         // note: mongoc_find_and_modify_opts_set_max_time_ms() takes in a 
-        // uint32_t, but it should be a positive 64-bit integer. thus, we
+        // uint32_t, but it should be a positive 64-bit integer, so we
         // set maxTimeMS by directly appending it instead. see CDRIVER-1329
         if let maxTime = maxTimeMS {
             guard maxTime > 0 else {

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -89,9 +89,9 @@ extension MongoCollection {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
-        if reply == [:] { return nil }
+        guard let value = reply["value"] as? Document else { return nil }
 
-        return try BsonDecoder().decode(CollectionType.self, from: reply)
+        return try BsonDecoder().decode(CollectionType.self, from: value)
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -15,8 +15,9 @@ extension MongoCollection {
      *   - A `DecodingError` if the deleted document cannot be decoded to a `CollectionType` value
      */
     @discardableResult
-    public func findOneAndDelete(_ filter: Document, options: FindOneAndDeleteOptions? = nil) throws -> CollectionType? {
-        throw MongoError.commandError(message: "Unimplemented command")
+    public func findOneAndDelete(_ filter: Document,
+                                 options: FindOneAndDeleteOptions? = nil) throws -> CollectionType? {
+        return try self.findAndModify(filter: filter, options: options)
     }
 
     /**
@@ -36,8 +37,9 @@ extension MongoCollection {
      */
     @discardableResult
     public func findOneAndReplace(filter: Document, replacement: CollectionType,
-                                  options: FindOneAndDeleteOptions? = nil) throws -> CollectionType? {
-        throw MongoError.commandError(message: "Unimplemented command")
+                                  options: FindOneAndReplaceOptions? = nil) throws -> CollectionType? {
+        let update = try BsonEncoder().encode(replacement)
+        return try self.findAndModify(filter: filter, update: update, options: options)
     }
 
     /**
@@ -57,25 +59,53 @@ extension MongoCollection {
     @discardableResult
     public func findOneAndUpdate(filter: Document, update: Document,
                                  options: FindOneAndUpdateOptions? = nil) throws -> CollectionType? {
-        throw MongoError.commandError(message: "Unimplemented command")
+        return try self.findAndModify(filter: filter, update: update, options: options)
+    }
+
+    /// A private helper method for findAndModify operations to use
+    private func findAndModify(filter: Document, update: Document? = nil,
+                               options: FindAndModifyOptionsConvertible? = nil) throws -> CollectionType? {
+
+        var opts = try options?.asOpts()
+
+        if let update = update {
+            // if no options were provided but we need to set update, create them
+            opts = opts ?? FindAndModifyOptions()
+            try opts!.setUpdate(update)
+        }
+
+        let reply = Document()
+        var error = bson_error_t()
+
+        if !mongoc_collection_find_and_modify_with_opts(self._collection,
+        filter.data, opts?._options, reply.data, &error) {
+            // TODO SWIFT-144: replace with more descriptive error type(s)
+            throw MongoError.commandError(message: toErrorString(error))
+        }
+
+        if reply == [:] { return nil }
+
+        return try BsonDecoder().decode(CollectionType.self, from: reply)
     }
 }
 
 /// Indicates which document to return in a find and modify operation.
-public enum ReturnDocument: Encodable {
+public enum ReturnDocument {
     /// Indicates to return the document before the update, replacement, or insert occured.
     case before
 
     ///  Indicates to return the document after the update, replacement, or insert occured.
     case after
+}
 
-    public func encode(to encoder: Encoder) throws {
-        // fill in later on
-    }
+/// Indicates that an option type can be represented as a `FindAndModifyOptions`
+private protocol FindAndModifyOptionsConvertible {
+    /// Converts `self` to a `FindAndModifyOptions`
+    func asOpts() throws -> FindAndModifyOptions
 }
 
 /// Options to use when executing a `findOneAndDelete` command on a `MongoCollection`. 
-public struct FindOneAndDeleteOptions: Encodable {
+public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible {
     /// Specifies a collation to use.
     public let collation: Document?
 
@@ -90,10 +120,25 @@ public struct FindOneAndDeleteOptions: Encodable {
 
     /// An optional `WriteConcern` to use for the command.
     public let writeConcern: WriteConcern?
+
+    fileprivate func asOpts() throws -> FindAndModifyOptions {
+        return try FindAndModifyOptions(collation: collation, maxTimeMS: maxTimeMS, projection: projection,
+                                        remove: true, sort: sort, writeConcern: writeConcern)
+    }
+
+    /// Convenience initializer allowing any/all parameters to be omitted/optional
+    public init(collation: Document? = nil, maxTimeMS: Int64? = nil, projection: Document? = nil, sort: Document? = nil,
+                writeConcern: WriteConcern? = nil) {
+        self.collation = collation
+        self.maxTimeMS = maxTimeMS
+        self.projection = projection
+        self.sort = sort
+        self.writeConcern = writeConcern
+    }
 }
 
 /// Options to use when executing a `findOneAndReplace` command on a `MongoCollection`. 
-public struct FindOneAndReplaceOptions: Encodable {
+public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible {
     /// If `true`, allows the write to opt-out of document level validation.
     public let bypassDocumentValidation: Bool?
 
@@ -117,10 +162,30 @@ public struct FindOneAndReplaceOptions: Encodable {
 
     /// An optional `WriteConcern` to use for the command.
     public let writeConcern: WriteConcern?
+
+    fileprivate func asOpts() throws -> FindAndModifyOptions {
+        return try FindAndModifyOptions(bypassDocumentValidation: bypassDocumentValidation, collation: collation,
+                                        maxTimeMS: maxTimeMS, projection: projection, returnDocument: returnDocument,
+                                        sort: sort, upsert: upsert, writeConcern: writeConcern)
+    }
+
+    /// Convenience initializer allowing any/all parameters to be omitted/optional
+    public init(bypassDocumentValidation: Bool? = nil, collation: Document? = nil, maxTimeMS: Int64? = nil,
+                projection: Document? = nil, returnDocument: ReturnDocument? = nil, sort: Document? = nil,
+                upsert: Bool? = nil, writeConcern: WriteConcern? = nil) {
+        self.bypassDocumentValidation = bypassDocumentValidation
+        self.collation = collation
+        self.maxTimeMS = maxTimeMS
+        self.projection = projection
+        self.returnDocument = returnDocument
+        self.sort = sort
+        self.upsert = upsert
+        self.writeConcern = writeConcern
+    }
 }
 
 /// Options to use when executing a `findOneAndUpdate` command on a `MongoCollection`. 
-public struct FindOneAndUpdateOptions: Encodable {
+public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible {
     /// A set of filters specifying to which array elements an update should apply.
     public let arrayFilters: [Document]?
 
@@ -147,4 +212,100 @@ public struct FindOneAndUpdateOptions: Encodable {
 
     /// An optional `WriteConcern` to use for the command.
     public let writeConcern: WriteConcern?
+
+    fileprivate func asOpts() throws -> FindAndModifyOptions {
+        return try FindAndModifyOptions(arrayFilters: arrayFilters, bypassDocumentValidation: bypassDocumentValidation,
+                                        collation: collation, maxTimeMS: maxTimeMS, projection: projection,
+                                        returnDocument: returnDocument, sort: sort, upsert: upsert,
+                                        writeConcern: writeConcern)
+    }
+
+    /// Convenience initializer allowing any/all parameters to be omitted/optional
+    public init(arrayFilters: [Document]? = nil, bypassDocumentValidation: Bool? = nil, collation: Document? = nil,
+                maxTimeMS: Int64? = nil, projection: Document? = nil, returnDocument: ReturnDocument? = nil,
+                sort: Document? = nil, upsert: Bool? = nil, writeConcern: WriteConcern? = nil) {
+        self.arrayFilters = arrayFilters
+        self.bypassDocumentValidation = bypassDocumentValidation
+        self.collation = collation
+        self.maxTimeMS = maxTimeMS
+        self.projection = projection
+        self.returnDocument = returnDocument
+        self.sort = sort
+        self.upsert = upsert
+        self.writeConcern = writeConcern
+    }
+}
+
+/// A class wrapping a `mongoc_find_and_modify_opts_t`, for use with `MongoCollection.findAndModify`
+private class FindAndModifyOptions {
+    // an `OpaquePointer` to a `mongoc_find_and_modify_opts_t`
+    var _options: OpaquePointer?
+
+    init() {
+        self._options = mongoc_find_and_modify_opts_new()
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    init(arrayFilters: [Document]? = nil, bypassDocumentValidation: Bool? = nil, collation: Document?,
+         maxTimeMS: Int64?, projection: Document?, remove: Bool? = nil, returnDocument: ReturnDocument? = nil,
+         sort: Document?, upsert: Bool? = nil, writeConcern: WriteConcern?) throws {
+        self._options = mongoc_find_and_modify_opts_new()
+
+        if let bypass = bypassDocumentValidation,
+        !mongoc_find_and_modify_opts_set_bypass_document_validation(self._options, bypass) {
+            throw MongoError.invalidArgument(message: "Error setting bypassDocumentValidation to \(bypass)")
+        }
+
+        if let fields = projection, !mongoc_find_and_modify_opts_set_fields(self._options, fields.data) {
+            throw MongoError.invalidArgument(message: "Error setting fields to \(fields)")
+        }
+
+        // build a mongoc_find_and_modify_flags_t
+        var flags = MONGOC_FIND_AND_MODIFY_NONE.rawValue
+        if remove == true { flags |= MONGOC_FIND_AND_MODIFY_REMOVE.rawValue }
+        if upsert == true { flags |= MONGOC_FIND_AND_MODIFY_UPSERT.rawValue }
+        if returnDocument == .after { flags |= MONGOC_FIND_AND_MODIFY_RETURN_NEW.rawValue }
+        let mongocFlags = mongoc_find_and_modify_flags_t(rawValue: flags)
+
+        if mongocFlags != MONGOC_FIND_AND_MODIFY_NONE,
+        !mongoc_find_and_modify_opts_set_flags(self._options, mongocFlags) {
+            let remStr = String(describing: remove)
+            let upsStr = String(describing: upsert)
+            let retStr = String(describing: returnDocument)
+            throw MongoError.invalidArgument(message:
+                "Error setting flags to \(flags); remove=\(remStr), upsert=\(upsStr), returnDocument=\(retStr)")
+        }
+
+        if let sort = sort, !mongoc_find_and_modify_opts_set_sort(self._options, sort.data) {
+            throw MongoError.invalidArgument(message: "Error setting sort to \(sort)")
+        }
+
+        // build an "extra" document of fields without their own setters
+        var extra = Document()
+        if let filters = arrayFilters { extra["arrayFilters"] = filters }
+        if let coll = collation { extra["collation"] = coll }
+        // note: mongoc_find_and_modify_opts_set_max_time_ms() takes in a 
+        // uint32_t, but it should be a positive 64-bit integer. thus, we
+        // set maxTimeMS by directly appending it instead. see CDRIVER-1329
+        if let maxTime = maxTimeMS { extra["maxTimeMS"] = maxTime }
+        if let wc = writeConcern { extra["writeConcern"] = try BsonEncoder().encode(wc) }
+
+        if extra != [:], !mongoc_find_and_modify_opts_append(self._options, extra.data) {
+            throw MongoError.invalidArgument(message: "Error appending extra fields \(extra)")
+        }
+    }
+
+    /// Sets the `update` value on a `mongoc_find_and_modify_opts_t`. We need to have this separate from the 
+    /// initializer because its value comes from the API methods rather than their options types.
+    fileprivate func setUpdate(_ update: Document) throws {
+        if !mongoc_find_and_modify_opts_set_update(self._options, update.data) {
+            throw MongoError.invalidArgument(message: "Error setting update to \(update)")
+        }
+    }
+
+    deinit {
+        guard let options = self._options else { return }
+        mongoc_find_and_modify_opts_destroy(options)
+        self._options = nil
+    }
 }

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -77,7 +77,7 @@ extension MongoCollection {
         // encode provided options, or create empty ones. we always need
         // to send *something*, as findAndModify requires one of "remove"
         // or "update" to be set. 
-        var opts = try options?.asOpts() ?? FindAndModifyOptions()
+        let opts = try options?.asOpts() ?? FindAndModifyOptions()
 
         if let update = update { try opts.setUpdate(update) }
 
@@ -273,8 +273,8 @@ private class FindAndModifyOptions {
         if returnDocument == .after { flags |= MONGOC_FIND_AND_MODIFY_RETURN_NEW.rawValue }
         let mongocFlags = mongoc_find_and_modify_flags_t(rawValue: flags)
 
-        if mongocFlags != MONGOC_FIND_AND_MODIFY_NONE,
-        !mongoc_find_and_modify_opts_set_flags(self._options, mongocFlags) {
+        if mongocFlags != MONGOC_FIND_AND_MODIFY_NONE
+        && !mongoc_find_and_modify_opts_set_flags(self._options, mongocFlags) {
             let remStr = String(describing: remove)
             let upsStr = String(describing: upsert)
             let retStr = String(describing: returnDocument)
@@ -309,7 +309,7 @@ private class FindAndModifyOptions {
             }
         }
 
-        if extra.keys.count > 0, !mongoc_find_and_modify_opts_append(self._options, extra.data) {
+        if extra.keys.count > 0 && !mongoc_find_and_modify_opts_append(self._options, extra.data) {
             throw MongoError.invalidArgument(message: "Error appending extra fields \(extra)")
         }
     }

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -6,16 +6,7 @@ import XCTest
 // Files to skip because we don't currently support the operations they test.
 private var skippedFiles = [
     // TODO SWIFT-147: enable this
-    "bulkWrite-arrayFilters",
-    // TODO SWIFT-156: enable these
-    "findOneAndDelete-collation",
-    "findOneAndDelete",
-    "findOneAndReplace-collation",
-    "findOneAndReplace-upsert",
-    "findOneAndReplace",
-    "findOneAndUpdate-arrayFilters",
-    "findOneAndUpdate-collation",
-    "findOneAndUpdate"
+    "bulkWrite-arrayFilters"
 ]
 
 internal extension Document {
@@ -158,11 +149,20 @@ private class CrudTest {
     let args: Document
     let result: BsonValue?
     let collection: Document?
+
+    var arrayFilters: [Document]? { return self.args["arrayFilters"] as? [Document] }
+    var batchSize: Int32? { if let b = self.args["batchSize"] as? Int { return Int32(b) } else { return nil } }
     var collation: Document? { return self.args["collation"] as? Document }
     var sort: Document? { return self.args["sort"] as? Document }
     var skip: Int64? { if let s = self.args["skip"] as? Int { return Int64(s) } else { return nil } }
     var limit: Int64? { if let l = self.args["limit"] as? Int { return Int64(l) } else { return nil } }
-    var batchSize: Int32? { if let b = self.args["batchSize"] as? Int { return Int32(b) } else { return nil } }
+    var projection: Document? { return self.args["projection"] as? Document }
+    var returnDoc: ReturnDocument? {
+        if let ret = self.args["returnDocument"] as? String {
+            return ret == "After" ? .after : .before
+        }
+        return nil
+    }
     var upsert: Bool? { return self.args["upsert"] as? Bool }
 
     /// Initializes a new `CrudTest` from a `Document`. 
@@ -203,6 +203,16 @@ private class CrudTest {
             expect(upsertedId).to(equal(expected?["upsertedId"] as? Int))
         } else {
             expect(expected?["upsertedId"] as? Int).to(beNil())
+        }
+    }
+
+    /// Given the response to a findAndModify command, verify that it matches the expected
+    /// results for this `CrudTest`. Meant for use by findAndModify subclasses, i.e. findOneAndX. 
+    func verifyFindAndModifyResult(_ result: Document?) {
+        if self.result == nil {
+            expect(result?["value"]).to(beNil())
+        } else {
+            expect(result?["value"] as? Document).to(equal(self.result as? Document))
         }
     }
 }
@@ -276,7 +286,7 @@ private class DistinctTest: CrudTest {
 private class FindTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter: Document = try self.args.get("filter")
-        let options = FindOptions(batchSize: batchSize, collation: collation, limit: self.limit,
+        let options = FindOptions(batchSize: self.batchSize, collation: self.collation, limit: self.limit,
                                     skip: self.skip, sort: self.sort)
         let result = try Array(coll.find(filter, options: options))
         expect(result).to(equal(self.result as? [Document]))
@@ -286,21 +296,39 @@ private class FindTest: CrudTest {
 /// A class for executing `findOneAndDelete` tests
 private class FindOneAndDeleteTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
-        XCTFail("Unimplemented")
+        let filter: Document = try self.args.get("filter")
+        let opts = FindOneAndDeleteOptions(collation: self.collation, projection: self.projection, sort: self.sort)
+        
+        let result = try coll.findOneAndDelete(filter, options: opts)
+        self.verifyFindAndModifyResult(result)
     }
 }
 
 /// A class for executing `findOneAndUpdate` tests
 private class FindOneAndReplaceTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
-        XCTFail("Unimplemented")
+        let filter: Document = try self.args.get("filter")
+        let replacement: Document = try self.args.get("replacement")
+
+        let opts = FindOneAndReplaceOptions(collation: self.collation, projection: self.projection,
+                                            returnDocument: self.returnDoc, sort: self.sort, upsert: self.upsert)
+
+        let result = try coll.findOneAndReplace(filter: filter, replacement: replacement, options: opts)
+        self.verifyFindAndModifyResult(result)
     }
 }
 
 /// A class for executing `findOneAndReplace` tests
 private class FindOneAndUpdateTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
-        XCTFail("Unimplemented")
+        let filter: Document = try self.args.get("filter")
+        let update: Document = try self.args.get("update")
+
+        let opts = FindOneAndUpdateOptions(arrayFilters: self.arrayFilters, collation: self.collation,
+            projection: self.projection, returnDocument: self.returnDoc, sort: self.sort, upsert: self.upsert)
+
+        let result = try coll.findOneAndUpdate(filter: filter, update: update, options: opts)
+        self.verifyFindAndModifyResult(result)
     }
 }
 
@@ -349,8 +377,7 @@ private class UpdateTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter: Document = try self.args.get("filter")
         let update: Document = try self.args.get("update")
-        let arrayFilters = self.args["arrayFilters"] as? [Document]
-        let options = UpdateOptions(arrayFilters: arrayFilters, collation: self.collation, upsert: self.upsert)
+        let options = UpdateOptions(arrayFilters: self.arrayFilters, collation: self.collation, upsert: self.upsert)
         let result: UpdateResult?
         if self.operationName == "updateOne" {
             result = try coll.updateOne(filter: filter, update: update, options: options)

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -210,9 +210,9 @@ private class CrudTest {
     /// results for this `CrudTest`. Meant for use by findAndModify subclasses, i.e. findOneAndX. 
     func verifyFindAndModifyResult(_ result: Document?) {
         if self.result == nil {
-            expect(result?["value"]).to(beNil())
+            expect(result).to(beNil())
         } else {
-            expect(result?["value"] as? Document).to(equal(self.result as? Document))
+            expect(result).to(equal(self.result as? Document))
         }
     }
 }


### PR DESCRIPTION
This fills out the API sketch and implements the corresponding CRUD tests. I plan on adding more test cases tomorrow in `MongoCollectionTests` to check that nothing catastrophic happens when using the options the CRUD tests don't cover, but I figured I would put up what I have so far.

I think the options encoding solution is pretty good: I've created a `private class FindAndModifyOptions` wrapping a `mongoc_find_and_modify_opts_t`. Each of the Swift options `struct`s conforms to the `FindAndModifyOptionsConvertible` protocol, which means it knows how to represent itself as a `FindAndModifyOptions`. The private `findAndModify` method that we route all the public API methods through can then just do the conversion right before it sends the command. 