### PR TITLE
SWIFT-198: Use setValue where possible rather than subscript setter

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -103,7 +103,7 @@ extension Array: BSONValue {
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         // An array is just a document with keys '0', '1', etc. corresponding to indexes
         var arr = Document()
-        for (i, v) in self.enumerated() { arr[String(i)] = v as? BSONValue }
+        for (i, v) in self.enumerated() { try arr.setValue(forKey: String(i), to: v as? BSONValue) }
         guard bson_append_array(storage.pointer, key, Int32(key.count), arr.data) else {
             throw bsonEncodeError(value: self, forKey: key)
         }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -103,7 +103,12 @@ extension Array: BSONValue {
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         // An array is just a document with keys '0', '1', etc. corresponding to indexes
         var arr = Document()
-        for (i, v) in self.enumerated() { try arr.setValue(forKey: String(i), to: v as? BSONValue) }
+        for (i, v) in self.enumerated() {
+            if self as? [BSONValue?] == nil {
+                throw MongoError.invalidArgument(message: "Cannot encode a non-BSONValue array element: \(v)")
+            }
+            try arr.setValue(forKey: String(i), to: v as? BSONValue)
+        }
         guard bson_append_array(storage.pointer, key, Int32(key.count), arr.data) else {
             throw bsonEncodeError(value: self, forKey: key)
         }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -102,11 +102,11 @@ extension Array: BSONValue {
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         // An array is just a document with keys '0', '1', etc. corresponding to indexes
+        if self as? [BSONValue?] == nil {
+            throw MongoError.invalidArgument(message: "Cannot encode a non-BSONValue array element")
+        }
         var arr = Document()
         for (i, v) in self.enumerated() {
-            if self as? [BSONValue?] == nil {
-                throw MongoError.invalidArgument(message: "Cannot encode a non-BSONValue array element: \(v)")
-            }
             try arr.setValue(forKey: String(i), to: v as? BSONValue)
         }
         guard bson_append_array(storage.pointer, key, Int32(key.count), arr.data) else {

--- a/Sources/MongoSwift/BSON/Document+Codable.swift
+++ b/Sources/MongoSwift/BSON/Document+Codable.swift
@@ -46,9 +46,10 @@ extension Document: Codable {
         for key in container.allKeys {
             let k = key.stringValue
             if try container.decodeNil(forKey: key) {
-                output[k] = nil
+                try output.setValue(forKey: k, to: nil)
             } else {
-                output[k] = try container.decode(AnyBSONValue.self, forKey: key).value
+                let val = try container.decode(AnyBSONValue.self, forKey: key).value
+                try output.setValue(forKey: k, to: val)
             }
         }
         self = output

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -293,7 +293,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      * For example:
      *      let doc1: Document = ["a": 1]
      *      var doc2 = doc1
-     *      doc2["b"] = 2
+     *      doc2.setValue(forKey: "b", to: 2)
      *
      * Therefore, this function should be called just before we are about to modify a document - either by
      * setting a value or merging in another doc.

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -270,7 +270,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      *  - Throws: A `MongoError.typeError` if the value cannot be cast to type `T` or is not in the `Document`
      *
      */
-    public func get<T: BSONValue>(_ key: String) throws -> T {
+    internal func get<T: BSONValue>(_ key: String) throws -> T {
         guard let value = self[key] as? T else {
             throw MongoError.typeError(message: "Could not cast value for key \(key) to type \(T.self)")
         }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -207,7 +207,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
     /// Sets key to newValue. if checkForKey=false, the key/value pair will be appended without checking for the key's
     /// presence first.
-    private mutating func setValue(forKey key: String, to newValue: BSONValue?, checkForKey: Bool = true) throws {
+    internal mutating func setValue(forKey key: String, to newValue: BSONValue?, checkForKey: Bool = true) throws {
         // if the key already exists in the `Document`, we need to replace it
         if checkForKey, let existingType = DocumentIterator(forDocument: self, advancedTo: key)?.currentType {
 

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -292,8 +292,8 @@ private class FindAndModifyOptions {
 
         // build an "extra" document of fields without their own setters
         var extra = Document()
-        if let filters = arrayFilters { extra["arrayFilters"] = filters }
-        if let coll = collation { extra["collation"] = coll }
+        if let filters = arrayFilters { try extra.setValue(forKey: "arrayFilters", to: filters) }
+        if let coll = collation { try extra.setValue(forKey: "collation", to: coll) }
 
         // note: mongoc_find_and_modify_opts_set_max_time_ms() takes in a
         // uint32_t, but it should be a positive 64-bit integer, so we
@@ -302,12 +302,12 @@ private class FindAndModifyOptions {
             guard maxTime > 0 else {
                 throw MongoError.invalidArgument(message: "maxTimeMS must be positive, but got value \(maxTime)")
             }
-            extra["maxTimeMS"] = maxTime
+            try extra.setValue(forKey: "maxTimeMS", to: maxTime)
         }
 
         if let wc = writeConcern {
             do {
-                extra["writeConcern"] = try BSONEncoder().encode(wc)
+                try extra.setValue(forKey: "writeConcern", to: try BSONEncoder().encode(wc))
             } catch {
                 throw MongoError.invalidArgument(message: "Error encoding WriteConcern \(wc): \(error)")
             }

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -720,6 +720,10 @@ final class CodecTests: XCTestCase {
         let arr2: [BSONValue?] = [1, "hi", nil]
         expect(try encoder.encode(OptionalAnyBSONWrapper(arr2))).to(equal(["val": arr2]))
 
+        // an array with a non-BSONValue
+        let arr3: [Any?] = [1, "hi", nil, Int16(4)]
+        expect(try arr3.encode(to: DocumentStorage(), forKey: "arr3")).to(throwError())
+
         // nil value
         expect(try encoder.encode(OptionalAnyBSONWrapper(nil))).to(beNil())
 


### PR DESCRIPTION
[SWIFT-198](https://jira.mongodb.org/browse/SWIFT-198)

This PR replaces instances where we use subscript-setting in a throwing function with `setValue()`. This should help avoid `preconditionFailure`'s and instead propagate a non-fatal error for the end-user.

There were some instances of functions that were declared as `rethrows`. From my understanding, these functions only throw if their argument which is a function/closure throws itself, so we cannot use `setValue()` without marking those function as `throws`. This was enough of a change that I figured it shouldn't be included in this ticket. Plus, these were implemented in conformance to `Sequence`, and I believe marking them as `throws` would break the conformance.

As usual with these kinds of PRs, let me know if you think I have missed any instances.