### PR TITLE
SWIFT-246: README link for "Things to install" in Development.md is broken

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -15,7 +15,7 @@
 	* Use this to install Swift 4.0 if you don't have it already.
 * [jazzy](https://github.com/realm/jazzy#installation): the tool we use to generate documentation.
 * [swiftlint](https://github.com/realm/SwiftLint#using-homebrew): the Swift linter we use. 
-* [libmongoc](http://mongoc.org/libmongoc/current/api.html): the MongoDB C driver, which this library wraps. See the installation instructions provided in our [README](README.md#first-install-the-mongodb-c-driver) or on the [libmongoc docs](http://mongoc.org/libmongoc/current/installing.html). 
+* [libmongoc](http://mongoc.org/libmongoc/current/api.html): the MongoDB C driver, which this library wraps. See the installation instructions provided in our [README](https://github.com/mongodb/mongo-swift-driver#first-install-the-mongodb-c-driver) or on the [libmongoc docs](http://mongoc.org/libmongoc/current/installing.html).
 
 ### If you are using (Vim/Neovim)
 * [swift.vim](https://github.com/Utagai/swift.vim): A fork of Keith Smiley's `swift.vim` with fixed indenting rules. This adds proper indenting and syntax for Swift to Vim. This fork also provides a match rule for column width highlighting.

--- a/Development.md
+++ b/Development.md
@@ -15,7 +15,7 @@
 	* Use this to install Swift 4.0 if you don't have it already.
 * [jazzy](https://github.com/realm/jazzy#installation): the tool we use to generate documentation.
 * [swiftlint](https://github.com/realm/SwiftLint#using-homebrew): the Swift linter we use. 
-* [libmongoc](http://mongoc.org/libmongoc/current/api.html): the MongoDB C driver, which this library wraps. See the installation instructions provided in our [README](https://github.com/mongodb/mongo-swift-driver#first-install-the-mongodb-c-driver) or on the [libmongoc docs](http://mongoc.org/libmongoc/current/installing.html).
+* [libmongoc](http://mongoc.org/libmongoc/current/api.html): the MongoDB C driver, which this library wraps. See the installation instructions provided in our [README](https://mongodb.github.io/mongo-swift-driver/#first-install-the-mongodb-c-driver) or on the [libmongoc docs](http://mongoc.org/libmongoc/current/installing.html).
 
 ### If you are using (Vim/Neovim)
 * [swift.vim](https://github.com/Utagai/swift.vim): A fork of Keith Smiley's `swift.vim` with fixed indenting rules. This adds proper indenting and syntax for Swift to Vim. This fork also provides a match rule for column width highlighting.


### PR DESCRIPTION
[SWIFT-246](https://jira.mongodb.org/browse/SWIFT-246)

This is just something small I noticed when I was trying to upgrade to version 1.13.0 for the `mongo-c-driver` for the sake of doing [SWIFT-200](https://jira.mongodb.org/browse/SWIFT-200).

This should fix the link for the `README` to point to the fragment on our GitHub repository's README. I tested this by rendering the Markdown locally on Safari and clicking through the link.

I tried looking to see if we had a `README.md` hosted up on the `https://mongodb.github.io/mongo-swift-driver/` site, but I could not find anything promising, since https://mongodb.github.io/mongo-swift-driver/README.md also gave a 404.

Since this seemed like a pretty quick fix, I decided I'd just put up the PR for it before heading home.