### PR TITLE
SWIFT-89 Add failable initializer for Decimal128

### DIFF
--- a/Tests/MongoSwiftTests/BsonValueTests.swift
+++ b/Tests/MongoSwiftTests/BsonValueTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+@testable import MongoSwift
+import Nimble
+import XCTest
+
+final class BsonValueTests: XCTestCase {
+    static var allTests: [(String, (BsonValueTests) -> () throws -> Void)] {
+        return [
+            ("testInvalidDecimal128", testInvalidDecimal128),
+            ("testUUIDBytes", testUUIDBytes)
+        ]
+    }
+
+    func testInvalidDecimal128() throws {
+        expect(Decimal128(ifValid: "hi")).to(beNil())
+        expect(Decimal128(ifValid: "123.4.5")).to(beNil())
+        expect(Decimal128(ifValid: "10")).toNot(beNil())
+    }
+
+    func testUUIDBytes() throws {
+        let twoBytes = Data(base64Encoded: "//8=")!
+        let sixteenBytes = Data(base64Encoded: "c//SZESzTGmQ6OfR38A11A==")!
+
+        // UUIDs must have 16 bytes
+        expect(try Binary(data: twoBytes, subtype: .uuidDeprecated)).to(throwError())
+        expect(try Binary(data: twoBytes, subtype: .uuid)).to(throwError())
+        expect(try Binary(data: sixteenBytes, subtype: .uuidDeprecated)).toNot(throwError())
+        expect(try Binary(data: sixteenBytes, subtype: .uuid)).toNot(throwError())
+    }
+}

--- a/Tests/MongoSwiftTests/XCTestManifests.swift
+++ b/Tests/MongoSwiftTests/XCTestManifests.swift
@@ -3,11 +3,12 @@ import XCTest
 #if !os(macOS)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(MongoClientTests.allTests),
+        testCase(BsonValueTests.allTests),
         testCase(CodecTests.allTests),
-        testCase(MongoCollectionTests.allTests),
         testCase(CommandMonitoringTests.allTests),
         testCase(CrudTests.allTests),
+        testCase(MongoClientTests.allTests),
+        testCase(MongoCollectionTests.allTests),
         testCase(MongoDatabaseTests.allTests),
         testCase(DocumentTests.allTests),
         testCase(ReadPreferenceTests.allTests),


### PR DESCRIPTION
This adds a new failable initializer for `Decimal128`, which validates the string by testing `bson_decimal128_t` initialization. 

It seemed to me that it should be an alternate initializer, differentiated by the argument label `ifValid`, so we don't force the performance penalty in unneeded cases.

I thought a failable initializer was more appropriate than throwing (as we do from some other initializers), reasons being that:
1) there is only one very opaque error we would throw from here ("invalid decimal128 string") 
2) this feels more consistent with other Swift methods for parsing types from strings, for example [Int](https://developer.apple.com/documentation/swift/int/2927504-init) and [Data](https://developer.apple.com/documentation/foundation/data/1780388-init).