### PR TITLE
SWIFT-210: Add very basic Kitura and Vapor examples

### DIFF
--- a/Examples/Kitura/Package.resolved
+++ b/Examples/Kitura/Package.resolved
@@ -1,0 +1,124 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Socket",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueSocket.git",
+        "state": {
+          "branch": null,
+          "revision": "ce36f72f2c36b88f847de50c8c0ed8021ff80097",
+          "version": "1.0.16"
+        }
+      },
+      {
+        "package": "SSLService",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueSSLService.git",
+        "state": {
+          "branch": null,
+          "revision": "a8e24ec6db452ed202502ebae885b39f43e34d98",
+          "version": "1.0.16"
+        }
+      },
+      {
+        "package": "CCurl",
+        "repositoryURL": "https://github.com/IBM-Swift/CCurl.git",
+        "state": {
+          "branch": null,
+          "revision": "2a431e3a5fb8d004aa7d4d1bebb5d511f568c43e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "Kitura",
+        "repositoryURL": "https://github.com/IBM-Swift/Kitura.git",
+        "state": {
+          "branch": null,
+          "revision": "38ca4d1c8385ea11ccbc7a0c841aff49accbcf17",
+          "version": "2.5.1"
+        }
+      },
+      {
+        "package": "Kitura-net",
+        "repositoryURL": "https://github.com/IBM-Swift/Kitura-net.git",
+        "state": {
+          "branch": null,
+          "revision": "4023a2ea525e0c46d9ea793770d83f75df8a1707",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "Kitura-TemplateEngine",
+        "repositoryURL": "https://github.com/IBM-Swift/Kitura-TemplateEngine.git",
+        "state": {
+          "branch": null,
+          "revision": "b030d2d176719acc6a902c40db1b87dc6a83e2fc",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "KituraContracts",
+        "repositoryURL": "https://github.com/IBM-Swift/KituraContracts.git",
+        "state": {
+          "branch": null,
+          "revision": "8e41f3fc81b662722020754f74a8fd8c7bdbbf3b",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "LoggerAPI",
+        "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
+        "state": {
+          "branch": null,
+          "revision": "5041f2673aa75d6e973d9b6bd3956bc5068387c8",
+          "version": "1.7.3"
+        }
+      },
+      {
+        "package": "MongoSwift",
+        "repositoryURL": "https://github.com/mongodb/mongo-swift-driver",
+        "state": {
+          "branch": null,
+          "revision": "38195cb4b7aeab759fc1c2445925f67a22640e5d",
+          "version": "0.0.3"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "7c61d8e7e830dd37f7161ce2b894be178532163c",
+          "version": "7.3.0"
+        }
+      },
+      {
+        "package": "libbson",
+        "repositoryURL": "https://github.com/mongodb/swift-bson",
+        "state": {
+          "branch": null,
+          "revision": "077a71336aead18a26223b6c3c07f94478c7921a",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "libmongoc",
+        "repositoryURL": "https://github.com/mongodb/swift-mongoc",
+        "state": {
+          "branch": null,
+          "revision": "b30d530dde407048a371a86fdbae77895e8635dd",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "TypeDecoder",
+        "repositoryURL": "https://github.com/IBM-Swift/TypeDecoder.git",
+        "state": {
+          "branch": null,
+          "revision": "aaf636e64089baf6a710ff5e7dd5f4c8798ff940",
+          "version": "1.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Examples/Kitura/Package.swift
+++ b/Examples/Kitura/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "KituraExample",
+    dependencies: [
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.2.0"),
+        .package(url: "https://github.com/mongodb/mongo-swift-driver", from: "0.0.3")
+    ],
+    targets: [
+        .target(name: "KituraExample", dependencies: ["Kitura", "MongoSwift"])
+    ]
+)

--- a/Examples/Kitura/Sources/KituraExample/main.swift
+++ b/Examples/Kitura/Sources/KituraExample/main.swift
@@ -1,0 +1,24 @@
+import Kitura
+import MongoSwift
+
+struct Kitten: Codable {
+  var name: String
+  var color: String
+}
+
+let client = try MongoClient()
+let collection = try client.db("home").collection("kittens", withType: Kitten.self)
+
+let router: Router = {
+  let router = Router()
+
+  router.get("kittens") { request, response, next in
+    let docs = try collection.find()
+    response.send(Array(docs))
+  }
+
+  return router
+}()
+
+Kitura.addHTTPServer(onPort: 8080, with: router)
+Kitura.run()

--- a/Examples/Vapor/Package.resolved
+++ b/Examples/Vapor/Package.resolved
@@ -1,0 +1,196 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Console",
+        "repositoryURL": "https://github.com/vapor/console.git",
+        "state": {
+          "branch": null,
+          "revision": "5b9796d39f201b3dd06800437abd9d774a455e57",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "package": "Core",
+        "repositoryURL": "https://github.com/vapor/core.git",
+        "state": {
+          "branch": null,
+          "revision": "ad776ec35f0a811672128eaf796fb3de10a46d3f",
+          "version": "3.4.2"
+        }
+      },
+      {
+        "package": "Crypto",
+        "repositoryURL": "https://github.com/vapor/crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "4b85405430df1892ee3aa1554bdb477e96cf46ad",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "package": "DatabaseKit",
+        "repositoryURL": "https://github.com/vapor/database-kit.git",
+        "state": {
+          "branch": null,
+          "revision": "3a17dbbe9be5f8c37703e4b7982c1332ad6b00c4",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "package": "HTTP",
+        "repositoryURL": "https://github.com/vapor/http.git",
+        "state": {
+          "branch": null,
+          "revision": "818d7d48bbb03e87fd5ac682bb6fa47c04148e6c",
+          "version": "3.1.3"
+        }
+      },
+      {
+        "package": "MongoSwift",
+        "repositoryURL": "https://github.com/mongodb/mongo-swift-driver",
+        "state": {
+          "branch": null,
+          "revision": "38195cb4b7aeab759fc1c2445925f67a22640e5d",
+          "version": "0.0.3"
+        }
+      },
+      {
+        "package": "Multipart",
+        "repositoryURL": "https://github.com/vapor/multipart.git",
+        "state": {
+          "branch": null,
+          "revision": "e57007c23a52b68e44ebdfc70cbe882a7c4f1ec3",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "7c61d8e7e830dd37f7161ce2b894be178532163c",
+          "version": "7.3.0"
+        }
+      },
+      {
+        "package": "Routing",
+        "repositoryURL": "https://github.com/vapor/routing.git",
+        "state": {
+          "branch": null,
+          "revision": "3219e328491b0853b8554c5a694add344d2c6cfb",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "package": "Service",
+        "repositoryURL": "https://github.com/vapor/service.git",
+        "state": {
+          "branch": null,
+          "revision": "281a70b69783891900be31a9e70051b6fe19e146",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "libbson",
+        "repositoryURL": "https://github.com/mongodb/swift-bson",
+        "state": {
+          "branch": null,
+          "revision": "077a71336aead18a26223b6c3c07f94478c7921a",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "libmongoc",
+        "repositoryURL": "https://github.com/mongodb/swift-mongoc",
+        "state": {
+          "branch": null,
+          "revision": "b30d530dde407048a371a86fdbae77895e8635dd",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
+        "state": {
+          "branch": null,
+          "revision": "5d8148c8b45dfb449276557f22120694567dd1d2",
+          "version": "1.9.5"
+        }
+      },
+      {
+        "package": "swift-nio-ssl",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
+        "state": {
+          "branch": null,
+          "revision": "abd918baf65dcd06910ee80843438a8d8b26a286",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "package": "swift-nio-ssl-support",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl-support.git",
+        "state": {
+          "branch": null,
+          "revision": "c02eec4e0e6d351cd092938cf44195a8e669f555",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-nio-zlib-support",
+        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
+        "state": {
+          "branch": null,
+          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "TemplateKit",
+        "repositoryURL": "https://github.com/vapor/template-kit.git",
+        "state": {
+          "branch": null,
+          "revision": "db35b1c35aabd0f5db3abca0cfda7becfe9c43e2",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "URLEncodedForm",
+        "repositoryURL": "https://github.com/vapor/url-encoded-form.git",
+        "state": {
+          "branch": null,
+          "revision": "cbfe7ef6301557d3f2d0807a98165232ae06e1c6",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "Validation",
+        "repositoryURL": "https://github.com/vapor/validation.git",
+        "state": {
+          "branch": null,
+          "revision": "156f8adeac3440e868da3757777884efbc6ec0cc",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "Vapor",
+        "repositoryURL": "https://github.com/vapor/vapor.git",
+        "state": {
+          "branch": null,
+          "revision": "54632a6c1e7ecd9923c0d00b612de936de1c4745",
+          "version": "3.0.8"
+        }
+      },
+      {
+        "package": "WebSocket",
+        "repositoryURL": "https://github.com/vapor/websocket.git",
+        "state": {
+          "branch": null,
+          "revision": "141cb4d3814dc8062cb0b2f43e72801b5dfcf272",
+          "version": "1.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Examples/Vapor/Package.swift
+++ b/Examples/Vapor/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "VaporExample",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
+        .package(url: "https://github.com/mongodb/mongo-swift-driver", from: "0.0.3")
+    ],
+    targets: [
+        .target(name: "VaporExample", dependencies: ["Vapor", "MongoSwift"])
+    ]
+)
+

--- a/Examples/Vapor/Sources/VaporExample/main.swift
+++ b/Examples/Vapor/Sources/VaporExample/main.swift
@@ -1,0 +1,20 @@
+import Vapor
+import MongoSwift
+
+struct Kitten: Content {
+  var name: String
+  var color: String
+}
+
+let app = try Application()
+let router = try app.make(Router.self)
+let client = try MongoClient()
+let collection = try client.db("home").collection("kittens", withType: Kitten.self)
+
+router.get("kittens") { req -> [Kitten] in
+  let docs = try collection.find()
+  return Array(docs)
+}
+
+try app.run()
+

--- a/Examples/loadExampleData.sh
+++ b/Examples/loadExampleData.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mongo home --eval "db.kittens.insert([{\"name\":\"roscoe\",\"color\":\"tan\"},{\"name\":\"chester\",\"color\":\"orange\"}])"
+
+


### PR DESCRIPTION
These are the most basic examples you can have for using these services with MongoDB. Use the `loadExampleData.sh` script to insert the expected data, and then each of the examples run a server on `localhost:8080` with a single route `/kittens` provided