### PR TITLE
SWIFT-163 Use DocumentStorage rather than pointers in BsonValue protocol

### DIFF
--- a/Sources/MongoSwift/BSON/BsonEncoder.swift
+++ b/Sources/MongoSwift/BSON/BsonEncoder.swift
@@ -518,8 +518,8 @@ private class MutableArray: BsonValue {
         self.array.insert(value, at: index)
     }
 
-    func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
-        try self.array.encode(to: data, forKey: key)
+    func encode(to storage: DocumentStorage, forKey key: String) throws {
+        try self.array.encode(to: storage, forKey: key)
     }
 
     /// methods required by the BsonValue protocol that we don't actually need/use. MutableArray
@@ -566,8 +566,8 @@ private class MutableDictionary: BsonValue {
         return doc
     }
 
-    func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
-        try self.asDocument().encode(to: data, forKey: key)
+    func encode(to storage: DocumentStorage, forKey key: String) throws {
+        try self.asDocument().encode(to: storage, forKey: key)
     }
 
     /// methods required by the BsonValue protocol that we don't actually need/use. MutableDictionary

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -1,7 +1,8 @@
 import Foundation
 import libbson
 
-internal class DocumentStorage {
+/// The storage backing a MongoSwift `Document`.
+public class DocumentStorage {
     internal var pointer: UnsafeMutablePointer<bson_t>!
 
     init() {
@@ -21,8 +22,10 @@ internal class DocumentStorage {
 
 /// A struct representing the BSON document type.
 public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLiteral {
+    /// the storage backing this document 
     internal var storage: DocumentStorage
 
+    /// direct access to the storage's pointer to a bson_t
     internal var data: UnsafeMutablePointer<bson_t>! { return storage.pointer }
 
     /// Returns a `[String]` containing the keys in this `Document`.
@@ -209,7 +212,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
             }
 
             do {
-                try value.encode(to: self.data, forKey: key)
+                try value.encode(to: self.storage, forKey: key)
             } catch {
                 preconditionFailure("Failed to set the value for key \(key) to \(value): \(error)")
             }
@@ -271,8 +274,8 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 extension Document: BsonValue {
     public var bsonType: BsonType { return .document }
 
-    public func encode(to data: UnsafeMutablePointer<bson_t>, forKey key: String) throws {
-        if !bson_append_document(data, key, Int32(key.count), self.data) {
+    public func encode(to storage: DocumentStorage, forKey key: String) throws {
+        if !bson_append_document(storage.pointer, key, Int32(key.count), self.data) {
             throw bsonEncodeError(value: self, forKey: key)
         }
     }

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -18,7 +18,7 @@ extension MongoCollection {
         let encoder = BsonEncoder()
         let document = try encoder.encode(value)
         if document["_id"] == nil {
-            try ObjectId().encode(to: document.data, forKey: "_id")
+            try ObjectId().encode(to: document.storage, forKey: "_id")
         }
         let opts = try encoder.encode(options)
         var error = bson_error_t()
@@ -45,7 +45,7 @@ extension MongoCollection {
 
         let documents = try values.map { try encoder.encode($0) }
         for doc in documents where doc["_id"] == nil {
-            try ObjectId().encode(to: doc.data, forKey: "_id")
+            try ObjectId().encode(to: doc.storage, forKey: "_id")
         }
         var docPointers = documents.map { UnsafePointer($0.data) }
 


### PR DESCRIPTION
This is a pretty straightforward change. The `BsonValue` protocol's `encode` method now takes in a `DocumentStorage` wrapping an `UnsafeMutablePointer<bson_t>`, rather than the pointer directly. 

This did require changing `DocumentStorage` from `internal` to `public`, but we expose no methods or properties on it, so at least it's far more opaque to the user than the pointers were. 