### PR TITLE
Use libmongoc 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
   
   # clone and build libmongoc
-  - git clone -b r1.12 https://github.com/mongodb/mongo-c-driver /tmp/libmongoc
+  - git clone -b r1.13 https://github.com/mongodb/mongo-c-driver /tmp/libmongoc
   - pushd /tmp/libmongoc
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr; fi

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Core Server (i.e. SERVER) project are **public**.
 `MongoSwift` works with Swift 4.0+.
 
 ### FIRST: Install the MongoDB C Driver
-Because the driver wraps the MongoDB C driver, using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. The minimum required version of the C Driver is **1.11.0**.
+Because the driver wraps the MongoDB C driver, using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. The minimum required version of the C Driver is **1.13.0**.
 
 On a Mac, you can install both components at once using [Homebrew](https://brew.sh/): 
 `brew install mongo-c-driver`.


### PR DESCRIPTION
This will enable us to take advantage of newly added methods for overwriting fixed-length types in place ([SWIFT-200](https://jira.mongodb.org/browse/SWIFT-200)).

Since we have no way of requiring a particular libmongoc version currently, Travis is the only thing we need to change.

I have also updated the README to instruct users to install 1.13. while our latest release 0.0.3 doesn't actually require it, I fear we will forget to update this minimum version whenever we release 0.0.4, so better to just do it now. 