### PR TITLE
Upgrade Nimble to 7.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "9c1379fdcd58c4f2278aea5e029394ba9a2b8f07",
-          "version": "7.1.3"
+          "revision": "7c61d8e7e830dd37f7161ce2b894be178532163c",
+          "version": "7.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/mongodb/swift-bson", from: "1.0.0"),
         .package(url: "https://github.com/mongodb/swift-mongoc", from: "1.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.3")
+        .package(url: "https://github.com/Quick/Nimble.git", from: "7.3.0")
     ],
     targets: [
         .target(name: "MongoSwift", dependencies: ["libmongoc", "libbson"]),


### PR DESCRIPTION
This actually wasn't necessary for the assertions I needed in https://github.com/mongodb/mongo-swift-driver/pull/97, but it didn't seem to break anything in our existing tests either.