### PR TITLE
SWIFT-231: Don't hard-code in port number for tests

### DIFF
--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -210,8 +210,8 @@ public struct TopologyDescription {
     /// The largest electionId ever reported by a primary.
     public var maxElectionId: ObjectId?
 
-    /// The servers comprising this topology. By default, a single server at localhost:270107.
-    public var servers: [ServerDescription] = [ServerDescription(connectionId: ConnectionId())]
+    /// The servers comprising this topology. By default, no servers.
+    public var servers: [ServerDescription] = []
 
     /// For single-threaded clients, indicates whether the topology must be re-scanned.
     public let stale: Bool = false // currently, this will never be set

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -21,7 +21,7 @@ final class CommandMonitoringTests: XCTestCase {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         client.enableMonitoring(forEvents: .commandMonitoring)
 
-        let cmPath = self.getSpecsPath() + "/command-monitoring/tests"
+        let cmPath = self.specsPath + "/command-monitoring/tests"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: cmPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             // read in the file data and parse into a struct

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -21,7 +21,7 @@ final class CommandMonitoringTests: XCTestCase {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         client.enableMonitoring(forEvents: .commandMonitoring)
 
-        let cmPath = self.specsPath + "/command-monitoring/tests"
+        let cmPath = XCTestCase.specsPath + "/command-monitoring/tests"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: cmPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             // read in the file data and parse into a struct

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -81,13 +81,13 @@ final class CrudTests: XCTestCase {
 
     // Run all the tests at the /read path
     func testReads() throws {
-        let testFilesPath = self.getSpecsPath() + "/crud/tests/read"
+        let testFilesPath = self.specsPath + "/crud/tests/read"
         try doTests(forPath: testFilesPath)
     }
 
     // Run all the tests at the /write path
     func testWrites() throws {
-        let testFilesPath = self.getSpecsPath() + "/crud/tests/write"
+        let testFilesPath = self.specsPath + "/crud/tests/write"
         try doTests(forPath: testFilesPath)
     }
 }

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -81,13 +81,13 @@ final class CrudTests: XCTestCase {
 
     // Run all the tests at the /read path
     func testReads() throws {
-        let testFilesPath = self.specsPath + "/crud/tests/read"
+        let testFilesPath = XCTestCase.specsPath + "/crud/tests/read"
         try doTests(forPath: testFilesPath)
     }
 
     // Run all the tests at the /write path
     func testWrites() throws {
-        let testFilesPath = self.specsPath + "/crud/tests/write"
+        let testFilesPath = XCTestCase.specsPath + "/crud/tests/write"
         try doTests(forPath: testFilesPath)
     }
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -228,7 +228,7 @@ final class DocumentTests: XCTestCase {
             "Double type": ["1.23456789012345677E+18", "-1.23456789012345677E+18"]
         ]
 
-        let testFilesPath = self.specsPath + "/bson-corpus/tests"
+        let testFilesPath = XCTestCase.specsPath + "/bson-corpus/tests"
         var testFiles = try FileManager.default.contentsOfDirectory(atPath: testFilesPath)
         testFiles = testFiles.filter { $0.hasSuffix(".json") }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -228,7 +228,7 @@ final class DocumentTests: XCTestCase {
             "Double type": ["1.23456789012345677E+18", "-1.23456789012345677E+18"]
         ]
 
-        let testFilesPath = self.getSpecsPath() + "/bson-corpus/tests"
+        let testFilesPath = self.specsPath + "/bson-corpus/tests"
         var testFiles = try FileManager.default.contentsOfDirectory(atPath: testFilesPath)
         testFiles = testFiles.filter { $0.hasSuffix(".json") }
 

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -19,7 +19,7 @@ final class MongoClientTests: XCTestCase {
     }
 
     func testOpaqueInitialization() throws {
-        let connectionString = XCTestCase.getConnStr()
+        let connectionString = XCTestCase.connStr
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
             throw MongoError.invalidUri(message: toErrorString(error))

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -19,7 +19,7 @@ final class MongoClientTests: XCTestCase {
     }
 
     func testOpaqueInitialization() throws {
-        let connectionString = getConnStr()
+        let connectionString = XCTestCase.getConnStr()
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
             throw MongoError.invalidUri(message: toErrorString(error))

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -19,7 +19,7 @@ final class MongoClientTests: XCTestCase {
     }
 
     func testOpaqueInitialization() throws {
-        let connectionString = "mongodb://localhost"
+        let connectionString = getConnStr()
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
             throw MongoError.invalidUri(message: toErrorString(error))

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -14,7 +14,7 @@ final class MongoDatabaseTests: XCTestCase {
     }
 
     func testDatabase() throws {
-        let client = try MongoClient(connectionString: XCTestCase.getConnStr())
+        let client = try MongoClient(connectionString: XCTestCase.connStr)
         let db = try client.db("testDB")
 
         let command: Document = ["create": "coll1"]

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -14,7 +14,7 @@ final class MongoDatabaseTests: XCTestCase {
     }
 
     func testDatabase() throws {
-        let client = try MongoClient(connectionString: "mongodb://localhost:27017/")
+        let client = try MongoClient(connectionString: getConnStr())
         let db = try client.db("testDB")
 
         let command: Document = ["create": "coll1"]

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -14,7 +14,7 @@ final class MongoDatabaseTests: XCTestCase {
     }
 
     func testDatabase() throws {
-        let client = try MongoClient(connectionString: getConnStr())
+        let client = try MongoClient(connectionString: XCTestCase.getConnStr())
         let db = try client.db("testDB")
 
         let command: Document = ["create": "coll1"]

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -340,7 +340,7 @@ final class ReadWriteConcernTests: XCTestCase {
     }
 
     func testConnectionStrings() throws {
-        let csPath = "\(self.getSpecsPath())/read-write-concern/tests/connection-string"
+        let csPath = "\(self.specsPath)/read-write-concern/tests/connection-string"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: csPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             let testFilePath = URL(fileURLWithPath: "\(csPath)/\(filename)")
@@ -378,7 +378,7 @@ final class ReadWriteConcernTests: XCTestCase {
 
     func testDocuments() throws {
         let encoder = BSONEncoder()
-        let docsPath = "\(self.getSpecsPath())/read-write-concern/tests/document"
+        let docsPath = "\(self.specsPath)/read-write-concern/tests/document"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: docsPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             let testFilePath = URL(fileURLWithPath: "\(docsPath)/\(filename)")

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -340,7 +340,7 @@ final class ReadWriteConcernTests: XCTestCase {
     }
 
     func testConnectionStrings() throws {
-        let csPath = "\(self.specsPath)/read-write-concern/tests/connection-string"
+        let csPath = "\(XCTestCase.specsPath)/read-write-concern/tests/connection-string"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: csPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             let testFilePath = URL(fileURLWithPath: "\(csPath)/\(filename)")
@@ -378,7 +378,7 @@ final class ReadWriteConcernTests: XCTestCase {
 
     func testDocuments() throws {
         let encoder = BSONEncoder()
-        let docsPath = "\(self.specsPath)/read-write-concern/tests/document"
+        let docsPath = "\(XCTestCase.specsPath)/read-write-concern/tests/document"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: docsPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             let testFilePath = URL(fileURLWithPath: "\(docsPath)/\(filename)")

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -58,7 +58,7 @@ final class SDAMTests: XCTestCase {
         center.removeObserver(observer)
 
         var error = bson_error_t()
-        guard let uri = mongoc_uri_new_with_error(XCTestCase.getConnStr(), &error) else {
+        guard let uri = mongoc_uri_new_with_error(XCTestCase.connStr, &error) else {
             throw MongoError.invalidUri(message: toErrorString(error))
         }
 

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -104,6 +104,7 @@ final class SDAMTests: XCTestCase {
         expect(event4.topologyId).to(equal(event3.topologyId))
         let prevTopology = event4.previousDescription
         expect(prevTopology.type).to(equal(TopologyType.single))
+        expect(prevTopology.servers).to(beEmpty())
 
         let newTopology = event4.newDescription
         expect(newTopology.type).to(equal(TopologyType.single))

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -59,7 +59,8 @@ final class SDAMTests: XCTestCase {
 
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(XCTestCase.connStr, &error) else {
-            throw MongoError.invalidUri(message: toErrorString(error))
+            XCTFail(toErrorString(error))
+            return
         }
 
         guard let hostlist = mongoc_uri_get_hosts(uri) else {

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -82,6 +82,8 @@ final class SDAMTests: XCTestCase {
         expect(event1.topologyId).to(equal(event0.topologyId))
         expect(event1.previousDescription.type).to(equal(TopologyType.unknown))
         expect(event1.newDescription.type).to(equal(TopologyType.single))
+        // This is a bit of a deviation from the SDAM spec tests linked above. However, this is how mongoc responds so
+        // there is no other way to get around this.
         expect(event1.newDescription.servers).to(beEmpty())
 
         let event2 = receivedEvents[2] as! ServerOpeningEvent

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -58,7 +58,7 @@ final class SDAMTests: XCTestCase {
         center.removeObserver(observer)
 
         var error = bson_error_t()
-        guard let uri = mongoc_uri_new_with_error(getConnStr(), &error) else {
+        guard let uri = mongoc_uri_new_with_error(XCTestCase.getConnStr(), &error) else {
             throw MongoError.invalidUri(message: toErrorString(error))
         }
 

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -63,7 +63,8 @@ final class SDAMTests: XCTestCase {
         }
 
         guard let hostlist = mongoc_uri_get_hosts(uri) else {
-            throw MongoError.invalidResponse()
+            XCTFail("Could not get hostlists for uri: \(uri)")
+            return
         }
 
         // check event count and that events are of the expected types

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -18,6 +18,14 @@ extension XCTestCase {
         return path
     }
 
+    static func getConnStr() -> String {
+        if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {
+            return connStr
+        } else {
+            return "mongodb://127.0.0.1/"
+        }
+    }
+
     // indicates whether we are running on a 32-bit platform
     // Use MemoryLayout instead of Int.bitWidth to avoid a compiler warning.
     // See: https://forums.swift.org/t/how-can-i-condition-on-the-size-of-int/9080/4 */
@@ -116,15 +124,7 @@ extension MongoClient {
     }
 
     internal convenience init(options: ClientOptions? = nil) throws {
-        try self.init(connectionString: getConnStr(), options: options)
-    }
-}
-
-func getConnStr() -> String {
-    if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {
-        return connStr
-    } else {
-        return "mongodb://127.0.0.1/"
+        try self.init(connectionString: XCTestCase.getConnStr(), options: options)
     }
 }
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -123,7 +123,7 @@ func getConnStr() -> String {
     if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {
         return connStr
     } else {
-        return "mongodb://localhost:27017"
+        return "mongodb://127.0.0.1/"
     }
 }
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -8,27 +8,23 @@ extension XCTestCase {
     /// Gets the path of the directory containing spec files, depending on whether
     /// we're running from XCode or the command line
     static var specsPath: String {
-        get {
-            // if we can access the "/Tests" directory, assume we're running from command line
-            if FileManager.default.fileExists(atPath: "./Tests") { return "./Tests/Specs" }
-            // otherwise we're in Xcode, get the bundle's resource path
-            guard let path = Bundle(for: self).resourcePath else {
-                XCTFail("Missing resource path")
-                return ""
-            }
-            return path
+        // if we can access the "/Tests" directory, assume we're running from command line
+        if FileManager.default.fileExists(atPath: "./Tests") { return "./Tests/Specs" }
+        // otherwise we're in Xcode, get the bundle's resource path
+        guard let path = Bundle(for: self).resourcePath else {
+            XCTFail("Missing resource path")
+            return ""
         }
+        return path
     }
 
     /// Gets the connection string for the database being used for testing from the environment variable, $MONGODB_URI.
     /// If the environment variable does not exist, this will use a default of "mongodb://127.0.0.1/".
     static var connStr: String {
-        get {
-            if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {
-                return connStr
-            } else {
-                return "mongodb://127.0.0.1/"
-            }
+        if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {
+            return connStr
+        } else {
+            return "mongodb://127.0.0.1/"
         }
     }
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -7,12 +7,12 @@ import XCTest
 extension XCTestCase {
     /// Gets the path of the directory containing spec files, depending on whether
     /// we're running from XCode or the command line
-    var specsPath: String {
+    static var specsPath: String {
         get {
             // if we can access the "/Tests" directory, assume we're running from command line
             if FileManager.default.fileExists(atPath: "./Tests") { return "./Tests/Specs" }
             // otherwise we're in Xcode, get the bundle's resource path
-            guard let path = Bundle(for: type(of: self)).resourcePath else {
+            guard let path = Bundle(for: self).resourcePath else {
                 XCTFail("Missing resource path")
                 return ""
             }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -18,11 +18,13 @@ extension XCTestCase {
         return path
     }
 
-    static func getConnStr() -> String {
-        if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {
-            return connStr
-        } else {
-            return "mongodb://127.0.0.1/"
+    static var connStr: String {
+        get {
+            if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {
+                return connStr
+            } else {
+                return "mongodb://127.0.0.1/"
+            }
         }
     }
 
@@ -124,7 +126,7 @@ extension MongoClient {
     }
 
     internal convenience init(options: ClientOptions? = nil) throws {
-        try self.init(connectionString: XCTestCase.getConnStr(), options: options)
+        try self.init(connectionString: XCTestCase.connStr, options: options)
     }
 }
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -117,10 +117,6 @@ extension MongoClient {
     internal convenience init(options: ClientOptions? = nil) throws {
         try self.init(connectionString: getConnStr(), options: options)
     }
-
-    internal convenience init() throws {
-        try self.init(connectionString: getConnStr())
-    }
 }
 
 func getConnStr() -> String {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -3,6 +3,7 @@ import MongoSwift
 import Nimble
 import XCTest
 
+// TODO: Move contents of this extension to the base test class in SWIFT-207.
 extension XCTestCase {
     /// Gets the path of the directory containing spec files, depending on whether
     /// we're running from XCode or the command line

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -120,7 +120,7 @@ extension MongoClient {
 }
 
 func getConnStr() -> String {
-    if let connStr = ProcessInfo.processInfo.environment["MDB_CONN_STR"] {
+    if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {
         return connStr
     } else {
         return "mongodb://localhost:27017"

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -7,15 +7,17 @@ import XCTest
 extension XCTestCase {
     /// Gets the path of the directory containing spec files, depending on whether
     /// we're running from XCode or the command line
-    func getSpecsPath() -> String {
-        // if we can access the "/Tests" directory, assume we're running from command line
-        if FileManager.default.fileExists(atPath: "./Tests") { return "./Tests/Specs" }
-        // otherwise we're in Xcode, get the bundle's resource path
-        guard let path = Bundle(for: type(of: self)).resourcePath else {
-            XCTFail("Missing resource path")
-            return ""
+    var specsPath: String {
+        get {
+            // if we can access the "/Tests" directory, assume we're running from command line
+            if FileManager.default.fileExists(atPath: "./Tests") { return "./Tests/Specs" }
+            // otherwise we're in Xcode, get the bundle's resource path
+            guard let path = Bundle(for: type(of: self)).resourcePath else {
+                XCTFail("Missing resource path")
+                return ""
+            }
+            return path
         }
-        return path
     }
 
     static var connStr: String {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -20,6 +20,8 @@ extension XCTestCase {
         }
     }
 
+    /// Gets the connection string for the database being used for testing from the environment variable, $MONGODB_URI.
+    /// If the environment variable does not exist, this will use a default of "mongodb://127.0.0.1/".
     static var connStr: String {
         get {
             if let connStr = ProcessInfo.processInfo.environment["MONGODB_URI"] {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -113,6 +113,22 @@ extension MongoClient {
 
         return true
     }
+
+    internal convenience init(options: ClientOptions? = nil) throws {
+        try self.init(connectionString: getConnStr(), options: options)
+    }
+
+    internal convenience init() throws {
+        try self.init(connectionString: getConnStr())
+    }
+}
+
+func getConnStr() -> String {
+    if let connStr = ProcessInfo.processInfo.environment["MDB_CONN_STR"] {
+        return connStr
+    } else {
+        return "mongodb://localhost:27017"
+    }
 }
 
 /// Cleans and normalizes a given JSON string for comparison purposes


### PR DESCRIPTION
[SWIFT-231](https://jira.mongodb.org/browse/SWIFT-231)

This PR adds an ability for us to take a MDB connection string from the environment, defined via `$MDB_CONN_STR`, and use it to determine what `mongod` server to connect to for our tests. This is implemented with some convenience initializers, which lets us implement this ticket in a relatively small diff. Alternative approaches are welcome if this is not 'Swift-y'.