### PR TITLE
Correct linting violations and update travis XCode version

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,7 +15,6 @@ enabled_rules:
   - modifier_order
   - missing_docs
   - implicit_return
-  - function_default_parameter_at_end
   - fatal_error_message
 
 excluded:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode9.2
+osx_image: xcode9.4
 
 env:
   matrix:

--- a/Sources/MongoSwift/BSON/BsonDecoder.swift
+++ b/Sources/MongoSwift/BSON/BsonDecoder.swift
@@ -87,7 +87,7 @@ internal class _BsonDecoder: Decoder {
     fileprivate let options: BsonDecoder._Options
 
     /// The path to the current point in decoding.
-    fileprivate(set) public var codingPath: [CodingKey]
+    public fileprivate(set) var codingPath: [CodingKey]
 
     /// Contextual user-provided information for use during decoding.
     public var userInfo: [CodingUserInfoKey: Any] {
@@ -163,7 +163,7 @@ internal class _BsonDecoder: Decoder {
 internal struct _BsonDecodingStorage {
 
     /// The container stack, consisting of `BsonValue?`s. 
-    private(set) fileprivate var containers: [BsonValue?] = []
+    fileprivate private(set) var containers: [BsonValue?] = []
 
     /// Initializes `self` with no containers.
     fileprivate init() {}
@@ -240,7 +240,7 @@ private struct _BsonKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
     fileprivate let container: Document
 
     /// The path of coding keys taken to get to this point in decoding.
-    private(set) public var codingPath: [CodingKey]
+    public private(set) var codingPath: [CodingKey]
 
     /// Initializes `self`, referencing the given decoder and container.
     fileprivate init(referencing decoder: _BsonDecoder, wrapping container: Document) {
@@ -409,10 +409,10 @@ private struct _BsonUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     private let container: [BsonValue?]
 
     /// The path of coding keys taken to get to this point in decoding.
-    private(set) public var codingPath: [CodingKey]
+    public private(set) var codingPath: [CodingKey]
 
     /// The index of the element we're about to decode.
-    private(set) public var currentIndex: Int
+    public private(set) var currentIndex: Int
 
     /// Initializes `self` by referencing the given decoder and container.
     fileprivate init(referencing decoder: _BsonDecoder, wrapping container: [BsonValue?]) {

--- a/Sources/MongoSwift/BSON/BsonEncoder.swift
+++ b/Sources/MongoSwift/BSON/BsonEncoder.swift
@@ -233,7 +233,7 @@ private class _BsonReferencingEncoder: _BsonEncoder {
         self.codingPath.append(key)
     }
 
-    fileprivate override var canEncodeNewValue: Bool {
+    override fileprivate var canEncodeNewValue: Bool {
         // With a regular encoder, the storage and coding path grow together.
         // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
         // We have to take this into account.
@@ -308,7 +308,7 @@ private struct _BsonKeyedEncodingContainer<K: CodingKey> : KeyedEncodingContaine
     private let container: MutableDictionary
 
     /// The path of coding keys taken to get to this point in encoding.
-    private(set) public var codingPath: [CodingKey]
+    public private(set) var codingPath: [CodingKey]
 
     /// Initializes `self` with the given references.
     fileprivate init(referencing encoder: _BsonEncoder, codingPath: [CodingKey],
@@ -389,7 +389,7 @@ private struct _BsonUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     private let container: MutableArray
 
     /// The path of coding keys taken to get to this point in encoding.
-    private(set) public var codingPath: [CodingKey]
+    public private(set) var codingPath: [CodingKey]
 
     /// The number of elements encoded into the container.
     public var count: Int {

--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -1,7 +1,7 @@
 import libmongoc
 
 /// A utility class for libmongoc initialization and cleanup.
-final public class MongoSwift {
+public final class MongoSwift {
     /// The version of `MongoSwift`. 
     public static let versionString = "0.0.2"
 

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -5,7 +5,7 @@ import libmongoc
  *
  * - SeeAlso: https://docs.mongodb.com/manual/reference/read-preference/
  */
-final public class ReadPreference {
+public final class ReadPreference {
 
     /// An enumeration of possible ReadPreference modes.
     public enum Mode: String {


### PR DESCRIPTION
this corrects the violations I was missing before w/ old version of swiftlint.

it seems that travis hasn't upgraded to including the newest swiftlint yet, so I guess we can just catch these rule violations locally for now...


