### PR TITLE
SWIFT-189 Add server version method

### DIFF
--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -44,4 +44,8 @@ final class MongoClientTests: XCTestCase {
         // check that we fail gracefully with an error if passing in an invalid URI
         expect(try MongoClient(connectionString: "abcd")).to(throwError())
     }
+
+    func testGetServerVersion() throws {
+        expect(try MongoClient().getServerVersion()).toNot(throwError())
+    }
 }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -18,6 +18,16 @@ extension XCTestCase {
     }
 }
 
+extension MongoClient {
+    internal func getServerVersion() throws -> String {
+        let buildInfo = try self.db("admin").runCommand(["buildInfo": 1])
+        guard let versionString = buildInfo["version"] as? String else {
+            throw TestError(message: "buildInfo reply missing version string: \(buildInfo)")
+        }
+        return versionString
+    }
+}
+
 /// Cleans and normalizes a given JSON string for comparison purposes
 func clean(json: String?) -> String {
     guard let str = json else { return "" }


### PR DESCRIPTION
As part of the CRUD test updates we want to filter tests by current server version. This adds an extension within our tests to get the version string for a client, which we can compare to `minServerVersion` and `maxServerVersion` fields.