### PR TITLE
SWIFT-119 Initialize libmongoc before running tests from macOS command line

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,11 +1,5 @@
-import MongoSwift
 import MongoSwiftTests
 import XCTest
-
-/* Ensure libmongoc is initialized. Since XCTMain never returns, we have no
- * opportunity to cleanup libmongoc (either explicitly or with a deinit). This
- * may appear as a memory leak. */
-MongoSwift.initialize()
 
 var tests = [XCTestCaseEntry]()
 tests += MongoSwiftTests.allTests()

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -6,7 +6,7 @@ import XCTest
 class MongoSwiftTestCase: XCTestCase {
     /* Ensure libmongoc is initialized. This will be called multiple times, but that's ok
      * as repeated calls have no effect. There is no way to call final cleanup code just
-     * once at the very end, either explicitly or with a deinit). This may appear as a 
+     * once at the very end, either explicitly or with a deinit. This may appear as a 
      * memory leak. */
     override class func setUp() {
         MongoSwift.initialize()

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -4,6 +4,11 @@ import Nimble
 import XCTest
 
 class MongoSwiftTestCase: XCTestCase {
+    // this will be called multiple times, but that's ok as repeated calls have no effect.
+    override class func setUp() {
+        MongoSwift.initialize()
+    }
+
     /// Gets the path of the directory containing spec files, depending on whether
     /// we're running from XCode or the command line
     static var specsPath: String {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -4,7 +4,10 @@ import Nimble
 import XCTest
 
 class MongoSwiftTestCase: XCTestCase {
-    // this will be called multiple times, but that's ok as repeated calls have no effect.
+    /* Ensure libmongoc is initialized. This will be called multiple times, but that's ok
+     * as repeated calls have no effect. There is no way to call final cleanup code just
+     * once at the very end, either explicitly or with a deinit). This may appear as a 
+     * memory leak. */
     override class func setUp() {
         MongoSwift.initialize()
     }


### PR DESCRIPTION
Now that @Utagai added a base test class, this was super easy.

Note that this `class func` is called once before each of our separate test classes, i.e. once before `DocumentTests`, once before `CodecTests`, and so on. Since @jmikola wrote `MongoSwift.initialize()` so that repeated calls have no effect, this should be just fine. 

I believe this also removes the need to call `MongoSwift.initialize()` in `LinuxMain.swift`. 