### PR TITLE
SWIFT-207: Create base class for functional tests

### DIFF
--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Nimble
 import XCTest
 
-final class BSONValueTests: XCTestCase {
+final class BSONValueTests: MongoSwiftTestCase {
     static var allTests: [(String, (BSONValueTests) -> () throws -> Void)] {
         return [
             ("testInvalidDecimal128", testInvalidDecimal128),

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -2,7 +2,7 @@
 import Nimble
 import XCTest
 
-final class CodecTests: XCTestCase {
+final class CodecTests: MongoSwiftTestCase {
     static var allTests: [(String, (CodecTests) -> () throws -> Void)] {
         return [
             ("testEncodeListDatabasesOptions", testEncodeListDatabasesOptions),

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 let center = NotificationCenter.default
 
-final class CommandMonitoringTests: XCTestCase {
+final class CommandMonitoringTests: MongoSwiftTestCase {
     static var allTests: [(String, (CommandMonitoringTests) -> () throws -> Void)] {
         return [
             ("testCommandMonitoring", testCommandMonitoring),
@@ -21,7 +21,7 @@ final class CommandMonitoringTests: XCTestCase {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         client.enableMonitoring(forEvents: .commandMonitoring)
 
-        let cmPath = XCTestCase.specsPath + "/command-monitoring/tests"
+        let cmPath = MongoSwiftTestCase.specsPath + "/command-monitoring/tests"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: cmPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             // read in the file data and parse into a struct

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -10,7 +10,7 @@ internal extension Document {
     }
 }
 
-final class CrudTests: XCTestCase {
+final class CrudTests: MongoSwiftTestCase {
 
     static var allTests: [(String, (CrudTests) -> () throws -> Void)] {
         return [
@@ -81,13 +81,13 @@ final class CrudTests: XCTestCase {
 
     // Run all the tests at the /read path
     func testReads() throws {
-        let testFilesPath = XCTestCase.specsPath + "/crud/tests/read"
+        let testFilesPath = MongoSwiftTestCase.specsPath + "/crud/tests/read"
         try doTests(forPath: testFilesPath)
     }
 
     // Run all the tests at the /write path
     func testWrites() throws {
-        let testFilesPath = XCTestCase.specsPath + "/crud/tests/write"
+        let testFilesPath = MongoSwiftTestCase.specsPath + "/crud/tests/write"
         try doTests(forPath: testFilesPath)
     }
 }

--- a/Tests/MongoSwiftTests/Document+SequenceTests.swift
+++ b/Tests/MongoSwiftTests/Document+SequenceTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Nimble
 import XCTest
 
-final class Document_SequenceTests: XCTestCase {
+final class Document_SequenceTests: MongoSwiftTestCase {
     static var allTests: [(String, (Document_SequenceTests) -> () throws -> Void)] {
         return [
             ("testIterator", testIterator),

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -27,7 +27,7 @@ extension Data {
     }
 }
 
-final class DocumentTests: XCTestCase {
+final class DocumentTests: MongoSwiftTestCase {
     static var allTests: [(String, (DocumentTests) -> () throws -> Void)] {
         return [
             ("testDocument", testDocument),
@@ -199,7 +199,7 @@ final class DocumentTests: XCTestCase {
     }
 
     func testIntEncodesAsInt32OrInt64() {
-        if XCTestCase.is32Bit { return }
+        if MongoSwiftTestCase.is32Bit { return }
 
         let int32min_sub1 = Int64(Int32.min) - Int64(1)
         let int32max_add1 = Int64(Int32.max) + Int64(1)
@@ -233,7 +233,7 @@ final class DocumentTests: XCTestCase {
             "Double type": ["1.23456789012345677E+18", "-1.23456789012345677E+18"]
         ]
 
-        let testFilesPath = XCTestCase.specsPath + "/bson-corpus/tests"
+        let testFilesPath = MongoSwiftTestCase.specsPath + "/bson-corpus/tests"
         var testFiles = try FileManager.default.contentsOfDirectory(atPath: testFilesPath)
         testFiles = testFiles.filter { $0.hasSuffix(".json") }
 
@@ -430,7 +430,7 @@ final class DocumentTests: XCTestCase {
         ]))
 
         // return early as we will to use an Int requiring > 32 bits after this 
-        if XCTestCase.is32Bit {
+        if MongoSwiftTestCase.is32Bit {
             return
         }
 

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -3,7 +3,7 @@ import mongoc
 import Nimble
 import XCTest
 
-final class MongoClientTests: XCTestCase {
+final class MongoClientTests: MongoSwiftTestCase {
     static var allTests: [(String, (MongoClientTests) -> () throws -> Void)] {
         return [
             ("testListDatabases", testListDatabases),
@@ -19,7 +19,7 @@ final class MongoClientTests: XCTestCase {
     }
 
     func testOpaqueInitialization() throws {
-        let connectionString = XCTestCase.connStr
+        let connectionString = MongoSwiftTestCase.connStr
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
             throw MongoError.invalidUri(message: toErrorString(error))

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -2,7 +2,7 @@
 import Nimble
 import XCTest
 
-final class MongoCollection_BulkWriteTests: XCTestCase {
+final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
     static var allTests: [(String, (MongoCollection_BulkWriteTests) -> () throws -> Void)] {
         return [
             ("testEmptyRequests", testEmptyRequests),

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 var _client: MongoClient?
 
-final class MongoCollectionTests: XCTestCase {
+final class MongoCollectionTests: MongoSwiftTestCase {
     static var allTests: [(String, (MongoCollectionTests) -> () throws -> Void)] {
         return [
             ("testCount", testCount),

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -2,7 +2,7 @@
 import Nimble
 import XCTest
 
-final class MongoDatabaseTests: XCTestCase {
+final class MongoDatabaseTests: MongoSwiftTestCase {
     static var allTests: [(String, (MongoDatabaseTests) -> () throws -> Void)] {
         return [
             ("testDatabase", testDatabase)
@@ -14,7 +14,7 @@ final class MongoDatabaseTests: XCTestCase {
     }
 
     func testDatabase() throws {
-        let client = try MongoClient(connectionString: XCTestCase.connStr)
+        let client = try MongoClient(connectionString: MongoSwiftTestCase.connStr)
         let db = try client.db("testDB")
 
         let command: Document = ["create": "coll1"]

--- a/Tests/MongoSwiftTests/ReadPreferenceTests.swift
+++ b/Tests/MongoSwiftTests/ReadPreferenceTests.swift
@@ -2,7 +2,7 @@
 import Nimble
 import XCTest
 
-final class ReadPreferenceTests: XCTestCase {
+final class ReadPreferenceTests: MongoSwiftTestCase {
     static var allTests: [(String, (ReadPreferenceTests) -> () throws -> Void)] {
         return [
             ("testMode", testMode),

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -25,7 +25,7 @@ extension WriteConcern {
     }
 }
 
-final class ReadWriteConcernTests: XCTestCase {
+final class ReadWriteConcernTests: MongoSwiftTestCase {
     static var allTests: [(String, (ReadWriteConcernTests) -> () throws -> Void)] {
         return [
             ("testReadConcernType", testReadConcernType),
@@ -350,7 +350,7 @@ final class ReadWriteConcernTests: XCTestCase {
     }
 
     func testConnectionStrings() throws {
-        let csPath = "\(XCTestCase.specsPath)/read-write-concern/tests/connection-string"
+        let csPath = "\(MongoSwiftTestCase.specsPath)/read-write-concern/tests/connection-string"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: csPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             let testFilePath = URL(fileURLWithPath: "\(csPath)/\(filename)")
@@ -388,7 +388,7 @@ final class ReadWriteConcernTests: XCTestCase {
 
     func testDocuments() throws {
         let encoder = BSONEncoder()
-        let docsPath = "\(XCTestCase.specsPath)/read-write-concern/tests/document"
+        let docsPath = "\(MongoSwiftTestCase.specsPath)/read-write-concern/tests/document"
         let testFiles = try FileManager.default.contentsOfDirectory(atPath: docsPath).filter { $0.hasSuffix(".json") }
         for filename in testFiles {
             let testFilePath = URL(fileURLWithPath: "\(docsPath)/\(filename)")

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -4,7 +4,7 @@ import mongoc
 import Nimble
 import XCTest
 
-final class SDAMTests: XCTestCase {
+final class SDAMTests: MongoSwiftTestCase {
     static var allTests: [(String, (SDAMTests) -> () throws -> Void)] {
         return [
             ("testMonitoring", testMonitoring)
@@ -60,7 +60,7 @@ final class SDAMTests: XCTestCase {
         center.removeObserver(observer)
 
         var error = bson_error_t()
-        guard let uri = mongoc_uri_new_with_error(XCTestCase.connStr, &error) else {
+        guard let uri = mongoc_uri_new_with_error(MongoSwiftTestCase.connStr, &error) else {
             XCTFail(toErrorString(error))
             return
         }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -3,8 +3,7 @@ import MongoSwift
 import Nimble
 import XCTest
 
-// TODO: Move contents of this extension to the base test class in SWIFT-207.
-extension XCTestCase {
+class MongoSwiftTestCase: XCTestCase {
     /// Gets the path of the directory containing spec files, depending on whether
     /// we're running from XCode or the command line
     static var specsPath: String {
@@ -129,7 +128,7 @@ extension MongoClient {
     }
 
     internal convenience init(options: ClientOptions? = nil) throws {
-        try self.init(connectionString: XCTestCase.connStr, options: options)
+        try self.init(connectionString: MongoSwiftTestCase.connStr, options: options)
     }
 }
 


### PR DESCRIPTION
[SWIFT-207](https://jira.mongodb.org/browse/SWIFT-207)

This PR adds a test base class (`MongoSwiftTestCase`) meant to replace our extension to `XCTestCase`. It also introduces changes to migrate the existing test case to use the new base class.

It does not add any new functionality to the new base class.