### PR TITLE
SWIFT-236: Fix linter issues

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,7 +6,7 @@ disabled_rules:
   - type_name
   - type_body_length
 
-enabled_rules:
+opt_in_rules:
   - vertical_parameter_alignment_on_call
   - trailing_closure
   - sorted_imports

--- a/Examples/Kitura/Sources/KituraExample/main.swift
+++ b/Examples/Kitura/Sources/KituraExample/main.swift
@@ -12,7 +12,7 @@ let collection = try client.db("home").collection("kittens", withType: Kitten.se
 let router: Router = {
   let router = Router()
 
-  router.get("kittens") { request, response, next in
+  router.get("kittens") { _, response, _ in
     let docs = try collection.find()
     response.send(Array(docs))
   }

--- a/Examples/Vapor/Package.swift
+++ b/Examples/Vapor/Package.swift
@@ -11,4 +11,3 @@ let package = Package(
         .target(name: "VaporExample", dependencies: ["Vapor", "MongoSwift"])
     ]
 )
-

--- a/Examples/Vapor/Sources/VaporExample/main.swift
+++ b/Examples/Vapor/Sources/VaporExample/main.swift
@@ -1,5 +1,5 @@
-import Vapor
 import MongoSwift
+import Vapor
 
 struct Kitten: Content {
   var name: String
@@ -11,10 +11,9 @@ let router = try app.make(Router.self)
 let client = try MongoClient()
 let collection = try client.db("home").collection("kittens", withType: Kitten.self)
 
-router.get("kittens") { req -> [Kitten] in
+router.get("kittens") { _ -> [Kitten] in
   let docs = try collection.find()
   return Array(docs)
 }
 
 try app.run()
-

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -1,5 +1,5 @@
-import Foundation
 import bson
+import Foundation
 
 /// The possible types of BSON values and their corresponding integer values.
 public enum BSONType: UInt32 {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -205,7 +205,8 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         }
     }
 
-    /// Sets key to newValue. if checkForKey=false, the key/value pair will be appended without checking for the key's presence first.
+    /// Sets key to newValue. if checkForKey=false, the key/value pair will be appended without checking for the key's
+    // presence first.
     private mutating func setValue(forKey key: String, to newValue: BSONValue?, checkForKey: Bool = true) throws {
         // if the key already exists in the `Document`, we need to replace it
         if checkForKey, let existingType = DocumentIterator(forDocument: self, advancedTo: key)?.currentType {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -1,5 +1,5 @@
-import Foundation
 import bson
+import Foundation
 
 /// The storage backing a MongoSwift `Document`.
 public class DocumentStorage {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -206,7 +206,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
     }
 
     /// Sets key to newValue. if checkForKey=false, the key/value pair will be appended without checking for the key's
-    // presence first.
+    /// presence first.
     private mutating func setValue(forKey key: String, to newValue: BSONValue?, checkForKey: Bool = true) throws {
         // if the key already exists in the `Document`, we need to replace it
         if checkForKey, let existingType = DocumentIterator(forDocument: self, advancedTo: key)?.currentType {

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -155,7 +155,11 @@ extension MongoCollection {
             let opts = try encoder.encode(self.options)
             var error = bson_error_t()
 
-            guard mongoc_bulk_operation_replace_one_with_opts(bulk.bulk, self.filter.data, replacement.data, opts.data, &error) else {
+            guard mongoc_bulk_operation_replace_one_with_opts(bulk.bulk,
+                                                              self.filter.data,
+                                                              replacement.data,
+                                                              opts.data,
+                                                              &error) else {
                 throw MongoError.invalidArgument(message: toErrorString(error))
             }
         }
@@ -195,7 +199,11 @@ extension MongoCollection {
             let opts = try BSONEncoder().encode(self.options)
             var error = bson_error_t()
 
-            guard mongoc_bulk_operation_update_one_with_opts(bulk.bulk, self.filter.data, self.update.data, opts.data, &error) else {
+            guard mongoc_bulk_operation_update_one_with_opts(bulk.bulk,
+                                                             self.filter.data,
+                                                             self.update.data,
+                                                             opts.data,
+                                                             &error) else {
                 throw MongoError.invalidArgument(message: toErrorString(error))
             }
         }
@@ -229,7 +237,11 @@ extension MongoCollection {
             let opts = try BSONEncoder().encode(self.options)
             var error = bson_error_t()
 
-            guard mongoc_bulk_operation_update_many_with_opts(bulk.bulk, self.filter.data, self.update.data, opts.data, &error) else {
+            guard mongoc_bulk_operation_update_many_with_opts(bulk.bulk,
+                                                              self.filter.data,
+                                                              self.update.data,
+                                                              opts.data,
+                                                              &error) else {
                 throw MongoError.invalidArgument(message: toErrorString(error))
             }
         }

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -70,7 +70,12 @@ extension MongoCollection {
         let reply = Document()
         var error = bson_error_t()
 
-        let success = mongoc_collection_insert_many(self._collection, &docPointers, values.count, opts?.data, reply.data, &error)
+        let success = mongoc_collection_insert_many(self._collection,
+                                                    &docPointers,
+                                                    values.count,
+                                                    opts?.data,
+                                                    reply.data,
+                                                    &error)
         let result = try InsertManyResult(reply: reply, insertedIds: insertedIds)
         let isAcknowledged = self.isAcknowledged(options?.writeConcern)
 

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -76,9 +76,9 @@ extension MongoCollection {
 
         guard success else {
             throw MongoError.insertManyError(code: error.code, message: toErrorString(error),
-                                            result: (isAcknowledged ? result : nil),
-                                            writeErrors: result.writeErrors,
-                                            writeConcernError: result.writeConcernError)
+                                             result: (isAcknowledged ? result : nil),
+                                             writeErrors: result.writeErrors,
+                                             writeConcernError: result.writeConcernError)
         }
 
         return isAcknowledged ? result : nil


### PR DESCRIPTION
[SWIFT-236](https://jira.mongodb.org/browse/SWIFT-236)

This PR just fixes some linter issues we were not catching because of a slight issue with our Travis configuration that was ignoring warnings. That issue will be fixed as [SWIFT-237](https://jira.mongodb.org/browse/SWIFT-237).

This PR also renames `enabled_rules` to `opt_in_rules`, since `renamed_rules` will be removed, so we might as well do this now and not deal with issues later.