### PR TITLE
SWIFT-235 Fix UnsafeMutableRawPointer! deprecation warnings in Swift 4.1+

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -441,7 +441,7 @@ private func serverHeartbeatFailed(_event: OpaquePointer?) {
 /// Posts a Notification with the specified name, containing an event of type T generated using the provided _event
 /// and context function.
 private func postNotification<T: MongoEvent>(type: T.Type, _event: OpaquePointer?,
-                                             contextFunc: (OpaquePointer) -> UnsafeMutableRawPointer!
+                                             contextFunc: (OpaquePointer) -> UnsafeMutableRawPointer?
                                             ) where T: InitializableFromOpaquePointer {
     guard let event = _event else {
         preconditionFailure("Missing event pointer for \(type)")


### PR DESCRIPTION
Just a one line change. Compiles either way, but the compiler starts warning you about this as of 4.1. 