### PR TITLE
Update README to provide working example Podfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ CocoaPods is a dependency manager for Swift and Objective-C. You can install it 
 If you don't already have a `Podfile` for your project, run `pod init` in the main directory to automatically create one with smart defaults. Add `MongoSwift` as follows:
 
 ```ruby
-platform :ios, '11.0'
+platform :osx, '10.10'
 use_frameworks!
 
 target 'MyApp' do


### PR DESCRIPTION
I think the error we experienced the other day relates to this example not matching the minimum deployment requirements of our pod. Instead, we should show a working example, and one that does not target iOS to boot. 