### PR TITLE
SWIFT-237: Fix .travis.yml to fail whenever swiftlint has errors OR warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 before_script:
   - mkdir ${PWD}/mongodb-${MONGODB_VERSION}/data
   - ${PWD}/mongodb-${MONGODB_VERSION}/bin/mongod --dbpath ${PWD}/mongodb-${MONGODB_VERSION}/data --logpath ${PWD}/mongodb-${MONGODB_VERSION}/mongodb.log --enableMajorityReadConcern --fork
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swiftlint; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swiftlint --strict; fi
 
 script:
   - swift build -v


### PR DESCRIPTION
[SWIFT-237](https://jira.mongodb.org/browse/SWIFT-237)

Before, our Travis configuration for running `swiftlint` would only fail the build if we had 'serious' violations. This means that if we had warnings that `swiftlint` deemed not 'serious', then we would have a successful exit code of 0, and Travis would not fail the build. This PR adds the `--strict` command line option for `swiftlint` to the Travis configuration, making it so that warnings are treated as errors and therefore give a non-zero exit code. We should not be able to catch linter issues introduced as part of a PR.

This PR is a little weird. Technically, the fix for the things causing the linter to fail is part of #131, so this is somewhat blocked on that, and furthermore, we needed this branch to fail so that we can confirm that Travis is correctly failing.

Once #131 is finished, we can rebase this and verify that it also passes when all linter issues are resolved. These cases were tested locally, but it would be good to see that it works on Travis as well.