### PR TITLE
Replace Target() with .target in Package.swift example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ let package = Package(
         .package(url: "https://github.com/mongodb/mongo-swift-driver.git", from: "0.0.2"),
     ],
     targets: [
-        Target(
-            name: "MyPackage",
-            dependencies: ["MongoSwift"])
+        .target(name: "MyPackage", dependencies: ["MongoSwift"])
     ]
 )
 ```


### PR DESCRIPTION
`.target()` is consistent with current examples in https://swift.org/package-manager/. This is something I noticed while testing https://github.com/mongodb/mongo-swift-driver/pull/94 for [SWIFT-157](https://jira.mongodb.org/browse/SWIFT-157).