### PR TITLE
WIP SWIFT-196: Check if a key exists already before setting it

### DIFF
--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -357,16 +357,20 @@ extension Double: BsonValue {
 /// The `Int` will be encoded as an Int32 if possible, or an Int64 if necessary.
 extension Int: BsonValue {
 
-    public var bsonType: BsonType { return .int32 }
+    public var bsonType: BsonType { return self.int32Value != nil ? .int32 : .int64 }
+
+    internal var int32Value: Int32? { return Int32(exactly: self) }
+    internal var int64Value: Int64? { return Int64(exactly: self) }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        if let int32 = Int32(exactly: self) {
+        if let int32 = self.int32Value {
             return try int32.encode(to: storage, forKey: key)
         }
-        if let int64 = Int64(exactly: self) {
+        if let int64 = self.int64Value {
             return try int64.encode(to: storage, forKey: key)
         }
-        throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
+
+        preconditionFailure("`Int` value \(self) could not be encoded as `Int32` or `Int64`")
     }
 
     public init(from iter: DocumentIterator) throws {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -13,10 +13,6 @@ public class DocumentStorage {
         self.pointer = bson_copy(pointer)
     }
 
-    init(withoutCopying pointer: UnsafeMutablePointer<bson_t>) {
-        self.pointer = pointer
-    }
-
     deinit {
         guard let pointer = self.pointer else { return }
         bson_destroy(pointer)

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -372,4 +372,40 @@ final class DocumentTests: XCTestCase {
         expect(doc["a1"]).to(equal(arr1))
         expect(doc["a2"]).to(equal(arr2))
     }
+
+    func testOverwriteKey() throws {
+        // test with overwritable types
+        var doc1: Document = ["double": 2.5, "int32": Int32(32), "int64": Int64(64), "bool": false]
+        let originalStorage = doc1.storage                    
+
+        doc1["double"] = 3.0
+        expect(doc1["double"] as? Double).to(equal(3.0))
+        expect(doc1.count).to(equal(4))
+
+        // overwrite int32 with int32
+        doc1["int32"] = Int32(15)
+        expect(doc1["int32"] as? Int).to(equal(15))
+        expect(doc1.count).to(equal(4))
+
+        // overwrite int32 with int
+        doc1["int32"] = 20
+        expect(doc1["int32"] as? Int).to(equal(20))
+        expect(doc1.count).to(equal(4))
+
+        // overwrite int64 with int64
+        let bigInt64 = Int64(Int32.max) + 1
+        doc1["int64"] = bigInt64
+        expect(doc1["int64"] as? Int64).to(equal(bigInt64))
+        expect(doc1.count).to(equal(4))   
+
+        // overwrite int64 with int
+        // one off, so we can tell it's set
+        let bigInt = Int(bigInt64) + 1
+        doc1["int64"] = bigInt
+        expect(doc1["int64"] as? Int64).to(equal(bigInt64 + 1))
+        expect(doc1.count).to(equal(4))
+
+        // ideally, after all this, storage should be the same!
+        // expect(doc1.storage).to(equal(originalStorage))   
+    }
 }


### PR DESCRIPTION
I started on this but I ran into a bit of an issue trying to preserve copy-on-write behavior. I will add some inline comments to try to clarify, but the gist is:

Basically, I would like to use a `DocumentIterator` (initialized via the init that wraps `bson_iter_init_and_find`) to check if a key is already present in the `Document`, and if so, get its current type. This allows me to check whether it is a type that can be overwritten in place or a type that will require creating a new `bson_t` and copying over values. 

However, creating this iterator, which at least lives for the time I am trying to set the new value, means that the `Document`'s storage is no longer considered uniquely referenced and we will *always* end up making a copy before doing mutation, even if it's not really necessary, because the only other reference to the storage is the iterator that we're done with. 

I do think there is value in having the iterator keep its own reference to the storage, so that we don't need to caution users about modifying a doc while iterating through it, or destroying the doc too early, and so on. but in this case, it's also forcing us into some unneeded inefficiency.

some ideas for mitigating this:
- we could make `DocumentIterator.storage` optional and then add some additional `internal init` that doesn't set it, or provide a method to nil it out when done with the iterator. 
- we could create an alternative `internal` iterator class, that basically has behavior described in the previous bullet point
- we could use some of the convenience methods on `Document` that each create their own locally scoped iterators. this could lead to us creating more `bson_iter_t`s than necessary but it seems to alleviate the unique reference problem. 
- we could also just say screw it, if you're overwriting an existing value, we will always have to use a new`bson_t` and that is that. in which case I'm not even sure the overwriting optimizations I added would be worth it, because we'd always end up doing a `bson_copy` first anyway. 

Not sure how to best handle, let me know your thoughts.