### PR TITLE
SWIFT-192: Make Document conform to Collection protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,30 @@ print(doc["a"] ?? "") // prints `1`
 // Set a new value
 doc["d"] = 4
 print(doc) // prints `{"a" : 1, "b" : 2, "c" : 3, "d" : 4}`
+
+// Using functional methods like map, filter:
+let evensDoc = doc.filter { elem in
+    guard let value = elem.value as? Int else {
+        return false
+    }
+    return value % 2 == 0
+}
+print(evensDoc) // prints `{ "b" : 2, "d" : 4 }`
+
+let doubled = doc.map { elem -> Int in
+    guard let value = elem.value as? Int else {
+        return 0
+    }
+
+    return value * 2
+}
+print(doubled) // prints `[2, 4, 6, 8]`
 ```
+Note that `Document` conforms to `Collection`, so useful methods from
+[`Sequence`](https://developer.apple.com/documentation/swift/sequence) and
+[`Collection`](https://developer.apple.com/documentation/swift/collection) are
+all available.
+
 ## Development Instructions
 
 See our [development guide](https://mongodb.github.io/mongo-swift-driver/development.html) for instructions for building and testing the driver.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ print(doubled) // prints `[2, 4, 6, 8]`
 Note that `Document` conforms to `Collection`, so useful methods from
 [`Sequence`](https://developer.apple.com/documentation/swift/sequence) and
 [`Collection`](https://developer.apple.com/documentation/swift/collection) are
-all available.
+all available. However, runtime guarantees are not yet met for many of these
+methods.
 
 ## Development Instructions
 

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -17,7 +17,7 @@ extension Document: Collection {
     /// Returns the end index of the Document.
     public var endIndex: Int {
         precondition(self.count > 0)
-        return self.count
+        return self.countFast
     }
 
     private func validIndex(_ i: Int) -> Bool {

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -6,7 +6,6 @@ import Foundation
 extension Document: Collection {
     /// Returns the start index of the Document.
     public var startIndex: Int {
-        precondition(self.count > 0)
         return 0
     }
 

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -20,15 +20,10 @@ extension Document: Collection {
         return self.countFast
     }
 
-    // TODO: Can we use the internal helpers as defined in Collection.swift for this?
-    private func validIndex(_ i: Int) -> Bool {
-        return self.startIndex ... self.endIndex - 1 ~= i
-    }
-
     /// Returns the index after the given index for this Document.
     public func index(after i: Int) -> Int {
         // Index must be a valid one, meaning it must exist somewhere in self.keys.
-        precondition(validIndex(i))
+        _failEarlyRangeCheck(i, bounds: self.startIndex ... self.endIndex)
         return i + 1
     }
 
@@ -38,7 +33,7 @@ extension Document: Collection {
         // TODO: This method _should_ guarantee constant-time O(1) access, and it is possible to make it do so. This
         // criticism also applies to key-based subscripting via `String`.
         // See SWIFT-250.
-        precondition(validIndex(position))
+        _failEarlyRangeCheck(position, bounds: self.startIndex ... self.endIndex)
         return self.makeIterator().keyValuePairs[position]
     }
 

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -18,13 +18,18 @@ extension Document: Collection {
         return self.count
     }
 
+    private func validIndex(_ i: Int) -> Bool {
+        return self.startIndex ... self.endIndex - 1 ~= i
+    }
+
     public func index(after i: Int) -> Int {
         // Index must be a valid one, meaning it must exist somewhere in self.keys.
-        precondition(self.startIndex ... self.endIndex - 1 ~= i)
+        precondition(validIndex(i))
         return i + 1
     }
 
     public subscript(position: Int) -> Document.KeyValuePair {
-        return (self.keys[position], self.values[position])
+        precondition(validIndex(position))
+        return self.makeIterator().keyValuePairs[position]
     }
 }

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -1,0 +1,30 @@
+//
+//  Document+Collection.swift
+//  MongoSwift
+//
+//  Created by may on 11/8/18.
+//
+
+import Foundation
+
+extension Document: Collection {
+    public subscript(position: Int) -> Document.KeyValuePair {
+        return (self.keys[position], self.values[position])
+    }
+
+    public var startIndex: Int {
+        precondition(self.count > 0)
+        return self.keys.startIndex
+    }
+
+    public var endIndex: Int {
+        precondition(self.count > 0)
+        return self.keys.endIndex
+    }
+
+    public func index(after i: Int) -> Int {
+        // Index must be a valid one, meaning it must exist somewhere in self.keys.
+        precondition(self.startIndex ... self.endIndex - 1 ~= i)
+        return self.keys.index(after: i)
+    }
+}

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -31,7 +31,7 @@ extension Document: Collection {
 
     /// Allows access to a `KeyValuePair` from the `Document`, given the position of the desired `KeyValuePair` held
     /// within. This method does not guarantee constant-time (O(1)) access.
-    public subscript(position: Int) -> Document.KeyValuePair {
+    public subscript(position: Int) -> KeyValuePair {
         // TODO: This method _should_ guarantee constant-time O(1) access, and it is possible to make it do so. This
         // criticism also applies to key-based subscripting via `String`.
         // See SWIFT-250.

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -17,7 +17,7 @@ extension Document: Collection {
     /// Returns the end index of the Document.
     public var endIndex: Int {
         precondition(self.count > 0)
-        return self.countFast
+        return self.count
     }
 
     /// Returns the index after the given index for this Document.

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -1,12 +1,8 @@
-//
-//  Document+Collection.swift
-//  MongoSwift
-//
-//  Created by may on 11/8/18.
-//
-
 import Foundation
 
+/// An extension of `Document` to make it conform to the `Collection` protocol.
+/// This gives guarantees on non-destructive iteration, and offers an indexed
+/// ordering to the key value pairs in the document.
 extension Document: Collection {
     /// Returns the start index of the Document.
     public var startIndex: Int {

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -11,7 +11,6 @@ extension Document: Collection {
 
     /// Returns the end index of the Document.
     public var endIndex: Int {
-        precondition(self.count > 0)
         return self.count
     }
 

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -36,14 +36,14 @@ extension Document: Collection {
         // criticism also applies to key-based subscripting via `String`.
         // See SWIFT-250.
         failIndexCheck(position)
-        return self.keyValuePairs[position]
+        // Because of our failIndexCheck precondition, this call is guaranteed to provide a non-nil result.
+        return DocumentIterator.subsequence(of: self, startIndex: position, endIndex: position + 1).first!
     }
 
     /// Allows access to a `KeyValuePair` from the `Document`, given a range of indices of the desired `KeyValuePair`'s
     /// held within. This method does not guarantee constant-time (O(1)) access.
     public subscript(bounds: Range<Int>) -> Document {
-        let keyValues = self.keyValuePairs
         // TODO: SWIFT-252 should provide a more efficient implementation for this.
-        return Document(Array(keyValues[bounds]))
+        return DocumentIterator.subsequence(of: self, startIndex: bounds.lowerBound, endIndex: bounds.upperBound)
     }
 }

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -15,7 +15,11 @@ extension Document: Collection {
     }
 
     private func failIndexCheck(_ i: Int) {
-        precondition(self.startIndex ... self.endIndex - 1 ~= i, "Index \(i) is invalid")
+        let invalidIndexMsg = "Index \(i) is invalid"
+        if self.count == 0 {
+            precondition(i == 0, invalidIndexMsg)
+        }
+        precondition(self.startIndex ... self.endIndex - 1 ~= i, invalidIndexMsg)
     }
 
     /// Returns the index after the given index for this Document.

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -28,7 +28,12 @@ extension Document: Collection {
         return i + 1
     }
 
+    /// Allows access to a `KeyValuePair` from the `Document`, given the position of the desired `KeyValuePair` held
+    /// within. This method does not guarantee constant-time (O(1)) access.
     public subscript(position: Int) -> Document.KeyValuePair {
+        // TODO: This method _should_ guarantee constant-time O(1) access, and it is possible to make it do so. This
+        // criticism also applies to key-based subscripting via `String`.
+        // See SWIFT-250.
         precondition(validIndex(position))
         return self.makeIterator().keyValuePairs[position]
     }

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -8,11 +8,13 @@
 import Foundation
 
 extension Document: Collection {
+    /// Returns the start index of the Document.
     public var startIndex: Int {
         precondition(self.count > 0)
         return 0
     }
 
+    /// Returns the end index of the Document.
     public var endIndex: Int {
         precondition(self.count > 0)
         return self.count
@@ -22,6 +24,7 @@ extension Document: Collection {
         return self.startIndex ... self.endIndex - 1 ~= i
     }
 
+    /// Returns the index after the given index for this Document.
     public func index(after i: Int) -> Int {
         // Index must be a valid one, meaning it must exist somewhere in self.keys.
         precondition(validIndex(i))

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -32,7 +32,7 @@ extension Document: Collection {
         // criticism also applies to key-based subscripting via `String`.
         // See SWIFT-250.
         failIndexCheck(position)
-        return self.makeIterator().keyValuePairs[position]
+        return self.keyValuePairs[position]
     }
 
     /// Allows access to a `KeyValuePair` from the `Document`, given a range of indices of the desired `KeyValuePair`'s

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -21,7 +21,7 @@ extension Document: Collection {
     public func index(after i: Int) -> Int {
         // Index must be a valid one, meaning it must exist somewhere in self.keys.
         precondition(self.startIndex ... self.endIndex - 1 ~= i)
-        return self.keys.index(after: i)
+        return i + 1
     }
 
     public subscript(position: Int) -> Document.KeyValuePair {

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -20,6 +20,7 @@ extension Document: Collection {
         return self.countFast
     }
 
+    // TODO: Can we use the internal helpers as defined in Collection.swift for this?
     private func validIndex(_ i: Int) -> Bool {
         return self.startIndex ... self.endIndex - 1 ~= i
     }
@@ -39,5 +40,13 @@ extension Document: Collection {
         // See SWIFT-250.
         precondition(validIndex(position))
         return self.makeIterator().keyValuePairs[position]
+    }
+
+    /// Allows access to a `KeyValuePair` from the `Document`, given a range of indices of the desired `KeyValuePair`'s
+    /// held within. This method does not guarantee constant-time (O(1)) access.
+    public subscript(bounds: Range<Int>) -> Document {
+        let keyValues = self.keyValuePairs
+        // TODO: SWIFT-252 should provide a more efficient implementation for this.
+        return Document(Array(keyValues[bounds]))
     }
 }

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -8,23 +8,23 @@
 import Foundation
 
 extension Document: Collection {
-    public subscript(position: Int) -> Document.KeyValuePair {
-        return (self.keys[position], self.values[position])
-    }
-
     public var startIndex: Int {
         precondition(self.count > 0)
-        return self.keys.startIndex
+        return 0
     }
 
     public var endIndex: Int {
         precondition(self.count > 0)
-        return self.keys.endIndex
+        return self.count
     }
 
     public func index(after i: Int) -> Int {
         // Index must be a valid one, meaning it must exist somewhere in self.keys.
         precondition(self.startIndex ... self.endIndex - 1 ~= i)
         return self.keys.index(after: i)
+    }
+
+    public subscript(position: Int) -> Document.KeyValuePair {
+        return (self.keys[position], self.values[position])
     }
 }

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -14,10 +14,14 @@ extension Document: Collection {
         return self.count
     }
 
+    private func failIndexCheck(_ i: Int) {
+        precondition(self.startIndex ... self.endIndex - 1 ~= i, "Index \(i) is invalid")
+    }
+
     /// Returns the index after the given index for this Document.
     public func index(after i: Int) -> Int {
         // Index must be a valid one, meaning it must exist somewhere in self.keys.
-        _failEarlyRangeCheck(i, bounds: self.startIndex ... self.endIndex)
+        failIndexCheck(i)
         return i + 1
     }
 
@@ -27,7 +31,7 @@ extension Document: Collection {
         // TODO: This method _should_ guarantee constant-time O(1) access, and it is possible to make it do so. This
         // criticism also applies to key-based subscripting via `String`.
         // See SWIFT-250.
-        _failEarlyRangeCheck(position, bounds: self.startIndex ... self.endIndex)
+        failIndexCheck(position)
         return self.makeIterator().keyValuePairs[position]
     }
 

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -17,7 +17,7 @@ extension Document: Collection {
     private func failIndexCheck(_ i: Int) {
         let invalidIndexMsg = "Index \(i) is invalid"
         if self.count == 0 {
-            precondition(i == 0, invalidIndexMsg)
+            preconditionFailure(invalidIndexMsg)
         }
         precondition(self.startIndex ... self.endIndex - 1 ~= i, invalidIndexMsg)
     }

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -14,9 +14,6 @@ extension Document: Sequence {
     public typealias KeyValuePair = (key: String, value: BSONValue?)
     public typealias SubSequence = Document
 
-    /// Returns the number of (key, value) pairs stored at the top level of this `Document`.
-    public var count: Int { return Int(bson_count_keys(self.data)) }
-
     /// Returns a `Bool` indicating whether the document is empty.
     public var isEmpty: Bool { return !self.makeIterator().advance() }
 

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -12,8 +12,9 @@ import mongoc
 extension Document: Sequence {
     /// The element type of a document: a tuple containing an individual key-value pair.
     public typealias KeyValuePair = (key: String, value: BSONValue?)
-    /// Since a `Document` is a recursive structure, we want to enforce the use of it as a subsequence of itself,
-    /// instead of something like `Slice<Document>`.
+    // Since a `Document` is a recursive structure, we want to enforce the use of it as a subsequence of itself.
+    // instead of something like `Slice<Document>`.
+    /// The type that is returned from methods such as `dropFirst()` and `split()`.
     public typealias SubSequence = Document
 
     /// Returns a `Bool` indicating whether the document is empty.

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -12,6 +12,7 @@ import mongoc
 extension Document: Sequence {
     /// The element type of a document: a tuple containing an individual key-value pair.
     public typealias KeyValuePair = (key: String, value: BSONValue?)
+    public typealias SubSequence = Document
 
     /// Returns the number of (key, value) pairs stored at the top level of this `Document`.
     public var count: Int { return Int(bson_count_keys(self.data)) }

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -245,14 +245,6 @@ public class DocumentIterator: IteratorProtocol {
         return values
     }
 
-    /// Returns an array of `KeyValuePair`s from the iterator's current position to the end. The iter will be exhausted
-    /// after this property is accessed.
-    internal var keyValuePairs: [Document.KeyValuePair] {
-        var keyValuePairs = [Document.KeyValuePair]()
-        while self.advance() { keyValuePairs.append((self.currentKey, self.currentValue)) }
-        return keyValuePairs
-    }
-
     /// Returns the current value (equivalent to the `currentValue` property) or throws on error.
     internal func safeCurrentValue() throws -> BSONValue? {
         switch self.currentType {

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -248,6 +248,12 @@ public class DocumentIterator: IteratorProtocol {
         return values
     }
 
+    internal var keyValuePairs: [Document.KeyValuePair] {
+        var keyValuePairs = [Document.KeyValuePair]()
+        while self.advance() { keyValuePairs.append((self.currentKey, self.currentValue)) }
+        return keyValuePairs
+    }
+
     /// Returns the current value (equivalent to the `currentValue` property) or throws on error.
     internal func safeCurrentValue() throws -> BSONValue? {
         switch self.currentType {

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -12,6 +12,8 @@ import mongoc
 extension Document: Sequence {
     /// The element type of a document: a tuple containing an individual key-value pair.
     public typealias KeyValuePair = (key: String, value: BSONValue?)
+    /// Since a `Document` is a recursive structure, we want to enforce the use of it as a subsequence of itself,
+    /// instead of something like `Slice<Document>`.
     public typealias SubSequence = Document
 
     /// Returns a `Bool` indicating whether the document is empty.

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -248,6 +248,8 @@ public class DocumentIterator: IteratorProtocol {
         return values
     }
 
+    /// Returns an array of KeyValue pairs from the iterator's current position to the end. The iter will be exhausted
+    /// after this property is accessed.
     internal var keyValuePairs: [Document.KeyValuePair] {
         var keyValuePairs = [Document.KeyValuePair]()
         while self.advance() { keyValuePairs.append((self.currentKey, self.currentValue)) }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -45,6 +45,11 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         return self.makeIterator().values
     }
 
+    /// Returns a `[KeyValuePair]` containing the key-value pairs stored in this `Document`.
+    public var keyValuePairs: [KeyValuePair] {
+        return self.makeIterator().keyValuePairs
+    }
+
     /// Initializes a new, empty `Document`.
     public init() {
         self.storage = DocumentStorage()
@@ -121,12 +126,32 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      */
     internal init(_ elements: [BSONValue?]) {
         self.storage = DocumentStorage()
-        self.countFast = elements.count
+        self.countFast = 0
         for (i, elt) in elements.enumerated() {
             do {
                 try self.setValue(for: String(i), to: elt, checkForKey: false)
             } catch {
                 preconditionFailure("Failed to set the value for index \(i) to \(String(describing: elt)): \(error)")
+            }
+        }
+    }
+
+    /**
+     * Initializes a `Document` using an array where the values are KeyValuePairs.
+     *
+     * - Parameters:
+     *   - elements: a `[KeyValuePair]`
+     *
+     * - Returns: a new `Document`
+     */
+    internal init(_ elements: [KeyValuePair]) {
+        self.storage = DocumentStorage()
+        self.countFast = 0
+        for (key, value) in elements {
+            do {
+                try self.setValue(for: key, to: value)
+            } catch {
+                preconditionFailure("Failed to set the value for \(key) to \(String(describing: value)): \(error)")
             }
         }
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -53,11 +53,6 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         return self.makeIterator().values
     }
 
-    /// Returns a `[KeyValuePair]` containing the key-value pairs stored in this `Document`.
-    public var keyValuePairs: [KeyValuePair] {
-        return self.makeIterator().keyValuePairs
-    }
-
     /// Initializes a new, empty `Document`.
     public init() {
         self.storage = DocumentStorage()

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -5,6 +5,10 @@ import Foundation
 public class DocumentStorage {
     internal var pointer: UnsafeMutablePointer<bson_t>!
 
+    internal var count: Int {
+        return Int(bson_count_keys(self.pointer))
+    }
+
     init() {
         self.pointer = bson_new()
     }
@@ -69,7 +73,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      */
     internal init(fromPointer pointer: UnsafePointer<bson_t>) {
         self.storage = DocumentStorage(fromPointer: pointer)
-        self.count = Int(bson_count_keys(self.storage.pointer))
+        self.count = self.storage.count
     }
 
     /**
@@ -178,7 +182,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
             return UnsafePointer(bson)
         })
-        self.count = Int(bson_count_keys(self.storage.pointer))
+        self.count = self.storage.count
     }
 
     /// Convenience initializer for constructing a `Document` from a `String`
@@ -191,7 +195,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         self.storage = DocumentStorage(fromPointer: fromBSON.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
             bson_new_from_data(bytes, fromBSON.count)
         })
-        self.count = Int(bson_count_keys(self.storage.pointer))
+        self.count = self.storage.count
     }
 
     /// Returns the relaxed extended JSON representation of this `Document`.

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -5,6 +5,9 @@ import Foundation
 public class DocumentStorage {
     internal var pointer: UnsafeMutablePointer<bson_t>!
 
+    // Normally, this would go under Document, but computed properties cannot be used before all stored properties are
+    // initialized. Putting this under DocumentStorage gives a correct count and use of it inside of an init() as long
+    // as we have initialized Document.storage beforehand.
     internal var count: Int {
         return Int(bson_count_keys(self.pointer))
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -30,7 +30,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
 
     public var countFast: Int
 
-    /// Returns a `[String]` containing the keys in this `Document`. TODO: Create at initialization.
+    /// Returns a `[String]` containing the keys in this `Document`.
     public var keys: [String] {
         return self.makeIterator().keys
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -85,7 +85,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
         self.storage = DocumentStorage()
         // This is technically not consistent, but the only way this inconsistency can cause an issue is if we fail to
         // setValue(), in which case we crash anyways.
-        self.countFast = keyValuePairs.count
+        self.countFast = 0
         for (key, value) in keyValuePairs {
             do {
                 try self.setValue(for: key, to: value, checkForKey: false)

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -195,6 +195,9 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
      *  ```
      */
     public subscript(key: String) -> BSONValue? {
+        // TODO: This `get` method _should_ guarantee constant-time O(1) access, and it is possible to make it do so.
+        // This criticism also applies to indexed-based subscripting via `Int`.
+        // See SWIFT-250.
         get { return DocumentIterator(forDocument: self, advancedTo: key)?.currentValue }
         set(newValue) {
             do {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -28,7 +28,7 @@ public struct Document: ExpressibleByDictionaryLiteral, ExpressibleByArrayLitera
     /// direct access to the storage's pointer to a bson_t
     internal var data: UnsafeMutablePointer<bson_t>! { return storage.pointer }
 
-    /// Returns a `[String]` containing the keys in this `Document`.
+    /// Returns a `[String]` containing the keys in this `Document`. TODO: Create at initialization.
     public var keys: [String] {
         return self.makeIterator().keys
     }

--- a/Tests/MongoSwiftTests/Document+CollectionTests.swift
+++ b/Tests/MongoSwiftTests/Document+CollectionTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+@testable import MongoSwift
+import Nimble
+import XCTest
+
+final class Document_CollectionTests: MongoSwiftTestCase {
+    static var allTests: [(String, (Document_CollectionTests) -> () throws -> Void)] {
+        return [
+            ("testDocumentIndexLogic", testDocumentIndexLogic),
+            ("testMutators", testMutators),
+            ("testPrefixSuffix", testPrefixSuffix)
+        ]
+    }
+
+
+    func testDocumentIndexLogic() {
+        let doc: Document = ["a": 3, "b": 4]
+
+        // doc.startIndex, doc.endIndex, doc.index(after:), etc.
+        expect(doc.startIndex).to(equal(0))
+        expect(doc.endIndex).to(equal(doc.count))
+        expect(doc.index(after: doc.index(after: doc.startIndex))).to(equal(doc.endIndex))
+        expect(doc[1].key).to(equal("b"))
+        expect(doc[1].value).to(bsonEqual(4))
+
+        // doc.indices
+        expect(doc.indices.count).to(equal(doc.storage.count))
+        expect(doc.indices.startIndex).to(equal(doc.startIndex))
+        expect(doc.indices[1]).to(equal(doc.index(after: doc.startIndex)))
+        expect(doc.indices.endIndex).to(equal(doc.endIndex))
+
+        // doc.first
+        let firstElem = doc[doc.startIndex]
+        expect(doc.first?.key).to(equal(firstElem.key))
+        expect(doc.first?.value).to(bsonEqual(firstElem.value))
+
+        // doc.distance
+        expect(doc.distance(from: doc.startIndex, to: doc.endIndex)).to(equal(doc.count))
+        expect(doc.distance(from: doc.index(after: doc.startIndex), to: doc.endIndex)).to(equal(doc.count - 1))
+
+        // doc.formIndex
+        var firstIndex = 0
+        doc.formIndex(after: &firstIndex)
+        expect(firstIndex).to(equal(doc.index(after: doc.startIndex)))
+
+        // doc.index(offsetBy:), doc.index(offsetBy:,limitedBy:)
+        expect(doc.index(doc.startIndex, offsetBy: 2)).to(equal(doc.endIndex))
+        expect(doc.index(doc.startIndex, offsetBy: 2, limitedBy: doc.endIndex)).to(equal(doc.endIndex))
+        expect(doc.index(doc.startIndex, offsetBy: 99, limitedBy: 1)).to(beNil())
+
+        // firstIndex(where:); This line is commented out because Travis currently builds on 9.4, but this needs 10+
+        //            expect(doc.firstIndex { $0.key == "a" && bsonEquals($0.value, 3) }).to(equal(doc.startIndex))
+    }
+
+    func testMutators() throws {
+        var doc: Document = ["a": 3, "b": 2, "c": 5, "d": 4]
+
+        // doc.removeFirst
+        let firstElem = doc.removeFirst()
+        expect(firstElem.key).to(equal("a"))
+        expect(firstElem.value).to(bsonEqual(3))
+        expect(doc).to(equal(["b": 2, "c": 5, "d": 4]))
+        expect(doc).to(haveCorrectCount())
+
+        // doc.removeFirst(k:)
+        doc.removeFirst(2)
+        expect(doc).to(equal(["d": 4]))
+        expect(doc).to(haveCorrectCount())
+
+        // doc.popFirst
+        let lastElem = doc.popFirst()
+        expect(lastElem?.key).to(equal("d"))
+        expect(lastElem?.value).to(bsonEqual(4))
+        expect(doc).to(equal([:]))
+        expect(doc).to(haveCorrectCount())
+
+        // doc.merge
+        let newDoc: Document = ["e": 4, "f": 2]
+        try doc.merge(newDoc)
+        expect(doc).to(haveCorrectCount())
+    }
+
+    func testPrefixSuffix() {
+        let doc: Document = ["a": 3, "b": 2, "c": 5, "d": 4, "e": 3]
+
+        let upToPrefixDoc = doc.prefix(upTo: 2)
+        let throughPrefixDoc = doc.prefix(through: 1)
+        let suffixDoc = doc.suffix(from: 1)
+
+        // doc.prefix(upTo:)
+        expect(upToPrefixDoc).to(equal(["a": 3, "b": 2]))
+        expect(upToPrefixDoc).to(haveCorrectCount())
+
+        // doc.prefix(through:)
+        expect(throughPrefixDoc).to(equal(["a": 3, "b": 2]))
+        expect(throughPrefixDoc).to(haveCorrectCount())
+
+        // doc.suffix
+        expect(suffixDoc).to(equal(["b": 2, "c": 5, "d": 4, "e": 3]))
+        expect(suffixDoc).to(haveCorrectCount())
+    }
+}
+
+/// A Nimble matcher for testing that the count of a Document is what it should be.
+private func haveCorrectCount() -> Predicate<Document> {
+    return Predicate.define("have the correct count") { actualExpression, msg in
+        let actualValue = try actualExpression.evaluate()
+        switch actualValue {
+        case nil:
+            return PredicateResult(status: .fail, message: msg)
+        case let actual?:
+            let expectedCount = actual.storage.count
+            let failMsg = ExpectationMessage.expectedCustomValueTo("equal a count of \(expectedCount)",
+                "\(actual.count)")
+            let matches = (actual.count == expectedCount)
+            return PredicateResult(bool: matches, message: matches ? msg : failMsg)
+        }
+    }
+}
+

--- a/Tests/MongoSwiftTests/Document+CollectionTests.swift
+++ b/Tests/MongoSwiftTests/Document+CollectionTests.swift
@@ -6,13 +6,18 @@ import XCTest
 final class Document_CollectionTests: MongoSwiftTestCase {
     static var allTests: [(String, (Document_CollectionTests) -> () throws -> Void)] {
         return [
-            ("testDocumentIndexLogic", testDocumentIndexLogic),
+            ("testIndexLogic", testIndexLogic),
             ("testMutators", testMutators),
             ("testPrefixSuffix", testPrefixSuffix)
         ]
     }
 
-    func testDocumentIndexLogic() {
+    func testIndexLogic() {
+        var emptyDoc: Document = [:]
+
+        expect(emptyDoc.startIndex).to(equal(0))
+        expect(emptyDoc.endIndex).to(equal(emptyDoc.startIndex))
+
         let doc: Document = ["a": 3, "b": 4]
 
         // doc.startIndex, doc.endIndex, doc.index(after:), etc.

--- a/Tests/MongoSwiftTests/Document+CollectionTests.swift
+++ b/Tests/MongoSwiftTests/Document+CollectionTests.swift
@@ -101,7 +101,9 @@ final class Document_CollectionTests: MongoSwiftTestCase {
     }
 }
 
-/// A Nimble matcher for testing that the count of a Document is what it should be.
+/// A Nimble matcher for testing that the count of a Document is what it should be. This Nimble matcher is used in only
+/// this file for verifying that Document.count (a bookkeeping number in Document) matches the count that is reported by
+/// libbson.
 private func haveCorrectCount() -> Predicate<Document> {
     return Predicate.define("have the correct count") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()

--- a/Tests/MongoSwiftTests/Document+CollectionTests.swift
+++ b/Tests/MongoSwiftTests/Document+CollectionTests.swift
@@ -12,7 +12,6 @@ final class Document_CollectionTests: MongoSwiftTestCase {
         ]
     }
 
-
     func testDocumentIndexLogic() {
         let doc: Document = ["a": 3, "b": 4]
 
@@ -113,10 +112,9 @@ private func haveCorrectCount() -> Predicate<Document> {
         case let actual?:
             let expectedCount = actual.storage.count
             let failMsg = ExpectationMessage.expectedCustomValueTo("equal a count of \(expectedCount)",
-                "\(actual.count)")
+                                                                   "\(actual.count)")
             let matches = (actual.count == expectedCount)
             return PredicateResult(bool: matches, message: matches ? msg : failMsg)
         }
     }
 }
-

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -598,7 +598,7 @@ final class DocumentTests: MongoSwiftTestCase {
             expect(doc[1].value).to(bsonEqual(4))
 
             // doc.indices
-            expect(doc.indices.count).to(equal(Int(bson_count_keys(doc.data))))
+            expect(doc.indices.count).to(equal(doc.storage.count))
             expect(doc.indices.startIndex).to(equal(doc.startIndex))
             expect(doc.indices[1]).to(equal(doc.index(after: doc.startIndex)))
             expect(doc.indices.endIndex).to(equal(doc.endIndex))
@@ -690,7 +690,7 @@ private func haveCorrectCount() -> Predicate<Document> {
         case nil:
             return PredicateResult(status: .fail, message: msg)
         case let actual?:
-            let expectedCount = Int(bson_count_keys(actual.data))
+            let expectedCount = actual.storage.count
             let failMsg = ExpectationMessage.expectedCustomValueTo("equal a count of \(expectedCount)",
                                                                    "\(actual.count)")
             let matches = (actual.count == expectedCount)

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -1,4 +1,3 @@
-import bson
 import Foundation
 @testable import MongoSwift
 import Nimble

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -663,15 +663,15 @@ final class DocumentTests: MongoSwiftTestCase {
 
             // doc.prefix(upTo:)
             expect(upToPrefixDoc).to(equal(["a": 3, "b": 2]))
-            expect(doc).to(haveCorrectCount())
+            expect(upToPrefixDoc).to(haveCorrectCount())
 
             // doc.prefix(through:)
             expect(throughPrefixDoc).to(equal(["a": 3, "b": 2]))
-            expect(doc).to(haveCorrectCount())
+            expect(throughPrefixDoc).to(haveCorrectCount())
 
             // doc.suffix
             expect(suffixDoc).to(equal(["b": 2, "c": 5, "d": 4, "e": 3]))
-            expect(doc).to(haveCorrectCount())
+            expect(suffixDoc).to(haveCorrectCount())
         }
     }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -43,8 +43,7 @@ final class DocumentTests: MongoSwiftTestCase {
             ("testNonOverwritable", testNonOverwritable),
             ("testReplaceValueWithNewType", testReplaceValueWithNewType),
             ("testReplaceValueWithNil", testReplaceValueWithNil),
-            ("testReplaceValueNoop", testReplaceValueNoop),
-            ("testDocumentConformanceToCollection", testDocumentConformanceToCollection)
+            ("testReplaceValueNoop", testReplaceValueNoop)
         ]
     }
 
@@ -584,116 +583,5 @@ final class DocumentTests: MongoSwiftTestCase {
 
         expect(noops).to(equal(["null": 5, "maxkey": "hi", "minkey": false]))
     }
-
-    private struct CollectionConformance {
-        fileprivate static func testDocumentIndexLogic() {
-            let doc: Document = ["a": 3, "b": 4]
-
-            // doc.startIndex, doc.endIndex, doc.index(after:), etc.
-            expect(doc.startIndex).to(equal(0))
-            expect(doc.endIndex).to(equal(doc.count))
-            expect(doc.index(after: doc.index(after: doc.startIndex))).to(equal(doc.endIndex))
-            expect(doc[1].key).to(equal("b"))
-            expect(doc[1].value).to(bsonEqual(4))
-
-            // doc.indices
-            expect(doc.indices.count).to(equal(doc.storage.count))
-            expect(doc.indices.startIndex).to(equal(doc.startIndex))
-            expect(doc.indices[1]).to(equal(doc.index(after: doc.startIndex)))
-            expect(doc.indices.endIndex).to(equal(doc.endIndex))
-
-            // doc.first
-            let firstElem = doc[doc.startIndex]
-            expect(doc.first?.key).to(equal(firstElem.key))
-            expect(doc.first?.value).to(bsonEqual(firstElem.value))
-
-            // doc.distance
-            expect(doc.distance(from: doc.startIndex, to: doc.endIndex)).to(equal(doc.count))
-            expect(doc.distance(from: doc.index(after: doc.startIndex), to: doc.endIndex)).to(equal(doc.count - 1))
-
-            // doc.formIndex
-            var firstIndex = 0
-            doc.formIndex(after: &firstIndex)
-            expect(firstIndex).to(equal(doc.index(after: doc.startIndex)))
-
-            // doc.index(offsetBy:), doc.index(offsetBy:,limitedBy:)
-            expect(doc.index(doc.startIndex, offsetBy: 2)).to(equal(doc.endIndex))
-            expect(doc.index(doc.startIndex, offsetBy: 2, limitedBy: doc.endIndex)).to(equal(doc.endIndex))
-            expect(doc.index(doc.startIndex, offsetBy: 99, limitedBy: 1)).to(beNil())
-
-            // firstIndex(where:); This line is commented out because Travis currently builds on 9.4, but this needs 10+
-//            expect(doc.firstIndex { $0.key == "a" && bsonEquals($0.value, 3) }).to(equal(doc.startIndex))
-        }
-
-        fileprivate static func testMutators() throws {
-            var doc: Document = ["a": 3, "b": 2, "c": 5, "d": 4]
-
-            // doc.removeFirst
-            let firstElem = doc.removeFirst()
-            expect(firstElem.key).to(equal("a"))
-            expect(firstElem.value).to(bsonEqual(3))
-            expect(doc).to(equal(["b": 2, "c": 5, "d": 4]))
-            expect(doc).to(haveCorrectCount())
-
-            // doc.removeFirst(k:)
-            doc.removeFirst(2)
-            expect(doc).to(equal(["d": 4]))
-            expect(doc).to(haveCorrectCount())
-
-            // doc.popFirst
-            let lastElem = doc.popFirst()
-            expect(lastElem?.key).to(equal("d"))
-            expect(lastElem?.value).to(bsonEqual(4))
-            expect(doc).to(equal([:]))
-            expect(doc).to(haveCorrectCount())
-
-            // doc.merge
-            let newDoc: Document = ["e": 4, "f": 2]
-            try doc.merge(newDoc)
-            expect(doc).to(haveCorrectCount())
-        }
-
-        fileprivate static func testPrefixSuffix() {
-            let doc: Document = ["a": 3, "b": 2, "c": 5, "d": 4, "e": 3]
-
-            let upToPrefixDoc = doc.prefix(upTo: 2)
-            let throughPrefixDoc = doc.prefix(through: 1)
-            let suffixDoc = doc.suffix(from: 1)
-
-            // doc.prefix(upTo:)
-            expect(upToPrefixDoc).to(equal(["a": 3, "b": 2]))
-            expect(upToPrefixDoc).to(haveCorrectCount())
-
-            // doc.prefix(through:)
-            expect(throughPrefixDoc).to(equal(["a": 3, "b": 2]))
-            expect(throughPrefixDoc).to(haveCorrectCount())
-
-            // doc.suffix
-            expect(suffixDoc).to(equal(["b": 2, "c": 5, "d": 4, "e": 3]))
-            expect(suffixDoc).to(haveCorrectCount())
-        }
-    }
-
-    func testDocumentConformanceToCollection() throws {
-        CollectionConformance.testDocumentIndexLogic()
-        try CollectionConformance.testMutators()
-        CollectionConformance.testPrefixSuffix()
-    }
 }
 
-/// A Nimble matcher for testing that the count of a Document is what it should be.
-private func haveCorrectCount() -> Predicate<Document> {
-    return Predicate.define("have the correct count") { actualExpression, msg in
-        let actualValue = try actualExpression.evaluate()
-        switch actualValue {
-        case nil:
-            return PredicateResult(status: .fail, message: msg)
-        case let actual?:
-            let expectedCount = actual.storage.count
-            let failMsg = ExpectationMessage.expectedCustomValueTo("equal a count of \(expectedCount)",
-                                                                   "\(actual.count)")
-            let matches = (actual.count == expectedCount)
-            return PredicateResult(bool: matches, message: matches ? msg : failMsg)
-        }
-    }
-}

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -586,31 +586,98 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(noops).to(equal(["null": 5, "maxkey": "hi", "minkey": false]))
     }
 
-    func testDocumentConformanceToCollection() throws {
-        func trueDocCount(_ document: Document) -> Int {
-            return Int(bson_count_keys(document.data))
+    private struct CollectionConformance {
+        private static func checkCount(_ document: Document) -> Bool {
+            return document.countFast == Int(bson_count_keys(document.data))
         }
-        let secondKey = "b"
-        let secondVal: BSONValue = 2
 
-        var doc: Document = [ "a": 4, secondKey: secondVal ]
-        expect(doc.startIndex).to(equal(0))
-        expect(doc.endIndex).to(equal(doc.count))
-        expect(doc.index(after: doc.index(after: doc.startIndex))).to(equal(doc.endIndex))
-        expect(doc[1].key).to(equal(secondKey))
-        expect(doc[1].value).to(bsonEqual(secondVal))
+        fileprivate static func testDocumentIndexLogic() {
+            let doc: Document = ["a": 3, "b": 4]
 
-        // TODO: Change these `count` to `countFast` eventually
-        expect(doc.count).to(equal(trueDocCount(doc)))
-        let otherDoc: Document = ["c": 3, "d": "hello world"]
-        try doc.merge(otherDoc)
-        expect(doc.count).to(equal(trueDocCount(doc)))
+            // doc.startIndex, doc.endIndex, doc.index(after:), etc.
+            expect(doc.startIndex).to(equal(0))
+            expect(doc.endIndex).to(equal(doc.count))
+            expect(doc.index(after: doc.index(after: doc.startIndex))).to(equal(doc.endIndex))
+            expect(doc[1].key).to(equal("b"))
+            expect(doc[1].value).to(bsonEqual(4))
 
-        doc["new_key"] = "new value"
-        expect(doc.count).to(equal(trueDocCount(doc)))
+            // doc.indices
+            expect(doc.indices.count).to(equal(Int(bson_count_keys(doc.data))))
+            expect(doc.indices.startIndex).to(equal(doc.startIndex))
+            expect(doc.indices[1]).to(equal(doc.index(after: doc.startIndex)))
+            expect(doc.indices.endIndex).to(equal(doc.endIndex))
 
-        debugPrint("Doc: \(doc) with countfast: \(doc.countFast)")
-        let removedElem = doc.removeFirst()
-        debugPrint("removed elem: \(removedElem) and doc: \(doc) and now doc has countFast: \(doc.countFast)")
+            // doc.first
+            let firstElem = doc[doc.startIndex]
+            expect(doc.first?.key).to(equal(firstElem.key))
+            expect(doc.first?.value).to(bsonEqual(firstElem.value))
+
+            // doc.distance
+            expect(doc.distance(from: doc.startIndex, to: doc.endIndex)).to(equal(doc.countFast))
+            expect(doc.distance(from: doc.index(after: doc.startIndex), to: doc.endIndex)).to(equal(doc.countFast - 1))
+
+            // doc.formIndex
+            var firstIndex = 0
+            doc.formIndex(after: &firstIndex)
+            expect(firstIndex).to(equal(doc.index(after: doc.startIndex)))
+
+            // doc.index(offsetBy:), doc.index(offsetBy:,limitedBy:)
+            expect(doc.index(doc.startIndex, offsetBy: 2)).to(equal(doc.endIndex))
+            expect(doc.index(doc.startIndex, offsetBy: 2, limitedBy: doc.endIndex)).to(equal(doc.endIndex))
+            expect(doc.index(doc.startIndex, offsetBy: 99, limitedBy: 1)).to(beNil())
+
+            // firstIndex(where:)
+            // TODO: Perhaps make Document.KeyValuePair conform to Equatable?
+            expect(doc.firstIndex() { return $0.key == "a" && bsonEquals($0.value, 3) }).to(equal(doc.startIndex))
+        }
+
+        fileprivate static func testMutators() {
+            var doc: Document = ["a": 3, "b": 2, "c": 5, "d": 4]
+
+            // doc.removeFirst
+            let firstElem = doc.removeFirst()
+            expect(firstElem.key).to(equal("a"))
+            expect(firstElem.value).to(bsonEqual(3))
+            expect(doc).to(equal(["b": 2, "c": 5, "d": 4]))
+            expect(CollectionConformance.checkCount(doc)).to(beTrue())
+
+            // doc.removeFirst(k:)
+            doc.removeFirst(2)
+            expect(doc).to(equal(["d": 4]))
+            expect(CollectionConformance.checkCount(doc)).to(beTrue())
+
+            // doc.popFirst
+            let lastElem = doc.popFirst()
+            expect(lastElem?.key).to(equal("d"))
+            expect(lastElem?.value).to(bsonEqual(4))
+            expect(doc).to(equal([:]))
+            expect(CollectionConformance.checkCount(doc)).to(beTrue())
+        }
+
+        fileprivate static func testPrefixSuffix() {
+            let doc: Document = ["a": 3, "b": 2, "c": 5, "d": 4, "e": 3]
+
+            let upToPrefixDoc = doc.prefix(upTo: 2)
+            let throughPrefixDoc = doc.prefix(through: 1)
+            let suffixDoc = doc.suffix(from: 1)
+
+            // doc.prefix(upTo:)
+            expect(upToPrefixDoc).to(equal(["a": 3, "b": 2]))
+            expect(CollectionConformance.checkCount(upToPrefixDoc)).to(beTrue())
+
+            // doc.prefix(through:)
+            expect(throughPrefixDoc).to(equal(["a": 3, "b": 2]))
+            expect(CollectionConformance.checkCount(throughPrefixDoc)).to(beTrue())
+
+            // doc.suffix
+            expect(suffixDoc).to(equal(["b": 2, "c": 5, "d": 4, "e": 3]))
+            expect(CollectionConformance.checkCount(suffixDoc)).to(beTrue())
+        }
+    }
+
+    func testDocumentConformanceToCollection() throws {
+        CollectionConformance.testDocumentIndexLogic()
+        CollectionConformance.testMutators()
+        CollectionConformance.testPrefixSuffix()
     }
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -1,3 +1,4 @@
+import bson
 import Foundation
 @testable import MongoSwift
 import Nimble
@@ -43,7 +44,8 @@ final class DocumentTests: MongoSwiftTestCase {
             ("testNonOverwritable", testNonOverwritable),
             ("testReplaceValueWithNewType", testReplaceValueWithNewType),
             ("testReplaceValueWithNil", testReplaceValueWithNil),
-            ("testReplaceValueNoop", testReplaceValueNoop)
+            ("testReplaceValueNoop", testReplaceValueNoop),
+            ("testDocumentConformanceToCollection", testDocumentConformanceToCollection)
         ]
     }
 
@@ -582,5 +584,28 @@ final class DocumentTests: MongoSwiftTestCase {
         }
 
         expect(noops).to(equal(["null": 5, "maxkey": "hi", "minkey": false]))
+    }
+
+    func testDocumentConformanceToCollection() throws {
+        func trueDocCount(_ document: Document) -> Int {
+            return Int(bson_count_keys(document.data))
+        }
+        let secondKey = "b"
+        let secondVal: BSONValue = 2
+
+        var doc: Document = [ "a": 4, secondKey: secondVal ]
+        expect(doc.startIndex).to(equal(0))
+        expect(doc.endIndex).to(equal(doc.count))
+        expect(doc.index(after: doc.index(after: doc.startIndex))).to(equal(doc.endIndex))
+        expect(doc[1].key).to(equal(secondKey))
+        expect(doc[1].value).to(bsonEqual(secondVal))
+
+        expect(doc.count).to(equal(trueDocCount(doc)))
+        let otherDoc: Document = ["c": 3, "d": "hello world"]
+        try doc.merge(otherDoc)
+        expect(doc.count).to(equal(trueDocCount(doc)))
+
+        doc["new_key"] = "new value"
+        expect(doc.count).to(equal(trueDocCount(doc)))
     }
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -588,7 +588,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
     private struct CollectionConformance {
         private static func checkCount(_ document: Document) -> Bool {
-            return document.countFast == Int(bson_count_keys(document.data))
+            return document.count == Int(bson_count_keys(document.data))
         }
 
         fileprivate static func testDocumentIndexLogic() {
@@ -613,8 +613,8 @@ final class DocumentTests: MongoSwiftTestCase {
             expect(doc.first?.value).to(bsonEqual(firstElem.value))
 
             // doc.distance
-            expect(doc.distance(from: doc.startIndex, to: doc.endIndex)).to(equal(doc.countFast))
-            expect(doc.distance(from: doc.index(after: doc.startIndex), to: doc.endIndex)).to(equal(doc.countFast - 1))
+            expect(doc.distance(from: doc.startIndex, to: doc.endIndex)).to(equal(doc.count))
+            expect(doc.distance(from: doc.index(after: doc.startIndex), to: doc.endIndex)).to(equal(doc.count - 1))
 
             // doc.formIndex
             var firstIndex = 0

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -627,7 +627,6 @@ final class DocumentTests: MongoSwiftTestCase {
             expect(doc.index(doc.startIndex, offsetBy: 99, limitedBy: 1)).to(beNil())
 
             // firstIndex(where:)
-            // TODO: Perhaps make Document.KeyValuePair conform to Equatable?
             expect(doc.firstIndex() { return $0.key == "a" && bsonEquals($0.value, 3) }).to(equal(doc.startIndex))
         }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -623,7 +623,7 @@ final class DocumentTests: MongoSwiftTestCase {
             expect(doc.index(doc.startIndex, offsetBy: 99, limitedBy: 1)).to(beNil())
 
             // firstIndex(where:)
-            expect(doc.firstIndex() { return $0.key == "a" && bsonEquals($0.value, 3) }).to(equal(doc.startIndex))
+            expect(doc.firstIndex { $0.key == "a" && bsonEquals($0.value, 3) }).to(equal(doc.startIndex))
         }
 
         fileprivate static func testMutators() throws {
@@ -683,16 +683,16 @@ final class DocumentTests: MongoSwiftTestCase {
 }
 
 /// A Nimble matcher for testing that the count of a Document is what it should be.
-fileprivate func haveCorrectCount() -> Predicate<Document> {
+private func haveCorrectCount() -> Predicate<Document> {
     return Predicate.define("have the correct count") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
-        switch (actualValue) {
+        switch actualValue {
         case nil:
             return PredicateResult(status: .fail, message: msg)
         case let actual?:
             let expectedCount = Int(bson_count_keys(actual.data))
             let failMsg = ExpectationMessage.expectedCustomValueTo("equal a count of \(expectedCount)",
-                "\(actual.count)")
+                                                                   "\(actual.count)")
             let matches = (actual.count == expectedCount)
             return PredicateResult(bool: matches, message: matches ? msg : failMsg)
         }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -600,6 +600,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc[1].key).to(equal(secondKey))
         expect(doc[1].value).to(bsonEqual(secondVal))
 
+        // TODO: Change these `count` to `countFast` eventually
         expect(doc.count).to(equal(trueDocCount(doc)))
         let otherDoc: Document = ["c": 3, "d": "hello world"]
         try doc.merge(otherDoc)
@@ -607,5 +608,9 @@ final class DocumentTests: MongoSwiftTestCase {
 
         doc["new_key"] = "new value"
         expect(doc.count).to(equal(trueDocCount(doc)))
+
+        debugPrint("Doc: \(doc) with countfast: \(doc.countFast)")
+        let removedElem = doc.removeFirst()
+        debugPrint("removed elem: \(removedElem) and doc: \(doc) and now doc has countFast: \(doc.countFast)")
     }
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -622,8 +622,8 @@ final class DocumentTests: MongoSwiftTestCase {
             expect(doc.index(doc.startIndex, offsetBy: 2, limitedBy: doc.endIndex)).to(equal(doc.endIndex))
             expect(doc.index(doc.startIndex, offsetBy: 99, limitedBy: 1)).to(beNil())
 
-            // firstIndex(where:)
-            expect(doc.firstIndex { $0.key == "a" && bsonEquals($0.value, 3) }).to(equal(doc.startIndex))
+            // firstIndex(where:); This line is commented out because Travis currently builds on 9.4, but this needs 10+
+//            expect(doc.firstIndex { $0.key == "a" && bsonEquals($0.value, 3) }).to(equal(doc.startIndex))
         }
 
         fileprivate static func testMutators() throws {

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -584,4 +584,3 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(noops).to(equal(["null": 5, "maxkey": "hi", "minkey": false]))
     }
 }
-

--- a/Tests/MongoSwiftTests/XCTestManifests.swift
+++ b/Tests/MongoSwiftTests/XCTestManifests.swift
@@ -14,6 +14,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(MongoDatabaseTests.allTests),
         testCase(DocumentTests.allTests),
         testCase(Document_SequenceTests.allTests),
+        testCase(Document_CollectionTests.allTests),
         testCase(ReadPreferenceTests.allTests),
         testCase(ReadWriteConcernTests.allTests),
         testCase(SDAMTests.allTests)


### PR DESCRIPTION
[SWIFT-192](https://jira.mongodb.org/browse/SWIFT-192)

This PR adds `Collection` conformance to `Document`.

This diff is not too big, but this ticket took quite a while due to various and significant issues with trying to get `Collection` conformance working for `Document`!!! I am very happy to finally get this PR out!

Performance improvements for reaching runtime guarantees of `Collection` conformance will be done separately.

I've also refrained from combining `Document+Sequence.swift` with `Document+Collection.swift`, since with the completion of SWIFT-259, I expect a decent amount of LoC increase and I am guessing it would be better to keep them separate for organizational purposes. We can merge them in a later if my guess is wrong.

Finally, I've added some tests that test the methods that are supplied by `Collection` conformance. This is because it turned out that the automatically generated methods were initially causing a crash in Swift because our (automatically generated) range-based subscript was not correct. After fixing it, I found myself still pretty paranoid, so I've added the tests, which are simple but just serve to make sure that nothing is terribly wrong. They can be removed if desired, although some of them also test the new `count` logic and should stay for that purpose.