### PR TITLE
SWIFT-196 Check if a key exists before setting it, and overwrite existing keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
   
   # clone and build libmongoc
-  - git clone -b r1.12 https://github.com/mongodb/mongo-c-driver /tmp/libmongoc
+  - git clone -b r1.13 https://github.com/mongodb/mongo-c-driver /tmp/libmongoc
   - pushd /tmp/libmongoc
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr; fi

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Core Server (i.e. SERVER) project are **public**.
 `MongoSwift` works with Swift 4.0+.
 
 ### FIRST: Install the MongoDB C Driver
-Because the driver wraps the MongoDB C driver, using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. The minimum required version of the C Driver is **1.11.0**.
+Because the driver wraps the MongoDB C driver, using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. The minimum required version of the C Driver is **1.13.0**.
 
 On a Mac, you can install both components at once using [Homebrew](https://brew.sh/): 
 `brew install mongo-c-driver`.

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -322,6 +322,10 @@ public struct Decimal128: BsonValue, Equatable, Codable {
         }
     }
 
+    public static func == (lhs: Decimal128, rhs: Decimal128) -> Bool {
+        return lhs.data == rhs.data
+    }
+
     /// Returns the provided string as a `bson_decimal128_t`, or throws an error if initialization fails due an
     /// invalid string.
     internal static func encode(_ str: String) throws -> bson_decimal128_t {
@@ -332,12 +336,8 @@ public struct Decimal128: BsonValue, Equatable, Codable {
         return value
     }
 
-    public static func == (lhs: Decimal128, rhs: Decimal128) -> Bool {
-        return lhs.data == rhs.data
-    }
-
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-       var value = try Decimal128.encode(self.data)
+        var value = try Decimal128.encode(self.data)
         if !bson_append_decimal128(storage.pointer, key, Int32(key.count), &value) {
             throw bsonEncodeError(value: self, forKey: key)
         }
@@ -378,15 +378,19 @@ extension Double: BsonValue {
 /// The `Int` will be encoded as an Int32 if possible, or an Int64 if necessary.
 extension Int: BsonValue {
 
-    public var bsonType: BsonType { return .int32 }
+    public var bsonType: BsonType { return self.int32Value != nil ? .int32 : .int64 }
+
+    internal var int32Value: Int32? { return Int32(exactly: self) }
+    internal var int64Value: Int64? { return Int64(exactly: self) }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        if let int32 = Int32(exactly: self) {
+        if let int32 = self.int32Value {
             return try int32.encode(to: storage, forKey: key)
         }
-        if let int64 = Int64(exactly: self) {
+        if let int64 = self.int64Value {
             return try int64.encode(to: storage, forKey: key)
         }
+
         throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
     }
 

--- a/Sources/MongoSwift/BSON/BsonValue.swift
+++ b/Sources/MongoSwift/BSON/BsonValue.swift
@@ -322,10 +322,6 @@ public struct Decimal128: BsonValue, Equatable, Codable {
         }
     }
 
-    public static func == (lhs: Decimal128, rhs: Decimal128) -> Bool {
-        return lhs.data == rhs.data
-    }
-
     /// Returns the provided string as a `bson_decimal128_t`, or throws an error if initialization fails due an
     /// invalid string.
     internal static func encode(_ str: String) throws -> bson_decimal128_t {
@@ -334,6 +330,10 @@ public struct Decimal128: BsonValue, Equatable, Codable {
             throw MongoError.bsonEncodeError(message: "Invalid Decimal128 string \(str)")
         }
         return value
+    }
+
+    public static func == (lhs: Decimal128, rhs: Decimal128) -> Bool {
+        return lhs.data == rhs.data
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -223,7 +223,7 @@ public class DocumentIterator: IteratorProtocol {
 
     /// Returns the current value's type. Assumes the iterator is in a valid position.
     internal var currentType: BsonType {
-        return BsonType(rawValue: bson_iter_type(&iter).rawValue) ?? .invalid
+        return BsonType(rawValue: bson_iter_type(&self.iter).rawValue) ?? .invalid
     }
 
     /// Returns the keys from the iterator's current position to the end. The iterator
@@ -273,6 +273,12 @@ public class DocumentIterator: IteratorProtocol {
         return self.advance() ? (self.currentKey, self.currentValue) : nil
     }
 
+    internal func overwriteCurrentValue(with newValue: Overwritable) throws {
+        precondition(newValue.bsonType == self.currentType,
+                     "Expected \(newValue) to have BSON type \(self.currentType), but has type \(newValue.bsonType)")
+        try newValue.writeToCurrentPosition(of: self)
+    }
+
     private static let BsonTypeMap: [BsonType: BsonValue.Type] = [
         .double: Double.self,
         .string: String.self,
@@ -294,4 +300,45 @@ public class DocumentIterator: IteratorProtocol {
         .minKey: MinKey.self,
         .maxKey: MaxKey.self
     ]
+}
+
+/// A protocol indicating that a type can be overwritten in-place on a `bson_t`.
+internal protocol Overwritable: BsonValue {
+    /// Overwrites the value at the current position of the iterator with self.
+    func writeToCurrentPosition(of iter: DocumentIterator) throws
+}
+
+extension Bool: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_bool(&iter.iter, self) }
+}
+
+extension Int: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) throws {
+        if let int32 = self.int32Value {
+            return int32.writeToCurrentPosition(of: iter)
+        } else if let int64 = self.int64Value {
+            return int64.writeToCurrentPosition(of: iter)
+        }
+
+        throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
+    }
+}
+
+extension Int32: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_int32(&iter.iter, self) }
+}
+
+extension Int64: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_int64(&iter.iter, self) }
+}
+
+extension Double: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_double(&iter.iter, self) }
+}
+
+extension Decimal128: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) throws {
+        var encoded = try Decimal128.encode(self.data)
+        bson_iter_overwrite_decimal128(&iter.iter, &encoded)
+    }
 }

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -256,6 +256,7 @@ public class DocumentIterator: IteratorProtocol {
 
         var output = Document()
 
+        // TODO SWIFT-224: use va_list variant of bson_copy_to_excluding to improve performance
         for _ in startIndex..<endIndex {
             if let next = iter.next() {
                 output[next.key] = next.value
@@ -300,45 +301,4 @@ public class DocumentIterator: IteratorProtocol {
         .minKey: MinKey.self,
         .maxKey: MaxKey.self
     ]
-}
-
-/// A protocol indicating that a type can be overwritten in-place on a `bson_t`.
-internal protocol Overwritable: BsonValue {
-    /// Overwrites the value at the current position of the iterator with self.
-    func writeToCurrentPosition(of iter: DocumentIterator) throws
-}
-
-extension Bool: Overwritable {
-    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_bool(&iter.iter, self) }
-}
-
-extension Int: Overwritable {
-    func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        if let int32 = self.int32Value {
-            return int32.writeToCurrentPosition(of: iter)
-        } else if let int64 = self.int64Value {
-            return int64.writeToCurrentPosition(of: iter)
-        }
-
-        throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
-    }
-}
-
-extension Int32: Overwritable {
-    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_int32(&iter.iter, self) }
-}
-
-extension Int64: Overwritable {
-    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_int64(&iter.iter, self) }
-}
-
-extension Double: Overwritable {
-    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_double(&iter.iter, self) }
-}
-
-extension Decimal128: Overwritable {
-    func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        var encoded = try Decimal128.encode(self.data)
-        bson_iter_overwrite_decimal128(&iter.iter, &encoded)
-    }
 }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -72,10 +72,15 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      *
      * - Returns: a new `Document`
      */
-    public init(dictionaryLiteral doc: (String, BsonValue?)...) {
+    public init(dictionaryLiteral keyValuePairs: (String, BsonValue?)...) {
+        // make sure all keys are unique
+        if Set(keyValuePairs.map { $0.0 }).count != keyValuePairs.count {
+            preconditionFailure("Dictionary literal \(keyValuePairs) contains duplicate keys")
+        }
+
         self.storage = DocumentStorage()
-        for (k, v) in doc {
-            self[k] = v
+        for (key, value) in keyValuePairs {
+            self[key] = value
         }
     }
     /**
@@ -213,12 +218,12 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
             } else {
                 var newSelf = Document()
                 var seen = false
-                self.forEach { pair in
+                try self.forEach { pair in
                     if !seen && pair.key == key {
                         seen = true
-                        newSelf[pair.key] = newValue
+                        try newSelf.setValue(forKey: pair.key, to: newValue)
                     } else {
-                        newSelf[pair.key] = pair.value
+                        try newSelf.setValue(forKey: pair.key, to: pair.value)
                     }
                 }
                 self = newSelf

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -225,6 +225,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
             // otherwise, we just create a new document and replace this key
             } else {
+                // TODO SWIFT-224: use va_list variant of bson_copy_to_excluding to improve performance
                 var newSelf = Document()
                 var seen = false
                 try self.forEach { pair in

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -1,0 +1,42 @@
+import libbson
+
+/// A protocol indicating that a type can be overwritten in-place on a `bson_t`.
+internal protocol Overwritable: BsonValue {
+    /// Overwrites the value at the current position of the iterator with self.
+    func writeToCurrentPosition(of iter: DocumentIterator) throws
+}
+
+extension Bool: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_bool(&iter.iter, self) }
+}
+
+extension Int: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) throws {
+        if let int32 = self.int32Value {
+            return int32.writeToCurrentPosition(of: iter)
+        } else if let int64 = self.int64Value {
+            return int64.writeToCurrentPosition(of: iter)
+        }
+
+        throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
+    }
+}
+
+extension Int32: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_int32(&iter.iter, self) }
+}
+
+extension Int64: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_int64(&iter.iter, self) }
+}
+
+extension Double: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) { bson_iter_overwrite_double(&iter.iter, self) }
+}
+
+extension Decimal128: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) throws {
+        var encoded = try Decimal128.encode(self.data)
+        bson_iter_overwrite_decimal128(&iter.iter, &encoded)
+    }
+}

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -16,6 +16,11 @@ extension XCTestCase {
         }
         return path
     }
+
+    // indicates whether we are running on a 32-bit platform
+    // Use MemoryLayout instead of Int.bitWidth to avoid a compiler warning.
+    // See: https://forums.swift.org/t/how-can-i-condition-on-the-size-of-int/9080/4 */
+    static let is32Bit = MemoryLayout<Int>.size == 4
 }
 
 extension MongoClient {


### PR DESCRIPTION
Alright, round 2 now that I resolved my unique reference issues.

I moved all the logic for setting a value on a document to a private `setValue` method, please pay attention in particular to the logic there... I think it makes sense re: when we do or don't need to copy underlying storage and overwrite values vs. make new docs, but a sanity check is appreciated. 