### PR TITLE
SWIFT-201: Refactor "if failure" conditions with guard statements

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -327,7 +327,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
     public func decodeNil(forKey key: Key) throws -> Bool {
         // check if the key exists in the document, so we can differentiate between
         // the key being set to nil and the key not existing at all.
-        if !self.contains(key) {
+        guard self.contains(key) else {
             throw DecodingError.keyNotFound(
                 key,
                 DecodingError.Context(codingPath: self.decoder.codingPath,

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -219,7 +219,7 @@ extension _BSONDecoder {
         // given that its encoded as an Int64 in BSON. therefore, if the value wasn't extracted from 
         // the `Document` as type `Date` but we're trying to decode as a `Date`, we should throw an error
         // rather than calling `Date.init(from decoder: Decoder)`. 
-        if type == Date.self {
+        guard type != Date.self else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -181,7 +181,7 @@ public class DocumentIterator: IteratorProtocol {
     internal init?(forDocument doc: Document) {
         self.iter = bson_iter_t()
         self.storage = doc.storage
-        if !bson_iter_init(&self.iter, doc.data) { return nil }
+        guard bson_iter_init(&self.iter, doc.data) else { return nil }
     }
 
     /// Initializes a new iterator over the contents of `doc`. Returns `nil` if an iterator cannot
@@ -189,7 +189,7 @@ public class DocumentIterator: IteratorProtocol {
     internal init?(forDocument doc: Document, advancedTo key: String) {
         self.iter = bson_iter_t()
         self.storage = doc.storage
-        if !bson_iter_init_find(&iter, doc.data, key.cString(using: .utf8)) {
+        guard bson_iter_init_find(&iter, doc.data, key.cString(using: .utf8)) else {
             return nil
         }
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -74,7 +74,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      */
     public init(dictionaryLiteral keyValuePairs: (String, BSONValue?)...) {
         // make sure all keys are unique
-        if Set(keyValuePairs.map { $0.0 }).count != keyValuePairs.count {
+        guard Set(keyValuePairs.map { $0.0 }).count == keyValuePairs.count else {
             preconditionFailure("Dictionary literal \(keyValuePairs) contains duplicate keys")
         }
 

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -245,8 +245,10 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
             if let value = newValue {
                 try value.encode(to: self.storage, forKey: key)
-            } else if !bson_append_null(self.data, key, Int32(key.count)) {
-                throw MongoError.bsonEncodeError(message: "Failed to set the value for key \(key) to null")
+            } else {
+                guard bson_append_null(self.data, key, Int32(key.count)) else {
+                    throw MongoError.bsonEncodeError(message: "Failed to set the value for key \(key) to null")
+                }
             }
         }
     }
@@ -277,7 +279,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
     /// Appends the key/value pairs from the provided `doc` to this `Document`. 
     public mutating func merge(_ doc: Document) throws {
         self.copyStorageIfRequired()
-        if !bson_concat(self.data, doc.data) {
+        guard bson_concat(self.data, doc.data) else {
             throw MongoError.bsonEncodeError(message: "Failed to merge \(doc) with \(self)")
         }
     }
@@ -307,7 +309,7 @@ extension Document: BSONValue {
     public var bsonType: BSONType { return .document }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        if !bson_append_document(storage.pointer, key, Int32(key.count), self.data) {
+        guard bson_append_document(storage.pointer, key, Int32(key.count), self.data) else {
             throw bsonEncodeError(value: self, forKey: key)
         }
     }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -128,7 +128,7 @@ public class MongoClient {
         }
 
         self._client = mongoc_client_new_from_uri(uri)
-        if self._client == nil {
+        guard self._client != nil else {
             throw MongoError.invalidClient()
         }
 

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -17,7 +17,7 @@ extension MongoCollection {
      */
     @discardableResult
     public func bulkWrite(_ requests: [WriteModel], options: BulkWriteOptions? = nil) throws -> BulkWriteResult? {
-        if requests.isEmpty {
+        guard !requests.isEmpty else {
             throw MongoError.invalidArgument(message: "requests cannot be empty")
         }
 

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -84,8 +84,8 @@ extension MongoCollection {
         let reply = Document()
         var error = bson_error_t()
 
-        if !mongoc_collection_find_and_modify_with_opts(self._collection, filter.data,
-                                                        opts._options, reply.data, &error) {
+        guard mongoc_collection_find_and_modify_with_opts(self._collection, filter.data,
+                                                          opts._options, reply.data, &error) else {
             // TODO SWIFT-144: replace with more descriptive error type(s)
             throw MongoError.commandError(message: toErrorString(error))
         }
@@ -317,7 +317,7 @@ private class FindAndModifyOptions {
     /// Sets the `update` value on a `mongoc_find_and_modify_opts_t`. We need to have this separate from the 
     /// initializer because its value comes from the API methods rather than their options types.
     fileprivate func setUpdate(_ update: Document) throws {
-        if !mongoc_find_and_modify_opts_set_update(self._options, update.data) {
+        guard mongoc_find_and_modify_opts_set_update(self._options, update.data) else {
             throw MongoError.invalidArgument(message: "Error setting update to \(update)")
         }
     }

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -313,8 +313,7 @@ private class FindAndModifyOptions {
             }
         }
 
-        let appendSuccess = extra.keys.count <= 0 || mongoc_find_and_modify_opts_append(self._options, extra.data)
-        guard appendSuccess else {
+        guard extra.isEmpty || mongoc_find_and_modify_opts_append(self._options, extra.data) else {
             throw MongoError.invalidArgument(message: "Error appending extra fields \(extra)")
         }
     }

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -262,8 +262,10 @@ private class FindAndModifyOptions {
             throw MongoError.invalidArgument(message: "Error setting bypassDocumentValidation to \(bypass)")
         }
 
-        if let fields = projection, !mongoc_find_and_modify_opts_set_fields(self._options, fields.data) {
-            throw MongoError.invalidArgument(message: "Error setting fields to \(fields)")
+        if let fields = projection {
+            guard mongoc_find_and_modify_opts_set_fields(self._options, fields.data) else {
+                throw MongoError.invalidArgument(message: "Error setting fields to \(fields)")
+            }
         }
 
         // build a mongoc_find_and_modify_flags_t
@@ -282,8 +284,10 @@ private class FindAndModifyOptions {
                 "Error setting flags to \(flags); remove=\(remStr), upsert=\(upsStr), returnDocument=\(retStr)")
         }
 
-        if let sort = sort, !mongoc_find_and_modify_opts_set_sort(self._options, sort.data) {
-            throw MongoError.invalidArgument(message: "Error setting sort to \(sort)")
+        if let sort = sort {
+            guard mongoc_find_and_modify_opts_set_sort(self._options, sort.data) else {
+                throw MongoError.invalidArgument(message: "Error setting sort to \(sort)")
+            }
         }
 
         // build an "extra" document of fields without their own setters
@@ -309,7 +313,8 @@ private class FindAndModifyOptions {
             }
         }
 
-        if extra.keys.count > 0 && !mongoc_find_and_modify_opts_append(self._options, extra.data) {
+        let appendSuccess = extra.keys.count <= 0 || mongoc_find_and_modify_opts_append(self._options, extra.data)
+        guard appendSuccess else {
             throw MongoError.invalidArgument(message: "Error appending extra fields \(extra)")
         }
     }

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -212,7 +212,7 @@ extension MongoCollection {
         let opts = try encoder.encode(options)
         var error = bson_error_t()
 
-        if !mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, nil, &error) {
+        guard mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, nil, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
@@ -230,7 +230,7 @@ extension MongoCollection {
     public func dropIndex(_ name: String, options: DropIndexOptions? = nil) throws {
         let opts = try BSONEncoder().encode(options)
         var error = bson_error_t()
-        if !mongoc_collection_drop_index_with_opts(self._collection, name, opts?.data, &error) {
+        guard mongoc_collection_drop_index_with_opts(self._collection, name, opts?.data, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
     }
@@ -284,7 +284,8 @@ extension MongoCollection {
         let opts = try BSONEncoder().encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, reply.data, &error) {
+        guard mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, reply.data, &error)
+        else {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return reply

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -284,8 +284,8 @@ extension MongoCollection {
         let opts = try BSONEncoder().encode(options)
         let reply = Document()
         var error = bson_error_t()
-        guard mongoc_collection_write_command_with_opts(self._collection, command.data, opts?.data, reply.data, &error)
-        else {
+        guard mongoc_collection_write_command_with_opts(
+            self._collection, command.data, opts?.data, reply.data, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return reply

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -121,8 +121,8 @@ extension MongoCollection {
         let rp = options?.readPreference?._readPreference
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_read_command_with_opts(
-            self._collection, command.data, rp, opts?.data, reply.data, &error) {
+        guard mongoc_collection_read_command_with_opts(
+            self._collection, command.data, rp, opts?.data, reply.data, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
 

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -50,7 +50,7 @@ extension MongoCollection {
      */
     @discardableResult
     public func insertMany(_ values: [CollectionType], options: InsertManyOptions? = nil) throws -> InsertManyResult? {
-        if values.isEmpty {
+        guard !values.isEmpty else {
             throw MongoError.invalidArgument(message: "values cannot be empty")
         }
 

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -22,7 +22,7 @@ extension MongoCollection {
         }
         let opts = try encoder.encode(options)
         var error = bson_error_t()
-        if !mongoc_collection_insert_one(self._collection, document.data, opts?.data, nil, &error) {
+        guard mongoc_collection_insert_one(self._collection, document.data, opts?.data, nil, &error) else {
             // TODO SWIFT-139: include writeErrors and writeConcernErrors from reply in the error
             throw MongoError.commandError(message: toErrorString(error))
         }
@@ -103,8 +103,8 @@ extension MongoCollection {
         let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_replace_one(
-            self._collection, filter.data, replacementDoc.data, opts?.data, reply.data, &error) {
+        guard mongoc_collection_replace_one(
+            self._collection, filter.data, replacementDoc.data, opts?.data, reply.data, &error) else {
             // TODO SWIFT-139: include writeErrors and writeConcernError from reply in the error
             throw MongoError.commandError(message: toErrorString(error))
         }
@@ -133,8 +133,8 @@ extension MongoCollection {
         let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_update_one(
-            self._collection, filter.data, update.data, opts?.data, reply.data, &error) {
+        guard mongoc_collection_update_one(
+            self._collection, filter.data, update.data, opts?.data, reply.data, &error) else {
             // TODO SWIFT-139: include writeErrors and writeConcernError from reply in the error
             throw MongoError.commandError(message: toErrorString(error))
         }
@@ -163,8 +163,8 @@ extension MongoCollection {
         let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_update_many(
-            self._collection, filter.data, update.data, opts?.data, reply.data, &error) {
+        guard mongoc_collection_update_many(
+            self._collection, filter.data, update.data, opts?.data, reply.data, &error) else {
             // TODO SWIFT-139: include writeErrors and writeConcernErrors from reply in the error
             throw MongoError.commandError(message: toErrorString(error))
         }
@@ -192,8 +192,8 @@ extension MongoCollection {
         let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_delete_one(
-            self._collection, filter.data, opts?.data, reply.data, &error) {
+        guard mongoc_collection_delete_one(
+            self._collection, filter.data, opts?.data, reply.data, &error) else {
              // TODO SWIFT-139: include writeErrors and writeConcernErrors from reply in the error
             throw MongoError.commandError(message: toErrorString(error))
         }
@@ -221,8 +221,8 @@ extension MongoCollection {
         let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_collection_delete_many(
-            self._collection, filter.data, opts?.data, reply.data, &error) {
+        guard mongoc_collection_delete_many(
+            self._collection, filter.data, opts?.data, reply.data, &error) else {
             // TODO SWIFT-139: include writeErrors and writeConcernErrors from reply in the error
             throw MongoError.commandError(message: toErrorString(error))
         }

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -62,7 +62,7 @@ public class MongoCollection<T: Codable> {
     /// Drops this collection from its parent database.
     public func drop() throws {
         var error = bson_error_t()
-        if !mongoc_collection_drop(self._collection, &error) {
+        guard mongoc_collection_drop(self._collection, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
     }

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -56,7 +56,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
             out.deinitialize(count: 1)
             out.deallocate(capacity: 1)
         }
-        if !mongoc_cursor_next(self._cursor, out) { return nil }
+        guard mongoc_cursor_next(self._cursor, out) else { return nil }
         let doc = Document(fromPointer: out.pointee!)
 
         do {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -186,7 +186,7 @@ public class MongoDatabase {
     /// Drops this database.
     public func drop() throws {
         var error = bson_error_t()
-        if !mongoc_database_drop(self._database, &error) {
+        guard mongoc_database_drop(self._database, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
     }
@@ -317,7 +317,7 @@ public class MongoDatabase {
         let opts = try BSONEncoder().encode(options)
         let reply = Document()
         var error = bson_error_t()
-        if !mongoc_database_command_with_opts(self._database, command.data, rp, opts?.data, reply.data, &error) {
+        guard mongoc_database_command_with_opts(self._database, command.data, rp, opts?.data, reply.data, &error) else {
             throw MongoError.commandError(message: toErrorString(error))
         }
         return reply

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -125,7 +125,7 @@ public class WriteConcern: Codable {
         }
 
         // we don't need to destroy the `mongoc_write_concern_t` here - `deinit` will be called anyway
-        if !self.isValid {
+        guard self.isValid else {
             let journalStr = String(describing: journal)
             let wStr = String(describing: w)
             let timeoutStr = String(describing: wtimeoutMS)

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -57,7 +57,9 @@ final class CommandMonitoringTests: XCTestCase {
                 var expectedEvents = test.expectations
                 let observer = center.addObserver(forName: nil, object: nil, queue: nil) { (notif) in
                     // ignore if it doesn't match one of the names we're looking for
-                    if !["commandStarted", "commandSucceeded", "commandFailed"].contains(notif.name.rawValue) { return }
+                    guard ["commandStarted", "commandSucceeded", "commandFailed"].contains(notif.name.rawValue) else {
+                        return
+                    }
 
                     // remove the next expectation for this test and verify it matches the received event
                     if expectedEvents.count > 0 {

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -26,7 +26,7 @@ final class MongoClientTests: XCTestCase {
         }
 
         let client_t = mongoc_client_new_from_uri(uri)
-        if client_t == nil {
+        guard client_t != nil else {
             throw MongoError.invalidClient()
         }
 

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -25,12 +25,11 @@ final class MongoClientTests: XCTestCase {
             throw MongoError.invalidUri(message: toErrorString(error))
         }
 
-        let client_t = mongoc_client_new_from_uri(uri)
-        guard client_t != nil else {
+        guard let client_t = mongoc_client_new_from_uri(uri) else {
             throw MongoError.invalidClient()
         }
 
-        let client = MongoClient(fromPointer: client_t!)
+        let client = MongoClient(fromPointer: client_t)
         let db = try client.db("test")
         let coll = try db.collection("foo")
         let insertResult = try coll.insertOne([ "test": 42 ])

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -39,8 +39,8 @@ final class SDAMTests: XCTestCase {
 
         let observer = center.addObserver(forName: nil, object: nil, queue: nil) { (notif) in
 
-            if !["serverDescriptionChanged", "serverOpening", "serverClosed", "topologyDescriptionChanged",
-                "topologyOpening", "topologyClosed"].contains(notif.name.rawValue) { return }
+            guard ["serverDescriptionChanged", "serverOpening", "serverClosed", "topologyDescriptionChanged",
+                "topologyOpening", "topologyClosed"].contains(notif.name.rawValue) else { return }
 
             guard let event = notif.userInfo?["event"] as? MongoEvent else {
                 XCTFail("Notification \(notif) did not contain an event")

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -41,7 +41,7 @@ extension MongoClient {
         /// initialize a server version from a string
         init(_ str: String) throws {
             let versionComponents = str.split(separator: ".").prefix(3)
-            if versionComponents.count < 2 {
+            guard versionComponents.count >= 2 else {
                 throw TestError(message: "Expected version string \(str) to have at least two .-separated components")
             }
 


### PR DESCRIPTION
[SWIFT-201](https://jira.mongodb.org/browse/SWIFT-201)

This PR finds places in the entire codebase where we should probably be using `guard` instead of an `if` statement.

Generally speaking, it seems like `guard` should be used to catch or, _guard_ against exceptional violations of (an) assumption(s) or invariant(s) in the rest of the current scope. Usually, this is involved with condition checks at the beginning of functions or protecting oneself from exceptional failures, e.g., calls to `mongoc_*` functions. Therefore, there may be a few cases where a `guard` is added for something that is not an explicit failure.

I've used the above idea to determine when to use `guard`. Since I essentially looked through the entire codebase, it is possible that I have missed some cases. If you think I've missed anything, just suggest it :). 