### PR TITLE
SWIFT-193: Proof-of-concept for various approaches

### DIFF
--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -531,7 +531,7 @@ private class MutableArray: BSONValue {
 
     /// methods required by the BSONValue protocol that we don't actually need/use. MutableArray
     /// is just a BSONValue to simplify usage alongside true BSONValues within the encoder.
-    required init(from iter: DocumentIterator) {
+    public static func fromIterator(from iter: DocumentIterator) -> BSONValue {
         fatalError("`MutableArray` is not meant to be initialized from a `DocumentIterator`")
     }
     func encode(to encoder: Encoder) throws {
@@ -581,7 +581,7 @@ private class MutableDictionary: BSONValue {
 
     /// methods required by the BSONValue protocol that we don't actually need/use. MutableDictionary
     /// is just a BSONValue to simplify usage alongside true BSONValues within the encoder.
-    required init(from iter: DocumentIterator) {
+    public static func fromIterator(from iter: DocumentIterator) -> BSONValue {
         fatalError("`MutableDictionary` is not meant to be initialized from a `DocumentIterator`")
     }
     func encode(to encoder: Encoder) throws {

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -531,7 +531,7 @@ private class MutableArray: BSONValue {
 
     /// methods required by the BSONValue protocol that we don't actually need/use. MutableArray
     /// is just a BSONValue to simplify usage alongside true BSONValues within the encoder.
-    public static func fromIterator(from iter: DocumentIterator) -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) -> BSONValue {
         fatalError("`MutableArray` is not meant to be initialized from a `DocumentIterator`")
     }
     func encode(to encoder: Encoder) throws {
@@ -581,7 +581,7 @@ private class MutableDictionary: BSONValue {
 
     /// methods required by the BSONValue protocol that we don't actually need/use. MutableDictionary
     /// is just a BSONValue to simplify usage alongside true BSONValues within the encoder.
-    public static func fromIterator(from iter: DocumentIterator) -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) -> BSONValue {
         fatalError("`MutableDictionary` is not meant to be initialized from a `DocumentIterator`")
     }
     func encode(to encoder: Encoder) throws {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -116,6 +116,33 @@ extension Array: BSONValue {
     }
 }
 
+extension NSNull: BSONValue {
+    public var bsonType: BSONType { return .null }
+
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+        let nullType = bson_type_t(BSONType.null.rawValue)
+        guard bson_iter_type(&iter.iter) != nullType else {
+            throw MongoError.bsonDecodeError(message: "expected iterator type null for encoding a NSNull")
+        }
+
+        return NSNull()
+    }
+
+    public func encode(to storage: DocumentStorage, forKey key: String) throws {
+        guard bson_append_null(storage.pointer, key, Int32(key.count)) else {
+            throw bsonEncodeError(value: self, forKey: key)
+        }
+    }
+
+    public static func == (lhs: BSONValue, rhs: NSNull) -> Bool {
+        return lhs.bsonType == .null
+    }
+
+    public static func == (lhs: NSNull, rhs: BSONValue) -> Bool {
+        return rhs.bsonType == .null
+    }
+}
+
 public struct BSONNull: BSONValue, Equatable {
     public var bsonType: BSONType { return .null }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -163,6 +163,10 @@ public struct BSONNull: BSONValue, Equatable {
         }
     }
 
+    public static func == (lhs: BSONNull, rhs: BSONNull) -> Bool {
+        return true
+    }
+
     public static func == (lhs: BSONValue, rhs: BSONNull) -> Bool {
         return lhs.bsonType == .null
     }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -109,6 +109,7 @@ extension Array: BSONValue {
         for (i, v) in self.enumerated() {
             try arr.setValue(for: String(i), to: v as? BSONValue)
         }
+
         guard bson_append_array(storage.pointer, key, Int32(key.count), arr.data) else {
             throw bsonEncodeError(value: self, forKey: key)
         }
@@ -125,8 +126,6 @@ public struct BSONNull: BSONValue, Equatable {
         guard bson_iter_type(&iter.iter) != nullType else {
             throw MongoError.bsonDecodeError(message: "expected iterator type null for encoding a BSONNull")
         }
-
-        self.init()
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
@@ -135,8 +134,12 @@ public struct BSONNull: BSONValue, Equatable {
         }
     }
 
-    public static func == (lhs: BSONNull, rhs: BSONNull) -> Bool {
-        return true
+    public static func == (lhs: BSONValue, rhs: BSONNull) -> Bool {
+        return lhs.bsonType == .null
+    }
+
+    public static func == (lhs: BSONNull, rhs: BSONValue) -> Bool {
+        return rhs == lhs
     }
 }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -115,6 +115,40 @@ extension Array: BSONValue {
     }
 }
 
+public struct BSONNull: BSONValue, Equatable {
+    public var bsonType: BSONType { return .null }
+
+    public init(from iter: DocumentIterator) throws {}
+
+    public func encode(to storage: DocumentStorage, forKey key: String) throws {}
+
+    public static func == (lhs: BSONNull, rhs: BSONNull) -> Bool {
+        return true
+    }
+}
+
+
+public struct BSONMissing: BSONValue, Equatable {
+    public var bsonType: BSONType { return .undefined }
+
+    public init() {}
+    public init(from iter: DocumentIterator) throws {}
+
+    public func encode(to storage: DocumentStorage, forKey key: String) throws {}
+
+    public static func == (lhs: BSONMissing, rhs: BSONMissing) -> Bool {
+        return true
+    }
+
+    public static func == (lhs: BSONValue, rhs: BSONMissing) -> Bool {
+        return lhs.bsonType == .undefined
+    }
+
+    public static func == (lhs: BSONMissing, rhs: BSONValue) -> Bool {
+        return rhs == lhs
+    }
+}
+
 /// A struct to represent the BSON Binary type.
 public struct Binary: BSONValue, Equatable, Codable {
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -139,7 +139,7 @@ extension NSNull: BSONValue {
     }
 
     public static func == (lhs: NSNull, rhs: BSONValue) -> Bool {
-        return rhs.bsonType == .null
+        return rhs == lhs
     }
 }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -68,7 +68,7 @@ public protocol BSONValue {
     * Given a `DocumentIterator` known to have a next value of this type,
     * initializes the value.
     */
-    init(from iter: DocumentIterator) throws
+    static func fromIterator(from iter: DocumentIterator) throws -> BSONValue
 }
 
 /// An extension of `Array` to represent the BSON array type.
@@ -76,7 +76,7 @@ extension Array: BSONValue {
 
     public var bsonType: BSONType { return .array }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         var length: UInt32 = 0
         let array = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
         defer {
@@ -97,7 +97,7 @@ extension Array: BSONValue {
             preconditionFailure("Failed to cast values for document \(arrDoc) to array")
         }
 
-       self = arr
+       return arr
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
@@ -121,11 +121,13 @@ public struct BSONNull: BSONValue, Equatable {
 
     public init() {}
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         let nullType = bson_type_t(BSONType.null.rawValue)
         guard bson_iter_type(&iter.iter) != nullType else {
             throw MongoError.bsonDecodeError(message: "expected iterator type null for encoding a BSONNull")
         }
+
+        return BSONNull()
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
@@ -148,7 +150,7 @@ public struct BSONMissing: BSONValue, Equatable {
     public var bsonType: BSONType { return .undefined }
 
     public init() {}
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         throw MongoError.bsonDecodeError(message: "BSONMissing cannot be initialized from an iterator")
     }
 
@@ -242,7 +244,7 @@ public struct Binary: BSONValue, Equatable, Codable {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         var subtype = bson_subtype_t(rawValue: 0)
         var length: UInt32 = 0
         let dataPointer = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
@@ -257,7 +259,7 @@ public struct Binary: BSONValue, Equatable, Codable {
         }
 
         let dataObj = Data(bytes: data, count: Int(length))
-        try self.init(data: dataObj, subtype: UInt8(subtype.rawValue))
+        return try self.init(data: dataObj, subtype: UInt8(subtype.rawValue))
     }
 
     public static func == (lhs: Binary, rhs: Binary) -> Bool {
@@ -276,8 +278,8 @@ extension Bool: BSONValue {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
-        self.init(bson_iter_bool(&iter.iter))
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+        return self.init(bson_iter_bool(&iter.iter))
     }
 }
 
@@ -302,8 +304,8 @@ extension Date: BSONValue {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
-        self.init(msSinceEpoch: bson_iter_date_time(&iter.iter))
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue  {
+        return self.init(msSinceEpoch: bson_iter_date_time(&iter.iter))
     }
 }
 
@@ -317,7 +319,7 @@ internal struct DBPointer: BSONValue {
         throw MongoError.bsonEncodeError(message: "`DBPointer`s are deprecated; use a DBRef document instead")
     }
 
-    init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         throw MongoError.bsonDecodeError(message:
             "`DBPointer`s are deprecated; use `DBPointer.asDocument` to create a DBRef document instead")
     }
@@ -402,14 +404,14 @@ public struct Decimal128: BSONValue, Equatable, Codable {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         var value = bson_decimal128_t()
         guard bson_iter_decimal128(&iter.iter, &value) else {
             throw MongoError.bsonDecodeError(message: "Failed to retrieve Decimal128 value from iterator")
         }
 
         var str = Data(count: Int(BSON_DECIMAL128_STRING))
-        self.init(str.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Int8>) in
+        return self.init(str.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Int8>) in
             bson_decimal128_to_string(&value, bytes)
             return String(cString: bytes)
         })
@@ -428,8 +430,8 @@ extension Double: BSONValue {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
-        self.init(bson_iter_double(&iter.iter))
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+        return self.init(bson_iter_double(&iter.iter))
     }
 }
 
@@ -453,8 +455,8 @@ extension Int: BSONValue {
         throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
     }
 
-    public init(from iter: DocumentIterator) throws {
-        self.init(Int(bson_iter_int32(&iter.iter)))
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+        return self.init(Int(bson_iter_int32(&iter.iter)))
     }
 }
 
@@ -469,8 +471,8 @@ extension Int32: BSONValue {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
-        self.init(bson_iter_int32(&iter.iter))
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+        return self.init(bson_iter_int32(&iter.iter))
     }
 }
 
@@ -485,8 +487,8 @@ extension Int64: BSONValue {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
-        self.init(bson_iter_int64(&iter.iter))
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+        return self.init(bson_iter_int64(&iter.iter))
     }
 }
 
@@ -520,14 +522,13 @@ public struct CodeWithScope: BSONValue, Equatable, Codable {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
 
         var length: UInt32 = 0
 
         if iter.currentType.rawValue == BSONType.javascript.rawValue {
             let code = String(cString: bson_iter_code(&iter.iter, &length))
-            self.init(code: code)
-            return
+            return self.init(code: code)
         }
 
         var scopeLength: UInt32 = 0
@@ -543,7 +544,7 @@ public struct CodeWithScope: BSONValue, Equatable, Codable {
         }
         let scopeDoc = Document(fromPointer: scopeData)
 
-        self.init(code: code, scope: scopeDoc)
+        return self.init(code: code, scope: scopeDoc)
     }
 
     public static func == (lhs: CodeWithScope, rhs: CodeWithScope) -> Bool {
@@ -567,7 +568,7 @@ public struct MaxKey: BSONValue, Equatable, Codable {
     /// Initializes a new `MaxKey` instance.
     public init() {}
 
-    public init(from iter: DocumentIterator) { self.init() }
+    public static func fromIterator(from iter: DocumentIterator) -> BSONValue { return self.init() }
 
     public static func == (lhs: MaxKey, rhs: MaxKey) -> Bool { return true }
 }
@@ -588,7 +589,7 @@ public struct MinKey: BSONValue, Equatable, Codable {
     /// Initializes a new `MinKey` instance.
     public init() {}
 
-    public init(from iter: DocumentIterator) { self.init() }
+    public static func fromIterator(from iter: DocumentIterator) -> BSONValue { return self.init() }
 
     public static func == (lhs: MinKey, rhs: MinKey) -> Bool { return true }
 }
@@ -654,11 +655,11 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         guard let oid = bson_iter_oid(&iter.iter) else {
             throw MongoError.bsonDecodeError(message: "Failed to retrieve ObjectID value")
         }
-        self.init(fromPointer: oid)
+        return self.init(fromPointer: oid)
     }
 
     public var description: String {
@@ -734,7 +735,7 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         let options = UnsafeMutablePointer<UnsafePointer<Int8>?>.allocate(capacity: 1)
         defer {
             options.deinitialize(count: 1)
@@ -751,7 +752,7 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
         }
         let optionsString = String(cString: stringOptions)
 
-        self.init(pattern: patternString, options: optionsString)
+        return self.init(pattern: patternString, options: optionsString)
     }
 
     /// Creates an `NSRegularExpression` with the pattern and options of this `RegularExpression`.
@@ -784,12 +785,12 @@ extension String: BSONValue {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         var length: UInt32 = 0
         guard let strValue = bson_iter_utf8(&iter.iter, &length) else {
            throw MongoError.bsonDecodeError(message: retrieveErrorMsg(type: "UTF-8", key: iter.currentKey))
         }
-        self.init(cString: strValue)
+        return self.init(cString: strValue)
     }
 }
 
@@ -803,7 +804,7 @@ internal struct Symbol: BSONValue {
         throw MongoError.bsonEncodeError(message: "Symbols are deprecated; use a string instead")
     }
 
-    init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         throw MongoError.bsonDecodeError(message:
             "`Symbol`s are deprecated; use `Symbol.asString` to parse as a string instead")
 
@@ -847,11 +848,11 @@ public struct Timestamp: BSONValue, Equatable, Codable {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         var t: UInt32 = 0
         var i: UInt32 = 0
         bson_iter_timestamp(&iter.iter, &t, &i)
-        self.init(timestamp: t, inc: i)
+        return self.init(timestamp: t, inc: i)
     }
 
     public static func == (lhs: Timestamp, rhs: Timestamp) -> Bool {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -68,7 +68,7 @@ public protocol BSONValue {
     * Given a `DocumentIterator` known to have a next value of this type,
     * initializes the value.
     */
-    static func fromIterator(from iter: DocumentIterator) throws -> BSONValue
+    static func from(iterator iter: DocumentIterator) throws -> BSONValue
 }
 
 /// An extension of `Array` to represent the BSON array type.
@@ -76,7 +76,7 @@ extension Array: BSONValue {
 
     public var bsonType: BSONType { return .array }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         var length: UInt32 = 0
         let array = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
         defer {
@@ -119,7 +119,7 @@ extension Array: BSONValue {
 extension NSNull: BSONValue {
     public var bsonType: BSONType { return .null }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         let nullType = bson_type_t(BSONType.null.rawValue)
         guard bson_iter_type(&iter.iter) != nullType else {
             throw MongoError.bsonDecodeError(message: "expected iterator type null for encoding a NSNull")
@@ -148,7 +148,7 @@ public struct BSONNull: BSONValue, Equatable {
 
     public init() {}
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         let nullType = bson_type_t(BSONType.null.rawValue)
         guard bson_iter_type(&iter.iter) != nullType else {
             throw MongoError.bsonDecodeError(message: "expected iterator type null for encoding a BSONNull")
@@ -177,7 +177,7 @@ public struct BSONMissing: BSONValue, Equatable {
     public var bsonType: BSONType { return .undefined }
 
     public init() {}
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         throw MongoError.bsonDecodeError(message: "BSONMissing cannot be initialized from an iterator")
     }
 
@@ -271,7 +271,7 @@ public struct Binary: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         var subtype = bson_subtype_t(rawValue: 0)
         var length: UInt32 = 0
         let dataPointer = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
@@ -305,7 +305,7 @@ extension Bool: BSONValue {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         return self.init(bson_iter_bool(&iter.iter))
     }
 }
@@ -331,7 +331,7 @@ extension Date: BSONValue {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue  {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue  {
         return self.init(msSinceEpoch: bson_iter_date_time(&iter.iter))
     }
 }
@@ -346,7 +346,7 @@ internal struct DBPointer: BSONValue {
         throw MongoError.bsonEncodeError(message: "`DBPointer`s are deprecated; use a DBRef document instead")
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         throw MongoError.bsonDecodeError(message:
             "`DBPointer`s are deprecated; use `DBPointer.asDocument` to create a DBRef document instead")
     }
@@ -431,7 +431,7 @@ public struct Decimal128: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         var value = bson_decimal128_t()
         guard bson_iter_decimal128(&iter.iter, &value) else {
             throw MongoError.bsonDecodeError(message: "Failed to retrieve Decimal128 value from iterator")
@@ -457,7 +457,7 @@ extension Double: BSONValue {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         return self.init(bson_iter_double(&iter.iter))
     }
 }
@@ -482,7 +482,7 @@ extension Int: BSONValue {
         throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         return self.init(Int(bson_iter_int32(&iter.iter)))
     }
 }
@@ -498,7 +498,7 @@ extension Int32: BSONValue {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         return self.init(bson_iter_int32(&iter.iter))
     }
 }
@@ -514,7 +514,7 @@ extension Int64: BSONValue {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         return self.init(bson_iter_int64(&iter.iter))
     }
 }
@@ -549,7 +549,7 @@ public struct CodeWithScope: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
 
         var length: UInt32 = 0
 
@@ -595,7 +595,7 @@ public struct MaxKey: BSONValue, Equatable, Codable {
     /// Initializes a new `MaxKey` instance.
     public init() {}
 
-    public static func fromIterator(from iter: DocumentIterator) -> BSONValue { return self.init() }
+    public static func from(iterator iter: DocumentIterator) -> BSONValue { return self.init() }
 
     public static func == (lhs: MaxKey, rhs: MaxKey) -> Bool { return true }
 }
@@ -616,7 +616,7 @@ public struct MinKey: BSONValue, Equatable, Codable {
     /// Initializes a new `MinKey` instance.
     public init() {}
 
-    public static func fromIterator(from iter: DocumentIterator) -> BSONValue { return self.init() }
+    public static func from(iterator iter: DocumentIterator) -> BSONValue { return self.init() }
 
     public static func == (lhs: MinKey, rhs: MinKey) -> Bool { return true }
 }
@@ -682,7 +682,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         guard let oid = bson_iter_oid(&iter.iter) else {
             throw MongoError.bsonDecodeError(message: "Failed to retrieve ObjectID value")
         }
@@ -762,7 +762,7 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         let options = UnsafeMutablePointer<UnsafePointer<Int8>?>.allocate(capacity: 1)
         defer {
             options.deinitialize(count: 1)
@@ -812,7 +812,7 @@ extension String: BSONValue {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         var length: UInt32 = 0
         guard let strValue = bson_iter_utf8(&iter.iter, &length) else {
            throw MongoError.bsonDecodeError(message: retrieveErrorMsg(type: "UTF-8", key: iter.currentKey))
@@ -831,7 +831,7 @@ internal struct Symbol: BSONValue {
         throw MongoError.bsonEncodeError(message: "Symbols are deprecated; use a string instead")
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         throw MongoError.bsonDecodeError(message:
             "`Symbol`s are deprecated; use `Symbol.asString` to parse as a string instead")
 
@@ -875,7 +875,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         var t: UInt32 = 0
         var i: UInt32 = 0
         bson_iter_timestamp(&iter.iter, &t, &i)

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -172,7 +172,6 @@ public struct BSONNull: BSONValue, Equatable {
     }
 }
 
-
 public struct BSONMissing: BSONValue, Equatable {
     public var bsonType: BSONType { return .undefined }
 
@@ -331,7 +330,7 @@ extension Date: BSONValue {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue  {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         return self.init(msSinceEpoch: bson_iter_date_time(&iter.iter))
     }
 }

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -219,7 +219,7 @@ public class DocumentIterator: IteratorProtocol {
             case .dbPointer:
                 return try DBPointer.asDocument(from: self)
             default:
-                return try DocumentIterator.bsonTypeMap[currentType]?.fromIterator(from: self)
+                return try DocumentIterator.bsonTypeMap[currentType]?.from(iterator: self)
             }
         } catch {
             preconditionFailure("Error getting current value from iterator: \(error)")
@@ -255,7 +255,7 @@ public class DocumentIterator: IteratorProtocol {
         case .dbPointer:
             return try DBPointer.asDocument(from: self)
         default:
-            return try DocumentIterator.bsonTypeMap[currentType]?.fromIterator(from: self)
+            return try DocumentIterator.bsonTypeMap[currentType]?.from(iterator: self)
         }
     }
 

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -219,7 +219,7 @@ public class DocumentIterator: IteratorProtocol {
             case .dbPointer:
                 return try DBPointer.asDocument(from: self)
             default:
-                return try DocumentIterator.bsonTypeMap[currentType]?.init(from: self)
+                return try DocumentIterator.bsonTypeMap[currentType]?.fromIterator(from: self)
             }
         } catch {
             preconditionFailure("Error getting current value from iterator: \(error)")
@@ -255,7 +255,7 @@ public class DocumentIterator: IteratorProtocol {
         case .dbPointer:
             return try DBPointer.asDocument(from: self)
         default:
-            return try DocumentIterator.bsonTypeMap[currentType]?.init(from: self)
+            return try DocumentIterator.bsonTypeMap[currentType]?.fromIterator(from: self)
         }
     }
 

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -195,7 +195,18 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      *  ```
      */
     public subscript(key: String) -> BSONValue? {
-        get { return DocumentIterator(forDocument: self, advancedTo: key)?.currentValue }
+        get {
+            let iter = DocumentIterator(forDocument: self, advancedTo: key)
+            if iter == nil {
+                debugPrint("Invalid key given probably, so iter is null.")
+                return BSONMissing()
+            }
+            if let iter = iter {
+                return iter.currentValue
+            } else {
+                return nil
+            }
+        }
         set(newValue) {
             do {
                 try self.setValue(for: key, to: newValue)

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -200,22 +200,14 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
             guard let iter = iterOptional else {
                 preconditionFailure("Could not get document iterator for document in subscript")
             }
+
             guard iter.move(to: key) else {
-                return nil
+                return BSONMissing() // BSONMissing/Simultaneous
+                //return nil // BSONNull
             }
 
-//            if iter == nil {
-//                // This logic should be propagated to other parts of the codebase for getting a value, but for PoC
-//                // purposes, this is sufficient.
-//                debugPrint("Invalid key given probably, so iter is null.")
-//                return BSONMissing()
-//            }
-//            if let iter = iter {
-//                return iter.currentValue
-//            } else {
-//                return nil
-//            }
-            return iter.currentValue == nil ? BSONNull() : iter.currentValue
+            return iter.currentValue // BSONMissing
+            //return iter.currentValue == nil ? BSONNull() : iter.currentValue // BSONNull/Simultaneous
         }
         set(newValue) {
             do {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -196,16 +196,26 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      */
     public subscript(key: String) -> BSONValue? {
         get {
-            let iter = DocumentIterator(forDocument: self, advancedTo: key)
-            if iter == nil {
-                debugPrint("Invalid key given probably, so iter is null.")
-                return BSONMissing()
+            let iterOptional = DocumentIterator(forDocument: self)
+            guard let iter = iterOptional else {
+                preconditionFailure("Could not get document iterator for document in subscript")
             }
-            if let iter = iter {
-                return iter.currentValue
-            } else {
+            guard iter.move(to: key) else {
                 return nil
             }
+
+//            if iter == nil {
+//                // This logic should be propagated to other parts of the codebase for getting a value, but for PoC
+//                // purposes, this is sufficient.
+//                debugPrint("Invalid key given probably, so iter is null.")
+//                return BSONMissing()
+//            }
+//            if let iter = iter {
+//                return iter.currentValue
+//            } else {
+//                return nil
+//            }
+            return iter.currentValue == nil ? BSONNull() : iter.currentValue
         }
         set(newValue) {
             do {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -209,8 +209,8 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
             }
 
             //return iter.currentValue // BSONMissing
-            //let nullVal = BSONNull() // BSONNull
-            let nullVal = NSNull() // NSNull
+            let nullVal = BSONNull() // BSONNull
+            //let nullVal = NSNull() // NSNull
             return iter.currentValue == nil ? nullVal : iter.currentValue // BSONNull/NSNull/Simultaneous
         }
         set(newValue) {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -347,7 +347,7 @@ extension Document: BSONValue {
         }
     }
 
-    public init(from iter: DocumentIterator) throws {
+    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
         var length: UInt32 = 0
         let document = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
         defer {
@@ -361,7 +361,7 @@ extension Document: BSONValue {
             throw MongoError.bsonDecodeError(message: "Failed to create a bson_t from document data")
         }
 
-        self.init(fromPointer: docData)
+        return self.init(fromPointer: docData)
     }
 }
 

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -201,13 +201,15 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
                 preconditionFailure("Could not get document iterator for document in subscript")
             }
 
+            // The following added logic for this PoC should be propagated to other areas of the codebase, such as for
+            // getValue(), but for demo purposes, it is sufficient.
             guard iter.move(to: key) else {
                 return BSONMissing() // BSONMissing/Simultaneous
                 //return nil // BSONNull
             }
 
-            return iter.currentValue // BSONMissing
-            //return iter.currentValue == nil ? BSONNull() : iter.currentValue // BSONNull/Simultaneous
+            //return iter.currentValue // BSONMissing
+            return iter.currentValue == nil ? BSONNull() : iter.currentValue // BSONNull/Simultaneous
         }
         set(newValue) {
             do {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -204,12 +204,14 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
             // The following added logic for this PoC should be propagated to other areas of the codebase, such as for
             // getValue(), but for demo purposes, it is sufficient.
             guard iter.move(to: key) else {
-                return BSONMissing() // BSONMissing/Simultaneous
-                //return nil // BSONNull
+                //return BSONMissing() // BSONMissing/Simultaneous
+                return nil // BSONNull/NSNull
             }
 
             //return iter.currentValue // BSONMissing
-            return iter.currentValue == nil ? BSONNull() : iter.currentValue // BSONNull/Simultaneous
+            //let nullVal = BSONNull() // BSONNull
+            let nullVal = NSNull() // NSNull
+            return iter.currentValue == nil ? nullVal : iter.currentValue // BSONNull/NSNull/Simultaneous
         }
         set(newValue) {
             do {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -204,14 +204,14 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
             // The following added logic for this PoC should be propagated to other areas of the codebase, such as for
             // getValue(), but for demo purposes, it is sufficient.
             guard iter.move(to: key) else {
-                //return BSONMissing() // BSONMissing/Simultaneous
-                return nil // BSONNull/NSNull
+                return BSONMissing() // BSONMissing/Simultaneous
+                //return nil // BSONNull/NSNull
             }
 
-            //return iter.currentValue // BSONMissing
-            let nullVal = BSONNull() // BSONNull
+            return iter.currentValue // BSONMissing
+            //let nullVal = BSONNull() // BSONNull
             //let nullVal = NSNull() // NSNull
-            return iter.currentValue == nil ? nullVal : iter.currentValue // BSONNull/NSNull/Simultaneous
+            //return iter.currentValue == nil ? nullVal : iter.currentValue // BSONNull/NSNull/Simultaneous
         }
         set(newValue) {
             do {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -349,7 +349,7 @@ extension Document: BSONValue {
         }
     }
 
-    public static func fromIterator(from iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         var length: UInt32 = 0
         let document = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
         defer {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -208,10 +208,10 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
                 //return nil // BSONNull/NSNull
             }
 
-            return iter.currentValue // BSONMissing
-            //let nullVal = BSONNull() // BSONNull
+            //return iter.currentValue // BSONMissing
+            let nullVal = BSONNull() // BSONNull
             //let nullVal = NSNull() // NSNull
-            //return iter.currentValue == nil ? nullVal : iter.currentValue // BSONNull/NSNull/Simultaneous
+            return iter.currentValue == nil ? nullVal : iter.currentValue // BSONNull/NSNull/Simultaneous
         }
         set(newValue) {
             do {

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -258,8 +258,10 @@ final class BSONValueTests: XCTestCase {
             }
         }
 
-        // Note that one can also combine NSNull with BSONMissing, the semantics are identical, with
+        // NOTE: that one can also combine NSNull with BSONMissing, the semantics are identical, with
         // BSONNull() -> NSNull().
+        // NOTE: This has uses of `if let`, but in fact, we can remove `BSONValue?` (optional) entirely with this
+        // approach.
         print(bsonBoth.header)
         for key in keys {
             let keyVal = bsonBoth.doc[key]

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -217,12 +217,14 @@ final class BSONValueTests: XCTestCase {
 
         print(BSONValueTests.swiftDocHeader)
         for key in keys {
-            let keyVal = swiftDoc[key]
-            if let keyVal = keyVal {
+            let keyVal = doubleOptional[key]
+            if let keyVal = keyVal { // Having double optional makes us lose brevity/clarity here.
                 if keyVal == nil {
                     debugPrint(null)
                 } else {
-                    debugPrint(exists)
+                    if let keyValInner = keyVal {
+                        debugPrint(exists + ": \(keyValInner)")
+                    }
                 }
             } else {
                 debugPrint(dne)

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -102,9 +102,14 @@ final class BSONValueTests: XCTestCase {
         public var header: String
         public var doc: Document
 
-        public init(_ header: String, _ doc: Document) {
+        public init(_ header: String, _ meaning: BSONValue?) {
             self.header = header
-            self.doc = doc
+            self.doc = [
+                BSONValueTests.hello: 42,
+                BSONValueTests.whatIsUp: "nothing much man",
+                BSONValueTests.meaningOfLife: meaning,
+                BSONValueTests.pizza: true
+            ]
         }
     }
 
@@ -128,39 +133,19 @@ final class BSONValueTests: XCTestCase {
         let docTests = [
             DocumentTest(
                 "BSONMissing ========================================",
-                [
-                    BSONValueTests.hello: 42,
-                    BSONValueTests.whatIsUp: "nothing much man",
-                    BSONValueTests.meaningOfLife: nil,
-                    BSONValueTests.pizza: true
-                ]
+                nil
             ),
             DocumentTest(
                 "BSONNull ===========================================",
-                 [
-                    BSONValueTests.hello: 42,
-                    BSONValueTests.whatIsUp: "nothing much man",
-                    BSONValueTests.meaningOfLife: BSONNull(),
-                    BSONValueTests.pizza: true
-                 ]
+                 BSONNull()
             ),
             DocumentTest(
                 "Both BSONNull and BSONMissing ======================",
-                [
-                    BSONValueTests.hello: 42,
-                    BSONValueTests.whatIsUp: "nothing much man",
-                    BSONValueTests.meaningOfLife: BSONNull(),
-                    BSONValueTests.pizza: true
-                ]
+                BSONNull()
             ),
             DocumentTest(
                 "NSNull ======================",
-                [
-                    BSONValueTests.hello: 42,
-                    BSONValueTests.whatIsUp: "nothing much man",
-                    BSONValueTests.meaningOfLife: NSNull(),
-                    BSONValueTests.pizza: true
-                ]
+                NSNull()
             )
         ]
 
@@ -225,7 +210,7 @@ final class BSONValueTests: XCTestCase {
 
     func distinguishingValueKinds(_ swiftDoc: [String: BSONValue?], _ testDocs: [DocumentTest]) {
         let (bsonMissing, bsonNull, bsonBoth, nsNull) = getDocumentTests(testDocs)
-        let keys = ["hello", "i am missing", "what is the meaning of life"]
+        let keys = [BSONValueTests.hello, "i am missing", BSONValueTests.meaningOfLife]
         let (dne, exists, null) = ("Key DNE!", "Key exists!", "Key is null!")
 
         print("\n=== DISTINGUISHING VALUE KINDS ===\n")
@@ -297,7 +282,7 @@ final class BSONValueTests: XCTestCase {
 
     func gettingNilKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: [DocumentTest]) {
         let (bsonMissing, bsonNull, bsonBoth, nsNull) = getDocumentTests(testDocs)
-        let nullKey = "what is the meaning of life"
+        let nullKey = BSONValueTests.meaningOfLife
         let msg = "Got back null val: "
 
         print("\n=== GETTING A NIL VALUE ===\n")

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -99,20 +99,21 @@ final class BSONValueTests: XCTestCase {
     }
 
     func testBSONInterfaces() throws {
-        var swiftDoc: [String: BSONValue?] = [:]
-        swiftDoc["hello"] = 42
-        swiftDoc["what is up"] = "nothing much man"
-        swiftDoc["what is the meaning of life"] = nil as BSONValue?
-        swiftDoc["why is pizza so good"] = true
+        let swiftDoc: [String: BSONValue?] = [
+            "hello": 42,
+            "what is up": "nothing much man",
+            "what is the meaning of life": nil as BSONValue?,
+            "why is pizza so good": true
+        ]
 
-        var bsonMissingDoc: Document = [
+        let bsonMissingDoc: Document = [
             "hello": 42,
             "what is up": "nothing much man",
             "what is the meaning of life": nil,
             "why is pizza so good": true
         ]
 
-        var bsonNullDoc: Document = [
+        let bsonNullDoc: Document = [
             "hello": 42,
             "what is up": "nothing much man",
             "what is the meaning of life": BSONNull(),
@@ -120,7 +121,17 @@ final class BSONValueTests: XCTestCase {
         ]
 
         // use cases
-        // 1. Get existing key's value from document:
+        // 1. Get existing key's value from document and using it:
+        usingExistingKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc)
+
+        // 2. Distinguishing between nil value for key, missing value for key, and existing value for key
+        distinguishingValueKinds(swiftDoc, bsonMissingDoc, bsonNullDoc)
+
+        // 3. Getting the value for a key, where the value is nil
+        gettingNilKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc)
+    }
+
+    func usingExistingKeyValue(_ swiftDoc: [String: BSONValue?], _ bsonMissingDoc: Document, _ bsonNullDoc: Document) {
         let existingBSONMissing = bsonMissingDoc["hello"] as? Int
         debugPrint("Got back existing key value from bsonMissingDoc: \(String(describing: existingBSONMissing))")
         if let existingBSONMissing = existingBSONMissing {
@@ -141,9 +152,11 @@ final class BSONValueTests: XCTestCase {
             let sumDict = existingbsonNull + 10
             debugPrint("sumDoc: \(sumDict)")
         }
+    }
 
-        // 2. Distinguishing between nil value for key, missing value for key, and existing value for key
+    func distinguishingValueKinds(_ swiftDoc: [String: BSONValue?], _ bsonMissingDoc: Document, _ bsonNullDoc: Document) {
         let keys = ["hello", "i am missing", "what is the meaning of life"]
+
         print("BSONMissing =========================")
         for key in keys {
             let keyVal = bsonMissingDoc[key]
@@ -159,7 +172,6 @@ final class BSONValueTests: XCTestCase {
         print("SWIFT (BSONValue?) =====================")
         for key in keys {
             let keyVal = swiftDoc[key]
-            debugPrint("\(key) -> \(String(describing: keyVal))")
             if let keyVal = keyVal {
                 if keyVal == nil {
                     debugPrint("Key is null!")
@@ -174,8 +186,6 @@ final class BSONValueTests: XCTestCase {
         print("BSONNull =====================")
         for key in keys {
             let keyVal = bsonNullDoc[key]
-            debugPrint("\(key) -> \(String(describing: keyVal))")
-            // This doesn't actually work currently since the implementation returns BSONMissing, but this is how it would appear.
             if let keyVal = keyVal, keyVal == BSONNull() {
                 debugPrint("Key is null!")
             } else if keyVal != nil {
@@ -184,14 +194,26 @@ final class BSONValueTests: XCTestCase {
                 debugPrint("Key DNE!")
             }
         }
+    }
 
-        // 3. Getting the value for a key, where the value is nil
-        let nulValDoc = bsonMissingDoc["what is the meaning of life"]
-        debugPrint("Got back null val from doc: \(String(describing: nulValDoc))")
+    func gettingNilKeyValue(_ swiftDoc: [String: BSONValue?], _ bsonMissingDoc: Document, _ bsonNullDoc: Document) {
+        let bsonMissingVal = bsonMissingDoc["what is the meaning of life"]
+        if bsonMissingVal == nil {
+            debugPrint("Got back null val from doc: \(String(describing: bsonMissingVal))")
+        }
 
-        let nulValDict = swiftDoc["what is the meaning of life"]
-        if let nulValDict = nulValDict {
-            debugPrint("Got back null val from dict: \(String(describing: nulValDict))")
+        let swiftVal = swiftDoc["what is the meaning of life"]
+        if let swiftVal = swiftVal {
+            if swiftVal == nil {
+                debugPrint("Got back null val from dict: \(String(describing: swiftVal))")
+            }
+        }
+
+        let bsonNullVal = bsonNullDoc["what is the meaning of life"]
+        if let bsonNullVal = bsonNullVal {
+            if bsonNullVal == BSONNull() {
+                debugPrint("Got back null val from doc: \(String(describing: bsonNullVal))")
+            }
         }
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -98,11 +98,12 @@ final class BSONValueTests: XCTestCase {
         expect(4).toNot(bsonEqual("swift"))
     }
 
-    static var (swiftDocHeader, bsonMissingHeader, bsonNullHeader, bsonBothHeader) = (
+    static var (swiftDocHeader, bsonMissingHeader, bsonNullHeader, bsonBothHeader, nsNullHeader) = (
         "BSONMissing ========================================",
         "SWIFT (BSONValue?) =================================",
         "BSONNull ===========================================",
-        "Both BSONNull and BSONMissing ======================"
+        "Both BSONNull and BSONMissing ======================",
+        "NSNull ======================"
     )
 
     static var (hello, whatIsUp, meaningOfLife, pizza) = (
@@ -141,19 +142,26 @@ final class BSONValueTests: XCTestCase {
             BSONValueTests.pizza: true
         ]
 
+        let nsNullDoc: Document = [
+            BSONValueTests.hello: 42,
+            BSONValueTests.whatIsUp: "nothing much man",
+            BSONValueTests.meaningOfLife: NSNull(),
+            BSONValueTests.pizza: true
+        ]
+
         // use cases
         // 1. Get existing key's value from document and using it:
-        usingExistingKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc)
+        usingExistingKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc)
 
         // 2. Distinguishing between nil value for key, missing value for key, and existing value for key
-        distinguishingValueKinds(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc)
+        distinguishingValueKinds(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc)
 
         // 3. Getting the value for a key, where the value is nil
-        gettingNilKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc)
+        gettingNilKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc)
     }
 
     func usingExistingKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
-        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
+        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc) = getTestingDocuments(testDocs)
         let msg = "Got back existing key value from: "
         let sumDocMsg = "sumDoc: "
 
@@ -190,10 +198,18 @@ final class BSONValueTests: XCTestCase {
             let sumDict = existingBSONBoth + 10
             debugPrint(sumDocMsg + "\(sumDict)")
         }
+
+        print(BSONValueTests.nsNullHeader)
+        let existingNSNull = nsNullDoc["hello"] as? Int
+        debugPrint(msg + "\(String(describing: existingNSNull))")
+        if let existingNSNull = existingNSNull {
+            let sumDict = existingNSNull + 10
+            debugPrint(sumDocMsg + "\(sumDict)")
+        }
     }
 
     func distinguishingValueKinds(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
-        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
+        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc) = getTestingDocuments(testDocs)
         let keys = ["hello", "i am missing", "what is the meaning of life"]
         let (dne, exists, null) = ("Key DNE!", "Key exists!", "Key is null!")
 
@@ -237,6 +253,8 @@ final class BSONValueTests: XCTestCase {
             }
         }
 
+        // Note that one can also combine NSNull with BSONMissing, the semantics are identical, with
+        // BSONNull() -> NSNull().
         print(BSONValueTests.bsonBothHeader)
         for key in keys {
             let keyVal = bsonBothDoc[key]
@@ -248,10 +266,22 @@ final class BSONValueTests: XCTestCase {
                 debugPrint(exists)
             }
         }
+
+        print(BSONValueTests.nsNullHeader)
+        for key in keys {
+            let keyVal = nsNullDoc[key]
+            if let keyVal = keyVal, keyVal == NSNull() {
+                debugPrint(null)
+            } else if keyVal != nil {
+                debugPrint(exists)
+            } else {
+                debugPrint(dne)
+            }
+        }
     }
 
     func gettingNilKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
-        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
+        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc) = getTestingDocuments(testDocs)
         let nullKey = "what is the meaning of life"
         let msg = "Got back null val: "
 
@@ -286,9 +316,17 @@ final class BSONValueTests: XCTestCase {
                 debugPrint(msg + "\(String(describing: bsonBothVal))")
             }
         }
+
+        print(BSONValueTests.nsNullHeader)
+        let nsNullVal = nsNullDoc[nullKey]
+        if let nsNullVal = nsNullVal {
+            if nsNullVal == NSNull() {
+                debugPrint(msg + "\(String(describing: nsNullVal))")
+            }
+        }
     }
 
-    func getTestingDocuments(_ documents: [Document]) -> (Document, Document, Document) {
-        return (documents[0], documents[1], documents[2])
+    func getTestingDocuments(_ documents: [Document]) -> (Document, Document, Document, Document) {
+        return (documents[0], documents[1], documents[2], documents[3])
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -120,18 +120,27 @@ final class BSONValueTests: XCTestCase {
             "why is pizza so good": true
         ]
 
+        let bsonBothDoc: Document = [
+            "hello": 42,
+            "what is up": "nothing much man",
+            "what is the meaning of life": BSONNull(),
+            "why is pizza so good": true
+        ]
+
         // use cases
         // 1. Get existing key's value from document and using it:
-        usingExistingKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc)
+        usingExistingKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc)
 
         // 2. Distinguishing between nil value for key, missing value for key, and existing value for key
-        distinguishingValueKinds(swiftDoc, bsonMissingDoc, bsonNullDoc)
+        distinguishingValueKinds(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc)
 
         // 3. Getting the value for a key, where the value is nil
-        gettingNilKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc)
+        gettingNilKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc)
     }
 
-    func usingExistingKeyValue(_ swiftDoc: [String: BSONValue?], _ bsonMissingDoc: Document, _ bsonNullDoc: Document) {
+    func usingExistingKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
+        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
+
         let existingBSONMissing = bsonMissingDoc["hello"] as? Int
         debugPrint("Got back existing key value from bsonMissingDoc: \(String(describing: existingBSONMissing))")
         if let existingBSONMissing = existingBSONMissing {
@@ -146,15 +155,23 @@ final class BSONValueTests: XCTestCase {
             debugPrint("sumDoc: \(sumDict)")
         }
 
-        let existingbsonNull = bsonNullDoc["hello"] as? Int
-        debugPrint("Got back existing key value from bsonNullDoc: \(String(describing: existingbsonNull))")
-        if let existingbsonNull = existingbsonNull {
-            let sumDict = existingbsonNull + 10
+        let existingBSONNull = bsonNullDoc["hello"] as? Int
+        debugPrint("Got back existing key value from bsonNullDoc: \(String(describing: existingBSONNull))")
+        if let existingBSONNull = existingBSONNull {
+            let sumDict = existingBSONNull + 10
+            debugPrint("sumDoc: \(sumDict)")
+        }
+
+        let existingBSONBoth = bsonBothDoc["hello"] as? Int
+        debugPrint("Got back existing key value from bsonBothDoc: \(String(describing: existingBSONBoth))")
+        if let existingBSONBoth = existingBSONBoth {
+            let sumDict = existingBSONBoth + 10
             debugPrint("sumDoc: \(sumDict)")
         }
     }
 
-    func distinguishingValueKinds(_ swiftDoc: [String: BSONValue?], _ bsonMissingDoc: Document, _ bsonNullDoc: Document) {
+    func distinguishingValueKinds(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
+        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
         let keys = ["hello", "i am missing", "what is the meaning of life"]
 
         print("BSONMissing =========================")
@@ -194,9 +211,24 @@ final class BSONValueTests: XCTestCase {
                 debugPrint("Key DNE!")
             }
         }
+
+        print("Both BSONNull and BSONMissing ==========s===========")
+        for key in keys {
+            let keyVal = bsonBothDoc[key]
+            debugPrint("\(key) -> \(keyVal)")
+            if let keyVal = keyVal, keyVal == BSONNull() {
+                debugPrint("Key is null!")
+            } else if let keyVal = keyVal, keyVal == BSONMissing() {
+                debugPrint("Key DNE!")
+            } else {
+                debugPrint("Key exists!")
+            }
+        }
     }
 
-    func gettingNilKeyValue(_ swiftDoc: [String: BSONValue?], _ bsonMissingDoc: Document, _ bsonNullDoc: Document) {
+    func gettingNilKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
+        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
+
         let bsonMissingVal = bsonMissingDoc["what is the meaning of life"]
         if bsonMissingVal == nil {
             debugPrint("Got back null val from doc: \(String(describing: bsonMissingVal))")
@@ -215,5 +247,16 @@ final class BSONValueTests: XCTestCase {
                 debugPrint("Got back null val from doc: \(String(describing: bsonNullVal))")
             }
         }
+
+        let bsonBothVal = bsonBothDoc["what is the meaning of life"]
+        if let bsonBothVal = bsonBothVal {
+            if bsonBothVal == BSONNull() {
+                debugPrint("Got back null val from doc: \(String(describing: bsonBothVal))")
+            }
+        }
+    }
+
+    func getTestingDocuments(_ documents: [Document]) -> (Document, Document, Document) {
+        return (documents[0], documents[1], documents[2])
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -98,13 +98,17 @@ final class BSONValueTests: XCTestCase {
         expect(4).toNot(bsonEqual("swift"))
     }
 
-    static var (swiftDocHeader, bsonMissingHeader, bsonNullHeader, bsonBothHeader, nsNullHeader) = (
-        "BSONMissing ========================================",
-        "SWIFT (BSONValue?) =================================",
-        "BSONNull ===========================================",
-        "Both BSONNull and BSONMissing ======================",
-        "NSNull ======================"
-    )
+    internal struct DocumentTest {
+        public var header: String
+        public var doc: Document
+
+        public init(_ header: String, _ doc: Document) {
+            self.header = header
+            self.doc = doc
+        }
+    }
+
+    static var swiftDocHeader = "SWIFT (BSONValue?) ================================="
 
     static var (hello, whatIsUp, meaningOfLife, pizza) = (
         "hello",
@@ -121,61 +125,72 @@ final class BSONValueTests: XCTestCase {
             BSONValueTests.pizza: true
         ]
 
-        let bsonMissingDoc: Document = [
-            BSONValueTests.hello: 42,
-            BSONValueTests.whatIsUp: "nothing much man",
-            BSONValueTests.meaningOfLife: nil,
-            BSONValueTests.pizza: true
-        ]
-
-        let bsonNullDoc: Document = [
-            BSONValueTests.hello: 42,
-            BSONValueTests.whatIsUp: "nothing much man",
-            BSONValueTests.meaningOfLife: BSONNull(),
-            BSONValueTests.pizza: true
-        ]
-
-        let bsonBothDoc: Document = [
-            BSONValueTests.hello: 42,
-            BSONValueTests.whatIsUp: "nothing much man",
-            BSONValueTests.meaningOfLife: BSONNull(),
-            BSONValueTests.pizza: true
-        ]
-
-        let nsNullDoc: Document = [
-            BSONValueTests.hello: 42,
-            BSONValueTests.whatIsUp: "nothing much man",
-            BSONValueTests.meaningOfLife: NSNull(),
-            BSONValueTests.pizza: true
+        let docTests = [
+            DocumentTest(
+                "BSONMissing ========================================",
+                [
+                    BSONValueTests.hello: 42,
+                    BSONValueTests.whatIsUp: "nothing much man",
+                    BSONValueTests.meaningOfLife: nil,
+                    BSONValueTests.pizza: true
+                ]
+            ),
+            DocumentTest(
+                "BSONNull ===========================================",
+                 [
+                    BSONValueTests.hello: 42,
+                    BSONValueTests.whatIsUp: "nothing much man",
+                    BSONValueTests.meaningOfLife: BSONNull(),
+                    BSONValueTests.pizza: true
+                 ]
+            ),
+            DocumentTest(
+                "Both BSONNull and BSONMissing ======================",
+                [
+                    BSONValueTests.hello: 42,
+                    BSONValueTests.whatIsUp: "nothing much man",
+                    BSONValueTests.meaningOfLife: BSONNull(),
+                    BSONValueTests.pizza: true
+                ]
+            ),
+            DocumentTest(
+                "NSNull ======================",
+                [
+                    BSONValueTests.hello: 42,
+                    BSONValueTests.whatIsUp: "nothing much man",
+                    BSONValueTests.meaningOfLife: NSNull(),
+                    BSONValueTests.pizza: true
+                ]
+            )
         ]
 
         // use cases
         // 1. Get existing key's value from document and using it:
-        usingExistingKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc)
+        usingExistingKeyValue(swiftDoc, docTests)
 
         // 2. Distinguishing between nil value for key, missing value for key, and existing value for key
-        distinguishingValueKinds(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc)
+        distinguishingValueKinds(swiftDoc, docTests)
 
         // 3. Getting the value for a key, where the value is nil
-        gettingNilKeyValue(swiftDoc, bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc)
+        gettingNilKeyValue(swiftDoc, docTests)
     }
 
-    func usingExistingKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
-        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc) = getTestingDocuments(testDocs)
+    func usingExistingKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: [DocumentTest]) {
+        let (bsonMissing, bsonNull, bsonBoth, nsNull) = getDocumentTests(testDocs)
         let msg = "Got back existing key value from: "
         let sumDocMsg = "sumDoc: "
 
         print("\n=== EXISTING KEY VALUE ===\n")
 
-        print(BSONValueTests.bsonMissingHeader)
-        let existingBSONMissing = bsonMissingDoc["hello"] as? Int
+        print(bsonMissing.header)
+        let existingBSONMissing = bsonMissing.doc["hello"] as? Int
         debugPrint(msg + "\(String(describing: existingBSONMissing))")
         if let existingBSONMissing = existingBSONMissing {
             let sumDoc = existingBSONMissing + 10
             debugPrint(sumDocMsg + "\(sumDoc)")
         }
 
-        print(BSONValueTests.bsonMissingHeader)
+        print(BSONValueTests.swiftDocHeader)
         let existingSwift = swiftDoc["hello"] as? Int
         debugPrint(msg + "\(String(describing: existingSwift))")
         if let existingSwift = existingSwift {
@@ -183,24 +198,24 @@ final class BSONValueTests: XCTestCase {
             debugPrint(sumDocMsg + "\(sumDict)")
         }
 
-        print(BSONValueTests.bsonNullHeader)
-        let existingBSONNull = bsonNullDoc["hello"] as? Int
+        print(bsonNull.header)
+        let existingBSONNull = bsonNull.doc["hello"] as? Int
         debugPrint(msg + "\(String(describing: existingBSONNull))")
         if let existingBSONNull = existingBSONNull {
             let sumDict = existingBSONNull + 10
             debugPrint(sumDocMsg + "\(sumDict)")
         }
 
-        print(BSONValueTests.bsonBothHeader)
-        let existingBSONBoth = bsonBothDoc["hello"] as? Int
+        print(bsonBoth.header)
+        let existingBSONBoth = bsonBoth.doc["hello"] as? Int
         debugPrint(msg + "\(String(describing: existingBSONBoth))")
         if let existingBSONBoth = existingBSONBoth {
             let sumDict = existingBSONBoth + 10
             debugPrint(sumDocMsg + "\(sumDict)")
         }
 
-        print(BSONValueTests.nsNullHeader)
-        let existingNSNull = nsNullDoc["hello"] as? Int
+        print(nsNull.header)
+        let existingNSNull = nsNull.doc["hello"] as? Int
         debugPrint(msg + "\(String(describing: existingNSNull))")
         if let existingNSNull = existingNSNull {
             let sumDict = existingNSNull + 10
@@ -208,16 +223,16 @@ final class BSONValueTests: XCTestCase {
         }
     }
 
-    func distinguishingValueKinds(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
-        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc) = getTestingDocuments(testDocs)
+    func distinguishingValueKinds(_ swiftDoc: [String: BSONValue?], _ testDocs: [DocumentTest]) {
+        let (bsonMissing, bsonNull, bsonBoth, nsNull) = getDocumentTests(testDocs)
         let keys = ["hello", "i am missing", "what is the meaning of life"]
         let (dne, exists, null) = ("Key DNE!", "Key exists!", "Key is null!")
 
         print("\n=== DISTINGUISHING VALUE KINDS ===\n")
 
-        print(BSONValueTests.bsonMissingHeader)
+        print(bsonMissing.header)
         for key in keys {
-            let keyVal = bsonMissingDoc[key]
+            let keyVal = bsonMissing.doc[key]
             if let keyVal = keyVal, keyVal == BSONMissing() {
                 debugPrint(dne)
             } else if keyVal != nil {
@@ -241,9 +256,9 @@ final class BSONValueTests: XCTestCase {
             }
         }
 
-        print(BSONValueTests.bsonNullHeader)
+        print(bsonNull.header)
         for key in keys {
-            let keyVal = bsonNullDoc[key]
+            let keyVal = bsonNull.doc[key]
             if let keyVal = keyVal, keyVal == BSONNull() {
                 debugPrint(null)
             } else if keyVal != nil {
@@ -255,9 +270,9 @@ final class BSONValueTests: XCTestCase {
 
         // Note that one can also combine NSNull with BSONMissing, the semantics are identical, with
         // BSONNull() -> NSNull().
-        print(BSONValueTests.bsonBothHeader)
+        print(bsonBoth.header)
         for key in keys {
-            let keyVal = bsonBothDoc[key]
+            let keyVal = bsonBoth.doc[key]
             if let keyVal = keyVal, keyVal == BSONNull() {
                 debugPrint(null)
             } else if let keyVal = keyVal, keyVal == BSONMissing() {
@@ -267,9 +282,9 @@ final class BSONValueTests: XCTestCase {
             }
         }
 
-        print(BSONValueTests.nsNullHeader)
+        print(nsNull.header)
         for key in keys {
-            let keyVal = nsNullDoc[key]
+            let keyVal = nsNull.doc[key]
             if let keyVal = keyVal, keyVal == NSNull() {
                 debugPrint(null)
             } else if keyVal != nil {
@@ -280,15 +295,15 @@ final class BSONValueTests: XCTestCase {
         }
     }
 
-    func gettingNilKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
-        let (bsonMissingDoc, bsonNullDoc, bsonBothDoc, nsNullDoc) = getTestingDocuments(testDocs)
+    func gettingNilKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: [DocumentTest]) {
+        let (bsonMissing, bsonNull, bsonBoth, nsNull) = getDocumentTests(testDocs)
         let nullKey = "what is the meaning of life"
         let msg = "Got back null val: "
 
         print("\n=== GETTING A NIL VALUE ===\n")
 
-        print(BSONValueTests.bsonMissingHeader)
-        let bsonMissingVal = bsonMissingDoc[nullKey]
+        print(bsonMissing.header)
+        let bsonMissingVal = bsonMissing.doc[nullKey]
         if bsonMissingVal == nil {
             debugPrint(msg + "\(String(describing: bsonMissingVal))")
         }
@@ -301,24 +316,24 @@ final class BSONValueTests: XCTestCase {
             }
         }
 
-        print(BSONValueTests.bsonNullHeader)
-        let bsonNullVal = bsonNullDoc[nullKey]
+        print(bsonNull.header)
+        let bsonNullVal = bsonNull.doc[nullKey]
         if let bsonNullVal = bsonNullVal {
             if bsonNullVal == BSONNull() {
                 debugPrint(msg + "\(String(describing: bsonNullVal))")
             }
         }
 
-        print(BSONValueTests.bsonBothHeader)
-        let bsonBothVal = bsonBothDoc[nullKey]
+        print(bsonBoth.header)
+        let bsonBothVal = bsonBoth.doc[nullKey]
         if let bsonBothVal = bsonBothVal {
             if bsonBothVal == BSONNull() {
                 debugPrint(msg + "\(String(describing: bsonBothVal))")
             }
         }
 
-        print(BSONValueTests.nsNullHeader)
-        let nsNullVal = nsNullDoc[nullKey]
+        print(nsNull.header)
+        let nsNullVal = nsNull.doc[nullKey]
         if let nsNullVal = nsNullVal {
             if nsNullVal == NSNull() {
                 debugPrint(msg + "\(String(describing: nsNullVal))")
@@ -326,7 +341,7 @@ final class BSONValueTests: XCTestCase {
         }
     }
 
-    func getTestingDocuments(_ documents: [Document]) -> (Document, Document, Document, Document) {
-        return (documents[0], documents[1], documents[2], documents[3])
+    func getDocumentTests(_ tests: [DocumentTest]) -> (DocumentTest, DocumentTest, DocumentTest, DocumentTest) {
+        return (tests[0], tests[1], tests[2], tests[3])
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -8,7 +8,8 @@ final class BSONValueTests: XCTestCase {
         return [
             ("testInvalidDecimal128", testInvalidDecimal128),
             ("testUUIDBytes", testUUIDBytes),
-            ("testBSONEquals", testBSONEquals)
+            ("testBSONEquals", testBSONEquals),
+            ("testBSONInterfaces", testBSONInterfaces)
         ]
     }
 
@@ -95,5 +96,74 @@ final class BSONValueTests: XCTestCase {
         expect(bsonEquals([BSONEncoder()], [BSONEncoder(), BSONEncoder()])).to(beFalse())
         // Different types
         expect(4).toNot(bsonEqual("swift"))
+    }
+
+    func testBSONInterfaces() throws {
+        var dict: [String: BSONValue?] = [:]
+        dict["hello"] = 42
+        dict["what is up"] = "nothing much man"
+        dict["what is the meaning of life"] = nil as BSONValue?
+        dict["why is pizza so good"] = true
+
+        var doc: Document = [
+            "hello": 42,
+            "what is up": "nothing much man",
+            "what is the meaning of life": nil,
+            "why is pizza so good": true
+        ]
+
+        // use cases
+        // 1. Get existing key's value from document:
+        let existingKeyValueDoc = doc["hello"] as? Int
+        debugPrint("Got back existing key value from doc: \(existingKeyValueDoc)")
+        if let existingKeyValueDoc = existingKeyValueDoc {
+            let sumDoc = existingKeyValueDoc + 10
+            debugPrint("sumDoc: \(sumDoc)")
+        }
+
+        let existingKeyValueDict = dict["hello"] as? Int
+        debugPrint("Got back existing key value from dict: \(existingKeyValueDict)")
+        if let existingKeyValueDoc = existingKeyValueDoc {
+            let sumDict = existingKeyValueDoc + 10
+            debugPrint("sumDoc: \(sumDict)")
+        }
+
+        // 2. Distinguishing between nil value for key, missing value for key, and existing value for key
+        let keys = ["hello", "i am missing", "what is the meaning of life"]
+        print("DOING FOR DOC=========================")
+        for key in keys {
+            let keyVal = doc[key]
+            if let keyVal = keyVal, keyVal == BSONMissing() {
+                debugPrint("Key DNE!")
+            } else if keyVal != nil {
+                debugPrint("Key exists!")
+            } else {
+                debugPrint("Key is nil!")
+            }
+        }
+
+        print("Doing for DICT=====================")
+        for key in keys {
+            let keyVal = dict[key]
+            if let keyVal = keyVal {
+                if keyVal == nil {
+                    debugPrint("Key is nil!")
+                } else {
+                    debugPrint("Key exists!")
+                }
+            } else {
+                debugPrint("Key DNE!")
+            }
+        }
+
+        // 3. Getting the value for a key, where the value is nil
+
+        let nulValDoc = doc["what is the meaning of life"]
+        debugPrint("Got back null val from doc: \(nulValDoc)")
+
+        let nulValDict = dict["what is the meaning of life"]
+        if let nulValDict = nulValDict {
+            debugPrint("Got back null val from dict: \(nulValDict)")
+        }
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -98,33 +98,47 @@ final class BSONValueTests: XCTestCase {
         expect(4).toNot(bsonEqual("swift"))
     }
 
+    static var (swiftDocHeader, bsonMissingHeader, bsonNullHeader, bsonBothHeader) = (
+        "BSONMissing ========================================",
+        "SWIFT (BSONValue?) =================================",
+        "BSONNull ===========================================",
+        "Both BSONNull and BSONMissing ======================"
+    )
+
+    static var (hello, whatIsUp, meaningOfLife, pizza) = (
+        "hello",
+        "what is up",
+        "what is the meaning of life",
+        "why is pizza so good"
+    )
+
     func testBSONInterfaces() throws {
         let swiftDoc: [String: BSONValue?] = [
-            "hello": 42,
-            "what is up": "nothing much man",
-            "what is the meaning of life": nil as BSONValue?,
-            "why is pizza so good": true
+            BSONValueTests.hello: 42,
+            BSONValueTests.whatIsUp: "nothing much man",
+            BSONValueTests.meaningOfLife: nil as BSONValue?,
+            BSONValueTests.pizza: true
         ]
 
         let bsonMissingDoc: Document = [
-            "hello": 42,
-            "what is up": "nothing much man",
-            "what is the meaning of life": nil,
-            "why is pizza so good": true
+            BSONValueTests.hello: 42,
+            BSONValueTests.whatIsUp: "nothing much man",
+            BSONValueTests.meaningOfLife: nil,
+            BSONValueTests.pizza: true
         ]
 
         let bsonNullDoc: Document = [
-            "hello": 42,
-            "what is up": "nothing much man",
-            "what is the meaning of life": BSONNull(),
-            "why is pizza so good": true
+            BSONValueTests.hello: 42,
+            BSONValueTests.whatIsUp: "nothing much man",
+            BSONValueTests.meaningOfLife: BSONNull(),
+            BSONValueTests.pizza: true
         ]
 
         let bsonBothDoc: Document = [
-            "hello": 42,
-            "what is up": "nothing much man",
-            "what is the meaning of life": BSONNull(),
-            "why is pizza so good": true
+            BSONValueTests.hello: 42,
+            BSONValueTests.whatIsUp: "nothing much man",
+            BSONValueTests.meaningOfLife: BSONNull(),
+            BSONValueTests.pizza: true
         ]
 
         // use cases
@@ -140,118 +154,136 @@ final class BSONValueTests: XCTestCase {
 
     func usingExistingKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
         let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
+        let msg = "Got back existing key value from: "
+        let sumDocMsg = "sumDoc: "
 
+        print("\n=== EXISTING KEY VALUE ===\n")
+
+        print(BSONValueTests.bsonMissingHeader)
         let existingBSONMissing = bsonMissingDoc["hello"] as? Int
-        debugPrint("Got back existing key value from bsonMissingDoc: \(String(describing: existingBSONMissing))")
+        debugPrint(msg + "\(String(describing: existingBSONMissing))")
         if let existingBSONMissing = existingBSONMissing {
             let sumDoc = existingBSONMissing + 10
-            debugPrint("sumDoc: \(sumDoc)")
+            debugPrint(sumDocMsg + "\(sumDoc)")
         }
 
+        print(BSONValueTests.bsonMissingHeader)
         let existingSwift = swiftDoc["hello"] as? Int
-        debugPrint("Got back existing key value from swiftDoc: \(String(describing: existingSwift))")
+        debugPrint(msg + "\(String(describing: existingSwift))")
         if let existingSwift = existingSwift {
             let sumDict = existingSwift + 10
-            debugPrint("sumDoc: \(sumDict)")
+            debugPrint(sumDocMsg + "\(sumDict)")
         }
 
+        print(BSONValueTests.bsonNullHeader)
         let existingBSONNull = bsonNullDoc["hello"] as? Int
-        debugPrint("Got back existing key value from bsonNullDoc: \(String(describing: existingBSONNull))")
+        debugPrint(msg + "\(String(describing: existingBSONNull))")
         if let existingBSONNull = existingBSONNull {
             let sumDict = existingBSONNull + 10
-            debugPrint("sumDoc: \(sumDict)")
+            debugPrint(sumDocMsg + "\(sumDict)")
         }
 
+        print(BSONValueTests.bsonBothHeader)
         let existingBSONBoth = bsonBothDoc["hello"] as? Int
-        debugPrint("Got back existing key value from bsonBothDoc: \(String(describing: existingBSONBoth))")
+        debugPrint(msg + "\(String(describing: existingBSONBoth))")
         if let existingBSONBoth = existingBSONBoth {
             let sumDict = existingBSONBoth + 10
-            debugPrint("sumDoc: \(sumDict)")
+            debugPrint(sumDocMsg + "\(sumDict)")
         }
     }
 
     func distinguishingValueKinds(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
         let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
         let keys = ["hello", "i am missing", "what is the meaning of life"]
+        let (dne, exists, null) = ("Key DNE!", "Key exists!", "Key is null!")
 
-        print("BSONMissing =========================")
+        print("\n=== DISTINGUISHING VALUE KINDS ===\n")
+
+        print(BSONValueTests.bsonMissingHeader)
         for key in keys {
             let keyVal = bsonMissingDoc[key]
             if let keyVal = keyVal, keyVal == BSONMissing() {
-                debugPrint("Key DNE!")
+                debugPrint(dne)
             } else if keyVal != nil {
-                debugPrint("Key exists!")
+                debugPrint(exists)
             } else {
-                debugPrint("Key is null!")
+                debugPrint(null)
             }
         }
 
-        print("SWIFT (BSONValue?) =====================")
+        print(BSONValueTests.swiftDocHeader)
         for key in keys {
             let keyVal = swiftDoc[key]
             if let keyVal = keyVal {
                 if keyVal == nil {
-                    debugPrint("Key is null!")
+                    debugPrint(null)
                 } else {
-                    debugPrint("Key exists!")
+                    debugPrint(exists)
                 }
             } else {
-                debugPrint("Key DNE!")
+                debugPrint(dne)
             }
         }
 
-        print("BSONNull =====================")
+        print(BSONValueTests.bsonNullHeader)
         for key in keys {
             let keyVal = bsonNullDoc[key]
             if let keyVal = keyVal, keyVal == BSONNull() {
-                debugPrint("Key is null!")
+                debugPrint(null)
             } else if keyVal != nil {
-                debugPrint("Key exists!")
+                debugPrint(exists)
             } else {
-                debugPrint("Key DNE!")
+                debugPrint(dne)
             }
         }
 
-        print("Both BSONNull and BSONMissing ==========s===========")
+        print(BSONValueTests.bsonBothHeader)
         for key in keys {
             let keyVal = bsonBothDoc[key]
-            debugPrint("\(key) -> \(keyVal)")
             if let keyVal = keyVal, keyVal == BSONNull() {
-                debugPrint("Key is null!")
+                debugPrint(null)
             } else if let keyVal = keyVal, keyVal == BSONMissing() {
-                debugPrint("Key DNE!")
+                debugPrint(dne)
             } else {
-                debugPrint("Key exists!")
+                debugPrint(exists)
             }
         }
     }
 
     func gettingNilKeyValue(_ swiftDoc: [String: BSONValue?], _ testDocs: Document...) {
         let (bsonMissingDoc, bsonNullDoc, bsonBothDoc) = getTestingDocuments(testDocs)
+        let nullKey = "what is the meaning of life"
+        let msg = "Got back null val: "
 
-        let bsonMissingVal = bsonMissingDoc["what is the meaning of life"]
+        print("\n=== GETTING A NIL VALUE ===\n")
+
+        print(BSONValueTests.bsonMissingHeader)
+        let bsonMissingVal = bsonMissingDoc[nullKey]
         if bsonMissingVal == nil {
-            debugPrint("Got back null val from doc: \(String(describing: bsonMissingVal))")
+            debugPrint(msg + "\(String(describing: bsonMissingVal))")
         }
 
-        let swiftVal = swiftDoc["what is the meaning of life"]
+        print(BSONValueTests.swiftDocHeader)
+        let swiftVal = swiftDoc[nullKey]
         if let swiftVal = swiftVal {
             if swiftVal == nil {
-                debugPrint("Got back null val from dict: \(String(describing: swiftVal))")
+                debugPrint(msg + "\(String(describing: swiftVal))")
             }
         }
 
-        let bsonNullVal = bsonNullDoc["what is the meaning of life"]
+        print(BSONValueTests.bsonNullHeader)
+        let bsonNullVal = bsonNullDoc[nullKey]
         if let bsonNullVal = bsonNullVal {
             if bsonNullVal == BSONNull() {
-                debugPrint("Got back null val from doc: \(String(describing: bsonNullVal))")
+                debugPrint(msg + "\(String(describing: bsonNullVal))")
             }
         }
 
-        let bsonBothVal = bsonBothDoc["what is the meaning of life"]
+        print(BSONValueTests.bsonBothHeader)
+        let bsonBothVal = bsonBothDoc[nullKey]
         if let bsonBothVal = bsonBothVal {
             if bsonBothVal == BSONNull() {
-                debugPrint("Got back null val from doc: \(String(describing: bsonBothVal))")
+                debugPrint(msg + "\(String(describing: bsonBothVal))")
             }
         }
     }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -182,20 +182,20 @@ final class BSONValueTests: XCTestCase {
 
         print("\n=== EXISTING KEY VALUE ===\n")
 
-        print(bsonMissing.header)
-        let existingBSONMissing = bsonMissing.doc["hello"] as? Int
-        debugPrint(msg + "\(String(describing: existingBSONMissing))")
-        if let existingBSONMissing = existingBSONMissing {
-            let sumDoc = existingBSONMissing + 10
-            debugPrint(sumDocMsg + "\(sumDoc)")
-        }
-
         print(BSONValueTests.swiftDocHeader)
         let existingSwift = swiftDoc["hello"] as? Int
         debugPrint(msg + "\(String(describing: existingSwift))")
         if let existingSwift = existingSwift {
             let sumDict = existingSwift + 10
             debugPrint(sumDocMsg + "\(sumDict)")
+        }
+
+        print(bsonMissing.header)
+        let existingBSONMissing = bsonMissing.doc["hello"] as? Int
+        debugPrint(msg + "\(String(describing: existingBSONMissing))")
+        if let existingBSONMissing = existingBSONMissing {
+            let sumDoc = existingBSONMissing + 10
+            debugPrint(sumDocMsg + "\(sumDoc)")
         }
 
         print(bsonNull.header)
@@ -230,18 +230,6 @@ final class BSONValueTests: XCTestCase {
 
         print("\n=== DISTINGUISHING VALUE KINDS ===\n")
 
-        print(bsonMissing.header)
-        for key in keys {
-            let keyVal = bsonMissing.doc[key]
-            if let keyVal = keyVal, keyVal == BSONMissing() {
-                debugPrint(dne)
-            } else if keyVal != nil {
-                debugPrint(exists)
-            } else {
-                debugPrint(null)
-            }
-        }
-
         print(BSONValueTests.swiftDocHeader)
         for key in keys {
             let keyVal = swiftDoc[key]
@@ -253,6 +241,18 @@ final class BSONValueTests: XCTestCase {
                 }
             } else {
                 debugPrint(dne)
+            }
+        }
+
+        print(bsonMissing.header)
+        for key in keys {
+            let keyVal = bsonMissing.doc[key]
+            if let keyVal = keyVal, keyVal == BSONMissing() {
+                debugPrint(dne)
+            } else if keyVal != nil {
+                debugPrint(exists)
+            } else {
+                debugPrint(null)
             }
         }
 
@@ -302,18 +302,18 @@ final class BSONValueTests: XCTestCase {
 
         print("\n=== GETTING A NIL VALUE ===\n")
 
-        print(bsonMissing.header)
-        let bsonMissingVal = bsonMissing.doc[nullKey]
-        if bsonMissingVal == nil {
-            debugPrint(msg + "\(String(describing: bsonMissingVal))")
-        }
-
         print(BSONValueTests.swiftDocHeader)
         let swiftVal = swiftDoc[nullKey]
         if let swiftVal = swiftVal {
             if swiftVal == nil {
                 debugPrint(msg + "\(String(describing: swiftVal))")
             }
+        }
+
+        print(bsonMissing.header)
+        let bsonMissingVal = bsonMissing.doc[nullKey]
+        if bsonMissingVal == nil {
+            debugPrint(msg + "\(String(describing: bsonMissingVal))")
         }
 
         print(bsonNull.header)

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -99,55 +99,70 @@ final class BSONValueTests: XCTestCase {
     }
 
     func testBSONInterfaces() throws {
-        var dict: [String: BSONValue?] = [:]
-        dict["hello"] = 42
-        dict["what is up"] = "nothing much man"
-        dict["what is the meaning of life"] = nil as BSONValue?
-        dict["why is pizza so good"] = true
+        var swiftDoc: [String: BSONValue?] = [:]
+        swiftDoc["hello"] = 42
+        swiftDoc["what is up"] = "nothing much man"
+        swiftDoc["what is the meaning of life"] = nil as BSONValue?
+        swiftDoc["why is pizza so good"] = true
 
-        var doc: Document = [
+        var bsonMissingDoc: Document = [
             "hello": 42,
             "what is up": "nothing much man",
             "what is the meaning of life": nil,
             "why is pizza so good": true
         ]
 
+        var bsonNullDoc: Document = [
+            "hello": 42,
+            "what is up": "nothing much man",
+            "what is the meaning of life": BSONNull(),
+            "why is pizza so good": true
+        ]
+
         // use cases
         // 1. Get existing key's value from document:
-        let existingKeyValueDoc = doc["hello"] as? Int
-        debugPrint("Got back existing key value from doc: \(existingKeyValueDoc)")
-        if let existingKeyValueDoc = existingKeyValueDoc {
-            let sumDoc = existingKeyValueDoc + 10
+        let existingBSONMissing = bsonMissingDoc["hello"] as? Int
+        debugPrint("Got back existing key value from bsonMissingDoc: \(String(describing: existingBSONMissing))")
+        if let existingBSONMissing = existingBSONMissing {
+            let sumDoc = existingBSONMissing + 10
             debugPrint("sumDoc: \(sumDoc)")
         }
 
-        let existingKeyValueDict = dict["hello"] as? Int
-        debugPrint("Got back existing key value from dict: \(existingKeyValueDict)")
-        if let existingKeyValueDoc = existingKeyValueDoc {
-            let sumDict = existingKeyValueDoc + 10
+        let existingSwift = swiftDoc["hello"] as? Int
+        debugPrint("Got back existing key value from swiftDoc: \(String(describing: existingSwift))")
+        if let existingSwift = existingSwift {
+            let sumDict = existingSwift + 10
+            debugPrint("sumDoc: \(sumDict)")
+        }
+
+        let existingbsonNull = bsonNullDoc["hello"] as? Int
+        debugPrint("Got back existing key value from bsonNullDoc: \(String(describing: existingbsonNull))")
+        if let existingbsonNull = existingbsonNull {
+            let sumDict = existingbsonNull + 10
             debugPrint("sumDoc: \(sumDict)")
         }
 
         // 2. Distinguishing between nil value for key, missing value for key, and existing value for key
         let keys = ["hello", "i am missing", "what is the meaning of life"]
-        print("DOING FOR DOC=========================")
+        print("BSONMissing =========================")
         for key in keys {
-            let keyVal = doc[key]
+            let keyVal = bsonMissingDoc[key]
             if let keyVal = keyVal, keyVal == BSONMissing() {
                 debugPrint("Key DNE!")
             } else if keyVal != nil {
                 debugPrint("Key exists!")
             } else {
-                debugPrint("Key is nil!")
+                debugPrint("Key is null!")
             }
         }
 
-        print("Doing for DICT=====================")
+        print("SWIFT (BSONValue?) =====================")
         for key in keys {
-            let keyVal = dict[key]
+            let keyVal = swiftDoc[key]
+            debugPrint("\(key) -> \(String(describing: keyVal))")
             if let keyVal = keyVal {
                 if keyVal == nil {
-                    debugPrint("Key is nil!")
+                    debugPrint("Key is null!")
                 } else {
                     debugPrint("Key exists!")
                 }
@@ -156,14 +171,27 @@ final class BSONValueTests: XCTestCase {
             }
         }
 
+        print("BSONNull =====================")
+        for key in keys {
+            let keyVal = bsonNullDoc[key]
+            debugPrint("\(key) -> \(String(describing: keyVal))")
+            // This doesn't actually work currently since the implementation returns BSONMissing, but this is how it would appear.
+            if let keyVal = keyVal, keyVal == BSONNull() {
+                debugPrint("Key is null!")
+            } else if keyVal != nil {
+                debugPrint("Key exists!")
+            } else {
+                debugPrint("Key DNE!")
+            }
+        }
+
         // 3. Getting the value for a key, where the value is nil
+        let nulValDoc = bsonMissingDoc["what is the meaning of life"]
+        debugPrint("Got back null val from doc: \(String(describing: nulValDoc))")
 
-        let nulValDoc = doc["what is the meaning of life"]
-        debugPrint("Got back null val from doc: \(nulValDoc)")
-
-        let nulValDict = dict["what is the meaning of life"]
+        let nulValDict = swiftDoc["what is the meaning of life"]
         if let nulValDict = nulValDict {
-            debugPrint("Got back null val from dict: \(nulValDict)")
+            debugPrint("Got back null val from dict: \(String(describing: nulValDict))")
         }
     }
 }

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -205,7 +205,6 @@ private class CrudTest {
     /// Given the response to a findAndModify command, verify that it matches the expected
     /// results for this `CrudTest`. Meant for use by findAndModify subclasses, i.e. findOneAndX. 
     func verifyFindAndModifyResult(_ result: Document?) {
-        debugPrint("Got back self.result: \(self.result)")
         if self.result == nil {
             expect(result).to(beNil())
         } else if let res = self.result, res == NSNull() {

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -205,7 +205,10 @@ private class CrudTest {
     /// Given the response to a findAndModify command, verify that it matches the expected
     /// results for this `CrudTest`. Meant for use by findAndModify subclasses, i.e. findOneAndX. 
     func verifyFindAndModifyResult(_ result: Document?) {
+        debugPrint("Got back self.result: \(self.result)")
         if self.result == nil {
+            expect(result).to(beNil())
+        } else if let res = self.result, res == NSNull() {
             expect(result).to(beNil())
         } else {
             expect(result).to(equal(self.result as? Document))

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -130,9 +130,9 @@ final class DocumentTests: XCTestCase {
 
         expect(doc["array1"] as? [Int]).to(equal([1, 2]))
         expect(doc["array2"] as? [String]).to(equal(["string1", "string2"]))
-        //expect(doc["null"] as? BSONNull).to(equal(BSONNull()))
+        expect(doc["null"] as? BSONNull).to(equal(BSONNull()))
         //expect(doc["null"] as? NSNull).to(equal(NSNull()))
-        expect(doc["null"]).to(beNil())
+        //expect(doc["null"]).to(beNil())
 
         let code = doc["code"] as? CodeWithScope
         expect(code?.code).to(equal("console.log('hi');"))
@@ -164,9 +164,9 @@ final class DocumentTests: XCTestCase {
        expect(doc1.keys).to(equal(["0", "1", "2"]))
        expect(doc1["0"] as? String).to(equal("foo"))
        expect(doc1["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       //expect(doc1["2"] as? BSONNull).to(equal(BSONNull()))
+       expect(doc1["2"] as? BSONNull).to(equal(BSONNull()))
        //expect(doc1["2"] as? NSNull).to(equal(NSNull()))
-       expect(doc1["2"]).to(beNil())
+       //expect(doc1["2"]).to(beNil())
 
        let elements: [BSONValue?] = ["foo", MinKey(), nil]
        let doc2 = Document(elements)
@@ -174,9 +174,9 @@ final class DocumentTests: XCTestCase {
        expect(doc2.keys).to(equal(["0", "1", "2"]))
        expect(doc2["0"] as? String).to(equal("foo"))
        expect(doc2["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       //expect(doc2["2"] as? BSONNull).to(equal(BSONNull()))
+       expect(doc2["2"] as? BSONNull).to(equal(BSONNull()))
        //expect(doc2["2"] as? NSNull).to(equal(NSNull()))
-       expect(doc2["2"]).to(beNil())
+       //expect(doc2["2"]).to(beNil())
     }
 
     func testEquatable() {

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -130,9 +130,9 @@ final class DocumentTests: XCTestCase {
 
         expect(doc["array1"] as? [Int]).to(equal([1, 2]))
         expect(doc["array2"] as? [String]).to(equal(["string1", "string2"]))
-        expect(doc["null"] as? BSONNull).to(equal(BSONNull()))
+        //expect(doc["null"] as? BSONNull).to(equal(BSONNull()))
         //expect(doc["null"] as? NSNull).to(equal(NSNull()))
-        //expect(doc["null"]).to(beNil())
+        expect(doc["null"]).to(beNil())
 
         let code = doc["code"] as? CodeWithScope
         expect(code?.code).to(equal("console.log('hi');"))
@@ -164,9 +164,9 @@ final class DocumentTests: XCTestCase {
        expect(doc1.keys).to(equal(["0", "1", "2"]))
        expect(doc1["0"] as? String).to(equal("foo"))
        expect(doc1["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       expect(doc1["2"] as? BSONNull).to(equal(BSONNull()))
+       //expect(doc1["2"] as? BSONNull).to(equal(BSONNull()))
        //expect(doc1["2"] as? NSNull).to(equal(NSNull()))
-       //expect(doc1["2"]).to(beNil())
+       expect(doc1["2"]).to(beNil())
 
        let elements: [BSONValue?] = ["foo", MinKey(), nil]
        let doc2 = Document(elements)
@@ -174,9 +174,9 @@ final class DocumentTests: XCTestCase {
        expect(doc2.keys).to(equal(["0", "1", "2"]))
        expect(doc2["0"] as? String).to(equal("foo"))
        expect(doc2["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       expect(doc2["2"] as? BSONNull).to(equal(BSONNull()))
+       //expect(doc2["2"] as? BSONNull).to(equal(BSONNull()))
        //expect(doc2["2"] as? NSNull).to(equal(NSNull()))
-       //expect(doc2["2"]).to(beNil())
+       expect(doc2["2"]).to(beNil())
     }
 
     func testEquatable() {
@@ -195,7 +195,8 @@ final class DocumentTests: XCTestCase {
         var doc2 = doc1
         doc2["b"] = 2
         XCTAssertEqual(doc2["b"] as? Int, 2)
-        XCTAssertNil(doc1["b"])
+        //XCTAssertNil(doc1["b"])
+        XCTAssertEqual(doc1["b"] as? BSONMissing, BSONMissing())
         XCTAssertNotEqual(doc1, doc2)
     }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -130,7 +130,8 @@ final class DocumentTests: XCTestCase {
 
         expect(doc["array1"] as? [Int]).to(equal([1, 2]))
         expect(doc["array2"] as? [String]).to(equal(["string1", "string2"]))
-        expect(doc["null"]).to(beNil())
+        expect(doc["null"] as? NSNull).to(equal(NSNull()))
+        //expect(doc["null"]).to(beNil())
 
         let code = doc["code"] as? CodeWithScope
         expect(code?.code).to(equal("console.log('hi');"))
@@ -162,7 +163,8 @@ final class DocumentTests: XCTestCase {
        expect(doc1.keys).to(equal(["0", "1", "2"]))
        expect(doc1["0"] as? String).to(equal("foo"))
        expect(doc1["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       expect(doc1["2"]).to(beNil())
+       expect(doc1["2"] as? NSNull).to(equal(NSNull()))
+       //expect(doc1["2"]).to(beNil())
 
        let elements: [BSONValue?] = ["foo", MinKey(), nil]
        let doc2 = Document(elements)
@@ -170,7 +172,8 @@ final class DocumentTests: XCTestCase {
        expect(doc2.keys).to(equal(["0", "1", "2"]))
        expect(doc2["0"] as? String).to(equal("foo"))
        expect(doc2["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       expect(doc2["2"]).to(beNil())
+       expect(doc2["2"] as? NSNull).to(equal(NSNull()))
+       //expect(doc2["2"]).to(beNil())
     }
 
     func testEquatable() {

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -130,7 +130,8 @@ final class DocumentTests: XCTestCase {
 
         expect(doc["array1"] as? [Int]).to(equal([1, 2]))
         expect(doc["array2"] as? [String]).to(equal(["string1", "string2"]))
-        expect(doc["null"] as? NSNull).to(equal(NSNull()))
+        expect(doc["null"] as? BSONNull).to(equal(BSONNull()))
+        //expect(doc["null"] as? NSNull).to(equal(NSNull()))
         //expect(doc["null"]).to(beNil())
 
         let code = doc["code"] as? CodeWithScope
@@ -163,7 +164,8 @@ final class DocumentTests: XCTestCase {
        expect(doc1.keys).to(equal(["0", "1", "2"]))
        expect(doc1["0"] as? String).to(equal("foo"))
        expect(doc1["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       expect(doc1["2"] as? NSNull).to(equal(NSNull()))
+       expect(doc1["2"] as? BSONNull).to(equal(BSONNull()))
+       //expect(doc1["2"] as? NSNull).to(equal(NSNull()))
        //expect(doc1["2"]).to(beNil())
 
        let elements: [BSONValue?] = ["foo", MinKey(), nil]
@@ -172,7 +174,8 @@ final class DocumentTests: XCTestCase {
        expect(doc2.keys).to(equal(["0", "1", "2"]))
        expect(doc2["0"] as? String).to(equal("foo"))
        expect(doc2["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       expect(doc2["2"] as? NSNull).to(equal(NSNull()))
+       expect(doc2["2"] as? BSONNull).to(equal(BSONNull()))
+       //expect(doc2["2"] as? NSNull).to(equal(NSNull()))
        //expect(doc2["2"]).to(beNil())
     }
 

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -488,7 +488,8 @@ final class MongoCollectionTests: XCTestCase {
         let result2 = try self.coll.insertMany([["_id": NSNull()], ["_id": 20]])
         expect(result2).toNot(beNil())
         //expect(result2?.insertedIds[0]!).to(beNil())
-        expect(result2?.insertedIds[0] as? NSNull).to(equal(NSNull()))
+        //expect(result2?.insertedIds[0] as? NSNull).to(equal(NSNull()))
+        expect(result2?.insertedIds[0] as? BSONNull).to(equal(BSONNull()))
         expect(result2?.insertedIds[1] as? Int).to(equal(20))
     }
 }

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -487,9 +487,9 @@ final class MongoCollectionTests: XCTestCase {
 
         let result2 = try self.coll.insertMany([["_id": NSNull()], ["_id": 20]])
         expect(result2).toNot(beNil())
-        //expect(result2?.insertedIds[0]!).to(beNil())
+        expect(result2?.insertedIds[0]!).to(beNil())
         //expect(result2?.insertedIds[0] as? NSNull).to(equal(NSNull()))
-        expect(result2?.insertedIds[0] as? BSONNull).to(equal(BSONNull()))
+        //expect(result2?.insertedIds[0] as? BSONNull).to(equal(BSONNull()))
         expect(result2?.insertedIds[1] as? Int).to(equal(20))
     }
 }

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -485,9 +485,10 @@ final class MongoCollectionTests: XCTestCase {
 
         try self.coll.deleteOne(["_id": nil])
 
-        let result2 = try self.coll.insertMany([["_id": nil], ["_id": 20]])
+        let result2 = try self.coll.insertMany([["_id": NSNull()], ["_id": 20]])
         expect(result2).toNot(beNil())
-        expect(result2?.insertedIds[0]!).to(beNil())
+        //expect(result2?.insertedIds[0]!).to(beNil())
+        expect(result2?.insertedIds[0] as? NSNull).to(equal(NSNull()))
         expect(result2?.insertedIds[1] as? Int).to(equal(20))
     }
 }

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -487,9 +487,9 @@ final class MongoCollectionTests: XCTestCase {
 
         let result2 = try self.coll.insertMany([["_id": NSNull()], ["_id": 20]])
         expect(result2).toNot(beNil())
-        expect(result2?.insertedIds[0]!).to(beNil())
+        //expect(result2?.insertedIds[0]!).to(beNil())
         //expect(result2?.insertedIds[0] as? NSNull).to(equal(NSNull()))
-        //expect(result2?.insertedIds[0] as? BSONNull).to(equal(BSONNull()))
+        expect(result2?.insertedIds[0] as? BSONNull).to(equal(BSONNull()))
         expect(result2?.insertedIds[1] as? Int).to(equal(20))
     }
 }


### PR DESCRIPTION
[SWIFT-193](https://jira.mongodb.org/browse/SWIFT-193)

**_deep breath_**

This PR details nearly 5 (one is a combination of others) approaches for improving BSON usability in the driver. These are sorted in order of least to most promising (1 < 2 < 3 == 4 <? 5):
1. `BSONValue??` - Using a double optional so as to distinguish between `nil` and `Optional(nil)`, where the former suggests a missing value and the latter suggests a true `null` value in the BSON.
2. `BSONMissing` - Using a dedicated object for representing a missing value/non-existent key. This is (somewhat) akin to something like `undefined` for Javascript.
3. `BSONNull` - Similar to `BSONMissing`, but instead of providing a dedicated object for representing a missing value/non-existent key, we provide one for the BSON `null` value.
4. `NSNull` - Analogous to `BSONNull`, but uses the familiar (to Objective-C folks, at least) `NSNull`. This is what [MongoKitten](https://github.com/OpenKitten/MongoKitten) does.
5. `BSONMissing && (BSONNull || NSNull)` - A combination of 2 && (3 || 4) that provides a guarantee of `BSONValue` return from any BSON. In other words, since we would no longer require the use of `nil` as a return from retrieving values from the document, there is no reason to use `BSONValue?` and unwraps.

All of these approaches aim to remove the ambiguity of `nil` in our current BSON usability. This is the immediate improvement, but this improves experience of dealing with `Document` and `BSONValue` and `[BSONValue]` in general.

This PR holds all the approaches mentioned above in a single branch, meaning implementations co-exist, in some sense. Currently, the code is set to use one approach, with other approach-specific logic commented out nearby. However, the semantics/code for how an end-user may use each of the approaches is kept in a test case meant to be a demo area (in `BSONValueTests.swift`). This means however that some of the demo usage code is not actually correct, since the approach-specific logic may be commented out. This is fine, since the test case code is just meant to show how the end-user experience would look like.

Approach 1 is shown via a Swift dictionary holding `BSONValue??` since the semantics should be similar. @kmahar may be able to go further into depth with this, as this was a great suggestion from her.

Approach 5 seems very promising in removing `BSONValue?` hassles, but couldn't be included in part of this PR since it can't co-exist with the other approaches so it includes a question mark in its ranking. I am totally open to making a new PoC branch that branches off this one that tries showcasing the possibility of removing `BSONValue?` via approach 5. Its downside is that we break from using `nil` and Swift dictionary style.

The 'demos' were made with the goal of showing how an end-user would do the following things:
1. Getting an existing key out of the dictionary
2. Checking for key existence
3. Checking to see if the returned value implies a true `nil` or missing.
4. Getting the value of a key for which the value is `null`.

Finally, this is a proof-of-concept branch that _should not be merged_. This exists solely to get the team some visual examples on how the approaches would work, look and feel like. Once we choose an approach, a true `SWIFT-193` branch will be used with the chosen approach and put up as a 'true' PR. This PR will not be merged and therefore, I imagine it needs no reviewers.

With my ramblings, notes and disclaimers out of the way, let me know about your thoughts, use-cases/scenarios I should add, and so on!!! (Sorry for the many words)