### PR TITLE
SWIFT-265: ObjectId should expose timestamp

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -547,6 +547,9 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     /// This `ObjectId`'s data represented as a `String`.
     public let oid: String
 
+    /// The timestamp used to create this `ObjectId`
+    public let timestamp: TimeInterval
+
     /// Initializes a new `ObjectId`.
     public init() {
         var oid_t = bson_oid_t()
@@ -558,6 +561,9 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/objectid.rst
     public init(fromString oid: String) {
         self.oid = oid
+        var oid_t = bson_oid_t()
+        bson_oid_init_from_string(&oid_t, oid)
+        self.timestamp = TimeInterval(bson_oid_get_time_t(&oid_t))
     }
 
     /// Initializes an `ObjectId` from the provided `String`. Returns `nil` if the string is not a valid
@@ -579,6 +585,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
             bson_oid_to_string(oid_t, bytes)
             return String(cString: bytes)
         }
+        self.timestamp = TimeInterval(bson_oid_get_time_t(oid_t))
     }
 
     /// Returns the provided string as a `bson_oid_t`.

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -548,7 +548,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     public let oid: String
 
     /// The timestamp used to create this `ObjectId`
-    public let timestamp: TimeInterval
+    public let timestamp: UInt32
 
     /// Initializes a new `ObjectId`.
     public init() {
@@ -563,7 +563,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         self.oid = oid
         var oid_t = bson_oid_t()
         bson_oid_init_from_string(&oid_t, oid)
-        self.timestamp = TimeInterval(bson_oid_get_time_t(&oid_t))
+        self.timestamp = UInt32(bson_oid_get_time_t(&oid_t))
     }
 
     /// Initializes an `ObjectId` from the provided `String`. Returns `nil` if the string is not a valid
@@ -585,7 +585,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
             bson_oid_to_string(oid_t, bytes)
             return String(cString: bytes)
         }
-        self.timestamp = TimeInterval(bson_oid_get_time_t(oid_t))
+        self.timestamp = UInt32(bson_oid_get_time_t(oid_t))
     }
 
     /// Returns the provided string as a `bson_oid_t`.

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -120,10 +120,19 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // round trip the objectId.
         // expect the encoded oid to equal the original
-        let encoded = try BSONEncoder().encode(["_id": objectId])
-        print("!!DEBUG!!")
-        print(encoded["_id"] as! Document)
-        guard let _id = encoded["_id"] as? ObjectId else {
+        struct TestObject: Codable {
+            private let _id: ObjectId
+            private let foo = "bar"
+
+            init(id: ObjectId) {
+                self._id = id
+            }
+        }
+        
+        let testObject = TestObject(id: objectId)
+        let encodedTestObject = try BSONEncoder().encode(testObject)
+
+        guard let _id = encodedTestObject["_id"] as? ObjectId else {
             fail("encoded document did not contain objectId _id")
             return
         }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -121,6 +121,10 @@ final class BSONValueTests: MongoSwiftTestCase {
         // round trip the objectId.
         // expect the encoded oid to equal the original
         let encoded = try BSONEncoder().encode(["_id": objectId])
+        print(encoded)
+        print(type(of: encoded))
+        print(encoded["_id"])
+        print(type(of: encoded["_id"]))
         guard let _id = encoded["_id"] as? ObjectId else {
             fail("encoded document did not contain objectId _id")
             return

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -121,10 +121,8 @@ final class BSONValueTests: MongoSwiftTestCase {
         // round trip the objectId.
         // expect the encoded oid to equal the original
         let encoded = try BSONEncoder().encode(["_id": objectId])
-        print(encoded)
-        print(type(of: encoded))
-        print(encoded["_id"])
-        print(type(of: encoded["_id"]))
+        print("!!DEBUG!!")
+        print(encoded["_id"] as! Document)
         guard let _id = encoded["_id"] as? ObjectId else {
             fail("encoded document did not contain objectId _id")
             return

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -99,6 +99,16 @@ final class BSONValueTests: MongoSwiftTestCase {
         expect(4).toNot(bsonEqual("swift"))
     }
 
+    /// Test object for ObjectIdRoundTrip
+    struct TestObject: Codable {
+        private let _id: ObjectId
+        private let foo = "bar"
+
+        init(id: ObjectId) {
+            self._id = id
+        }
+    }
+
     func testObjectIdRoundTrip() throws {
         // alloc new bson_oid_t
         var oid_t = bson_oid_t()
@@ -120,15 +130,6 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // round trip the objectId.
         // expect the encoded oid to equal the original
-        struct TestObject: Codable {
-            private let _id: ObjectId
-            private let foo = "bar"
-
-            init(id: ObjectId) {
-                self._id = id
-            }
-        }
-        
         let testObject = TestObject(id: objectId)
         let encodedTestObject = try BSONEncoder().encode(testObject)
 

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -110,7 +110,7 @@ final class BSONValueTests: MongoSwiftTestCase {
         let oid = String.init(cString: &oid_c)
 
         // read the timestamp used to create the oid
-        let timestamp = TimeInterval(bson_oid_get_time_t(&oid_t))
+        let timestamp = UInt32(bson_oid_get_time_t(&oid_t))
 
         // initialize a new oid with the oid_t ptr
         // expect the values to be equal

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -100,7 +100,7 @@ final class BSONValueTests: MongoSwiftTestCase {
     }
 
     /// Test object for ObjectIdRoundTrip
-    struct TestObject: Codable {
+    private struct TestObject: Codable {
         private let _id: ObjectId
         private let foo = "bar"
 
@@ -115,16 +115,16 @@ final class BSONValueTests: MongoSwiftTestCase {
         bson_oid_init(&oid_t, nil)
 
         // read the hex string of the oid_t
-        var oid_c = [CChar].init(repeating: 0, count: 25)
+        var oid_c = [CChar](repeating: 0, count: 25)
         bson_oid_to_string(&oid_t, &oid_c)
-        let oid = String.init(cString: &oid_c)
+        let oid = String(cString: &oid_c)
 
         // read the timestamp used to create the oid
         let timestamp = UInt32(bson_oid_get_time_t(&oid_t))
 
         // initialize a new oid with the oid_t ptr
         // expect the values to be equal
-        let objectId = ObjectId.init(fromPointer: &oid_t)
+        let objectId = ObjectId(fromPointer: &oid_t)
         expect(objectId.oid).to(equal(oid))
         expect(objectId.timestamp).to(equal(timestamp))
 
@@ -143,7 +143,7 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // expect that we can pull the correct timestamp if
         // initialized from the original string
-        let objectIdFromString = ObjectId.init(fromString: oid)
+        let objectIdFromString = ObjectId(fromString: oid)
         expect(objectIdFromString.oid).to(equal(oid))
         expect(objectIdFromString.timestamp).to(equal(timestamp))
     }


### PR DESCRIPTION
- Read timestamp from `bson_oid_get_time_t`
- Expose as `timestamp` within `ObjectId` class