### PR TITLE
SWIFT-199: Add a throwing getValue method

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -272,7 +272,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
     /// Private helper function to check for a value in self.container. Returns the value stored
     /// under `key`, or throws an error if the value is not found.
     private func getValue(forKey key: Key) throws -> BSONValue {
-        guard let entry = try self.container.getValue(forKey: key.stringValue) else {
+        guard let entry = try self.container.getValue(for: key.stringValue) else {
             throw DecodingError.keyNotFound(
                 key,
                 DecodingError.Context(codingPath: self.decoder.codingPath,
@@ -333,7 +333,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
                 DecodingError.Context(codingPath: self.decoder.codingPath,
                                       debugDescription: "Key \(_errorDescription(of: key)) not found."))
         }
-        return try self.container.getValue(forKey: key.stringValue) == nil
+        return try self.container.getValue(for: key.stringValue) == nil
     }
 
     // swiftlint:disable line_length
@@ -384,7 +384,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
     /// Private method to create a superDecoder for the provided key.
     private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
         return try self.decoder.with(pushedKey: key) {
-            let value: BSONValue? = try self.container.getValue(forKey: key.stringValue)
+            let value: BSONValue? = try self.container.getValue(for: key.stringValue)
             return _BSONDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
         }
     }

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -272,7 +272,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
     /// Private helper function to check for a value in self.container. Returns the value stored
     /// under `key`, or throws an error if the value is not found.
     private func getValue(forKey key: Key) throws -> BSONValue {
-        guard let entry = self.container[key.stringValue] else {
+        guard let entry = try self.container.getValue(forKey: key.stringValue) else {
             throw DecodingError.keyNotFound(
                 key,
                 DecodingError.Context(codingPath: self.decoder.codingPath,
@@ -333,7 +333,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
                 DecodingError.Context(codingPath: self.decoder.codingPath,
                                       debugDescription: "Key \(_errorDescription(of: key)) not found."))
         }
-        return self.container[key.stringValue] == nil
+        return try self.container.getValue(forKey: key.stringValue) == nil
     }
 
     // swiftlint:disable line_length
@@ -383,8 +383,8 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
 
     /// Private method to create a superDecoder for the provided key.
     private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
-        return self.decoder.with(pushedKey: key) {
-            let value: BSONValue? = self.container[key.stringValue]
+        return try self.decoder.with(pushedKey: key) {
+            let value: BSONValue? = try self.container.getValue(forKey: key.stringValue)
             return _BSONDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
         }
     }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -107,7 +107,7 @@ extension Array: BSONValue {
         }
         var arr = Document()
         for (i, v) in self.enumerated() {
-            try arr.setValue(forKey: String(i), to: v as? BSONValue)
+            try arr.setValue(for: String(i), to: v as? BSONValue)
         }
         guard bson_append_array(storage.pointer, key, Int32(key.count), arr.data) else {
             throw bsonEncodeError(value: self, forKey: key)

--- a/Sources/MongoSwift/BSON/Document+Codable.swift
+++ b/Sources/MongoSwift/BSON/Document+Codable.swift
@@ -46,10 +46,10 @@ extension Document: Codable {
         for key in container.allKeys {
             let k = key.stringValue
             if try container.decodeNil(forKey: key) {
-                try output.setValue(forKey: k, to: nil)
+                try output.setValue(for: k, to: nil)
             } else {
                 let val = try container.decode(AnyBSONValue.self, forKey: key).value
-                try output.setValue(forKey: k, to: val)
+                try output.setValue(for: k, to: val)
             }
         }
         self = output

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -200,6 +200,11 @@ public class DocumentIterator: IteratorProtocol {
         return bson_iter_next(&self.iter)
     }
 
+    /// Moves the iterator to the specified key. Returns false if the key does not exist. Returns true otherwise.
+    internal func move(to key: String) -> Bool {
+        return bson_iter_find(&self.iter, key.cString(using: .utf8))
+    }
+
     /// Returns the current key. Assumes the iterator is in a valid position.
     internal var currentKey: String {
         return String(cString: bson_iter_key(&self.iter))

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -242,6 +242,17 @@ public class DocumentIterator: IteratorProtocol {
         return values
     }
 
+    internal func safeCurrentValue() throws -> BSONValue? {
+        switch self.currentType {
+        case .symbol:
+            return try Symbol.asString(from: self)
+        case .dbPointer:
+            return try DBPointer.asDocument(from: self)
+        default:
+            return try DocumentIterator.bsonTypeMap[currentType]?.init(from: self)
+        }
+    }
+
     // uses an iterator to copy (key, value) pairs of the provided document from range [startIndex, endIndex) into a new
     // document. starts at the startIndex-th pair and ends at the end of the document or the (endIndex-1)th index,
     // whichever comes first.

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -242,6 +242,8 @@ public class DocumentIterator: IteratorProtocol {
         return values
     }
 
+    /// Returns the current value, equivalently to the `currentValue` property, but in the case of error, will throw
+    /// instead of causing a fatal `preconditionFailure`.
     internal func safeCurrentValue() throws -> BSONValue? {
         switch self.currentType {
         case .symbol:

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -247,7 +247,7 @@ public class DocumentIterator: IteratorProtocol {
         return values
     }
 
-    /// Returns the current value (equivalent to the currentValue property) or throws on error
+    /// Returns the current value (equivalent to the `currentValue` property) or throws on error.
     internal func safeCurrentValue() throws -> BSONValue? {
         switch self.currentType {
         case .symbol:

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -242,8 +242,7 @@ public class DocumentIterator: IteratorProtocol {
         return values
     }
 
-    /// Returns the current value, equivalently to the `currentValue` property, but in the case of error, will throw
-    /// instead of causing a fatal `preconditionFailure`.
+    /// Returns the current value (equivalent to the currentValue property) or throws on error
     internal func safeCurrentValue() throws -> BSONValue? {
         switch self.currentType {
         case .symbol:

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -258,7 +258,6 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         guard let iter = DocumentIterator(forDocument: self, advancedTo: key) else {
             throw MongoError.invalidArgument(message: "Failed to construct an iterator advanced to \(key)")
         }
-
         return try iter.safeCurrentValue()
     }
 
@@ -279,7 +278,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      *
      */
     public func get<T: BSONValue>(_ key: String) throws -> T {
-        guard let value = self[key] as? T else {
+        guard let value = try self.getValue(forKey: key) as? T else {
             throw MongoError.typeError(message: "Could not cast value for key \(key) to type \(T.self)")
         }
         return value

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -256,9 +256,13 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
     /// Retrieves the value associated with forKey as a BSONValue?, which can be nil.
     internal func getValue(forKey key: String) throws -> BSONValue? {
-        guard let iter = DocumentIterator(forDocument: self, advancedTo: key) else {
+        guard let iter = DocumentIterator(forDocument: self) else {
+            throw MongoError.bsonDecodeError(message: "BSON buffer is unexpectedly too small (< 5 bytes)")
+        }
+        guard iter.move(to: key) else {
             return nil
         }
+
         return try iter.safeCurrentValue()
     }
 

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -254,7 +254,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         }
     }
 
-    /// Retrieves the value associated with for as a BSONValue?, which can be nil.
+    /// Retrieves the value associated with for as a `BSONValue?`, which can be nil.
     internal func getValue(for key: String) throws -> BSONValue? {
         guard let iter = DocumentIterator(forDocument: self) else {
             throw MongoError.bsonDecodeError(message: "BSON buffer is unexpectedly too small (< 5 bytes)")

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -254,6 +254,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         }
     }
 
+    /// Retrieves the value associated with forKey as a BSONValue?, which can be nil.
     internal func getValue(forKey key: String) throws -> BSONValue? {
         guard let iter = DocumentIterator(forDocument: self, advancedTo: key) else {
             return nil

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -254,6 +254,14 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         }
     }
 
+    internal func getValue(forKey key: String) throws -> BSONValue? {
+        guard let iter = DocumentIterator(forDocument: self, advancedTo: key) else {
+            throw MongoError.invalidArgument(message: "Failed to construct an iterator advanced to \(key)")
+        }
+
+        return try iter.safeCurrentValue()
+    }
+
     /**
      * Allows retrieving and strongly typing a value at the same time. This means you can avoid
      * having to cast and unwrap values from the `Document` when you know what type they will be.

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -275,7 +275,8 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      *      - key: The key under which the value you are looking up is stored
      *      - `T`: Any type conforming to the `BSONValue` protocol
      *  - Returns: The value stored under key, as type `T`
-     *  - Throws: A `MongoError.typeError` if the value cannot be cast to type `T` or is not in the `Document`
+     *  - Throws: A `MongoError.typeError` if the value cannot be cast to type `T` or is not in the `Document`, or a
+     *            `MongoError.bsonDecodeError` if there is an issue decoding the `BSONValue`.
      *
      */
     public func get<T: BSONValue>(_ key: String) throws -> T {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -81,7 +81,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         self.storage = DocumentStorage()
         for (key, value) in keyValuePairs {
             do {
-                try self.setValue(forKey: key, to: value, checkForKey: false)
+                try self.setValue(for: key, to: value, checkForKey: false)
             } catch {
                 preconditionFailure("Error setting key \(key) to value \(String(describing: value)): \(error)")
             }
@@ -116,7 +116,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         self.storage = DocumentStorage()
         for (i, elt) in elements.enumerated() {
             do {
-                try self.setValue(forKey: String(i), to: elt, checkForKey: false)
+                try self.setValue(for: String(i), to: elt, checkForKey: false)
             } catch {
                 preconditionFailure("Failed to set the value for index \(i) to \(String(describing: elt)): \(error)")
             }
@@ -198,7 +198,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         get { return DocumentIterator(forDocument: self, advancedTo: key)?.currentValue }
         set(newValue) {
             do {
-                try self.setValue(forKey: key, to: newValue)
+                try self.setValue(for: key, to: newValue)
             } catch {
                 preconditionFailure("Failed to set the value for key \(key) to \(newValue ?? "nil"): \(error)")
             }
@@ -207,7 +207,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
     /// Sets key to newValue. if checkForKey=false, the key/value pair will be appended without checking for the key's
     /// presence first.
-    private mutating func setValue(forKey key: String, to newValue: BSONValue?, checkForKey: Bool = true) throws {
+    private mutating func setValue(for key: String, to newValue: BSONValue?, checkForKey: Bool = true) throws {
         // if the key already exists in the `Document`, we need to replace it
         if checkForKey, let existingType = DocumentIterator(forDocument: self, advancedTo: key)?.currentType {
 
@@ -232,9 +232,9 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
                 try self.forEach { pair in
                     if !seen && pair.key == key {
                         seen = true
-                        try newSelf.setValue(forKey: pair.key, to: newValue)
+                        try newSelf.setValue(for: pair.key, to: newValue)
                     } else {
-                        try newSelf.setValue(forKey: pair.key, to: pair.value)
+                        try newSelf.setValue(for: pair.key, to: pair.value)
                     }
                 }
                 self = newSelf
@@ -254,12 +254,12 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         }
     }
 
-    /// Retrieves the value associated with forKey as a BSONValue?, which can be nil.
-    internal func getValue(forKey key: String) throws -> BSONValue? {
+    /// Retrieves the value associated with for as a BSONValue?, which can be nil.
+    internal func getValue(for key: String) throws -> BSONValue? {
         guard let iter = DocumentIterator(forDocument: self) else {
             throw MongoError.bsonDecodeError(message: "BSON buffer is unexpectedly too small (< 5 bytes)")
         }
-        
+
         // TODO: Because documents can hold null as a valid value for a key, this currently means that there is no way
         // to be sure that the return value from this function suggests that the key does not exist or if the key's
         // value is nil. This should be considered for SWIFT-193.
@@ -288,7 +288,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      *
      */
     public func get<T: BSONValue>(_ key: String) throws -> T {
-        guard let value = try self.getValue(forKey: key) as? T else {
+        guard let value = try self.getValue(for: key) as? T else {
             throw MongoError.typeError(message: "Could not cast value for key \(key) to type \(T.self)")
         }
         return value

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -259,6 +259,10 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         guard let iter = DocumentIterator(forDocument: self) else {
             throw MongoError.bsonDecodeError(message: "BSON buffer is unexpectedly too small (< 5 bytes)")
         }
+        
+        // TODO: Because documents can hold null as a valid value for a key, this currently means that there is no way
+        // to be sure that the return value from this function suggests that the key does not exist or if the key's
+        // value is nil. This should be considered for SWIFT-193.
         guard iter.move(to: key) else {
             return nil
         }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -256,7 +256,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
     internal func getValue(forKey key: String) throws -> BSONValue? {
         guard let iter = DocumentIterator(forDocument: self, advancedTo: key) else {
-            throw MongoError.invalidArgument(message: "Failed to construct an iterator advanced to \(key)")
+            return nil
         }
         return try iter.safeCurrentValue()
     }

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -373,18 +373,18 @@ public struct BulkWriteResult {
      *   - insertedIds: Map of inserted IDs
      */
     fileprivate init(reply: Document, insertedIds: [Int: BSONValue?]) throws {
-        self.deletedCount = try reply.getValue(forKey: "nRemoved") as? Int ?? 0
-        self.insertedCount = try reply.getValue(forKey: "nInserted") as? Int ?? 0
+        self.deletedCount = try reply.getValue(for: "nRemoved") as? Int ?? 0
+        self.insertedCount = try reply.getValue(for: "nInserted") as? Int ?? 0
         self.insertedIds = insertedIds
-        self.matchedCount = try reply.getValue(forKey: "nMatched") as? Int ?? 0
-        self.modifiedCount = try reply.getValue(forKey: "nModified") as? Int ?? 0
-        self.upsertedCount = try reply.getValue(forKey: "nUpserted") as? Int ?? 0
+        self.matchedCount = try reply.getValue(for: "nMatched") as? Int ?? 0
+        self.modifiedCount = try reply.getValue(for: "nModified") as? Int ?? 0
+        self.upsertedCount = try reply.getValue(for: "nUpserted") as? Int ?? 0
 
         var upsertedIds = [Int: BSONValue?]()
 
-        if let upserted = try reply.getValue(forKey: "upserted") as? [Document] {
+        if let upserted = try reply.getValue(for: "upserted") as? [Document] {
             for upsert in upserted {
-                guard let index = try upsert.getValue(forKey: "index") as? Int else {
+                guard let index = try upsert.getValue(for: "index") as? Int else {
                     throw MongoError.typeError(message: "Could not cast upserted index to `Int`")
                 }
                 upsertedIds[index] = upsert["_id"]
@@ -393,11 +393,11 @@ public struct BulkWriteResult {
 
         self.upsertedIds = upsertedIds
 
-        if let writeErrors = try reply.getValue(forKey: "writeErrors") as? [Document] {
+        if let writeErrors = try reply.getValue(for: "writeErrors") as? [Document] {
             self.writeErrors = try writeErrors.map { try BSONDecoder().decode(WriteError.self, from: $0) }
         }
 
-        if let writeConcernErrors = try reply.getValue(forKey: "writeConcernErrors") as? [Document],
+        if let writeConcernErrors = try reply.getValue(for: "writeConcernErrors") as? [Document],
             writeConcernErrors.indices.contains(0) {
             self.writeConcernError = try BSONDecoder().decode(WriteConcernError.self, from: writeConcernErrors[0])
         }

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -373,18 +373,18 @@ public struct BulkWriteResult {
      *   - insertedIds: Map of inserted IDs
      */
     fileprivate init(reply: Document, insertedIds: [Int: BSONValue?]) throws {
-        self.deletedCount = reply["nRemoved"] as? Int ?? 0
-        self.insertedCount = reply["nInserted"] as? Int ?? 0
+        self.deletedCount = try reply.getValue(forKey: "nRemoved") as? Int ?? 0
+        self.insertedCount = try reply.getValue(forKey: "nInserted") as? Int ?? 0
         self.insertedIds = insertedIds
-        self.matchedCount = reply["nMatched"] as? Int ?? 0
-        self.modifiedCount = reply["nModified"] as? Int ?? 0
-        self.upsertedCount = reply["nUpserted"] as? Int ?? 0
+        self.matchedCount = try reply.getValue(forKey: "nMatched") as? Int ?? 0
+        self.modifiedCount = try reply.getValue(forKey: "nModified") as? Int ?? 0
+        self.upsertedCount = try reply.getValue(forKey: "nUpserted") as? Int ?? 0
 
         var upsertedIds = [Int: BSONValue?]()
 
-        if let upserted = reply["upserted"] as? [Document] {
+        if let upserted = try reply.getValue(forKey: "upserted") as? [Document] {
             for upsert in upserted {
-                guard let index = upsert["index"] as? Int else {
+                guard let index = try upsert.getValue(forKey: "index") as? Int else {
                     throw MongoError.typeError(message: "Could not cast upserted index to `Int`")
                 }
                 upsertedIds[index] = upsert["_id"]
@@ -393,11 +393,12 @@ public struct BulkWriteResult {
 
         self.upsertedIds = upsertedIds
 
-        if let writeErrors = reply["writeErrors"] as? [Document] {
+        if let writeErrors = try reply.getValue(forKey: "writeErrors") as? [Document] {
             self.writeErrors = try writeErrors.map { try BSONDecoder().decode(WriteError.self, from: $0) }
         }
 
-        if let writeConcernErrors = reply["writeConcernErrors"] as? [Document], writeConcernErrors.indices.contains(0) {
+        if let writeConcernErrors = try reply.getValue(forKey: "writeConcernErrors") as? [Document],
+            writeConcernErrors.indices.contains(0) {
             self.writeConcernError = try BSONDecoder().decode(WriteConcernError.self, from: writeConcernErrors[0])
         }
     }

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -292,8 +292,8 @@ private class FindAndModifyOptions {
 
         // build an "extra" document of fields without their own setters
         var extra = Document()
-        if let filters = arrayFilters { try extra.setValue(forKey: "arrayFilters", to: filters) }
-        if let coll = collation { try extra.setValue(forKey: "collation", to: coll) }
+        if let filters = arrayFilters { try extra.setValue(for: "arrayFilters", to: filters) }
+        if let coll = collation { try extra.setValue(for: "collation", to: coll) }
 
         // note: mongoc_find_and_modify_opts_set_max_time_ms() takes in a
         // uint32_t, but it should be a positive 64-bit integer, so we
@@ -302,12 +302,12 @@ private class FindAndModifyOptions {
             guard maxTime > 0 else {
                 throw MongoError.invalidArgument(message: "maxTimeMS must be positive, but got value \(maxTime)")
             }
-            try extra.setValue(forKey: "maxTimeMS", to: maxTime)
+            try extra.setValue(for: "maxTimeMS", to: maxTime)
         }
 
         if let wc = writeConcern {
             do {
-                try extra.setValue(forKey: "writeConcern", to: try BSONEncoder().encode(wc))
+                try extra.setValue(for: "writeConcern", to: try BSONEncoder().encode(wc))
             } catch {
                 throw MongoError.invalidArgument(message: "Error encoding WriteConcern \(wc): \(error)")
             }

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -90,7 +90,7 @@ extension MongoCollection {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
-        guard let value = reply["value"] as? Document else { return nil }
+        guard let value = try reply.getValue(forKey: "value") as? Document else { return nil }
 
         return try BSONDecoder().decode(CollectionType.self, from: value)
     }

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -90,7 +90,7 @@ extension MongoCollection {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
-        guard let value = try reply.getValue(forKey: "value") as? Document else { return nil }
+        guard let value = try reply.getValue(for: "value") as? Document else { return nil }
 
         return try BSONDecoder().decode(CollectionType.self, from: value)
     }

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -126,7 +126,7 @@ extension MongoCollection {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
-        guard let values = reply["values"] as? [BSONValue?] else {
+        guard let values = try reply.getValue(forKey: "values") as? [BSONValue?] else {
             throw MongoError.commandError(message:
                 "expected server reply \(reply) to contain an array of distinct values")
         }

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -126,7 +126,7 @@ extension MongoCollection {
             throw MongoError.commandError(message: toErrorString(error))
         }
 
-        guard let values = try reply.getValue(forKey: "values") as? [BSONValue?] else {
+        guard let values = try reply.getValue(for: "values") as? [BSONValue?] else {
             throw MongoError.commandError(message:
                 "expected server reply \(reply) to contain an array of distinct values")
         }

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -31,7 +31,7 @@ extension MongoCollection {
             return nil
         }
 
-        return InsertOneResult(insertedId: document["_id"])
+        return InsertOneResult(insertedId: try document.getValue(forKey: "_id"))
     }
 
     /**
@@ -398,14 +398,15 @@ public struct InsertManyResult {
      *   - insertedIds: Map of inserted IDs
      */
     fileprivate init(reply: Document, insertedIds: [Int: BSONValue?]) throws {
-        self.insertedCount = reply["insertedCount"] as? Int ?? 0
+        self.insertedCount = try reply.getValue(forKey: "insertedCount") as? Int ?? 0
         self.insertedIds = insertedIds
 
-        if let writeErrors = reply["writeErrors"] as? [Document] {
+        if let writeErrors = try reply.getValue(forKey: "writeErrors") as? [Document] {
             self.writeErrors = try writeErrors.map { try BSONDecoder().decode(WriteError.self, from: $0) }
         }
 
-        if let writeConcernErrors = reply["writeConcernErrors"] as? [Document], writeConcernErrors.indices.contains(0) {
+        if let writeConcernErrors = try reply.getValue(forKey: "writeConcernErrors") as? [Document],
+            writeConcernErrors.indices.contains(0) {
             self.writeConcernError = try BSONDecoder().decode(WriteConcernError.self, from: writeConcernErrors[0])
         }
     }

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -31,7 +31,7 @@ extension MongoCollection {
             return nil
         }
 
-        return InsertOneResult(insertedId: try document.getValue(forKey: "_id"))
+        return InsertOneResult(insertedId: try document.getValue(for: "_id"))
     }
 
     /**
@@ -398,14 +398,14 @@ public struct InsertManyResult {
      *   - insertedIds: Map of inserted IDs
      */
     fileprivate init(reply: Document, insertedIds: [Int: BSONValue?]) throws {
-        self.insertedCount = try reply.getValue(forKey: "insertedCount") as? Int ?? 0
+        self.insertedCount = try reply.getValue(for: "insertedCount") as? Int ?? 0
         self.insertedIds = insertedIds
 
-        if let writeErrors = try reply.getValue(forKey: "writeErrors") as? [Document] {
+        if let writeErrors = try reply.getValue(for: "writeErrors") as? [Document] {
             self.writeErrors = try writeErrors.map { try BSONDecoder().decode(WriteError.self, from: $0) }
         }
 
-        if let writeConcernErrors = try reply.getValue(forKey: "writeConcernErrors") as? [Document],
+        if let writeConcernErrors = try reply.getValue(for: "writeConcernErrors") as? [Document],
             writeConcernErrors.indices.contains(0) {
             self.writeConcernError = try BSONDecoder().decode(WriteConcernError.self, from: writeConcernErrors[0])
         }


### PR DESCRIPTION
[SWIFT-199](https://jira.mongodb.org/browse/SWIFT-199)

This PR adds a function to `Document` that is the `get` analog of `setValue()`. This function throws instead of triggering a fatal `preconditionFailure()`, which should help reduce the number of fatal errors. This is implemented via the addition of a throwing function equivalent to `currentValue` of `DocumentIterator`. Eventually, this seemed like the optimal choice, since it lets us package the logic of extracting the current value inside the iterator, where such logic should exist, instead of `Document`.

As usual with these kinds of PRs, let me know if I have missed any instances where we should be using `getValue()`, but this should be all. I used a `git grep` regex to find them all.
