### PR TITLE
SWIFT-200: Use libbson overwrite methods for ObjectId, Timestamp, Datetime 

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -315,7 +315,7 @@ public struct Decimal128: BSONValue, Equatable, Codable {
     /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst
     public init?(ifValid data: String) {
         do {
-            _ = try Decimal128.encode(data)
+            _ = try Decimal128.toLibBSONType(data)
             self.init(data)
         } catch {
             return nil
@@ -324,7 +324,7 @@ public struct Decimal128: BSONValue, Equatable, Codable {
 
     /// Returns the provided string as a `bson_decimal128_t`, or throws an error if initialization fails due an
     /// invalid string.
-    internal static func encode(_ str: String) throws -> bson_decimal128_t {
+    internal static func toLibBSONType(_ str: String) throws -> bson_decimal128_t {
         var value = bson_decimal128_t()
         guard bson_decimal128_from_string(str, &value) else {
             throw MongoError.bsonEncodeError(message: "Invalid Decimal128 string \(str)")
@@ -337,7 +337,7 @@ public struct Decimal128: BSONValue, Equatable, Codable {
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        var value = try Decimal128.encode(self.data)
+        var value = try Decimal128.toLibBSONType(self.data)
         guard bson_append_decimal128(storage.pointer, key, Int32(key.count), &value) else {
             throw bsonEncodeError(value: self, forKey: key)
         }
@@ -565,7 +565,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     }
 
     /// Returns the provided string as a `bson_oid_t`.
-    internal static func encode(_ str: String) -> bson_oid_t {
+    internal static func toLibBSONType(_ str: String) -> bson_oid_t {
         var value = bson_oid_t()
         bson_oid_init_from_string(&value, str)
         return value
@@ -573,7 +573,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         // create a new bson_oid_t with self.oid
-        var oid = ObjectId.encode(self.oid)
+        var oid = ObjectId.toLibBSONType(self.oid)
         // encode the bson_oid_t to the bson_t
         guard bson_append_oid(storage.pointer, key, Int32(key.count), &oid) else {
             throw bsonEncodeError(value: self, forKey: key)

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -559,11 +559,10 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     /// ObjectId.
     /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/objectid.rst
     public init?(ifValid oid: String) {
-        do {
-            _ = try ObjectId.toLibBSONType(oid)
-            self.init(fromString: oid)
-        } catch {
+        if !bson_oid_is_valid(oid, oid.count) {
             return nil
+        } else {
+            self.init(fromString: oid)
         }
     }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -564,10 +564,16 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         }
     }
 
+    /// Returns the provided string as a `bson_oid_t`.
+    internal static func encode(_ str: String) -> bson_oid_t {
+        var value = bson_oid_t()
+        bson_oid_init_from_string(&value, str)
+        return value
+    }
+
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         // create a new bson_oid_t with self.oid
-        var oid = bson_oid_t()
-        bson_oid_init_from_string(&oid, self.oid)
+        var oid = ObjectId.encode(self.oid)
         // encode the bson_oid_t to the bson_t
         guard bson_append_oid(storage.pointer, key, Int32(key.count), &oid) else {
             throw bsonEncodeError(value: self, forKey: key)

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -43,8 +43,8 @@ extension Decimal128: Overwritable {
 }
 
 extension ObjectId: Overwritable {
-    func writeToCurrentPosition(of iter: DocumentIterator) {
-        var encoded = ObjectId.toLibBSONType(self.oid)
+    func writeToCurrentPosition(of iter: DocumentIterator) throws {
+        var encoded = try ObjectId.toLibBSONType(self.oid)
         bson_iter_overwrite_oid(&iter.iter, &encoded)
     }
 }

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -37,14 +37,14 @@ extension Double: Overwritable {
 
 extension Decimal128: Overwritable {
     func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        var encoded = try Decimal128.encode(self.data)
+        var encoded = try Decimal128.toLibBSONType(self.data)
         bson_iter_overwrite_decimal128(&iter.iter, &encoded)
     }
 }
 
 extension ObjectId: Overwritable {
     func writeToCurrentPosition(of iter: DocumentIterator) {
-        var encoded = ObjectId.encode(self.oid)
+        var encoded = ObjectId.toLibBSONType(self.oid)
         bson_iter_overwrite_oid(&iter.iter, &encoded)
     }
 }

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -1,4 +1,5 @@
 import bson
+import Foundation
 
 /// A protocol indicating that a type can be overwritten in-place on a `bson_t`.
 internal protocol Overwritable: BSONValue {
@@ -38,5 +39,24 @@ extension Decimal128: Overwritable {
     func writeToCurrentPosition(of iter: DocumentIterator) throws {
         var encoded = try Decimal128.encode(self.data)
         bson_iter_overwrite_decimal128(&iter.iter, &encoded)
+    }
+}
+
+extension ObjectId: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) {
+        var encoded = ObjectId.encode(self.oid)
+        bson_iter_overwrite_oid(&iter.iter, &encoded)
+    }
+}
+
+extension Timestamp: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) {
+        bson_iter_overwrite_timestamp(&iter.iter, self.timestamp, self.increment)
+    }
+}
+
+extension Date: Overwritable {
+    func writeToCurrentPosition(of iter: DocumentIterator) {
+        bson_iter_overwrite_date_time(&iter.iter, self.msSinceEpoch)
     }
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -526,7 +526,7 @@ final class DocumentTests: XCTestCase {
         var doc1 = Document(fromPointer: DocumentTests.overwritables.data)
         var pointer1 = doc1.data
 
-        ["double", "int32", "int64", "bool", "decimal"].forEach {
+        ["double", "int32", "int64", "bool", "decimal", "oid", "timestamp", "datetime"].forEach {
             doc1[$0] = nil
             // the storage should change every time 
             expect(doc1.data).toNot(equal(pointer1))
@@ -536,14 +536,14 @@ final class DocumentTests: XCTestCase {
         var doc2 = Document(fromPointer: DocumentTests.nonOverwritables.data)
         var pointer2 = doc2.data
 
-        ["string", "doc", "arr", "oid"].forEach {
+        ["string", "doc", "arr"].forEach {
             doc2[$0] = nil
             // the storage should change every time 
             expect(doc2.data).toNot(equal(pointer2))
             pointer2 = doc2.data
         }
 
-        expect(doc2).to(equal(["string": nil, "nil": nil, "doc": nil, "arr": nil, "oid": nil]))
+        expect(doc2).to(equal(["string": nil, "nil": nil, "doc": nil, "arr": nil]))
     }
 
     // Test types where replacing them with an instance of their own type is a no-op

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -354,7 +354,16 @@ final class DocumentTests: XCTestCase {
     }
 
     // exclude Int64 value on 32-bit platforms
-    static let overwritables: Document = ["double": 2.5, "int32": Int32(32), "int64": Int64.max, "bool": false, "decimal": Decimal128("1.2E+10")]
+    static let overwritables: Document = [
+        "double": 2.5,
+        "int32": Int32(32),
+        "int64": Int64.max,
+        "bool": false,
+        "decimal": Decimal128("1.2E+10"),
+        "oid": ObjectId(),
+        "timestamp": Timestamp(timestamp: 1, inc: 2),
+        "datetime": Date(msSinceEpoch: 1000)
+    ]
 
     static let nonOverwritables: Document = ["string": "hello", "nil": nil, "doc": ["x": 1] as Document, "arr": [1, 2] as [Int]]
 
@@ -398,8 +407,27 @@ final class DocumentTests: XCTestCase {
         doc["int64"] = bigInt
         expect(doc.data).to(equal(pointer))
 
+        let newOid = ObjectId()
+        doc["oid"] = newOid
+        expect(doc.data).to(equal(pointer))
+
+        doc["timestamp"] = Timestamp(timestamp: 5, inc: 10)
+        expect(doc.data).to(equal(pointer))
+
+        doc["datetime"] = Date(msSinceEpoch: 2000)
+        expect(doc.data).to(equal(pointer))
+
         // final values
-        expect(doc).to(equal(["double": 3.0, "int32": 20, "int64": bigInt, "bool": true, "decimal": Decimal128("100")]))
+        expect(doc).to(equal([
+            "double": 3.0,
+            "int32": 20,
+            "int64": bigInt,
+            "bool": true,
+            "decimal": Decimal128("100"),
+            "oid": newOid,
+            "timestamp": Timestamp(timestamp: 5, inc: 10),
+            "datetime": Date(msSinceEpoch: 2000)
+        ]))
     }
 
     // test replacing some of the non-Overwritable types with values of their own types

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -398,15 +398,6 @@ final class DocumentTests: XCTestCase {
         doc["int64"] = Int64.min
         expect(doc.data).to(equal(pointer))
 
-        // return early as we will to use an Int requiring > 32 bits after this 
-        if XCTestCase.is32Bit {
-            expect(doc).to(equal(["double": 3.0, "int32": 20, "int64": Int64.min, "bool": true, "decimal": Decimal128("100")]))
-        }
-
-        let bigInt = Int(Int32.max) + 1
-        doc["int64"] = bigInt
-        expect(doc.data).to(equal(pointer))
-
         let newOid = ObjectId()
         doc["oid"] = newOid
         expect(doc.data).to(equal(pointer))
@@ -415,6 +406,24 @@ final class DocumentTests: XCTestCase {
         expect(doc.data).to(equal(pointer))
 
         doc["datetime"] = Date(msSinceEpoch: 2000)
+        expect(doc.data).to(equal(pointer))
+
+        // return early as we will to use an Int requiring > 32 bits after this 
+        if XCTestCase.is32Bit {
+            expect(doc).to(equal([
+                "double": 3.0,
+                "int32": 20,
+                "int64": Int64.min,
+                "bool": true,
+                "decimal": Decimal128("100"),
+                "oid": newOid,
+                "timestamp": Timestamp(timestamp: 5, inc: 10),
+                "datetime": Date(msSinceEpoch: 2000)
+            ]))
+        }
+
+        let bigInt = Int(Int32.max) + 1
+        doc["int64"] = bigInt
         expect(doc.data).to(equal(pointer))
 
         // final values

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -470,13 +470,13 @@ final class DocumentTests: XCTestCase {
     // test replacing both overwritable and nonoverwritable values with values of different types
     func testReplaceValueWithNewType() throws {
         // make a deep copy so we start off with uniquely referenced storage
-        var doc1 = Document(fromPointer: DocumentTests.overwritables.data)
+        var overwritableDoc = Document(fromPointer: DocumentTests.overwritables.data)
 
         // save a reference to original bson_t so we can verify it changes
-        var pointer1 = doc1.data
+        var overwritablePointer = overwritableDoc.data
 
         let newOid = ObjectId()
-        let newPairs1: [(String, BSONValue?)] = [
+        let overwritablePairs: [(String, BSONValue?)] = [
             ("double", Int(10)),
             ("int32", "hi"),
             ("int64", Decimal128("1.0")),
@@ -487,13 +487,13 @@ final class DocumentTests: XCTestCase {
             ("datetime", Timestamp(timestamp: 1, inc: 2))
         ]
 
-        newPairs1.forEach { (k, v) in
-            doc1[k] = v
-            expect(doc1.data).toNot(equal(pointer1))
-            pointer1 = doc1.data
+        overwritablePairs.forEach { (k, v) in
+            overwritableDoc[k] = v
+            expect(overwritableDoc.data).toNot(equal(overwritablePointer))
+            overwritablePointer = overwritableDoc.data
         }
 
-        expect(doc1).to(equal([
+        expect(overwritableDoc).to(equal([
             "double": 10,
             "int32": "hi",
             "int64": Decimal128("1.0"),
@@ -505,45 +505,45 @@ final class DocumentTests: XCTestCase {
         ]))
 
         // make a deep copy so we start off with uniquely referenced storage
-        var doc2 = Document(fromPointer: DocumentTests.nonOverwritables.data)
+        var nonOverwritableDoc = Document(fromPointer: DocumentTests.nonOverwritables.data)
 
         // save a reference to original bson_t so we can verify it changes
-        var pointer2 = doc2.data
+        var nonOverwritablePointer = nonOverwritableDoc.data
 
-        let newPairs2: [(String, BSONValue?)] = [("string", 1), ("nil", "hello"), ("doc", "hi"), ("arr", 5)]
+        let nonOverwritablePairs: [(String, BSONValue?)] = [("string", 1), ("nil", "hello"), ("doc", "hi"), ("arr", 5)]
 
-        newPairs2.forEach { (k, v) in
-            doc2[k] = v
-            expect(doc2.data).toNot(equal(pointer2))
-            pointer2 = doc2.data
+        nonOverwritablePairs.forEach { (k, v) in
+            nonOverwritableDoc[k] = v
+            expect(nonOverwritableDoc.data).toNot(equal(nonOverwritablePointer))
+            nonOverwritablePointer = nonOverwritableDoc.data
         }
 
-        expect(doc2).to(equal(["string": 1, "nil": "hello", "doc": "hi", "arr": 5]))
+        expect(nonOverwritableDoc).to(equal(["string": 1, "nil": "hello", "doc": "hi", "arr": 5]))
     }
 
     // test setting both overwritable and nonoverwritable values to nil
     func testReplaceValueWithNil() throws {
-        var doc1 = Document(fromPointer: DocumentTests.overwritables.data)
-        var pointer1 = doc1.data
+        var overwritableDoc = Document(fromPointer: DocumentTests.overwritables.data)
+        var overwritablePointer = overwritableDoc.data
 
         ["double", "int32", "int64", "bool", "decimal", "oid", "timestamp", "datetime"].forEach {
-            doc1[$0] = nil
+            overwritableDoc[$0] = nil
             // the storage should change every time 
-            expect(doc1.data).toNot(equal(pointer1))
-            pointer1 = doc1.data
+            expect(overwritableDoc.data).toNot(equal(overwritablePointer))
+            overwritablePointer = overwritableDoc.data
         }
 
-        var doc2 = Document(fromPointer: DocumentTests.nonOverwritables.data)
-        var pointer2 = doc2.data
+        var nonOverwritableDoc = Document(fromPointer: DocumentTests.nonOverwritables.data)
+        var nonOverwritablePointer = nonOverwritableDoc.data
 
         ["string", "doc", "arr"].forEach {
-            doc2[$0] = nil
+            nonOverwritableDoc[$0] = nil
             // the storage should change every time 
-            expect(doc2.data).toNot(equal(pointer2))
-            pointer2 = doc2.data
+            expect(nonOverwritableDoc.data).toNot(equal(nonOverwritablePointer))
+            nonOverwritablePointer = nonOverwritableDoc.data
         }
 
-        expect(doc2).to(equal(["string": nil, "nil": nil, "doc": nil, "arr": nil]))
+        expect(nonOverwritableDoc).to(equal(["string": nil, "nil": nil, "doc": nil, "arr": nil]))
     }
 
     // Test types where replacing them with an instance of their own type is a no-op

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -461,7 +461,17 @@ final class DocumentTests: XCTestCase {
         // save a reference to original bson_t so we can verify it changes
         var pointer1 = doc1.data
 
-        let newPairs1: [(String, BSONValue?)] = [("double", Int(10)), ("int32", "hi"), ("int64", Decimal128("1.0")), ("bool", [1, 2, 3]), ("decimal", 100)]
+        let newOid = ObjectId()
+        let newPairs1: [(String, BSONValue?)] = [
+            ("double", Int(10)),
+            ("int32", "hi"),
+            ("int64", Decimal128("1.0")),
+            ("bool", [1, 2, 3]),
+            ("decimal", 100),
+            ("oid", 25.5),
+            ("timestamp", newOid),
+            ("datetime", Timestamp(timestamp: 1, inc: 2))
+        ]
 
         newPairs1.forEach { (k, v) in
             doc1[k] = v
@@ -469,7 +479,16 @@ final class DocumentTests: XCTestCase {
             pointer1 = doc1.data
         }
 
-        expect(doc1).to(equal(["double": 10, "int32": "hi", "int64": Decimal128("1.0"), "bool": [1, 2, 3] as [Int], "decimal": 100]))
+        expect(doc1).to(equal([
+            "double": 10,
+            "int32": "hi",
+            "int64": Decimal128("1.0"),
+            "bool": [1, 2, 3] as [Int],
+            "decimal": 100,
+            "oid": 25.5,
+            "timestamp": newOid,
+            "datetime": Timestamp(timestamp: 1, inc: 2)
+        ]))
 
         // make a deep copy so we start off with uniquely referenced storage
         var doc2 = Document(fromPointer: DocumentTests.nonOverwritables.data)
@@ -477,7 +496,7 @@ final class DocumentTests: XCTestCase {
         // save a reference to original bson_t so we can verify it changes
         var pointer2 = doc2.data
 
-        let newPairs2: [(String, BSONValue?)] = [("string", 1), ("nil", "hello"), ("doc", "hi"), ("arr", 5), ("oid", 25.5)]
+        let newPairs2: [(String, BSONValue?)] = [("string", 1), ("nil", "hello"), ("doc", "hi"), ("arr", 5)]
 
         newPairs2.forEach { (k, v) in
             doc2[k] = v
@@ -485,7 +504,7 @@ final class DocumentTests: XCTestCase {
             pointer2 = doc2.data
         }
 
-        expect(doc2).to(equal(["string": 1, "nil": "hello", "doc": "hi", "arr": 5, "oid": 25.5]))
+        expect(doc2).to(equal(["string": 1, "nil": "hello", "doc": "hi", "arr": 5]))
     }
 
     // test setting both overwritable and nonoverwritable values to nil

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -365,7 +365,12 @@ final class DocumentTests: XCTestCase {
         "datetime": Date(msSinceEpoch: 1000)
     ]
 
-    static let nonOverwritables: Document = ["string": "hello", "nil": nil, "doc": ["x": 1] as Document, "arr": [1, 2] as [Int]]
+    static let nonOverwritables: Document = [
+        "string": "hello",
+        "nil": nil,
+        "doc": ["x": 1] as Document,
+        "arr": [1, 2] as [Int]
+    ]
 
     // test replacing `Overwritable` types with values of their own type
     func testOverwritable() throws {

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -413,18 +413,20 @@ final class DocumentTests: XCTestCase {
         doc["datetime"] = Date(msSinceEpoch: 2000)
         expect(doc.data).to(equal(pointer))
 
+        expect(doc).to(equal([
+            "double": 3.0,
+            "int32": 20,
+            "int64": Int64.min,
+            "bool": true,
+            "decimal": Decimal128("100"),
+            "oid": newOid,
+            "timestamp": Timestamp(timestamp: 5, inc: 10),
+            "datetime": Date(msSinceEpoch: 2000)
+        ]))
+
         // return early as we will to use an Int requiring > 32 bits after this 
         if XCTestCase.is32Bit {
-            expect(doc).to(equal([
-                "double": 3.0,
-                "int32": 20,
-                "int64": Int64.min,
-                "bool": true,
-                "decimal": Decimal128("100"),
-                "oid": newOid,
-                "timestamp": Timestamp(timestamp: 5, inc: 10),
-                "datetime": Date(msSinceEpoch: 2000)
-            ]))
+            return
         }
 
         let bigInt = Int(Int32.max) + 1

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -356,7 +356,7 @@ final class DocumentTests: XCTestCase {
     // exclude Int64 value on 32-bit platforms
     static let overwritables: Document = ["double": 2.5, "int32": Int32(32), "int64": Int64.max, "bool": false, "decimal": Decimal128("1.2E+10")]
 
-    static let nonOverwritables: Document = ["string": "hello", "nil": nil, "doc": ["x": 1] as Document, "arr": [1, 2] as [Int], "oid": ObjectId()]
+    static let nonOverwritables: Document = ["string": "hello", "nil": nil, "doc": ["x": 1] as Document, "arr": [1, 2] as [Int]]
 
     // test replacing `Overwritable` types with values of their own type
     func testOverwritable() throws {
@@ -412,9 +412,8 @@ final class DocumentTests: XCTestCase {
 
         // save these to compare to at the end
         let newDoc: Document = ["y": 1]
-        let oid = ObjectId()
 
-        let newPairs: [(String, BSONValue?)] = [("string", "hi"), ("doc", newDoc), ("arr", [3, 4]), ("oid", oid)]
+        let newPairs: [(String, BSONValue?)] = [("string", "hi"), ("doc", newDoc), ("arr", [3, 4])]
 
         newPairs.forEach { (k, v) in
             doc[k] = v
@@ -423,7 +422,7 @@ final class DocumentTests: XCTestCase {
             pointer = doc.data
         }
 
-        expect(doc).to(equal(["string": "hi", "nil": nil, "doc": newDoc, "arr": [3, 4] as [Int], "oid": oid]))
+        expect(doc).to(equal(["string": "hi", "nil": nil, "doc": newDoc, "arr": [3, 4] as [Int]]))
     }
 
     // test replacing both overwritable and nonoverwritable values with values of different types


### PR DESCRIPTION
[SWIFT-200](https://jira.mongodb.org/browse/SWIFT-200)

This PR has a fairly self-explanatory title. It extends `ObjectId`, `Timestamp` and `Datetime` with overwrite methods so that they can conform to `Overwritable`. Alongside this, it updates the tests in `DocumentTests.swift` to include the new conformances.

This PR also includes some fixes to linter issues in `DocumentTests.swift`, as well as a rename of some variables in the related test cases, which should improve the readability of the test cases.

Is there a way to test this stuff on 32-bit systems? It seems like our Travis configuration does not run on 32-bit systems.