### PR TITLE
SWIFT-229: Use new optimized document methods for key presence, count, etc. everywhere possible

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -261,7 +261,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
 
     /// Returns a Boolean value indicating whether the decoder contains a value associated with the given key.
     public func contains(_ key: Key) -> Bool {
-        return self.container.keys.contains(key.stringValue)
+        return self.container.hasKey(key.stringValue)
     }
 
     /// A string description of a CodingKey, for use in error messages.

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -60,7 +60,7 @@ extension MongoCollection {
         var insertedIds: [Int: BSONValue?] = [:]
 
         try documents.enumerated().forEach { (index, document) in
-            if !document.keys.contains("_id") {
+            if !document.hasKey("_id") {
                 try ObjectId().encode(to: document.storage, forKey: "_id")
             }
             insertedIds[index] = document["_id"]


### PR DESCRIPTION
[SWIFT-229](https://jira.mongodb.org/browse/SWIFT-229)

So this diff just changes two lines. I couldn't find any other cases where we were using `keys.isEmpty` or `keys.count`.

This makes me a little suspicious, because I expected there to be more instances, but I `git grep`'ed for `keys.count`, `keys.isEmpty` and `keys.contains` and literally just found these two cases. From what I understand, any possible cases that need to be changed must have `keys.<function>` as its format, so those `grep` searches should be exhaustive.

If you feel like I've definitely missed something just let me know...