### PR TITLE
SWIFT-94 Filter tests by current server version

### DIFF
--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -44,4 +44,8 @@ final class MongoClientTests: XCTestCase {
         // check that we fail gracefully with an error if passing in an invalid URI
         expect(try MongoClient(connectionString: "abcd")).to(throwError())
     }
+
+    func testGetServerVersion() throws {
+        expect(try MongoClient().serverVersion()).toNot(throwError())
+    }
 }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -45,7 +45,57 @@ final class MongoClientTests: XCTestCase {
         expect(try MongoClient(connectionString: "abcd")).to(throwError())
     }
 
-    func testGetServerVersion() throws {
+    func testServerVersion() throws {
+        typealias Version = MongoClient.ServerVersion
+
         expect(try MongoClient().serverVersion()).toNot(throwError())
+
+        let three6 = Version(major: 3, minor: 6)
+        let three61 = Version(major: 3, minor: 6, patch: 1)
+        let three7 = Version(major: 3, minor: 7)
+
+        // test equality 
+        expect(try Version("3.6")).to(equal(three6))
+        expect(try Version("3.6.0")).to(equal(three6))
+
+        expect(try Version("3.6.1")).to(equal(three61))
+        expect(try Version("3.6.1.1")).to(equal(three61))
+
+        // lt
+        expect(three6.isLessThan(three6)).to(beFalse())
+        expect(three6.isLessThan(three61)).to(beTrue())
+        expect(three61.isLessThan(three6)).to(beFalse())
+        expect(three61.isLessThan(three7)).to(beTrue())
+        expect(three7.isLessThan(three6)).to(beFalse())
+        expect(three7.isLessThan(three61)).to(beFalse())
+
+        // lte
+        expect(three6.isLessThanOrEqualTo(three6)).to(beTrue())
+        expect(three6.isLessThanOrEqualTo(three61)).to(beTrue())
+        expect(three61.isLessThanOrEqualTo(three6)).to(beFalse())
+        expect(three61.isLessThanOrEqualTo(three7)).to(beTrue())
+        expect(three7.isLessThanOrEqualTo(three6)).to(beFalse())
+        expect(three7.isLessThanOrEqualTo(three61)).to(beFalse())
+
+        // gt
+        expect(three6.isGreaterThan(three6)).to(beFalse())
+        expect(three6.isGreaterThan(three61)).to(beFalse())
+        expect(three61.isGreaterThan(three6)).to(beTrue())
+        expect(three61.isGreaterThan(three7)).to(beFalse())
+        expect(three7.isGreaterThan(three6)).to(beTrue())
+        expect(three7.isGreaterThan(three61)).to(beTrue())
+
+        // gte
+        expect(three6.isGreaterThanOrEqualTo(three6)).to(beTrue())
+        expect(three6.isGreaterThanOrEqualTo(three61)).to(beFalse())
+        expect(three61.isGreaterThanOrEqualTo(three6)).to(beTrue())
+        expect(three61.isGreaterThanOrEqualTo(three7)).to(beFalse())
+        expect(three7.isGreaterThanOrEqualTo(three6)).to(beTrue())
+        expect(three7.isGreaterThanOrEqualTo(three61)).to(beTrue())
+
+        // invalid strings
+        expect(try Version("hi")).to(throwError())
+        expect(try Version("3")).to(throwError())
+        expect(try Version("3.x")).to(throwError())
     }
 }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -57,6 +57,7 @@ final class MongoClientTests: XCTestCase {
         // test equality 
         expect(try Version("3.6")).to(equal(three6))
         expect(try Version("3.6.0")).to(equal(three6))
+        expect(try Version("3.6.0-rc1")).to(equal(three6))
 
         expect(try Version("3.6.1")).to(equal(three61))
         expect(try Version("3.6.1.1")).to(equal(three61))

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -18,6 +18,23 @@ extension XCTestCase {
     }
 }
 
+extension MongoClient {
+    internal func serverVersion() throws -> String {
+        let buildInfo = try self.db("admin").runCommand(["buildInfo": 1])
+        guard let versionString = buildInfo["version"] as? String else {
+            throw TestError(message: "buildInfo reply missing version string: \(buildInfo)")
+        }
+        return versionString
+    }
+
+    internal func serverVersionIsInRange(_ min: String?, _ max: String?) throws -> Bool {
+        let version = try self.serverVersion()
+        if let min = min, min > version { return false }
+        if let max = max, max < version { return false }
+        return true
+    }
+}
+
 /// Cleans and normalizes a given JSON string for comparison purposes
 func clean(json: String?) -> String {
     guard let str = json else { return "" }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -75,32 +75,31 @@ extension MongoClient {
         }
 
         func isLessThan(_ version: ServerVersion) -> Bool {
-            switch self.major {
-
-            case 0..<version.major: return true
-
-            case version.major:
-                switch self.minor {
-                case 0..<version.minor: return true
-                case version.minor: return self.patch < version.patch
-                default: return false
+            if self.major == version.major {
+                if self.minor == version.minor {
+                    // if major & minor equal, just compare patches
+                    return self.patch < version.patch
                 }
-
-            default: return false
+                // major equal but minor isn't, so compare minor
+                return self.minor < version.minor 
             }
+            // just compare major versions
+            return self.major < version.major
+        }
+
+        func isLessThanOrEqualTo(_ version: ServerVersion) -> Bool {
+            return self == version || self.isLessThan(version)
         }
 
         func isGreaterThan(_ version: ServerVersion) -> Bool {
-            return !self.isLessThan(version) && !(self == version)
+            return !self.isLessThanOrEqualTo(version)
         }
 
         func isGreaterThanOrEqualTo(_ version: ServerVersion) -> Bool {
             return !self.isLessThan(version)
         }
 
-        func isLessThanOrEqualTo(_ version: ServerVersion) -> Bool {
-            return self == version || self.isLessThan(version)
-        }
+
     }
 
     internal func serverVersionIsInRange(_ min: String?, _ max: String?) throws -> Bool {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -98,15 +98,13 @@ extension MongoClient {
         func isGreaterThanOrEqualTo(_ version: ServerVersion) -> Bool {
             return !self.isLessThan(version)
         }
-
-
     }
 
     internal func serverVersionIsInRange(_ min: String?, _ max: String?) throws -> Bool {
         let version = try self.serverVersion()
 
-        if let min = min, version.isLessThanOrEqualTo(try ServerVersion(min)) { return false }
-        if let max = max, version.isGreaterThanOrEqualTo(try ServerVersion(max)) { return false }
+        if let min = min, version.isLessThan(try ServerVersion(min)) { return false }
+        if let max = max, version.isGreaterThan(try ServerVersion(max)) { return false }
 
         return true
     }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -27,15 +27,17 @@ extension MongoClient {
         return try ServerVersion(versionString)
     }
 
+    /// A struct representing a server version. 
     internal struct ServerVersion: Equatable {
         let major: Int
         let minor: Int
         let patch: Int
 
+        /// initialize a server version from a string
         init(_ str: String) throws {
             let versionComponents = str.split(separator: ".").prefix(3)
             if versionComponents.count < 2 {
-                throw TestError(message: "Expected version string \(str) to have at least a major and a minor version")
+                throw TestError(message: "Expected version string \(str) to have at least two .-separated components")
             }
 
             guard let major = Int(versionComponents[0]) else {
@@ -47,7 +49,10 @@ extension MongoClient {
 
             var patch = 0
             if versionComponents.count == 3 {
-                guard let patchValue = Int(versionComponents[2]) else {
+                // in case there is text at the end, for ex "3.6.0-rc1", stop first time 
+                /// we encounter a non-numeric character. 
+                let numbersOnly = versionComponents[2].prefix { "0123456789".contains($0) }
+                guard let patchValue = Int(numbersOnly) else {
                     throw TestError(message: "Error parsing patch version from \(str)")
                 }
                 patch = patchValue
@@ -56,6 +61,7 @@ extension MongoClient {
             self.init(major: major, minor: minor, patch: patch)
         }
 
+        // initialize given major, minor, and optional patch
         init(major: Int, minor: Int, patch: Int? = nil) {
             self.major = major
             self.minor = minor
@@ -95,8 +101,6 @@ extension MongoClient {
         func isLessThanOrEqualTo(_ version: ServerVersion) -> Bool {
             return self == version || self.isLessThan(version)
         }
-
-
     }
 
     internal func serverVersionIsInRange(_ min: String?, _ max: String?) throws -> Bool {


### PR DESCRIPTION
This builds on the work in SWIFT-189 to add a server version method to `MongoClient`. 

Basically, for the server version dependent tests we now get the version of the server and compare it to the min/max in the files. 
While I was in there I also did some code cleanup to get rid of unneeded try/catches, simplify file parsing by using a `BsonDecoder`, etc. 