### PR TITLE
SWIFT-191: Add a way to provide a default value when looking up a key in a Document

### DIFF
--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -100,6 +100,12 @@ extension Document {
         }
     }
 
+    /// An implementation identical to subscript(key: String), but offers the ability to choose a default value if the
+    /// key is missing.
+    public subscript(key: String, default defaultValue: @autoclosure () -> BSONValue) -> BSONValue {
+        return self[key] ?? defaultValue()
+    }
+
     /// Sets key to newValue. if checkForKey=false, the key/value pair will be appended without checking for the key's
     /// presence first.
     internal mutating func setValue(for key: String, to newValue: BSONValue, checkForKey: Bool = true) throws {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -329,8 +329,16 @@ extension Document {
         }
     }
 
-    /// An implementation identical to subscript(key: String), but offers the ability to choose a default value if the
-    /// key is missing.
+    /**
+     * An implementation identical to subscript(key: String), but offers the ability to choose a default value if the
+     * key is missing.
+     * For example:
+     *  ```
+     *  let d: Document = ["hello": "world"]
+     *  print(d["hello", default: "foo"]) // prints "world"
+     *  print(d["a", default: "foo"]) // prints "foo"
+     *  ```
+     */
     public subscript(key: String, default defaultValue: @autoclosure () -> BSONValue) -> BSONValue {
         return self[key] ?? defaultValue()
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -357,7 +357,7 @@ extension Document {
     public subscript(key: String, default defaultValue: @autoclosure () -> BSONValue) -> BSONValue {
         return self[key] ?? defaultValue()
     }
-  
+
     /**
      * Allows setting values and retrieving values using dot-notation syntax.
      * For example:

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -100,12 +100,6 @@ extension Document {
         }
     }
 
-    /// An implementation identical to subscript(key: String), but offers the ability to choose a default value if the
-    /// key is missing.
-    public subscript(key: String, default defaultValue: @autoclosure () -> BSONValue) -> BSONValue {
-        return self[key] ?? defaultValue()
-    }
-
     /// Sets key to newValue. if checkForKey=false, the key/value pair will be appended without checking for the key's
     /// presence first.
     internal mutating func setValue(for key: String, to newValue: BSONValue, checkForKey: Bool = true) throws {
@@ -333,6 +327,12 @@ extension Document {
                 preconditionFailure("Failed to set the value for key \(key) to \(newValue ?? "nil"): \(error)")
             }
         }
+    }
+
+    /// An implementation identical to subscript(key: String), but offers the ability to choose a default value if the
+    /// key is missing.
+    public subscript(key: String, default defaultValue: @autoclosure () -> BSONValue) -> BSONValue {
+        return self[key] ?? defaultValue()
     }
 }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -675,7 +675,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["DNE", default: floatVal]).to(bsonEqual(floatVal))
         expect(doc["hello", default: floatVal]).to(bsonEqual(doc["hello"]))
         expect(doc["DNE", default: stringVal]).to(bsonEqual(stringVal))
-        expect(doc["DNE", default: NSNull()]).to(bsonEqual(NSNull()))
+        expect(doc["DNE", default: BSONNull()]).to(bsonEqual(BSONNull()))
         expect(doc["autoclosure test", default: floatVal * floatVal]).to(bsonEqual(floatVal * floatVal))
         expect(doc["autoclosure test", default: "\(stringVal) and \(floatVal)" + stringVal])
             .to(bsonEqual("\(stringVal) and \(floatVal)" + stringVal))

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -44,7 +44,8 @@ final class DocumentTests: MongoSwiftTestCase {
             ("testReplaceValueWithNewType", testReplaceValueWithNewType),
             ("testReplaceValueWithNil", testReplaceValueWithNil),
             ("testReplaceValueNoop", testReplaceValueNoop),
-            ("testDocumentDictionarySimilarity", testDocumentDictionarySimilarity)
+            ("testDocumentDictionarySimilarity", testDocumentDictionarySimilarity),
+            ("testDefaultSubscript", testDefaultSubscript)
         ]
     }
 
@@ -598,5 +599,15 @@ final class DocumentTests: MongoSwiftTestCase {
 
         expect(doc["remove_me"]).to(beNil())
         expect(doc.hasKey("remove_me")).to(beFalse())
+    }
+
+    func testDefaultSubscript() throws {
+        let doc: Document = ["hello": "world"]
+        let floatVal = 18.2
+        let stringVal = "this is a string"
+        expect(doc["DNE", default: floatVal]).to(bsonEqual(floatVal))
+        expect(doc["hello", default: floatVal]).to(bsonEqual(doc["hello"]))
+        expect(doc["DNE", default: stringVal]).to(bsonEqual(stringVal))
+        expect(doc["DNE", default: NSNull()]).to(bsonEqual(NSNull()))
     }
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -610,5 +610,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["DNE", default: stringVal]).to(bsonEqual(stringVal))
         expect(doc["DNE", default: NSNull()]).to(bsonEqual(NSNull()))
         expect(doc["autoclosure test", default: floatVal * floatVal]).to(bsonEqual(floatVal * floatVal))
+        expect(doc["autoclosure test", default: "\(stringVal) and \(floatVal)" + stringVal])
+            .to(bsonEqual("\(stringVal) and \(floatVal)" + stringVal))
     }
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -609,5 +609,6 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["hello", default: floatVal]).to(bsonEqual(doc["hello"]))
         expect(doc["DNE", default: stringVal]).to(bsonEqual(stringVal))
         expect(doc["DNE", default: NSNull()]).to(bsonEqual(NSNull()))
+        expect(doc["autoclosure test", default: floatVal * floatVal]).to(bsonEqual(floatVal * floatVal))
     }
 }


### PR DESCRIPTION
[SWIFT-191](https://jira.mongodb.org/browse/SWIFT-191)

**NOTE** This PR can only be merged after [the PR for SWIFT-193](https://github.com/mongodb/mongo-swift-driver/pull/145). The excessive amounts of commits are mostly from that branch, so after it is merged I'll rebase and almost all of them should go away. As a result of this, this PR's diff is basically contaminated by the diff from SWIFT-193. It's probably best to wait for SWIFT-193 to be merged before even trying to review this PR, but if you'd like, the two files of interest are `Document.swift` and `DocumentTests.swift`.

This PR adds functionality to `Document` such that users can now supply a default value to the `subscript()` function. An example of this can be found in `DocumentTests.swift`, at the bottom, but here is a snippet:
```swift
let doc: Document = ["hello": "world"]
doc["DNE", default: 18.2] // Returns 18.2
doc["hello", default: 18.2] // Returns "world"
doc["DNE", default: "this is a string"] // Returns "this is a string"
doc["DNE", default: NSNull()] // Returns NSNull
```

This is added as a second subscript function that just coalesces on a call to the former. We have to do this because `subscript()` implementations cannot take default valued parameters.