### PR TITLE
SWIFT-115 Clean up linting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,3 +3,23 @@ disabled_rules:
   - function_body_length
   - identifier_name
   - todo
+  - type_name
+  - type_body_length
+
+enabled_rules:
+  - vertical_parameter_alignment_on_call
+  - trailing_closure
+  - sorted_imports
+  - redundant_type_annotation
+  - operator_usage_whitespace
+  - modifier_order
+  - missing_docs
+  - implicit_return
+  - function_default_parameter_at_end
+  - fatal_error_message
+
+excluded:
+  - build
+  - .build
+  - docs
+  - Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 before_script:
   - mkdir ${PWD}/mongodb-${MONGODB_VERSION}/data
   - ${PWD}/mongodb-${MONGODB_VERSION}/bin/mongod --dbpath ${PWD}/mongodb-${MONGODB_VERSION}/data --logpath ${PWD}/mongodb-${MONGODB_VERSION}/mongodb.log --enableMajorityReadConcern --fork
+  - swiftlint
 
 script:
   # - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os:
-#  - linux
+  - linux
   - osx
 language: generic
 sudo: required
@@ -34,7 +34,7 @@ install:
 before_script:
   - mkdir ${PWD}/mongodb-${MONGODB_VERSION}/data
   - ${PWD}/mongodb-${MONGODB_VERSION}/bin/mongod --dbpath ${PWD}/mongodb-${MONGODB_VERSION}/data --logpath ${PWD}/mongodb-${MONGODB_VERSION}/mongodb.log --enableMajorityReadConcern --fork
-  - swiftlint
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swiftlint; fi
 
 script:
   # - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os:
-  - linux
-#  - osx
+#  - linux
+  - osx
 language: generic
 sudo: required
 dist: trusty

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,8 @@ benchmark:
 	swift test -v $(CFLAGS) $(LDFLAGS) --filter MongoSwiftBenchmarks
 
 lint:
+	swiftlint autocorrect
 	swiftlint
-
-format:
-	swiftformat --disable trailingCommas  --indent 2 .
 
 clean:
 	rm -rf Packages

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -526,8 +526,8 @@ extension MongoClient {
      *  - Parameters:
      *      - forEvents:   A `MongoEventType?` to enable monitoring for, defaulting to nil. If unspecified, monitoring
      *                     will be enabled for both `.commandMonitoring` and `.serverMonitoring` events.
-     *      - usingCenter: A `NotificationCenter` that event notifications should be posted to, defaulting to the default
-     *                     `NotificationCenter` for the application.
+     *      - usingCenter: A `NotificationCenter` that event notifications should be posted to, defaulting to the
+     *                     default `NotificationCenter` for the application.
      *
      */
     public func enableMonitoring(forEvents eventType: MongoEventType? = nil,

--- a/Sources/MongoSwift/BSON/AnyBsonValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBsonValue.swift
@@ -35,9 +35,10 @@ public struct AnyBsonValue: Codable {
             if let c = self.value as? Codable {
                 try c.encode(to: encoder)
             } else {
-                throw EncodingError.invalidValue(self.value,
-                EncodingError.Context(codingPath: [],
-                    debugDescription: "Encountered a non-Codable value while encoding \(self)"))
+                throw EncodingError.invalidValue(
+                    self.value,
+                    EncodingError.Context(codingPath: [],
+                                          debugDescription: "Encountered a non-Codable value while encoding \(self)"))
 
             }
         }
@@ -61,9 +62,10 @@ public struct AnyBsonValue: Codable {
         // short-circuit in the `BsonDecoder` case
         if let bsonDecoder = decoder as? _BsonDecoder {
             guard let value = bsonDecoder.storage.topContainer else {
-                throw DecodingError.valueNotFound(BsonValue.self,
+                throw DecodingError.valueNotFound(
+                    BsonValue.self,
                     DecodingError.Context(codingPath: bsonDecoder.codingPath,
-                        debugDescription: "Expected BsonValue but found null instead."))
+                                          debugDescription: "Expected BsonValue but found null instead."))
             }
             self.value = value
             return

--- a/Sources/MongoSwift/BSON/BsonDecoder.swift
+++ b/Sources/MongoSwift/BSON/BsonDecoder.swift
@@ -65,8 +65,9 @@ public class BsonDecoder {
             return s.value
         }
 
-        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [],
-                                            debugDescription: "Unable to parse JSON string \(json)"))
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [],
+                                  debugDescription: "Unable to parse JSON string \(json)"))
     }
 
     /// A struct to wrap a `Decodable` type, allowing us to support decoding to types that
@@ -105,7 +106,8 @@ internal class _BsonDecoder: Decoder {
     }
 
     /// Initializes `self` with the given top-level container and options.
-    fileprivate init(referencing container: BsonValue?, at codingPath: [CodingKey] = [], options: BsonDecoder._Options) {
+    fileprivate init(referencing container: BsonValue?, at codingPath: [CodingKey] = [],
+                     options: BsonDecoder._Options) {
         self.storage = _BsonDecodingStorage()
         self.storage.push(container: container)
         self.codingPath = codingPath
@@ -115,34 +117,42 @@ internal class _BsonDecoder: Decoder {
     // Returns the data stored in this decoder as represented in a container keyed by the given key type.
     public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
         guard self.storage.topContainer != nil  else {
-            throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
-                                  DecodingError.Context(codingPath: self.codingPath,
-                                                        debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+            throw DecodingError.valueNotFound(
+                KeyedDecodingContainer<Key>.self,
+                DecodingError.Context(codingPath: self.codingPath,
+                                      debugDescription:
+                                      "Cannot get keyed decoding container -- found null value instead."))
         }
 
         guard let topContainer = self.storage.topContainer as? Document else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: Document.self, reality: self.storage.topContainer)
+            throw DecodingError._typeMismatch(at: self.codingPath,
+                                              expectation: Document.self,
+                                              reality: self.storage.topContainer)
         }
 
         let container = _BsonKeyedDecodingContainer<Key>(referencing: self, wrapping: topContainer)
         return KeyedDecodingContainer(container)
     }
 
-    // Returns the data stored in this decoder as represented in a container appropriate for holding a single primitive value.
+    // Returns the data stored in this decoder in a container appropriate for holding a single primitive value.
     public func singleValueContainer() throws -> SingleValueDecodingContainer {
         return self
     }
 
-    // Returns the data stored in this decoder as represented in a container appropriate for holding values with no keys.
+    // Returns the data stored in this decoder in a container appropriate for holding values with no keys.
     public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
         guard self.storage.topContainer != nil else {
-            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
-                                  DecodingError.Context(codingPath: self.codingPath,
-                                                        debugDescription: "Cannot get unkeyed decoding container -- found null value instead."))
+            throw DecodingError.valueNotFound(
+                UnkeyedDecodingContainer.self,
+                DecodingError.Context(codingPath: self.codingPath,
+                                      debugDescription:
+                                      "Cannot get unkeyed decoding container -- found null value instead."))
         }
 
         guard let arr = self.storage.topContainer as? [BsonValue?] else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [BsonValue?].self, reality: self.storage.topContainer)
+            throw DecodingError._typeMismatch(at: self.codingPath,
+                                              expectation: [BsonValue?].self,
+                                              reality: self.storage.topContainer)
         }
 
         return _BsonUnkeyedDecodingContainer(referencing: self, wrapping: arr)
@@ -263,7 +273,10 @@ private struct _BsonKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
     /// under `key`, or throws an error if the value is not found.
     private func getValue(forKey key: Key) throws -> BsonValue {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(
+                key,
+                DecodingError.Context(codingPath: self.decoder.codingPath,
+                                      debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         return entry
     }
@@ -273,7 +286,10 @@ private struct _BsonKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
         let entry = try getValue(forKey: key)
         return try self.decoder.with(pushedKey: key) {
             guard let value = try decoder.unboxBsonValue(entry, as: type) else {
-                throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+                throw DecodingError.valueNotFound(
+                    type,
+                    DecodingError.Context(codingPath: self.decoder.codingPath,
+                                          debugDescription: "Expected \(type) value but found null instead."))
             }
             return value
         }
@@ -284,7 +300,10 @@ private struct _BsonKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
         let entry = try getValue(forKey: key)
         return try self.decoder.with(pushedKey: key) {
             guard let value = try decoder.unboxNumber(entry, as: type) else {
-                throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+                throw DecodingError.valueNotFound(
+                    type,
+                    DecodingError.Context(codingPath: self.decoder.codingPath,
+                                          debugDescription: "Expected \(type) value but found null instead."))
             }
             return value
         }
@@ -295,7 +314,10 @@ private struct _BsonKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
         let entry = try getValue(forKey: key)
         return try self.decoder.with(pushedKey: key) {
             guard let value = try decoder.unbox(entry, as: type) else {
-                throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+                throw DecodingError.valueNotFound(
+                    type,
+                    DecodingError.Context(codingPath: self.decoder.codingPath,
+                                          debugDescription: "Expected \(type) value but found null instead."))
             }
             return value
         }
@@ -306,11 +328,15 @@ private struct _BsonKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
         // check if the key exists in the document, so we can differentiate between
         // the key being set to nil and the key not existing at all.
         if !self.contains(key) {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Key \(_errorDescription(of: key)) not found."))
+            throw DecodingError.keyNotFound(
+                key,
+                DecodingError.Context(codingPath: self.decoder.codingPath,
+                                      debugDescription: "Key \(_errorDescription(of: key)) not found."))
         }
         return self.container[key.stringValue] == nil
     }
 
+    // swiftlint:disable line_length
     public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool { return try decodeBsonType(type, forKey: key) }
     public func decode(_ type: Int.Type, forKey key: Key) throws -> Int { return try decodeNumber(type, forKey: key) }
     public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 { return try decodeNumber(type, forKey: key) }
@@ -325,9 +351,11 @@ private struct _BsonKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
     public func decode(_ type: Float.Type, forKey key: Key) throws -> Float { return try decodeNumber(type, forKey: key) }
     public func decode(_ type: Double.Type, forKey key: Key) throws -> Double { return try decodeNumber(type, forKey: key) }
     public func decode(_ type: String.Type, forKey key: Key) throws -> String { return try decodeBsonType(type, forKey: key) }
+    // swiftlint:enable line_length
 
     /// Returns the data stored for the given key as represented in a container keyed by the given key type.
-    public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+    public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type,
+                                           forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
         return try self.decoder.with(pushedKey: key) {
             let value = try getValue(forKey: key)
 
@@ -403,7 +431,10 @@ private struct _BsonUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     /// A private helper function to check if we're at the end of the container, and if so throw an error. 
     private func checkAtEnd() throws {
         guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(BsonValue?.self, DecodingError.Context(codingPath: self.decoder.codingPath + [_BsonKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+            throw DecodingError.valueNotFound(
+                BsonValue?.self,
+                DecodingError.Context(codingPath: self.decoder.codingPath + [_BsonKey(index: self.currentIndex)],
+                                      debugDescription: "Unkeyed container is at end."))
         }
     }
 
@@ -412,7 +443,9 @@ private struct _BsonUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         try self.checkAtEnd()
         return try self.decoder.with(pushedKey: _BsonKey(index: self.currentIndex)) {
             guard let typed = try self.decoder.unboxBsonValue(self.container[currentIndex], as: type) else {
-                throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: self.container[self.currentIndex])
+                throw DecodingError._typeMismatch(at: self.codingPath,
+                                                  expectation: type,
+                                                  reality: self.container[self.currentIndex])
             }
             self.currentIndex += 1
             return typed
@@ -424,7 +457,9 @@ private struct _BsonUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         try self.checkAtEnd()
         return try self.decoder.with(pushedKey: _BsonKey(index: self.currentIndex)) {
             guard let typed = try self.decoder.unboxNumber(self.container[currentIndex], as: type) else {
-                throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: self.container[self.currentIndex])
+                throw DecodingError._typeMismatch(at: self.codingPath,
+                                                  expectation: type,
+                                                  reality: self.container[self.currentIndex])
             }
             self.currentIndex += 1
             return typed
@@ -436,7 +471,11 @@ private struct _BsonUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         try self.checkAtEnd()
         return try self.decoder.with(pushedKey: _BsonKey(index: self.currentIndex)) {
             guard let decoded = try self.decoder.unbox(self.container[currentIndex], as: T.self) else {
-                throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_BsonKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+                throw DecodingError.valueNotFound(
+                    type,
+                    DecodingError.Context(
+                        codingPath: self.decoder.codingPath + [_BsonKey(index: self.currentIndex)],
+                        debugDescription: "Expected \(type) but found null instead."))
             }
             self.currentIndex += 1
             return decoded
@@ -471,7 +510,8 @@ private struct _BsonUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     public mutating func decode(_ type: String.Type) throws -> String { return try self.decodeBsonType(type) }
 
     /// Decodes a nested container keyed by the given type.
-    public mutating func nestedContainer<NestedKey: CodingKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+    public mutating func nestedContainer<NestedKey: CodingKey>(keyedBy type: NestedKey.Type)
+        throws -> KeyedDecodingContainer<NestedKey> {
         return try self.decoder.with(pushedKey: _BsonKey(index: self.currentIndex)) {
             try self.checkAtEnd()
             let doc = try self.decodeBsonType(Document.self)
@@ -508,7 +548,10 @@ extension _BsonDecoder: SingleValueDecodingContainer {
     /// Assert that the top container for this decoder is non-null.
     private func expectNonNull<T>(_ type: T.Type) throws {
         guard !self.decodeNil() else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected \(type) but found null value instead."))
+            throw DecodingError.valueNotFound(
+                type,
+                DecodingError.Context(codingPath: self.codingPath,
+                                      debugDescription: "Expected \(type) but found null value instead."))
         }
     }
 

--- a/Sources/MongoSwift/BSON/BsonEncoder.swift
+++ b/Sources/MongoSwift/BSON/BsonEncoder.swift
@@ -39,15 +39,17 @@ public class BsonEncoder {
         let encoder = _BsonEncoder(options: self.options)
 
         guard let topLevel = try encoder.box(value) else {
-            throw EncodingError.invalidValue(value,
+            throw EncodingError.invalidValue(
+                value,
                 EncodingError.Context(codingPath: [],
-                    debugDescription: "Top-level \(T.self) did not encode any values."))
+                                      debugDescription: "Top-level \(T.self) did not encode any values."))
         }
 
         guard let dict = topLevel as? MutableDictionary else {
-            throw EncodingError.invalidValue(value,
+            throw EncodingError.invalidValue(
+                value,
                 EncodingError.Context(codingPath: [],
-                    debugDescription: "Top-level \(T.self) was not encoded as a complete document."))
+                                      debugDescription: "Top-level \(T.self) was not encoded as a complete document."))
         }
 
         return dict.asDocument()
@@ -309,7 +311,8 @@ private struct _BsonKeyedEncodingContainer<K: CodingKey> : KeyedEncodingContaine
     private(set) public var codingPath: [CodingKey]
 
     /// Initializes `self` with the given references.
-    fileprivate init(referencing encoder: _BsonEncoder, codingPath: [CodingKey], wrapping container: MutableDictionary) {
+    fileprivate init(referencing encoder: _BsonEncoder, codingPath: [CodingKey],
+                     wrapping container: MutableDictionary) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
@@ -344,7 +347,8 @@ private struct _BsonKeyedEncodingContainer<K: CodingKey> : KeyedEncodingContaine
         self.container[key.stringValue] = try encoder.box(value)
     }
 
-    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type,
+                                                    forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         let dictionary = MutableDictionary()
         self.container[key.stringValue] = dictionary
 
@@ -429,7 +433,8 @@ private struct _BsonUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         self.container.add(try encoder.box(value))
     }
 
-    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type)
+        -> KeyedEncodingContainer<NestedKey> {
         self.codingPath.append(_BsonKey(index: self.count))
         defer { self.codingPath.removeLast() }
 
@@ -460,7 +465,7 @@ extension _BsonEncoder: SingleValueEncodingContainer {
 
     private func assertCanEncodeNewValue() {
         precondition(self.canEncodeNewValue,
-            "Attempt to encode value through single value container when previously value already encoded.")
+                     "Attempt to encode value through single value container when previously value already encoded.")
     }
 
     public func encodeNil() throws {

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -194,7 +194,8 @@ public struct Binary: BsonValue, Equatable, Codable {
     /// Throws an error if the base64 `String` is invalid.
     public init(base64: String, subtype: UInt8) throws {
         guard let dataObj = Data(base64Encoded: base64) else {
-            throw MongoError.invalidArgument(message: "failed to create Data object from invalid base64 string \(base64)")
+            throw MongoError.invalidArgument(message:
+                "failed to create Data object from invalid base64 string \(base64)")
         }
         self.init(data: dataObj, subtype: subtype)
     }
@@ -239,7 +240,9 @@ public struct Binary: BsonValue, Equatable, Codable {
 
 /// An extension of `Bool` to represent the BSON Boolean type.
 extension Bool: BsonValue {
+
     public var bsonType: BsonType { return .boolean }
+
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         if !bson_append_bool(storage.pointer, key, Int32(key.count), self) {
             throw bsonEncodeError(value: self, forKey: key)
@@ -253,6 +256,7 @@ extension Bool: BsonValue {
 
 /// An extension of `Date` to represent the BSON Datetime type.
 extension Date: BsonValue {
+
     public var bsonType: BsonType { return .dateTime }
 
     /// Initializes a new `Date` representing the instance `msSinceEpoch` milliseconds
@@ -280,13 +284,13 @@ extension Date: BsonValue {
 /// be created, we may need to parse them into `Document`s, and this provides a place for that logic.
 internal struct DBPointer: BsonValue {
 
-    public var bsonType: BsonType { return .dbPointer }
+    var bsonType: BsonType { return .dbPointer }
 
-    public func encode(to storage: DocumentStorage, forKey key: String) throws {
+    func encode(to storage: DocumentStorage, forKey key: String) throws {
         throw MongoError.bsonEncodeError(message: "DBPointers are deprecated; use a DBRef instead")
     }
 
-    public static func from(iter: inout bson_iter_t) -> BsonValue {
+    static func from(iter: inout bson_iter_t) -> BsonValue {
         var length: UInt32 = 0
         let collectionPP = UnsafeMutablePointer<UnsafePointer<Int8>?>.allocate(capacity: 1)
         defer {
@@ -338,7 +342,7 @@ public struct Decimal128: BsonValue, Equatable, Codable {
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         var value: bson_decimal128_t = bson_decimal128_t()
         precondition(bson_decimal128_from_string(self.data, &value),
-            "Failed to parse Decimal128 string \(self.data)")
+                     "Failed to parse Decimal128 string \(self.data)")
         if !bson_append_decimal128(storage.pointer, key, Int32(key.count), &value) {
             throw bsonEncodeError(value: self, forKey: key)
         }
@@ -359,7 +363,9 @@ public struct Decimal128: BsonValue, Equatable, Codable {
 
 /// An extension of `Double` to represent the BSON Double type.
 extension Double: BsonValue {
+
     public var bsonType: BsonType { return .double }
+
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         if !bson_append_double(storage.pointer, key, Int32(key.count), self) {
             throw bsonEncodeError(value: self, forKey: key)
@@ -374,7 +380,9 @@ extension Double: BsonValue {
 /// An extension of `Int` to represent the BSON Int32 or Int64 type.
 /// The `Int` will be encoded as an Int32 if possible, or an Int64 if necessary.
 extension Int: BsonValue {
+
     public var bsonType: BsonType { return .int32 }
+
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         if let int32 = Int32(exactly: self) {
             return try int32.encode(to: storage, forKey: key)
@@ -392,7 +400,9 @@ extension Int: BsonValue {
 
 /// An extension of `Int32` to represent the BSON Int32 type.
 extension Int32: BsonValue {
+
     public var bsonType: BsonType { return .int32 }
+
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         if !bson_append_int32(storage.pointer, key, Int32(key.count), self) {
             throw bsonEncodeError(value: self, forKey: key)
@@ -406,7 +416,9 @@ extension Int32: BsonValue {
 
 /// An extension of `Int64` to represent the BSON Int64 type.
 extension Int64: BsonValue {
+
     public var bsonType: BsonType { return .int64 }
+
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         if !bson_append_int64(storage.pointer, key, Int32(key.count), self) {
             throw bsonEncodeError(value: self, forKey: key)
@@ -599,7 +611,7 @@ extension NSRegularExpression {
 }
 
 /// A struct to represent a BSON regular expression.
-struct RegularExpression: BsonValue, Equatable, Codable {
+public struct RegularExpression: BsonValue, Equatable, Codable {
 
     public var bsonType: BsonType { return .regularExpression }
 
@@ -668,7 +680,9 @@ struct RegularExpression: BsonValue, Equatable, Codable {
 
 /// An extension of String to represent the BSON string type.
 extension String: BsonValue {
+
     public var bsonType: BsonType { return .string }
+
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         if !bson_append_utf8(storage.pointer, key, Int32(key.count), self, Int32(self.count)) {
             throw bsonEncodeError(value: self, forKey: key)
@@ -692,12 +706,14 @@ extension String: BsonValue {
 /// An internal struct to represent the deprecated Symbol type. While Symbols cannot be
 /// created, we may need to parse them into `String`s, and this provides a place for that logic.
 internal struct Symbol: BsonValue {
-    public var bsonType: BsonType { return .symbol }
-    public func encode(to storage: DocumentStorage, forKey key: String) throws {
+
+    var bsonType: BsonType { return .symbol }
+
+    func encode(to storage: DocumentStorage, forKey key: String) throws {
         throw MongoError.bsonEncodeError(message: "Symbols are deprecated; use a string instead")
     }
 
-    public static func from(iter: inout bson_iter_t) -> BsonValue {
+    static func from(iter: inout bson_iter_t) -> BsonValue {
         var length: UInt32 = 0
         let value = bson_iter_symbol(&iter, &length)
         guard let strValue = value else {
@@ -713,6 +729,7 @@ internal struct Symbol: BsonValue {
 
 /// A struct to represent the BSON Timestamp type.
 public struct Timestamp: BsonValue, Equatable, Codable {
+
     public var bsonType: BsonType { return .timestamp }
 
     /// A timestamp representing seconds since the Unix epoch.

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -152,7 +152,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
     /// Constructs a `Document` from raw BSON `Data`
     public init(fromBSON: Data) {
         self.storage = DocumentStorage(fromPointer: fromBSON.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
-            return bson_new_from_data(bytes, fromBSON.count)
+            bson_new_from_data(bytes, fromBSON.count)
         })
     }
 

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -84,8 +84,8 @@ extension MongoCollection {
         let reply = Document()
         var error = bson_error_t()
 
-        if !mongoc_collection_find_and_modify_with_opts(self._collection,
-        filter.data, opts._options, reply.data, &error) {
+        if !mongoc_collection_find_and_modify_with_opts(self._collection, filter.data,
+                                                        opts._options, reply.data, &error) {
             // TODO SWIFT-144: replace with more descriptive error type(s)
             throw MongoError.commandError(message: toErrorString(error))
         }
@@ -298,12 +298,12 @@ private class FindAndModifyOptions {
             guard maxTime > 0 else {
                 throw MongoError.invalidArgument(message: "maxTimeMS must be positive, but got value \(maxTime)")
             }
-            extra["maxTimeMS"] = maxTime 
+            extra["maxTimeMS"] = maxTime
         }
 
         if let wc = writeConcern {
             do {
-                extra["writeConcern"] = try BsonEncoder().encode(wc) 
+                extra["writeConcern"] = try BsonEncoder().encode(wc)
             } catch {
                 throw MongoError.invalidArgument(message: "Error encoding WriteConcern \(wc): \(error)")
             }

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -247,7 +247,7 @@ extension MongoCollection {
      */
     @discardableResult
     public func dropIndex(_ keys: Document, options: IndexOptions? = nil,
-                            commandOptions: DropIndexOptions? = nil) throws -> Document {
+                          commandOptions: DropIndexOptions? = nil) throws -> Document {
         return try dropIndex(IndexModel(keys: keys, options: options), options: commandOptions)
     }
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -102,7 +102,7 @@ extension MongoCollection {
      *
      * - Parameters:
      *   - fieldName: The field for which the distinct values will be found
-     *   - filter: a `Document` representing the filter that documents must match in order to be considered for this operation
+     *   - filter: a `Document` representing the filter documents must match in order to be considered for the operation
      *   - options: Optional `DistinctOptions` to use when executing the command
      *
      * - Returns: A `[BsonValue?]` containing the distinct values for the specified criteria

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -71,7 +71,8 @@ extension MongoCollection {
      *            is unacknowledged, `nil` is returned.
      */
     @discardableResult
-    public func replaceOne(filter: Document, replacement: CollectionType, options: ReplaceOptions? = nil) throws -> UpdateResult? {
+    public func replaceOne(filter: Document, replacement: CollectionType,
+                           options: ReplaceOptions? = nil) throws -> UpdateResult? {
         let encoder = BsonEncoder()
         let replacementDoc = try encoder.encode(replacement)
         let opts = try encoder.encode(options)

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -216,7 +216,7 @@ public class MongoDatabase {
      * - Returns: the requested `MongoCollection<T>`
      */
     public func collection<T: Codable>(_ name: String, withType: T.Type,
-                                              options: CollectionOptions? = nil) throws -> MongoCollection<T> {
+                                       options: CollectionOptions? = nil) throws -> MongoCollection<T> {
         guard let collection = mongoc_database_get_collection(self._database, name) else {
             throw MongoError.invalidCollection(message: "Could not get collection '\(name)'")
         }

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -32,7 +32,8 @@ public enum MongoError {
     /// Thrown when there is an error executing a write command.
     case writeError(code: Int32, message: String)
     /// Thrown when there is an error executing a bulk write command. 
-    indirect case bulkWriteError(code: Int32, message: String, result: BulkWriteResult?, writeErrors: [MongoError]?, writeConcernError: MongoError?)
+    indirect case bulkWriteError(code: Int32, message: String, result: BulkWriteResult?,
+                                writeErrors: [MongoError]?, writeConcernError: MongoError?)
 }
 
 /// An extension of `MongoError` to support printing out descriptive error messages.

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -66,6 +66,7 @@ final public class ReadPreference {
 
         let wrapped = Document(fromPointer: bson)
 
+        // swiftlint:disable:next force_cast
         return wrapped.values as! [Document]
     }
 
@@ -117,10 +118,11 @@ final public class ReadPreference {
 
         if let maxStalenessSeconds = maxStalenessSeconds {
             guard maxStalenessSeconds >= MONGOC_SMALLEST_MAX_STALENESS_SECONDS else {
-                throw MongoError.readPreferenceError(message: "Expected maxStalenessSeconds to be >= \(MONGOC_SMALLEST_MAX_STALENESS_SECONDS), \(maxStalenessSeconds) given")
+                throw MongoError.readPreferenceError(message: "Expected maxStalenessSeconds to be >= " +
+                    " \(MONGOC_SMALLEST_MAX_STALENESS_SECONDS), \(maxStalenessSeconds) given")
             }
 
-            mongoc_read_prefs_set_max_staleness_seconds(self._readPreference, maxStalenessSeconds);
+            mongoc_read_prefs_set_max_staleness_seconds(self._readPreference, maxStalenessSeconds)
         }
     }
 

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -1,5 +1,5 @@
-import libmongoc
 import Foundation
+import libmongoc
 
 /// A class to represent a MongoDB write concern.
 public class WriteConcern: Codable {
@@ -64,10 +64,11 @@ public class WriteConcern: Codable {
             if let wTag = mongoc_write_concern_get_wtag(self._writeConcern) {
                 return .tag(String(cString: wTag))
             }
-            fallthrough
         default:
-            return .number(number)
+            break
         }
+
+        return .number(number)
     }
 
     /// Indicates whether to wait for the write operation to get committed to the journal.
@@ -129,7 +130,7 @@ public class WriteConcern: Codable {
             let wStr = String(describing: w)
             let timeoutStr = String(describing: wtimeoutMS)
             throw MongoError.invalidArgument(message:
-                "Invalid combination of WriteConcern options: journal=\(journalStr), w=\(wStr), wtimeoutMS=\(timeoutStr)")
+                "Invalid combination of options: journal=\(journalStr), w=\(wStr), wtimeoutMS=\(timeoutStr)")
         }
     }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,6 @@
-import XCTest
 import MongoSwift
 import MongoSwiftTests
+import XCTest
 
 /* Ensure libmongoc is initialized. Since XCTMain never returns, we have no
  * opportunity to cleanup libmongoc (either explicitly or with a deinit). This

--- a/Tests/MongoSwiftBenchmarks/DocumentBenchmarks.swift
+++ b/Tests/MongoSwiftBenchmarks/DocumentBenchmarks.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import MongoSwift
-import XCTest
 import Nimble
+import XCTest
 
 let tweetFile = URL(fileURLWithPath: basePath + "/tweet.json")
 let tweetSize = 16.22

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -2,7 +2,7 @@
 import Nimble
 import XCTest
 
-let center =  NotificationCenter.default
+let center = NotificationCenter.default
 
 // TODO: don't hardcode this
 let VERSION = "3.6"

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -1,5 +1,5 @@
-@testable import MongoSwift
 import Foundation
+@testable import MongoSwift
 import Nimble
 import XCTest
 
@@ -298,7 +298,7 @@ private class FindOneAndDeleteTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let filter: Document = try self.args.get("filter")
         let opts = FindOneAndDeleteOptions(collation: self.collation, projection: self.projection, sort: self.sort)
-        
+
         let result = try coll.findOneAndDelete(filter, options: opts)
         self.verifyFindAndModifyResult(result)
     }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -9,7 +9,7 @@ extension Data {
         let len = hexString.count / 2
         var data = Data(capacity: len)
         for i in 0..<len {
-            let j = hexString.index(hexString.startIndex, offsetBy: i*2)
+            let j = hexString.index(hexString.startIndex, offsetBy: i * 2)
             let k = hexString.index(j, offsetBy: 2)
             let bytes = hexString[j..<k]
             if var num = UInt8(bytes, radix: 16) {

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -1,7 +1,7 @@
+import libmongoc
 @testable import MongoSwift
 import Nimble
 import XCTest
-import libmongoc
 
 final class MongoClientTests: XCTestCase {
     static var allTests: [(String, (MongoClientTests) -> () throws -> Void)] {

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -1,6 +1,6 @@
 @testable import MongoSwift
-import XCTest
 import Nimble
+import XCTest
 
 var _client: MongoClient?
 
@@ -281,7 +281,7 @@ final class MongoCollectionTests: XCTestCase {
 
     func testCursorIteration() throws {
         let findResult1 = try coll.find(["cat": "cat"])
-        while let _  = try findResult1.nextOrError() { }
+        while let _ = try findResult1.nextOrError() { }
 
         let findResult2 = try coll.find(["cat": "cat"])
         for _ in findResult2 { }

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -291,7 +291,7 @@ final class ReadWriteConcernTests: XCTestCase {
 
         let coll = try db.createCollection("coll1")
         let wc1 = try WriteConcern(w: .number(1))
-        let wc2 =  WriteConcern()
+        let wc2 = WriteConcern()
         let wc3 = try WriteConcern(journal: true)
 
         let command: Document = ["insert": "coll1", "documents": [nextDoc()] as [Document]]

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -1,5 +1,5 @@
-@testable import MongoSwift
 import Foundation
+@testable import MongoSwift
 import Nimble
 import XCTest
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -1,7 +1,7 @@
 import Foundation
-import XCTest
 import MongoSwift
 import Nimble
+import XCTest
 
 extension XCTestCase {
     /// Gets the path of the directory containing spec files, depending on whether


### PR DESCRIPTION
- I opted into and disabled various rules in `.swiftlint.yml`. I also excluded the `Tests/` directory because it has like a million violations (mostly about line length) that I will fix some other time. 
- I edited `.travis.yml` to run `swiftlint` on OS X before building
- `make lint` now runs `swiftlint autocorrect` first
- correct various linting violations throughout `Sources/MongoSwift`