### PR TITLE
SWIFT-239 use BSONType instead of libbson equivalent

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -465,7 +465,7 @@ public struct CodeWithScope: BSONValue, Equatable, Codable {
 
         var length: UInt32 = 0
 
-        if iter.currentType.rawValue == BSON_TYPE_CODE.rawValue {
+        if iter.currentType.rawValue == BSONType.javascript.rawValue {
             let code = String(cString: bson_iter_code(&iter.iter, &length))
             self.init(code: code)
             return


### PR DESCRIPTION
Due to reasons we've yet to exactly determine, the driver will not build in Swift 4.2 in some cases due to an error about BSON_TYPE_CODE not being defined. This switches to using our own BSONType enum (which we should've been doing in the first place) and fixes the compilation errors in 4.2. 
