### PR TITLE
SWIFT-158 Add filter and mapValues methods to Document

### DIFF
--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -94,7 +94,7 @@ public class DocumentIterator: IteratorProtocol {
     }
 
     /// Returns the next value in the sequence, or `nil` if the iterator is exhausted.
-    public func next() -> (key: String, value: BsonValue?)? {
+    public func next() -> Document.Element? {
         if self.advance() {
             return (self.currentKey, self.currentValue)
         }

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -10,12 +10,52 @@ import libmongoc
 /// }
 /// ```
 extension Document: Sequence {
+    /// The element type of a document: a tuple containing an individual key-value pair.
+    public typealias KeyValuePair = (key: String, value: BsonValue?)
+
     /// Returns a `DocumentIterator` over the values in this `Document`. 
     public func makeIterator() -> DocumentIterator {
         guard let iter = DocumentIterator(forDocument: self) else {
             preconditionFailure("Failed to initialize an iterator over document \(self)")
         }
         return iter
+    }
+
+    // this overrides the Sequence protocol's default implementation for `filter`. 
+    /**
+     * Returns a new document containing the key-value pairs of the dictionary that satisfy the given predicate.
+     * 
+     * - Parameters:
+     *   - isIncluded: A closure that takes a key-value pair as its argument and returns a `Bool` indicating whether 
+     *                 the pair should be included in the returned document.
+     * - Returns: A document of the key-value pairs that `isIncluded` allows.
+     * - Throws: An error if `isIncluded` throws an error.
+     */
+    public func filter(_ isIncluded: (KeyValuePair) throws -> Bool) rethrows -> Document {
+        var output = Document()
+        for elt in self where try isIncluded(elt) {
+            output[elt.key] = elt.value
+        }
+        return output
+    }
+
+    /**
+     * Returns a new document containing the keys of this document with the values transformed by
+     * the given closure.
+     *
+     * - Parameters:
+     *   - transform: A closure that transforms a `BsonValue?`. `transform` accepts each value of the
+     *                document as its parameter and returns a transformed `BsonValue?` of the same or 
+     *                of a different type.
+     * - Returns: A document containing the keys and transformed values of this document.
+     * - Throws: An error if `transform` throws an error.
+     */
+    public func mapValues(_ transform: (BsonValue?) throws -> BsonValue?) rethrows -> Document {
+        var output = Document()
+        for (k, v) in self {
+            output[k] = try transform(v)
+        }
+        return output
     }
 }
 
@@ -94,7 +134,7 @@ public class DocumentIterator: IteratorProtocol {
     }
 
     /// Returns the next value in the sequence, or `nil` if the iterator is exhausted.
-    public func next() -> Document.Element? {
+    public func next() -> Document.KeyValuePair? {
         if self.advance() {
             return (self.currentKey, self.currentValue)
         }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -20,10 +20,7 @@ public class DocumentStorage {
     }
 }
 
-/// A struct representing the BSON document type. `Document`s are append-only and do not support
-/// overwriting or removing keys in-place, or provide safeguards against duplicate keys. 
-/// To transform documents, use `Sequence` protocol methods along with `filter` and `mapValues`.
-/// To check for existing keys, use the `.keys` property.
+/// A struct representing the BSON document type.
 public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLiteral {
     /// the storage backing this document 
     internal var storage: DocumentStorage

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -25,10 +25,6 @@ public class DocumentStorage {
 /// To transform documents, use `Sequence` protocol methods along with `filter` and `mapValues`.
 /// To check for existing keys, use the `.keys` property.
 public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLiteral {
-
-    /// The element type of a document: a tuple containing an individual key-value pair.
-    public typealias Element = (key: String, value: BsonValue?)
-
     /// the storage backing this document 
     internal var storage: DocumentStorage
 
@@ -261,42 +257,6 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         if !isKnownUniquelyReferenced(&self.storage) {
             self.storage = DocumentStorage(fromPointer: self.data)
         }
-    }
-
-    /**
-     * Returns a new document containing the keys of this document with the values transformed by
-     * the given closure.
-     *
-     * - Parameters:
-     *   - transform: A closure that transforms a `BsonValue?`. `transform` accepts each value of the
-     *                document as its parameter and returns a transformed `BsonValue?` of the same or 
-     *                of a different type.
-     * - Returns: A document containing the keys and transformed values of this document.
-     * - Throws: An error if `transform` throws an error.
-     */
-    public func mapValues(_ transform: (BsonValue?) throws -> BsonValue?) rethrows -> Document {
-        var output = Document()
-        for (k, v) in self {
-            output[k] = try transform(v)
-        }
-        return output
-    }
-
-    /**
-     * Returns a new document containing the key-value pairs of the dictionary that satisfy the given predicate.
-     * 
-     * - Parameters:
-     *   - isIncluded: A closure that takes a key-value pair as its argument and returns a `Bool` indicating whether 
-     *                 the pair should be included in the returned document.
-     * - Returns: A document of the key-value pairs that `isIncluded` allows.
-     * - Throws: An error if `isIncluded` throws an error.
-     */
-    public func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> Document {
-        var output = Document()
-        for elt in self where try isIncluded(elt) {
-            output[elt.key] = elt.value
-        }
-        return output
     }
 }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -372,4 +372,32 @@ final class DocumentTests: XCTestCase {
         expect(doc["a1"]).to(equal(arr1))
         expect(doc["a2"]).to(equal(arr2))
     }
+
+    func testMapFilter() throws {
+        let doc1: Document = ["a": 1, "b": nil, "c": 3, "d": 4, "e": nil]
+        expect(doc1.mapValues { $0 ?? 1 }).to(equal(["a": 1, "b": 1, "c": 3, "d": 4, "e": 1]))
+        let output1 = doc1.mapValues { val in
+            if let int = val as? Int { return int + 1 }
+            return val
+        }
+        expect(output1).to(equal(["a": 2, "b": nil, "c": 4, "d": 5, "e": nil]))
+        expect(doc1.filter { $0.value != nil }).to(equal(["a": 1, "c": 3, "d": 4]))
+
+        let doc2: Document = ["a": 1, "b": "hello", "c": [1, 2] as [Int]]
+        expect(doc2.filter { $0.value is String }).to(equal(["b": "hello"]))
+        let output2 = doc2.mapValues { val in
+            switch val {
+            case let val as Int:
+                return val + 1
+            case let val as String:
+                return val + " there"
+            case let val as [Int]:
+                return val.reduce(0, +)
+            default:
+                return val
+            }
+        }
+        expect(output2).to(equal(["a": 2, "b": "hello there", "c": 3]))
+    }
+
 }


### PR DESCRIPTION
This adds a `mapValues` method similar to [Dictionary's](https://developer.apple.com/documentation/swift/dictionary/2995348-mapvalues).

This also overrides the default `filter` implementation (which we got from conforming to the `Sequence` protocol).
Before the signature was 
```swift
public func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> [Element]`
```
and now it's
```swift
public func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> Document
```

We have default `map` and `reduce` implementations already from conforming to `Sequence`.

I also added `isEmpty` to go along with `count`, since it seems to be more idiomatic.

I'm going to dig further through the `Dictionary` docs and source code and potentially open more tickets to see if there are any other methods like this, either to add or override, that could improve usability/similarity to dictionaries and help alleviate append-only issues. 