### PR TITLE
SWIFT-226: Provide a way to compare equality of BSONValues

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -812,7 +812,10 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     case (let l as [BSONValue?], let r as [BSONValue?]):
         return try zip(l, r).reduce(true, {prev, next in try bsonEquals(lhs: next.0, rhs: next.1) && prev})
     case (_ as [Any], _ as [Any]):
-        preconditionFailure("arrays not of type [BSONValue?] should not be compared with bsonEqual()")
+        enum BSONEqualsError: Error { case InvalidArrayArgument(String) }
+        throw BSONEqualsError.InvalidArrayArgument(
+            "arrays not of type [BSONValue?] should not be compared with bsonEqual()"
+        )
     default:
         // For BSONTypes that do not have actual classes/structs associated
         // with them, the behavior is known regardless.

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -795,7 +795,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
  *   - lhs: The left-hand-side BSONValue to compare.
  *   - rhs: The right-hand-side BSONValue to compare.
  *
- * - Returns: True if lhs is equal to rhs, false otherwise.
+ * - Returns: `true` if `lhs` is equal to `rhs`, `false` otherwise.
  */
 func bsonEquals(_ lhs: BSONValue, _ rhs: BSONValue) -> Bool {
     validateBSONTypes(lhs, rhs)

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -781,12 +781,16 @@ public struct Timestamp: BSONValue, Equatable, Codable {
 
 enum BSONEqualsError: Error { case InvalidArrayArgument(String) }
 
+
 // See https://github.com/realm/SwiftLint/issues/461
 // swiftlint:disable cyclomatic_complexity
-// A helper function to test equality between two BSONValues. This function tests for exact BSON equality.
-// This means that, for example, differing types with equivalent value are not equivalent.
-// e.g.
-//  4.0 (Double) != 4 (Int)
+/**
+ *  A helper function to test equality between two BSONValues. This function tests for exact BSON equality.
+ *  This means that differing types with equivalent value are not equivalent.
+ *
+ *  e.g.
+ *      4.0 (Double) != 4 (Int)
+ */
 func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     validateBSONTypes(lhs: lhs, rhs: rhs)
 
@@ -817,8 +821,8 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     }
 }
 
-// A helper function to test equality between two BSONValue?s. See bsonEquals for BSONValues (non-optional) for more
-// information.
+/// A helper function to test equality between two BSONValue?s. See bsonEquals for BSONValues (non-optional) for more
+/// information.
 func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
     guard let left = lhs, let right = rhs else {
         return lhs == nil && rhs == nil
@@ -827,8 +831,8 @@ func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
     return try bsonEquals(lhs: left, rhs: right)
 }
 
-// A function for catching invalid BSONTypes that should not ever arise, and triggering a preconditionFailure when it
-// finds such types.
+/// A function for catching invalid BSONTypes that should not ever arise, and triggering a preconditionFailure when it
+/// finds such types.
 internal func validateBSONTypes(lhs: BSONValue, rhs: BSONValue) {
     let invalidTypes: [BSONType] = [.symbol, .dbPointer, .invalid, .undefined, .null]
     guard !invalidTypes.contains(lhs.bsonType) else {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -797,8 +797,8 @@ public struct Timestamp: BSONValue, Equatable, Codable {
  *
  * - Returns: True if lhs is equal to rhs, false otherwise.
  */
-func bsonEquals(lhs: BSONValue, rhs: BSONValue) -> Bool {
-    validateBSONTypes(lhs: lhs, rhs: rhs)
+func bsonEquals(_ lhs: BSONValue, _ rhs: BSONValue) -> Bool {
+    validateBSONTypes(lhs, rhs)
 
     switch (lhs, rhs) {
     case (let l as Int, let r as Int): return l == r
@@ -818,7 +818,7 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) -> Bool {
     case (let l as Binary, let r as Binary): return l == r
     case (let l as Document, let r as Document): return l == r
     case (let l as [BSONValue?], let r as [BSONValue?]): // TODO: SWIFT-242
-        return zip(l, r).reduce(true, {prev, next in bsonEquals(lhs: next.0, rhs: next.1) && prev})
+        return zip(l, r).reduce(true, {prev, next in bsonEquals(next.0, next.1) && prev})
     case (_ as [Any], _ as [Any]): return false
     default: return false
     }
@@ -834,17 +834,17 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) -> Bool {
  *
  * - Returns: True if lhs is equal to rhs, false otherwise.
  */
-public func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) -> Bool {
+public func bsonEquals(_ lhs: BSONValue?, _ rhs: BSONValue?) -> Bool {
     guard let left = lhs, let right = rhs else {
         return lhs == nil && rhs == nil
     }
 
-    return bsonEquals(lhs: left, rhs: right)
+    return bsonEquals(left, right)
 }
 
 /// A function for catching invalid BSONTypes that should not ever arise, and triggering a preconditionFailure when it
 /// finds such types.
-internal func validateBSONTypes(lhs: BSONValue, rhs: BSONValue) {
+fileprivate func validateBSONTypes(_ lhs: BSONValue, _ rhs: BSONValue) {
     let invalidTypes: [BSONType] = [.symbol, .dbPointer, .invalid, .undefined, .null]
     guard !invalidTypes.contains(lhs.bsonType) else {
         preconditionFailure("\(lhs.bsonType) should not be used")

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -779,17 +779,17 @@ public struct Timestamp: BSONValue, Equatable, Codable {
     }
 }
 
-func bsonEqual(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
+func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
     guard let left = lhs, let right = rhs else {
         return lhs == nil && rhs == nil
     }
 
-    return try bsonEqual(lhs: left, rhs: right)
+    return try bsonEquals(lhs: left, rhs: right)
 }
 
 // See https://github.com/realm/SwiftLint/issues/461
 // swiftlint:disable cyclomatic_complexity
-func bsonEqual(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
+func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     validateBSONTypes(lhs: lhs, rhs: rhs)
 
     switch (lhs, rhs) {
@@ -810,7 +810,7 @@ func bsonEqual(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     case (let l as Binary, let r as Binary): return l == r
     case (let l as Document, let r as Document): return l == r
     case (let l as [BSONValue?], let r as [BSONValue?]):
-        return try zip(l, r).reduce(true, {prev, next in try bsonEqual(lhs: next.0, rhs: next.1) && prev})
+        return try zip(l, r).reduce(true, {prev, next in try bsonEquals(lhs: next.0, rhs: next.1) && prev})
     case (_ as [Any], _ as [Any]):
         preconditionFailure("arrays not of type [BSONValue?] should not be compared with bsonEqual()")
     default:

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -790,6 +790,12 @@ enum BSONEqualsError: Error { case InvalidArrayArgument(String) }
  *
  *  e.g.
  *      4.0 (Double) != 4 (Int)
+ *
+ *  * - Parameters:
+ *   - lhs: The left-hand-side BSONValue to compare.
+ *   - rhs: The right-hand-side BSONValue to compare.
+ *
+ * - Returns: True if lhs is equal to rhs, false otherwise.
  */
 func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     validateBSONTypes(lhs: lhs, rhs: rhs)
@@ -821,8 +827,16 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     }
 }
 
-/// A helper function to test equality between two BSONValue?s. See bsonEquals for BSONValues (non-optional) for more
-/// information.
+/**
+ *  A helper function to test equality between two BSONValue?s. See bsonEquals for BSONValues (non-optional) for more
+ *  information.
+ *
+ *  * - Parameters:
+ *   - lhs: The left-hand-side BSONValue? to compare.
+ *   - rhs: The right-hand-side BSONValue? to compare.
+ *
+ * - Returns: True if lhs is equal to rhs, false otherwise.
+ */
 public func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
     guard let left = lhs, let right = rhs else {
         return lhs == nil && rhs == nil

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -844,7 +844,7 @@ public func bsonEquals(_ lhs: BSONValue?, _ rhs: BSONValue?) -> Bool {
 
 /// A function for catching invalid BSONTypes that should not ever arise, and triggering a preconditionFailure when it
 /// finds such types.
-fileprivate func validateBSONTypes(_ lhs: BSONValue, _ rhs: BSONValue) {
+private func validateBSONTypes(_ lhs: BSONValue, _ rhs: BSONValue) {
     let invalidTypes: [BSONType] = [.symbol, .dbPointer, .invalid, .undefined, .null]
     guard !invalidTypes.contains(lhs.bsonType) else {
         preconditionFailure("\(lhs.bsonType) should not be used")

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -788,8 +788,8 @@ public struct Timestamp: BSONValue, Equatable, Codable {
  *  e.g.
  *      4.0 (Double) != 4 (Int)
  *
- *  NOTE: This function will always return `false` if it is used with two arrays that are not of the type `[BSONValue]` or
- *  `[BSONValue?]`, because any arrays that are not of these types are not valid `BSONValue`'s.
+ *  NOTE: This function will always return `false` if it is used with two arrays that are not of the type `[BSONValue]`
+ *  or `[BSONValue?]`, because any arrays that are not of these types are not valid `BSONValue`'s.
  *
  *  * - Parameters:
  *   - lhs: The left-hand-side `BSONValue` to compare.

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -816,20 +816,12 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
         throw BSONEqualsError.InvalidArrayArgument(
             "arrays not of type [BSONValue?] should not be compared with bsonEqual()"
         )
-    default:
-        // For BSONTypes that do not have actual classes/structs associated
-        // with them, the behavior is known regardless.
-        switch (lhs.bsonType, rhs.bsonType) {
-        case (.invalid, .invalid): return true
-        case (.undefined, .undefined): return true
-        case (.null, .null): return true
-        default: return false
-        }
+    default: return false
     }
 }
 
 func validateBSONTypes(lhs: BSONValue, rhs: BSONValue) {
-    let invalidTypes: [BSONType] = [.symbol, .dbPointer]
+    let invalidTypes: [BSONType] = [.symbol, .dbPointer, .invalid, .undefined, .null]
     guard !invalidTypes.contains(lhs.bsonType) else {
         preconditionFailure("\(lhs.bsonType) should not be used")
     }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -793,8 +793,8 @@ func bsonEqual(lhs: BSONValue, rhs: BSONValue) -> Bool? {
     case (let l as RegularExpression, let r as RegularExpression): return l == r
     case (let l as Timestamp, let r as Timestamp): return l == r
     case (let l as Date, let r as Date): return l == r
-    case (let l as MinKey, let r as MinKey): return l == r
-    case (let l as MaxKey, let r as MaxKey): return l == r
+    case (_ as MinKey, _ as MinKey): return true
+    case (_ as MaxKey, _ as MaxKey): return true
     case (let l as ObjectId, let r as ObjectId): return l == r
     case (let l as CodeWithScope, let r as CodeWithScope): return l == r
     case (let l as Binary, let r as Binary): return l == r

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -823,7 +823,7 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
 
 /// A helper function to test equality between two BSONValue?s. See bsonEquals for BSONValues (non-optional) for more
 /// information.
-func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
+public func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
     guard let left = lhs, let right = rhs else {
         return lhs == nil && rhs == nil
     }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -779,8 +779,6 @@ public struct Timestamp: BSONValue, Equatable, Codable {
     }
 }
 
-enum BSONEqualsError: Error { case InvalidArrayArgument(String) }
-
 // See https://github.com/realm/SwiftLint/issues/461
 // swiftlint:disable cyclomatic_complexity
 /**

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -789,7 +789,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
  *      4.0 (Double) != 4 (Int)
  *
  *  NOTE: This function will always return false if it is used with two arrays that are not of the type [BSONValue] or
- *  [BSONValue?], because any arrays that are not of these types are not valid `BSONValue`'s.
+ *  `[BSONValue?]`, because any arrays that are not of these types are not valid `BSONValue`'s.
  *
  *  * - Parameters:
  *   - lhs: The left-hand-side `BSONValue` to compare.

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -782,7 +782,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
 // See https://github.com/realm/SwiftLint/issues/461
 // swiftlint:disable cyclomatic_complexity
 /**
- *  A helper function to test equality between two BSONValues. This function tests for exact BSON equality.
+ *  A helper function to test equality between two `BSONValue`s. This function tests for exact BSON equality.
  *  This means that differing types with equivalent value are not equivalent.
  *
  *  e.g.

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -784,20 +784,14 @@ func bsonEqual(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
         return lhs == nil && rhs == nil
     }
 
-    let invalidTypes: [BSONType] = [.symbol, .dbPointer]
-    guard !invalidTypes.contains(left.bsonType) else {
-        preconditionFailure("\(left.bsonType) should not be used")
-    }
-    guard !invalidTypes.contains(right.bsonType) else {
-        preconditionFailure("\(right.bsonType) should not be used")
-    }
-
     return try bsonEqual(lhs: left, rhs: right)
 }
 
 // See https://github.com/realm/SwiftLint/issues/461
 // swiftlint:disable cyclomatic_complexity
 func bsonEqual(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
+    validateBSONTypes(lhs: lhs, rhs: rhs)
+
     switch (lhs, rhs) {
     case (let l as Int, let r as Int): return l == r
     case (let l as Int32, let r as Int32): return l == r
@@ -828,6 +822,16 @@ func bsonEqual(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
         case (.null, .null): return true
         default: return false
         }
+    }
+}
+
+func validateBSONTypes(lhs: BSONValue, rhs: BSONValue) {
+    let invalidTypes: [BSONType] = [.symbol, .dbPointer]
+    guard !invalidTypes.contains(lhs.bsonType) else {
+        preconditionFailure("\(lhs.bsonType) should not be used")
+    }
+    guard !invalidTypes.contains(rhs.bsonType) else {
+        preconditionFailure("\(rhs.bsonType) should not be used")
     }
 }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -817,7 +817,7 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) -> Bool {
     case (let l as CodeWithScope, let r as CodeWithScope): return l == r
     case (let l as Binary, let r as Binary): return l == r
     case (let l as Document, let r as Document): return l == r
-    case (let l as [BSONValue?], let r as [BSONValue?]):
+    case (let l as [BSONValue?], let r as [BSONValue?]): // TODO: SWIFT-242
         return zip(l, r).reduce(true, {prev, next in bsonEquals(lhs: next.0, rhs: next.1) && prev})
     case (_ as [Any], _ as [Any]): return false
     default: return false

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -792,7 +792,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
  *  [BSONValue?], because any arrays that are not of these types are not valid `BSONValue`'s.
  *
  *  * - Parameters:
- *   - lhs: The left-hand-side BSONValue to compare.
+ *   - lhs: The left-hand-side `BSONValue` to compare.
  *   - rhs: The right-hand-side `BSONValue` to compare.
  *
  * - Returns: `true` if `lhs` is equal to `rhs`, `false` otherwise.

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -779,8 +779,6 @@ public struct Timestamp: BSONValue, Equatable, Codable {
     }
 }
 
-// See https://github.com/realm/SwiftLint/issues/461
-// swiftlint:disable cyclomatic_complexity
 func bsonEqual(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
     guard let left = lhs, let right = rhs else {
         return lhs == nil && rhs == nil
@@ -794,7 +792,13 @@ func bsonEqual(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
         preconditionFailure("\(right.bsonType) should not be used")
     }
 
-    switch (left, right) {
+    return try bsonEqual(lhs: left, rhs: right)
+}
+
+// See https://github.com/realm/SwiftLint/issues/461
+// swiftlint:disable cyclomatic_complexity
+func bsonEqual(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
+    switch (lhs, rhs) {
     case (let l as Int, let r as Int): return l == r
     case (let l as Int32, let r as Int32): return l == r
     case (let l as Int64, let r as Int64): return l == r
@@ -818,7 +822,7 @@ func bsonEqual(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
     default:
         // For BSONTypes that do not have actual classes/structs associated
         // with them, the behavior is known regardless.
-        switch (left.bsonType, right.bsonType) {
+        switch (lhs.bsonType, rhs.bsonType) {
         case (.invalid, .invalid): return true
         case (.undefined, .undefined): return true
         case (.null, .null): return true

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -793,7 +793,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
  *
  *  * - Parameters:
  *   - lhs: The left-hand-side BSONValue to compare.
- *   - rhs: The right-hand-side BSONValue to compare.
+ *   - rhs: The right-hand-side `BSONValue` to compare.
  *
  * - Returns: `true` if `lhs` is equal to `rhs`, `false` otherwise.
  */

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -788,7 +788,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
  *  e.g.
  *      4.0 (Double) != 4 (Int)
  *
- *  NOTE: This function will always return false if it is used with two arrays that are not of the type [BSONValue] or
+ *  NOTE: This function will always return `false` if it is used with two arrays that are not of the type `[BSONValue]` or
  *  `[BSONValue?]`, because any arrays that are not of these types are not valid `BSONValue`'s.
  *
  *  * - Parameters:

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -779,6 +779,8 @@ public struct Timestamp: BSONValue, Equatable, Codable {
     }
 }
 
+// A helper function to test equality between two BSONValue?s. See bsonEquals for BSONValues (non-optional) for more
+// information.
 func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
     guard let left = lhs, let right = rhs else {
         return lhs == nil && rhs == nil
@@ -789,6 +791,10 @@ func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
 
 // See https://github.com/realm/SwiftLint/issues/461
 // swiftlint:disable cyclomatic_complexity
+// A helper function to test equality between two BSONValues. This function tests for exact BSON equality.
+// This means that, for example, differing types with equivalent value are not equivalent.
+// e.g.
+//  4.0 (Double) != 4 (Int)
 func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     validateBSONTypes(lhs: lhs, rhs: rhs)
 
@@ -820,7 +826,9 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     }
 }
 
-func validateBSONTypes(lhs: BSONValue, rhs: BSONValue) {
+// A function for catching invalid BSONTypes that should not ever arise, and triggering a preconditionFailure when it
+// finds such types.
+internal func validateBSONTypes(lhs: BSONValue, rhs: BSONValue) {
     let invalidTypes: [BSONType] = [.symbol, .dbPointer, .invalid, .undefined, .null]
     guard !invalidTypes.contains(lhs.bsonType) else {
         preconditionFailure("\(lhs.bsonType) should not be used")

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -779,6 +779,42 @@ public struct Timestamp: BSONValue, Equatable, Codable {
     }
 }
 
+// See https://github.com/realm/SwiftLint/issues/461
+// swiftlint:disable cyclomatic_complexity
+func bsonEqual(lhs: BSONValue, rhs: BSONValue) -> Bool? {
+    switch (lhs, rhs) {
+    case (let l as Int, let r as Int): return l == r
+    case (let l as Int32, let r as Int32): return l == r
+    case (let l as Int64, let r as Int64): return l == r
+    case (let l as Double, let r as Double): return l == r
+    case (let l as Decimal128, let r as Decimal128): return l == r
+    case (let l as Bool, let r as Bool): return l == r
+    case (let l as String, let r as String): return l == r
+    case (let l as RegularExpression, let r as RegularExpression): return l == r
+    case (let l as Timestamp, let r as Timestamp): return l == r
+    case (let l as Date, let r as Date): return l == r
+    case (let l as MinKey, let r as MinKey): return l == r
+    case (let l as MaxKey, let r as MaxKey): return l == r
+    case (let l as ObjectId, let r as ObjectId): return l == r
+    case (let l as CodeWithScope, let r as CodeWithScope): return l == r
+    case (let l as Binary, let r as Binary): return l == r
+    case (let l as Document, let r as Document): return l == r
+    // We don't support these cases, meaning there is no verdict of 'true' or 'false' here.
+    case (_ as [Any], _ as [Any]): return nil
+    case (_ as [Symbol], _ as [Symbol]): return nil
+    case (_ as [DBPointer], _ as [DBPointer]): return nil
+    default:
+        // For BSONTypes that do not have actual classes/structs associated
+        // with them, the behavior is known regardless.
+        switch (lhs.bsonType, rhs.bsonType) {
+        case (.invalid, .invalid): return true
+        case (.undefined, .undefined): return true
+        case (.null, .null): return true
+        default: return false
+        }
+    }
+}
+
 func retrieveErrorMsg(type: String, key: String) -> String {
     return "Failed to retrieve the \(type) value for key '\(key)'"
 }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -781,7 +781,6 @@ public struct Timestamp: BSONValue, Equatable, Codable {
 
 enum BSONEqualsError: Error { case InvalidArrayArgument(String) }
 
-
 // See https://github.com/realm/SwiftLint/issues/461
 // swiftlint:disable cyclomatic_complexity
 /**

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -779,15 +779,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
     }
 }
 
-// A helper function to test equality between two BSONValue?s. See bsonEquals for BSONValues (non-optional) for more
-// information.
-func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
-    guard let left = lhs, let right = rhs else {
-        return lhs == nil && rhs == nil
-    }
-
-    return try bsonEquals(lhs: left, rhs: right)
-}
+enum BSONEqualsError: Error { case InvalidArrayArgument(String) }
 
 // See https://github.com/realm/SwiftLint/issues/461
 // swiftlint:disable cyclomatic_complexity
@@ -818,12 +810,21 @@ func bsonEquals(lhs: BSONValue, rhs: BSONValue) throws -> Bool {
     case (let l as [BSONValue?], let r as [BSONValue?]):
         return try zip(l, r).reduce(true, {prev, next in try bsonEquals(lhs: next.0, rhs: next.1) && prev})
     case (_ as [Any], _ as [Any]):
-        enum BSONEqualsError: Error { case InvalidArrayArgument(String) }
         throw BSONEqualsError.InvalidArrayArgument(
             "arrays not of type [BSONValue?] should not be compared with bsonEqual()"
         )
     default: return false
     }
+}
+
+// A helper function to test equality between two BSONValue?s. See bsonEquals for BSONValues (non-optional) for more
+// information.
+func bsonEquals(lhs: BSONValue?, rhs: BSONValue?) throws -> Bool {
+    guard let left = lhs, let right = rhs else {
+        return lhs == nil && rhs == nil
+    }
+
+    return try bsonEquals(lhs: left, rhs: right)
 }
 
 // A function for catching invalid BSONTypes that should not ever arise, and triggering a preconditionFailure when it

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -29,26 +29,9 @@ final class BSONValueTests: XCTestCase {
         expect(try Binary(data: sixteenBytes, subtype: .uuid)).toNot(throwError())
     }
 
-    fileprivate func bsonEqual(expectedValue: BSONValue?) -> Predicate<BSONValue> {
-        return Predicate { (actualExpression: Expression<BSONValue>) throws -> PredicateResult in
-            let msg = ExpectationMessage.expectedActualValueTo("equal <\(String(describing: expectedValue)))>")
-            if let actualValue = try actualExpression.evaluate() {
-                return PredicateResult(
-                    bool: try bsonEquals(lhs: actualValue, rhs: expectedValue!),
-                    message: msg
-                )
-            } else {
-                return PredicateResult(
-                    status: .fail,
-                    message: msg.appendedBeNilHint()
-                )
-            }
-        }
-    }
-
     fileprivate func checkTrueAndFalse(val: BSONValue, alternate: BSONValue) {
-        expect(val).to(bsonEqual(expectedValue: val))
-        expect(val).toNot(bsonEqual(expectedValue: alternate))
+        expect(val).to(bsonEqual(val))
+        expect(val).toNot(bsonEqual(alternate))
     }
 
     func testBSONEquals() throws {
@@ -79,8 +62,8 @@ final class BSONValueTests: XCTestCase {
             alternate: Date(timeIntervalSinceReferenceDate: 5001)
         )
         // MinKey & MaxKey
-        expect(MinKey()).to(bsonEqual(expectedValue: MinKey()))
-        expect(MaxKey()).to(bsonEqual(expectedValue: MaxKey()))
+        expect(MinKey()).to(bsonEqual(MinKey()))
+        expect(MaxKey()).to(bsonEqual(MaxKey()))
         // ObjectId
         checkTrueAndFalse(val: ObjectId(), alternate: ObjectId())
         // CodeWithScope
@@ -111,6 +94,6 @@ final class BSONValueTests: XCTestCase {
         // Invalid Array type
         expect(try bsonEquals(lhs: [BSONEncoder()], rhs: [BSONEncoder(), BSONEncoder()])).to(throwError())
         // Different types
-        expect(4).toNot(bsonEqual(expectedValue: "swift"))
+        expect(4).toNot(bsonEqual("swift"))
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -29,35 +29,35 @@ final class BSONValueTests: XCTestCase {
         expect(try Binary(data: sixteenBytes, subtype: .uuid)).toNot(throwError())
     }
 
-    func testBSONValues(val: BSONValue, alternate: BSONValue) {
+    func checkTrueAndFalse(val: BSONValue, alternate: BSONValue) {
         expect(try bsonEqual(lhs: val, rhs: val)).to(beTrue())
         expect(try bsonEqual(lhs: val, rhs: alternate)).to(beFalse())
     }
 
     func testBSONEquals() throws {
         // Int
-        testBSONValues(val: 1, alternate: 2)
+        checkTrueAndFalse(val: 1, alternate: 2)
         // Int32
-        testBSONValues(val: Int32(32), alternate: Int32(33))
+        checkTrueAndFalse(val: Int32(32), alternate: Int32(33))
         // Int64
-        testBSONValues(val: Int64(64), alternate: Int64(65))
+        checkTrueAndFalse(val: Int64(64), alternate: Int64(65))
         // Double
-        testBSONValues(val: 1.618, alternate: 2.718)
+        checkTrueAndFalse(val: 1.618, alternate: 2.718)
         // Decimal128
-        testBSONValues(val: Decimal128("1.618"), alternate: Decimal128("2.718"))
+        checkTrueAndFalse(val: Decimal128("1.618"), alternate: Decimal128("2.718"))
         // Bool
-        testBSONValues(val: true, alternate: false)
+        checkTrueAndFalse(val: true, alternate: false)
         // String
-        testBSONValues(val: "some", alternate: "not some")
+        checkTrueAndFalse(val: "some", alternate: "not some")
         // RegularExpression
-        testBSONValues(
+        checkTrueAndFalse(
             val: RegularExpression(pattern: ".*", options: ""),
             alternate: RegularExpression(pattern: ".+", options: "")
         )
         // Timestamp
-        testBSONValues(val: Timestamp(timestamp: 1, inc: 2), alternate: Timestamp(timestamp: 5, inc: 10))
+        checkTrueAndFalse(val: Timestamp(timestamp: 1, inc: 2), alternate: Timestamp(timestamp: 5, inc: 10))
         // Date
-        testBSONValues(
+        checkTrueAndFalse(
             val: Date(timeIntervalSinceReferenceDate: 5000),
             alternate: Date(timeIntervalSinceReferenceDate: 5001)
         )
@@ -65,29 +65,31 @@ final class BSONValueTests: XCTestCase {
         expect(try bsonEqual(lhs: MinKey(), rhs: MinKey())).to(beTrue())
         expect(try bsonEqual(lhs: MaxKey(), rhs: MaxKey())).to(beTrue())
         // ObjectId
-        testBSONValues(val: ObjectId(), alternate: ObjectId())
+        checkTrueAndFalse(val: ObjectId(), alternate: ObjectId())
         // CodeWithScope
-        testBSONValues(
+        checkTrueAndFalse(
             val: CodeWithScope(code: "console.log('foo');"),
             alternate: CodeWithScope(code: "console.log(x);", scope: ["x": 2])
         )
         // Binary
-        testBSONValues(
+        checkTrueAndFalse(
             val: try Binary(data: Data(base64Encoded: "c//SZESzTGmQ6OfR38A11A==")!, subtype: .uuid),
             alternate: try Binary(data: Data(base64Encoded: "c//88KLnfdfefOfR33ddFA==")!, subtype: .uuid)
         )
         // Document
-        testBSONValues(
+        checkTrueAndFalse(
             val: [
                 "foo": 1.414,
                 "bar": "swift",
                 "nested": [ "a": 1, "b": "2" ] as Document
-            ] as Document,
+                ] as Document,
             alternate: [
                 "foo": 1.414,
                 "bar": "swift",
                 "nested": [ "a": 1, "b": "different" ] as Document
-            ] as Document
+                ] as Document
         )
+        // [BSONValue?]
+        checkTrueAndFalse(val: [4, 5, 1, nil, 3], alternate: [4, 5, 1, 2, 3])
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -92,7 +92,7 @@ final class BSONValueTests: XCTestCase {
         // [BSONValue?]
         checkTrueAndFalse(val: [4, 5, 1, nil, 3], alternate: [4, 5, 1, 2, 3])
         // Invalid Array type
-        expect(bsonEquals(lhs: [BSONEncoder()], rhs: [BSONEncoder(), BSONEncoder()])).to(beFalse())
+        expect(bsonEquals([BSONEncoder()], [BSONEncoder(), BSONEncoder()])).to(beFalse())
         // Different types
         expect(4).toNot(bsonEqual("swift"))
     }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -30,8 +30,8 @@ final class BSONValueTests: XCTestCase {
     }
 
     func testBSONValues(val: BSONValue, alternate: BSONValue) {
-        expect(bsonEqual(lhs: val, rhs: val)).to(beTrue())
-        expect(bsonEqual(lhs: val, rhs: alternate)).to(beFalse())
+        expect(try bsonEqual(lhs: val, rhs: val)).to(beTrue())
+        expect(try bsonEqual(lhs: val, rhs: alternate)).to(beFalse())
     }
 
     func testBSONEquals() throws {
@@ -62,8 +62,8 @@ final class BSONValueTests: XCTestCase {
             alternate: Date(timeIntervalSinceReferenceDate: 5001)
         )
         // MinKey & MaxKey
-        expect(bsonEqual(lhs: MinKey(), rhs: MinKey())).to(beTrue())
-        expect(bsonEqual(lhs: MaxKey(), rhs: MaxKey())).to(beTrue())
+        expect(try bsonEqual(lhs: MinKey(), rhs: MinKey())).to(beTrue())
+        expect(try bsonEqual(lhs: MaxKey(), rhs: MaxKey())).to(beTrue())
         // ObjectId
         testBSONValues(val: ObjectId(), alternate: ObjectId())
         // CodeWithScope

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -30,8 +30,8 @@ final class BSONValueTests: XCTestCase {
     }
 
     func checkTrueAndFalse(val: BSONValue, alternate: BSONValue) {
-        expect(try bsonEqual(lhs: val, rhs: val)).to(beTrue())
-        expect(try bsonEqual(lhs: val, rhs: alternate)).to(beFalse())
+        expect(try bsonEquals(lhs: val, rhs: val)).to(beTrue())
+        expect(try bsonEquals(lhs: val, rhs: alternate)).to(beFalse())
     }
 
     func testBSONEquals() throws {
@@ -62,8 +62,8 @@ final class BSONValueTests: XCTestCase {
             alternate: Date(timeIntervalSinceReferenceDate: 5001)
         )
         // MinKey & MaxKey
-        expect(try bsonEqual(lhs: MinKey(), rhs: MinKey())).to(beTrue())
-        expect(try bsonEqual(lhs: MaxKey(), rhs: MaxKey())).to(beTrue())
+        expect(try bsonEquals(lhs: MinKey(), rhs: MinKey())).to(beTrue())
+        expect(try bsonEquals(lhs: MaxKey(), rhs: MaxKey())).to(beTrue())
         // ObjectId
         checkTrueAndFalse(val: ObjectId(), alternate: ObjectId())
         // CodeWithScope

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -7,7 +7,8 @@ final class BSONValueTests: XCTestCase {
     static var allTests: [(String, (BSONValueTests) -> () throws -> Void)] {
         return [
             ("testInvalidDecimal128", testInvalidDecimal128),
-            ("testUUIDBytes", testUUIDBytes)
+            ("testUUIDBytes", testUUIDBytes),
+            ("testBSONEquals", testBSONEquals)
         ]
     }
 
@@ -26,5 +27,67 @@ final class BSONValueTests: XCTestCase {
         expect(try Binary(data: twoBytes, subtype: .uuid)).to(throwError())
         expect(try Binary(data: sixteenBytes, subtype: .uuidDeprecated)).toNot(throwError())
         expect(try Binary(data: sixteenBytes, subtype: .uuid)).toNot(throwError())
+    }
+
+    func testBSONValues(val: BSONValue, alternate: BSONValue) {
+        expect(bsonEqual(lhs: val, rhs: val)).to(beTrue())
+        expect(bsonEqual(lhs: val, rhs: alternate)).to(beFalse())
+    }
+
+    func testBSONEquals() throws {
+        // Int
+        testBSONValues(val: 1, alternate: 2)
+        // Int32
+        testBSONValues(val: Int32(32), alternate: Int32(33))
+        // Int64
+        testBSONValues(val: Int64(64), alternate: Int64(65))
+        // Double
+        testBSONValues(val: 1.618, alternate: 2.718)
+        // Decimal128
+        testBSONValues(val: Decimal128("1.618"), alternate: Decimal128("2.718"))
+        // Bool
+        testBSONValues(val: true, alternate: false)
+        // String
+        testBSONValues(val: "some", alternate: "not some")
+        // RegularExpression
+        testBSONValues(
+            val: RegularExpression(pattern: ".*", options: ""),
+            alternate: RegularExpression(pattern: ".+", options: "")
+        )
+        // Timestamp
+        testBSONValues(val: Timestamp(timestamp: 1, inc: 2), alternate: Timestamp(timestamp: 5, inc: 10))
+        // Date
+        testBSONValues(
+            val: Date(timeIntervalSinceReferenceDate: 5000),
+            alternate: Date(timeIntervalSinceReferenceDate: 5001)
+        )
+        // MinKey & MaxKey
+        expect(bsonEqual(lhs: MinKey(), rhs: MinKey())).to(beTrue())
+        expect(bsonEqual(lhs: MaxKey(), rhs: MaxKey())).to(beTrue())
+        // ObjectId
+        testBSONValues(val: ObjectId(), alternate: ObjectId())
+        // CodeWithScope
+        testBSONValues(
+            val: CodeWithScope(code: "console.log('foo');"),
+            alternate: CodeWithScope(code: "console.log(x);", scope: ["x": 2])
+        )
+        // Binary
+        testBSONValues(
+            val: try Binary(data: Data(base64Encoded: "c//SZESzTGmQ6OfR38A11A==")!, subtype: .uuid),
+            alternate: try Binary(data: Data(base64Encoded: "c//88KLnfdfefOfR33ddFA==")!, subtype: .uuid)
+        )
+        // Document
+        testBSONValues(
+            val: [
+                "foo": 1.414,
+                "bar": "swift",
+                "nested": [ "a": 1, "b": "2" ] as Document
+            ] as Document,
+            alternate: [
+                "foo": 1.414,
+                "bar": "swift",
+                "nested": [ "a": 1, "b": "different" ] as Document
+            ] as Document
+        )
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -91,5 +91,7 @@ final class BSONValueTests: XCTestCase {
         )
         // [BSONValue?]
         checkTrueAndFalse(val: [4, 5, 1, nil, 3], alternate: [4, 5, 1, 2, 3])
+        // Invalid Array type
+        expect(try bsonEquals(lhs: [BSONEncoder()], rhs: [BSONEncoder(), BSONEncoder()])).to(throwError())
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -93,5 +93,7 @@ final class BSONValueTests: XCTestCase {
         checkTrueAndFalse(val: [4, 5, 1, nil, 3], alternate: [4, 5, 1, 2, 3])
         // Invalid Array type
         expect(try bsonEquals(lhs: [BSONEncoder()], rhs: [BSONEncoder(), BSONEncoder()])).to(throwError())
+        // Different types
+        expect(try bsonEquals(lhs: 4, rhs: "swift")).to(beFalse())
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -29,7 +29,7 @@ final class BSONValueTests: XCTestCase {
         expect(try Binary(data: sixteenBytes, subtype: .uuid)).toNot(throwError())
     }
 
-    func bsonEqual(expectedValue: BSONValue?) -> Predicate<BSONValue> {
+    fileprivate func bsonEqual(expectedValue: BSONValue?) -> Predicate<BSONValue> {
         return Predicate { (actualExpression: Expression<BSONValue>) throws -> PredicateResult in
             let msg = ExpectationMessage.expectedActualValueTo("equal <\(String(describing: expectedValue)))>")
             if let actualValue = try actualExpression.evaluate() {
@@ -46,7 +46,7 @@ final class BSONValueTests: XCTestCase {
         }
     }
 
-    func checkTrueAndFalse(val: BSONValue, alternate: BSONValue) {
+    fileprivate func checkTrueAndFalse(val: BSONValue, alternate: BSONValue) {
         expect(val).to(bsonEqual(expectedValue: val))
         expect(val).toNot(bsonEqual(expectedValue: alternate))
     }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -92,7 +92,7 @@ final class BSONValueTests: XCTestCase {
         // [BSONValue?]
         checkTrueAndFalse(val: [4, 5, 1, nil, 3], alternate: [4, 5, 1, 2, 3])
         // Invalid Array type
-        expect(try bsonEquals(lhs: [BSONEncoder()], rhs: [BSONEncoder(), BSONEncoder()])).to(throwError())
+        expect(bsonEquals(lhs: [BSONEncoder()], rhs: [BSONEncoder(), BSONEncoder()])).to(beFalse())
         // Different types
         expect(4).toNot(bsonEqual("swift"))
     }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -206,3 +206,21 @@ internal func rearrangeDoc(_ input: Document, toLookLike standard: Document) -> 
     }
     return output
 }
+
+/// A Nimble matcher for testing BSONValue equality.
+internal func bsonEqual(_ expectedValue: BSONValue?) -> Predicate<BSONValue> {
+    return Predicate { (actualExpression: Expression<BSONValue>) throws -> PredicateResult in
+        let msg = ExpectationMessage.expectedActualValueTo("equal <\(String(describing: expectedValue)))>")
+        if let actualValue = try actualExpression.evaluate() {
+            return PredicateResult(
+                bool: try bsonEquals(lhs: actualValue, rhs: expectedValue!),
+                message: msg
+            )
+        } else {
+            return PredicateResult(
+                status: .fail,
+                message: msg.appendedBeNilHint()
+            )
+        }
+    }
+}

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -213,7 +213,7 @@ internal func bsonEqual(_ expectedValue: BSONValue?) -> Predicate<BSONValue> {
         let msg = ExpectationMessage.expectedActualValueTo("equal <\(String(describing: expectedValue)))>")
         if let actualValue = try actualExpression.evaluate() {
             return PredicateResult(
-                bool: bsonEquals(lhs: actualValue, rhs: expectedValue!),
+                bool: bsonEquals(actualValue, expectedValue!),
                 message: msg
             )
         } else {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -213,7 +213,7 @@ internal func bsonEqual(_ expectedValue: BSONValue?) -> Predicate<BSONValue> {
         let msg = ExpectationMessage.expectedActualValueTo("equal <\(String(describing: expectedValue)))>")
         if let actualValue = try actualExpression.evaluate() {
             return PredicateResult(
-                bool: try bsonEquals(lhs: actualValue, rhs: expectedValue!),
+                bool: bsonEquals(lhs: actualValue, rhs: expectedValue!),
                 message: msg
             )
         } else {


### PR DESCRIPTION
[SWIFT-226](https://jira.mongodb.org/browse/SWIFT-226)

This PR adds a convenience function, `bsonEquals` that lets the caller compare two arbitrary `BSONValue`s. This does _not_ add `Equatable` conformance to `BSONValue`, because this would cause us to provide an `Equatable` conformance to all arrays. I, or @kmahar can provide further detail on this if necessary.

This PR also adds many test cases for checking the code paths through `bsonEquals`, but does not check for `preconditionFailure`s, since these cause the program, including the tests, to halt. There is apparently [a way](https://www.cocoawithlove.com/blog/2016/02/02/partial-functions-part-two-catching-precondition-failures.html) to get around this, but it is apparently very hacky.

I've included some comments on my own patch here, that I'd like to draw attention to and get feedback for in particular, as I'm not experience enough in Swift to know if they are good practices.