### PR TITLE
SWIFT-195 Make Document SubSequence type a Document

### DIFF
--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -13,6 +13,12 @@ extension Document: Sequence {
     /// The element type of a document: a tuple containing an individual key-value pair.
     public typealias KeyValuePair = (key: String, value: BsonValue?)
 
+    /// Returns the number of (key, value) pairs stored at the top level of this `Document`.
+    public var count: Int { return Int(bson_count_keys(self.data)) }
+
+    /// Returns a `Bool` indicating whether the document is empty.
+    public var isEmpty: Bool { return self.makeIterator().advance() }
+
     /// Returns a `DocumentIterator` over the values in this `Document`. 
     public func makeIterator() -> DocumentIterator {
         guard let iter = DocumentIterator(forDocument: self) else {
@@ -28,7 +34,9 @@ extension Document: Sequence {
      * - Parameters:
      *   - isIncluded: A closure that takes a key-value pair as its argument and returns a `Bool` indicating whether 
      *                 the pair should be included in the returned document.
+     *
      * - Returns: A document of the key-value pairs that `isIncluded` allows.
+     *
      * - Throws: An error if `isIncluded` throws an error.
      */
     public func filter(_ isIncluded: (KeyValuePair) throws -> Bool) rethrows -> Document {
@@ -47,7 +55,9 @@ extension Document: Sequence {
      *   - transform: A closure that transforms a `BsonValue?`. `transform` accepts each value of the
      *                document as its parameter and returns a transformed `BsonValue?` of the same or 
      *                of a different type.
+     *
      * - Returns: A document containing the keys and transformed values of this document.
+     *
      * - Throws: An error if `transform` throws an error.
      */
     public func mapValues(_ transform: (BsonValue?) throws -> BsonValue?) rethrows -> Document {
@@ -55,6 +65,105 @@ extension Document: Sequence {
         for (k, v) in self {
             output[k] = try transform(v)
         }
+        return output
+    }
+
+    public func dropFirst(_ n: Int) -> Document {
+        switch n {
+        case ..<0:
+            preconditionFailure("Can't drop a negative number of elements from a document")
+        case 0:
+            return self
+        default:
+            // get all the key-value pairs from nth index on. subsequence will handle the case where n >= length of doc
+            // by creating an iter and calling advance until the end is reached. this is exactly what calling self.count
+            // would do in that situation via bson_count_keys, so no point in special casing self.count <= n here.
+            return DocumentIterator.subsequence(of: self, startIndex: n)
+        }
+    }
+
+    public func dropLast(_ n: Int) -> Document {
+        switch n {
+        case ..<0:
+            preconditionFailure("Can't drop a negative number of elements from a `Document`")
+        case 0:
+            return self
+        default:
+            // the subsequence we want is [0, length - n)
+            let end = self.count - n
+            // if we are dropping >= the length, just short circuit and return empty doc
+            return end <= 0 ? [:] : DocumentIterator.subsequence(of: self, endIndex: end)
+        }
+    }
+
+    public func drop(while predicate: (KeyValuePair) throws -> Bool) rethrows -> Document {
+        // tracks whether we are still in a "dropping" state. once we encounter
+        // an element that doesn't satisfy the predicate, we stop dropping.
+        var drop = true
+        return try self.filter { elt in
+            if drop {
+                // still in "drop" mode and it matches predicate
+                if try predicate(elt) { return false }
+                // else we've encountered our first non-matching element
+                drop = false
+                return true
+            }
+            // out of "drop" mode, so we keep everything
+            return true
+        }
+    }
+
+    public func prefix(_ maxLength: Int) -> Document {
+        switch maxLength {
+        case ..<0:
+            preconditionFailure("Can't retrieve a negative length prefix of a `Document`")
+        case 0:
+            return [:]
+        default:
+            // short circuit if there are fewer elements in the doc than requested
+            return self.count <= maxLength ? self : DocumentIterator.subsequence(of: self, endIndex: maxLength)
+        }
+    }
+
+    public func prefix(while predicate: (KeyValuePair) throws -> Bool) rethrows -> Document {
+        var output = Document()
+        for elt in self {
+            if try !predicate(elt) { break }
+            output[elt.key] = elt.value
+        }
+        return output
+    }
+
+    public func suffix(_ maxLength: Int) -> Document {
+        switch maxLength {
+        case ..<0:
+            preconditionFailure("Can't retrieve a negative length suffix of a `Document`")
+        case 0:
+            return [:]
+        default:
+            let start = self.count - maxLength
+            // short circuit if there are fewer elements in the doc than requested
+            return start <= 0 ? self : DocumentIterator.subsequence(of: self, startIndex: start)
+        }
+    }
+
+    public func split(maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true,
+                      whereSeparator isSeparator: (KeyValuePair) throws -> Bool) rethrows -> [Document] {
+        // rather than implementing the complex logic necessary for split, convert to an array and call split on that
+        let asArr = Array(self)
+        // convert to a [[KeyValuePair]]
+        let splitArrs = try asArr.split(maxSplits: maxSplits,
+                                        omittingEmptySubsequences: omittingEmptySubsequences,
+                                        whereSeparator: isSeparator)
+
+        // convert each nested [KeyValuePair] back to a Document
+        var output = [Document]()
+        splitArrs.forEach { array in
+            var doc = Document()
+            array.forEach { doc[$0.key] = $0.value }
+            output.append(doc)
+        }
+
         return output
     }
 }
@@ -87,7 +196,7 @@ public class DocumentIterator: IteratorProtocol {
 
     /// Advances the iterator forward one value. Returns false if there is an error moving forward
     /// or if at the end of the document. Returns true otherwise.
-    private func advance() -> Bool {
+    internal func advance() -> Bool {
         return bson_iter_next(&self.iter)
     }
 
@@ -133,12 +242,35 @@ public class DocumentIterator: IteratorProtocol {
         return values
     }
 
+    // uses an iterator to copy (key, value) pairs of the provided document from range [startIndex, endIndex) into a new
+    // document. starts at the startIndex-th pair and ends at the end of the document or the (endIndex-1)th index, 
+    // whichever comes first. 
+    internal static func subsequence(of doc: Document, startIndex: Int = 0, endIndex: Int = Int.max) -> Document {
+        precondition(endIndex >= startIndex, "endIndex must be >= startIndex")
+
+        guard let iter = DocumentIterator(forDocument: doc) else { return [:] }
+
+        // skip the values preceding startIndex. this is more performant than calling next, because
+        // it doesn't pull the unneeded key/values out of the iterator
+        for _ in 0..<startIndex { _ = iter.advance() }
+
+        var output = Document()
+
+        for _ in startIndex..<endIndex {
+            if let next = iter.next() {
+                output[next.key] = next.value
+            } else {
+                // we ran out of values
+                break
+            }
+        }
+
+        return output
+    }
+
     /// Returns the next value in the sequence, or `nil` if the iterator is exhausted.
     public func next() -> Document.KeyValuePair? {
-        if self.advance() {
-            return (self.currentKey, self.currentValue)
-        }
-        return nil
+        return self.advance() ? (self.currentKey, self.currentValue) : nil
     }
 
     private static let BsonTypeMap: [BsonType: BsonValue.Type] = [

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -38,12 +38,6 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         return self.makeIterator().values
     }
 
-    /// Returns the number of (key, value) pairs stored at the top level of this `Document`.
-    public var count: Int { return Int(bson_count_keys(self.data)) }
-
-    /// Returns a `Bool` indicating whether the document is empty.
-    public var isEmpty: Bool { return self.count == 0 }
-
     /// Initializes a new, empty `Document`.
     public init() {
         self.storage = DocumentStorage()

--- a/Tests/MongoSwiftTests/Document+SequenceTests.swift
+++ b/Tests/MongoSwiftTests/Document+SequenceTests.swift
@@ -1,0 +1,250 @@
+import Foundation
+@testable import MongoSwift
+import Nimble
+import XCTest
+
+final class Document_SequenceTests: XCTestCase {
+    static var allTests: [(String, (Document_SequenceTests) -> () throws -> Void)] {
+        return [
+            ("testIterator", testIterator),
+            ("testMapFilter", testMapFilter),
+            ("testDropFirst", testDropFirst),
+            ("testDropLast", testDropLast),
+            ("testDropPredicate", testDropPredicate),
+            ("testPrefixLength", testPrefixLength),
+            ("testPrefixPredicate", testPrefixPredicate),
+            ("testSuffix", testSuffix),
+            ("testSplit", testSplit)
+        ]
+    }
+
+    func testIterator() {
+        let doc: Document = [
+            "string": "test string",
+            "true": true,
+            "false": false,
+            "int": 25,
+            "int32": Int32(5),
+            "double": Double(15),
+            "decimal128": Decimal128("1.2E+10"),
+            "minkey": MinKey(),
+            "maxkey": MaxKey(),
+            "date": Date(timeIntervalSince1970: 5000),
+            "timestamp": Timestamp(timestamp: 5, inc: 10)
+        ]
+
+        // create and use iter manually
+        let iter = doc.makeIterator()
+
+        let stringTup = iter.next()!
+        expect(stringTup.key).to(equal("string"))
+        expect(stringTup.value as? String).to(equal("test string"))
+
+        let trueTup = iter.next()!
+        expect(trueTup.key).to(equal("true"))
+        expect(trueTup.value as? Bool).to(beTrue())
+
+        let falseTup = iter.next()!
+        expect(falseTup.key).to(equal("false"))
+        expect(falseTup.value as? Bool).to(beFalse())
+
+        let intTup = iter.next()!
+        expect(intTup.key).to(equal("int"))
+        expect(intTup.value as? Int).to(equal(25))
+
+        let int32Tup = iter.next()!
+        expect(int32Tup.key).to(equal("int32"))
+        expect(int32Tup.value as? Int).to(equal(5))
+
+        let doubleTup = iter.next()!
+        expect(doubleTup.key).to(equal("double"))
+        expect(doubleTup.value as? Double).to(equal(15))
+
+        let decimalTup = iter.next()!
+        expect(decimalTup.key).to(equal("decimal128"))
+        expect(decimalTup.value as? Decimal128).to(equal(Decimal128("1.2E+10")))
+
+        let minTup = iter.next()!
+        expect(minTup.key).to(equal("minkey"))
+        expect(minTup.value as? MinKey).to(equal(MinKey()))
+
+        let maxTup = iter.next()!
+        expect(maxTup.key).to(equal("maxkey"))
+        expect(maxTup.value as? MaxKey).to(equal(MaxKey()))
+
+        let dateTup = iter.next()!
+        expect(dateTup.key).to(equal("date"))
+        expect(dateTup.value as? Date).to(equal(Date(timeIntervalSince1970: 5000)))
+
+        let timeTup = iter.next()!
+        expect(timeTup.key).to(equal("timestamp"))
+        expect(timeTup.value as? Timestamp).to(equal(Timestamp(timestamp: 5, inc: 10)))
+
+        expect(iter.next()).to(beNil())
+
+        // iterate via looping
+        var expectedKeys = ["string", "true", "false", "int", "int32", "double",
+                            "decimal128", "minkey", "maxkey", "date", "timestamp"]
+        for (k, v) in doc {
+            expect(k).to(equal(expectedKeys.removeFirst()))
+            // we can't compare BsonValues for equality, nor can we cast v
+            // to a dynamically determined equatable type, so just verify
+            // it's a BsonValue anyway 
+            expect(v).to(beAKindOf(BsonValue.self))
+        }
+    }
+
+    func testMapFilter() throws {
+        let doc1: Document = ["a": 1, "b": nil, "c": 3, "d": 4, "e": nil]
+        expect(doc1.mapValues { $0 ?? 1 }).to(equal(["a": 1, "b": 1, "c": 3, "d": 4, "e": 1]))
+        let output1 = doc1.mapValues { val in
+            if let int = val as? Int { return int + 1 }
+            return val
+        }
+        expect(output1).to(equal(["a": 2, "b": nil, "c": 4, "d": 5, "e": nil]))
+        expect(doc1.filter { $0.value != nil }).to(equal(["a": 1, "c": 3, "d": 4]))
+
+        let doc2: Document = ["a": 1, "b": "hello", "c": [1, 2] as [Int]]
+        expect(doc2.filter { $0.value is String }).to(equal(["b": "hello"]))
+        let output2 = doc2.mapValues { val in
+            switch val {
+            case let val as Int:
+                return val + 1
+            case let val as String:
+                return val + " there"
+            case let val as [Int]:
+                return val.reduce(0, +)
+            default:
+                return val
+            }
+        }
+        expect(output2).to(equal(["a": 2, "b": "hello there", "c": 3]))
+    }
+
+    // shared docs for subsequence tests
+    let emptyDoc = Document()
+    let smallDoc: Document = ["x": 1]
+    let doc: Document = ["a": 1, "b": "hi", "c": [1, 2] as [Int], "d": false, "e": nil, "f": MinKey(), "g": 10]
+
+    // shared predicates for subsequence tests
+    func isInt(_ pair: Document.KeyValuePair) -> Bool { return pair.value is Int }
+    func isNotNil(_ pair: Document.KeyValuePair) -> Bool { return pair.value != nil }
+    func is10(_ pair: Document.KeyValuePair) -> Bool {
+        if let int = pair.value as? Int { return int == 10 } else { return false }
+    }
+    func isNot10(_ pair: Document.KeyValuePair) -> Bool { return !is10(pair) }
+
+    func testDropFirst() throws {
+        expect(self.emptyDoc.dropFirst(0)).to(equal([:]))
+        expect(self.emptyDoc.dropFirst(1)).to(equal([:]))
+
+        expect(self.smallDoc.dropFirst(0)).to(equal(smallDoc))
+        expect(self.smallDoc.dropFirst()).to(equal([:]))
+        expect(self.smallDoc.dropFirst(2)).to(equal([:]))
+
+        expect(self.doc.dropFirst(0)).to(equal(doc))
+        expect(self.doc.dropFirst()).to(equal(["b": "hi", "c": [1, 2] as [Int], "d": false, "e": nil, "f": MinKey(), "g": 10]))
+        expect(self.doc.dropFirst(4)).to(equal(["e": nil, "f": MinKey(), "g": 10]))
+        expect(self.doc.dropFirst(7)).to(equal([:]))
+        expect(self.doc.dropFirst(8)).to(equal([:]))
+    }
+
+    func testDropLast() throws {
+        expect(self.emptyDoc.dropLast(0)).to(equal([:]))
+        expect(self.emptyDoc.dropLast(1)).to(equal([:]))
+
+        expect(self.smallDoc.dropLast(0)).to(equal(smallDoc))
+        expect(self.smallDoc.dropLast()).to(equal([:]))
+        expect(self.smallDoc.dropLast(2)).to(equal([:]))
+
+        expect(self.doc.dropLast(0)).to(equal(doc))
+        expect(self.doc.dropLast()).to(equal(["a": 1, "b": "hi", "c": [1, 2] as [Int], "d": false, "e": nil, "f": MinKey()]))
+        expect(self.doc.dropLast(4)).to(equal(["a": 1, "b": "hi", "c": [1, 2] as [Int]]))
+        expect(self.doc.dropLast(7)).to(equal([:]))
+        expect(self.doc.dropLast(8)).to(equal([:]))
+    }
+
+    func testDropPredicate() throws {
+        expect(self.emptyDoc.drop(while: self.isInt)).to(equal([:]))
+        expect(self.smallDoc.drop(while: self.isInt)).to(equal([:]))
+        expect(self.doc.drop(while: self.isInt)).to(equal(["b": "hi", "c": [1, 2] as [Int], "d": false, "e": nil, "f": MinKey(), "g": 10]))
+
+        expect(self.emptyDoc.drop(while: self.isNotNil)).to(equal([:]))
+        expect(self.smallDoc.drop(while: self.isNotNil)).to(equal([:]))
+        expect(self.doc.drop(while: self.isNotNil)).to(equal(["e": nil, "f": MinKey(), "g": 10]))
+
+        expect(self.emptyDoc.drop(while: self.isNot10)).to(equal([:]))
+        expect(self.smallDoc.drop(while: self.isNot10)).to(equal([:]))
+        expect(self.doc.drop(while: self.isNot10)).to(equal(["g": 10]))
+
+        expect(self.emptyDoc.drop(while: self.is10)).to(equal([:]))
+        expect(self.smallDoc.drop(while: self.is10)).to(equal(smallDoc))
+        expect(self.doc.drop(while: self.is10)).to(equal(doc))
+    }
+
+    func testPrefixLength() throws {
+        expect(self.emptyDoc.prefix(0)).to(equal([:]))
+        expect(self.emptyDoc.prefix(1)).to(equal([:]))
+
+        expect(self.smallDoc.prefix(0)).to(equal([:]))
+        expect(self.smallDoc.prefix(1)).to(equal(smallDoc))
+        expect(self.smallDoc.prefix(2)).to(equal(smallDoc))
+
+        expect(self.doc.prefix(0)).to(equal([:]))
+        expect(self.doc.prefix(1)).to(equal(["a": 1]))
+        expect(self.doc.prefix(2)).to(equal(["a": 1, "b": "hi"]))
+        expect(self.doc.prefix(4)).to(equal(["a": 1, "b": "hi", "c": [1, 2] as [Int], "d": false]))
+        expect(self.doc.prefix(7)).to(equal(doc))
+        expect(self.doc.prefix(8)).to(equal(doc))
+    }
+
+    func testPrefixPredicate() throws {
+        expect(self.emptyDoc.prefix(while: self.isInt)).to(equal([:]))
+        expect(self.smallDoc.prefix(while: self.isInt)).to(equal(smallDoc))
+        expect(self.doc.prefix(while: self.isInt)).to(equal(["a": 1]))
+
+        expect(self.emptyDoc.prefix(while: self.isNotNil)).to(equal([:]))
+        expect(self.smallDoc.prefix(while: self.isNotNil)).to(equal(smallDoc))
+        expect(self.doc.prefix(while: self.isNotNil)).to(equal(["a": 1, "b": "hi", "c": [1, 2] as [Int], "d": false]))
+
+        expect(self.emptyDoc.prefix(while: self.isNot10)).to(equal([:]))
+        expect(self.smallDoc.prefix(while: self.isNot10)).to(equal(smallDoc))
+        expect(self.doc.prefix(while: self.isNot10)).to(equal(["a": 1, "b": "hi", "c": [1, 2] as [Int], "d": false, "e": nil, "f": MinKey()]))
+
+        expect(self.emptyDoc.prefix(while: self.is10)).to(equal([:]))
+        expect(self.smallDoc.prefix(while: self.is10)).to(equal([:]))
+        expect(self.doc.prefix(while: self.is10)).to(equal([:]))
+    }
+
+    func testSuffix() throws {
+        expect(self.emptyDoc.suffix(0)).to(equal([:]))
+        expect(self.emptyDoc.suffix(1)).to(equal([:]))
+        expect(self.emptyDoc.suffix(5)).to(equal([:]))
+
+        expect(self.smallDoc.suffix(0)).to(equal([:]))
+        expect(self.smallDoc.suffix(1)).to(equal(smallDoc))
+        expect(self.smallDoc.suffix(2)).to(equal(smallDoc))
+        expect(self.smallDoc.suffix(5)).to(equal(smallDoc))
+
+        expect(self.doc.suffix(0)).to(equal([]))
+        expect(self.doc.suffix(1)).to(equal(["g": 10]))
+        expect(self.doc.suffix(2)).to(equal(["f": MinKey(), "g": 10]))
+        expect(self.doc.suffix(4)).to(equal(["d": false, "e": nil, "f": MinKey(), "g": 10]))
+        expect(self.doc.suffix(7)).to(equal(doc))
+        expect(self.doc.suffix(8)).to(equal(doc))
+    }
+
+    func testSplit() throws {
+        expect(self.emptyDoc.split(whereSeparator: self.isInt)).to(equal([]))
+        expect(self.smallDoc.split(whereSeparator: self.isInt)).to(equal([]))
+        expect(self.doc.split(whereSeparator: self.isInt)).to(equal([["b": "hi", "c": [1, 2] as [Int], "d": false, "e": nil, "f": MinKey()]]))
+
+        expect(self.emptyDoc.split(omittingEmptySubsequences: false, whereSeparator: self.isInt)).to(equal([[:]]))
+        expect(self.smallDoc.split(omittingEmptySubsequences: false, whereSeparator: self.isInt)).to(equal([[:], [:]]))
+        expect(self.doc.split(omittingEmptySubsequences: false, whereSeparator: self.isInt)).to(equal([[:], ["b": "hi", "c": [1, 2] as [Int], "d": false, "e": nil, "f": MinKey()], [:]]))
+
+        expect(self.doc.split(maxSplits: 1, omittingEmptySubsequences: false, whereSeparator: self.isInt))
+            .to(equal([[:], ["b": "hi", "c": [1, 2] as [Int], "d": false, "e": nil, "f": MinKey(), "g": 10]]))
+
+    }
+}

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -32,7 +32,6 @@ final class DocumentTests: XCTestCase {
         return [
             ("testDocument", testDocument),
             ("testDocumentFromArray", testDocumentFromArray),
-            ("testIterator", testIterator),
             ("testEquatable", testEquatable),
             ("testRawBSON", testRawBSON),
             ("testValueBehavior", testValueBehavior),
@@ -166,26 +165,6 @@ final class DocumentTests: XCTestCase {
        expect(doc2["0"] as? String).to(equal("foo"))
        expect(doc2["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
        expect(doc2["2"]).to(beNil())
-    }
-
-    func testIterator() {
-        let doc: Document = [
-            "string": "test string",
-            "true": true,
-            "false": false,
-            "int": 25,
-            "int32": Int32(5),
-            "int64": Int64(10),
-            "double": Double(15),
-            "decimal128": Decimal128("1.2E+10"),
-            "minkey": MinKey(),
-            "maxkey": MaxKey(),
-            "date": Date(timeIntervalSince1970: 5000),
-            "timestamp": Timestamp(timestamp: 5, inc: 10)
-        ]
-
-        for (_, _) in doc { }
-
     }
 
     func testEquatable() {
@@ -372,32 +351,4 @@ final class DocumentTests: XCTestCase {
         expect(doc["a1"]).to(equal(arr1))
         expect(doc["a2"]).to(equal(arr2))
     }
-
-    func testMapFilter() throws {
-        let doc1: Document = ["a": 1, "b": nil, "c": 3, "d": 4, "e": nil]
-        expect(doc1.mapValues { $0 ?? 1 }).to(equal(["a": 1, "b": 1, "c": 3, "d": 4, "e": 1]))
-        let output1 = doc1.mapValues { val in
-            if let int = val as? Int { return int + 1 }
-            return val
-        }
-        expect(output1).to(equal(["a": 2, "b": nil, "c": 4, "d": 5, "e": nil]))
-        expect(doc1.filter { $0.value != nil }).to(equal(["a": 1, "c": 3, "d": 4]))
-
-        let doc2: Document = ["a": 1, "b": "hello", "c": [1, 2] as [Int]]
-        expect(doc2.filter { $0.value is String }).to(equal(["b": "hello"]))
-        let output2 = doc2.mapValues { val in
-            switch val {
-            case let val as Int:
-                return val + 1
-            case let val as String:
-                return val + " there"
-            case let val as [Int]:
-                return val.reduce(0, +)
-            default:
-                return val
-            }
-        }
-        expect(output2).to(equal(["a": 2, "b": "hello there", "c": 3]))
-    }
-
 }

--- a/Tests/MongoSwiftTests/XCTestManifests.swift
+++ b/Tests/MongoSwiftTests/XCTestManifests.swift
@@ -10,6 +10,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(CrudTests.allTests),
         testCase(MongoDatabaseTests.allTests),
         testCase(DocumentTests.allTests),
+        testCase(Document_SequenceTests.allTests),
         testCase(ReadPreferenceTests.allTests),
         testCase(ReadWriteConcernTests.allTests),
         testCase(SDAMTests.allTests)


### PR DESCRIPTION
I use map/filter in these methods so this is on top of [SWIFT-158](https://github.com/mongodb/mongo-swift-driver/pull/108).

there are a number of methods that come along with the sequence protocol such as `dropFirst`, `dropLast`, `prefix`, etc. that return subsequences. By default, the type of these subsequences is `[whatever your iterator returns]`, meaning we would return a`[(String, BsonValue?)]`.

Swift's `Dictionary` provides custom implementations of the `SubSequence` related methods, so that you get a new `Dictionary` back rather than an `[Dictionary.Element]`. This does the same for `Document`s. 