### PR TITLE
Refactor insertMany and test CRUD continue-on-error behavior

### DIFF
--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -348,7 +348,7 @@ public struct BulkWriteResult {
     fileprivate var writeConcernError: WriteConcernError?
 
     /**
-     * Create a BulkWriteResult operation from a reply and map of inserted IDs.
+     * Create a `BulkWriteResult` from a reply and map of inserted IDs.
      *
      * Note: we forgo using a Decodable initializer because we still need to
      * build a map for `upsertedIds` and explicitly add `insertedIds`. While

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -314,9 +314,9 @@ public struct BulkWriteOptions: Encodable {
     public let writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional
-    public init(bypassDocumentValidation: Bool? = nil, ordered: Bool = true, writeConcern: WriteConcern? = nil) {
-        self.ordered = ordered
+    public init(bypassDocumentValidation: Bool? = nil, ordered: Bool? = nil, writeConcern: WriteConcern? = nil) {
         self.bypassDocumentValidation = bypassDocumentValidation
+        self.ordered = ordered ?? true
         self.writeConcern = writeConcern
     }
 }

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -108,7 +108,7 @@ extension MongoCollection {
         /// Adds the `insertOne` operation to a bulk write
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
             let document = try BsonEncoder().encode(self.document)
-            if !document.keys.contains("_id") {
+            if !document.hasKey("_id") {
                 try ObjectId().encode(to: document.storage, forKey: "_id")
             }
 

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -17,7 +17,7 @@ extension MongoCollection {
     public func insertOne(_ value: CollectionType, options: InsertOneOptions? = nil) throws -> InsertOneResult? {
         let encoder = BsonEncoder()
         let document = try encoder.encode(value)
-        if !document.keys.contains("_id") {
+        if !document.hasKey("_id") {
             try ObjectId().encode(to: document.storage, forKey: "_id")
         }
         let opts = try encoder.encode(options)

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -29,7 +29,10 @@ public enum MongoError {
     case readPreferenceError(message: String)
     /// Thrown when a user-provided argument is invalid.
     case invalidArgument(message: String)
-    /// Thrown when there is an error executing a bulk write command.
+    /// Thrown when there is an error executing a multi-document insert operation.
+    case insertManyError(code: UInt32, message: String, result: InsertManyResult?, writeErrors: [WriteError],
+        writeConcernError: WriteConcernError?)
+    /// Thrown when there is an error executing a bulk write operation.
     case bulkWriteError(code: UInt32, message: String, result: BulkWriteResult?, writeErrors: [WriteError],
         writeConcernError: WriteConcernError?)
 }

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -140,6 +140,7 @@ private class CrudTest {
     let description: String
     let operationName: String
     let args: Document
+    let error: Bool?
     let result: BsonValue?
     let collection: Document?
 
@@ -165,6 +166,7 @@ private class CrudTest {
         self.operationName = try operation.get("name")
         self.args = try operation.get("arguments")
         let outcome: Document = try test.get("outcome")
+        self.error = outcome["error"] as? Bool
         self.result = outcome["result"]
         self.collection = outcome["collection"] as? Document
     }
@@ -235,9 +237,18 @@ private class BulkWriteTest: CrudTest {
         let requestDocuments: [Document] = try self.args.get("requests")
         let requests = try requestDocuments.map { try BulkWriteTest.parseWriteModel($0) }
         let options = BulkWriteTest.parseBulkWriteOptions(self.args["options"] as? Document)
+        let expectError = self.error ?? false
 
-        if let result = try coll.bulkWrite(requests, options: options) {
-            verifyBulkWriteResult(result)
+        do {
+            if let result = try coll.bulkWrite(requests, options: options) {
+                verifyBulkWriteResult(result)
+            }
+            expect(expectError).to(beFalse())
+        } catch MongoError.bulkWriteError(_, _, let result, _, _) {
+            if let result = result {
+                verifyBulkWriteResult(result)
+            }
+            expect(expectError).to(beTrue())
         }
     }
 
@@ -438,20 +449,55 @@ private class FindOneAndUpdateTest: CrudTest {
 /// A class for executing `insertMany` tests
 private class InsertManyTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
-        let docs: [Document] = try self.args.get("documents")
-        let result = try coll.insertMany(docs)
+        let documents: [Document] = try self.args.get("documents")
+        let options = InsertManyTest.parseInsertManyOptions(self.args["options"] as? Document)
+        let expectError = self.error ?? false
 
-        let insertedIds = result?.insertedIds
-        expect(insertedIds).toNot(beNil())
+        do {
+            if let result = try coll.insertMany(documents, options: options) {
+                verifyInsertManyResult(result)
+            }
+            expect(expectError).to(beFalse())
+        } catch MongoError.insertManyError(_, _, let result, _, _) {
+            if let result = result {
+                verifyInsertManyResult(result)
+            }
+            expect(expectError).to(beTrue())
+        }
+    }
 
-        // Convert the result's [Int64: BsonValue] to a Document for easy comparison
-        var reformattedResults = Document()
-        for (index, id) in insertedIds! {
-            reformattedResults[String(index)] = id
+    private static func parseInsertManyOptions(_ options: Document?) -> InsertManyOptions? {
+        guard let options = options else {
+            return nil
         }
 
-        let expected = self.result as? Document
-        expect(reformattedResults).to(equal(expected?["insertedIds"] as? Document))
+        let ordered = options["ordered"] as? Bool
+
+        return InsertManyOptions(ordered: ordered)
+    }
+
+    private static func prepareIds(_ ids: [Int: BsonValue?]) -> Document {
+        var document = Document()
+
+        // Dictionaries are unsorted. Sort before comparing with expected map
+        for (index, id) in ids.sorted(by: { $0.key < $1.key }) {
+            document[String(index)] = id
+        }
+
+        return document
+    }
+
+    private func verifyInsertManyResult(_ result: InsertManyResult) {
+        guard let expected = self.result as? Document else {
+            return
+        }
+
+        if let expectedInsertedCount = expected["insertedCount"] as? Int {
+            expect(result.insertedCount).to(equal(expectedInsertedCount))
+        }
+        if let expectedInsertedIds = expected["insertedIds"] as? Document {
+            expect(InsertManyTest.prepareIds(result.insertedIds)).to(equal(expectedInsertedIds))
+        }
     }
 }
 

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -36,11 +36,11 @@ final class CrudTests: XCTestCase {
         for (filename, file) in try parseFiles(atPath: forPath) {
 
             if try !client.serverVersionIsInRange(file.minServerVersion, file.maxServerVersion) {
-                print("Skipping tests from file \(filename).json for server version \(try client.serverVersion())")
+                print("Skipping tests from file \(filename) for server version \(try client.serverVersion())")
                 continue
             }
 
-            print("\n------------\nExecuting tests from file \(forPath)/\(filename).json...\n")
+            print("\n------------\nExecuting tests from file \(forPath)/\(filename)...\n")
 
             // For each file, execute the test cases contained in it
             for (i, test) in file.tests.enumerated() {

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -246,7 +246,7 @@ private class BulkWriteTest: CrudTest {
             return nil
         }
 
-        let ordered = options["ordered"] as? Bool ?? true
+        let ordered = options["ordered"] as? Bool
 
         return BulkWriteOptions(ordered: ordered)
     }

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -308,7 +308,8 @@ private class BulkWriteTest: CrudTest {
     private static func prepareIds(_ ids: [Int: BsonValue?]) -> Document {
         var document = Document()
 
-        for (index, id) in ids {
+        // Dictionaries are unsorted. Sort before comparing with expected map
+        for (index, id) in ids.sorted(by: { $0.key < $1.key }) {
             document[String(index)] = id
         }
 

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -13,6 +13,7 @@ final class MongoCollectionTests: XCTestCase {
             ("testAggregate", testAggregate),
             ("testDrop", testDrop),
             ("testInsertMany", testInsertMany),
+            ("testInsertManyWithEmptyValues", testInsertManyWithEmptyValues),
             ("testInsertManyWithUnacknowledgedWriteConcern", testInsertManyWithUnacknowledgedWriteConcern),
             ("testFind", testFind),
             ("testDeleteOne", testDeleteOne),
@@ -148,6 +149,10 @@ final class MongoCollectionTests: XCTestCase {
                 expect(v).to(beAnInstanceOf(ObjectId.self))
             }
         }
+    }
+
+    func testInsertManyWithEmptyValues() {
+        expect(try self.coll.insertMany([])).to(throwError(MongoError.invalidArgument(message: "")))
     }
 
     func testInsertManyWithUnacknowledgedWriteConcern() throws {

--- a/Tests/Specs/crud/tests/write/bulkWrite-collation.json
+++ b/Tests/Specs/crud/tests/write/bulkWrite-collation.json
@@ -1,0 +1,217 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": "ping"
+    },
+    {
+      "_id": 3,
+      "x": "pINg"
+    },
+    {
+      "_id": 4,
+      "x": "pong"
+    },
+    {
+      "_id": 5,
+      "x": "pONg"
+    }
+  ],
+  "minServerVersion": "3.4",
+  "tests": [
+    {
+      "description": "BulkWrite with delete operations and collation",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "x": "PING"
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            },
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "x": "PING"
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            },
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": "PONG"
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 4,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with update operations and collation",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": "ping"
+                },
+                "update": {
+                  "$set": {
+                    "x": "PONG"
+                  }
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 3
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "x": "ping"
+                },
+                "update": {
+                  "$set": {
+                    "x": "PONG"
+                  }
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "x": "ping"
+                },
+                "replacement": {
+                  "_id": 6,
+                  "x": "ping"
+                },
+                "upsert": true,
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 3
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": "pong"
+                },
+                "update": {
+                  "$set": {
+                    "x": "PONG"
+                  }
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 6,
+          "modifiedCount": 4,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "2": 6
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": "PONG"
+            },
+            {
+              "_id": 3,
+              "x": "PONG"
+            },
+            {
+              "_id": 4,
+              "x": "PONG"
+            },
+            {
+              "_id": 5,
+              "x": "PONG"
+            },
+            {
+              "_id": 6,
+              "x": "ping"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/write/bulkWrite.json
+++ b/Tests/Specs/crud/tests/write/bulkWrite.json
@@ -1,0 +1,790 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "minServerVersion": "2.6",
+  "tests": [
+    {
+      "description": "BulkWrite with deleteOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                }
+              }
+            },
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with deleteMany operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lt": 11
+                  }
+                }
+              }
+            },
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 2,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with insertOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "insertedIds": {
+            "0": 3,
+            "1": 4
+          },
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with replaceOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "replacement": {
+                  "_id": 1,
+                  "x": 11
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "replacement": {
+                  "x": 12
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "x": 33
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 2,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with updateOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 0
+                },
+                "update": {
+                  "$set": {
+                    "x": 0
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "update": {
+                  "$set": {
+                    "x": 11
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "update": {
+                  "$set": {
+                    "x": 33
+                  }
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 2,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with updateMany operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lt": 11
+                  }
+                },
+                "update": {
+                  "$set": {
+                    "x": 0
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                },
+                "update": {
+                  "$unset": {
+                    "y": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "update": {
+                  "$set": {
+                    "x": 33
+                  }
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 4,
+          "modifiedCount": 2,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with mixed ordered operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            },
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$nin": [
+                      24,
+                      34
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 4
+                },
+                "replacement": {
+                  "_id": 4,
+                  "x": 44
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 2,
+          "insertedCount": 2,
+          "insertedIds": {
+            "0": 3,
+            "3": 4
+          },
+          "matchedCount": 3,
+          "modifiedCount": 3,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "5": 4
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 34
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with mixed unordered operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "_id": 3,
+                  "x": 33
+                },
+                "upsert": true
+              }
+            },
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "0": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite continue-on-error behavior with unordered (preexisting duplicate key)",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 2,
+                  "x": 22
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite continue-on-error behavior with unordered (duplicate key in requests)",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/write/insertMany.json
+++ b/Tests/Specs/crud/tests/write/insertMany.json
@@ -20,7 +20,10 @@
               "_id": 3,
               "x": 33
             }
-          ]
+          ],
+          "options": {
+            "ordered": true
+          }
         }
       },
       "outcome": {
@@ -29,6 +32,110 @@
             "0": 2,
             "1": 3
           }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (preexisting duplicate key)",
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (duplicate key in requests)",
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
         },
         "collection": {
           "data": [


### PR DESCRIPTION
This refactors `insertMany()` a bit to be consistent with `bulkWrite()`. We introduce a `MongoError.insertManyError`, which contains an optional `InsertManyResult`.

This also syncs write tests from https://github.com/mongodb/specifications/pull/399, which test for continue-on-error behavior. Additionally, bulkWrite collation tests have been pulled in (and pass). CRUD spec read tests have not been synced due to new count helpers not being implemented (see: [SWIFT-227](https://jira.mongodb.org/browse/SWIFT-227)).