### PR TITLE
SWIFT-244 TopologyDescription.hasReadableServer should take in a Read…

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -163,8 +163,10 @@ public struct ServerDescriptionChangedEvent: MongoEvent, InitializableFromOpaque
         var oid = bson_oid_t()
         mongoc_apm_server_changed_get_topology_id(event, &oid)
         self.topologyId = ObjectId(fromPointer: &oid)
-        self.previousDescription = ServerDescription(mongoc_apm_server_changed_get_previous_description(event), nil)
-        self.newDescription = ServerDescription(mongoc_apm_server_changed_get_new_description(event), Date())
+        self.previousDescription = ServerDescription(mongoc_apm_server_changed_get_previous_description(event))
+        self.newDescription = ServerDescription(
+                mongoc_apm_server_changed_get_new_description(event),
+                updateTime: Date())
     }
 }
 

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -163,8 +163,8 @@ public struct ServerDescriptionChangedEvent: MongoEvent, InitializableFromOpaque
         var oid = bson_oid_t()
         mongoc_apm_server_changed_get_topology_id(event, &oid)
         self.topologyId = ObjectId(fromPointer: &oid)
-        self.previousDescription = ServerDescription(mongoc_apm_server_changed_get_previous_description(event))
-        self.newDescription = ServerDescription(mongoc_apm_server_changed_get_new_description(event))
+        self.previousDescription = ServerDescription(mongoc_apm_server_changed_get_previous_description(event), nil)
+        self.newDescription = ServerDescription(mongoc_apm_server_changed_get_new_description(event), Date())
     }
 }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -267,6 +267,10 @@ extension Date: BSONValue {
     public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
         return self.init(msSinceEpoch: bson_iter_date_time(&iter.iter))
     }
+
+    internal static func - (lhs: Date, rhs: Date) -> TimeInterval {
+        return lhs.timeIntervalSinceReferenceDate - rhs.timeIntervalSinceReferenceDate
+    }
 }
 
 /// An internal struct to represent the deprecated DBPointer type. While DBPointers cannot

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -268,6 +268,7 @@ extension Date: BSONValue {
         return self.init(msSinceEpoch: bson_iter_date_time(&iter.iter))
     }
 
+    /// Returns the difference in seconds between the two dates.
     internal static func - (lhs: Date, rhs: Date) -> TimeInterval {
         return lhs.timeIntervalSinceReferenceDate - rhs.timeIntervalSinceReferenceDate
     }

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -177,7 +177,8 @@ public struct ServerDescription {
         return true
     }
 
-    /// An internal initializer to create a `ServerDescription` for testing purposes.
+    /// An internal initializer to create a `ServerDescription` for testing purposes. This is defined here instead of
+    /// in an extension in the test files due to restrictions introduced in SE-0189.
     internal init(connectionId: ConnectionId, type: ServerType, isMaster: Document, updateTime: Date?) {
         self.connectionId = connectionId
         self.type = type
@@ -339,7 +340,8 @@ public struct TopologyDescription {
         return [.single, .replicaSetWithPrimary].contains(self.type)
     }
 
-    /// An internal initializer to create a `TopologyDescription` for testing purposes
+    /// An internal initializer to create a `TopologyDescription` for testing purposes. This is defined here instead of
+    /// in an extension in the test files due to restrictions introduced in SE-0189.
     internal init(type: TopologyType, servers: [ServerDescription]) {
         self.type = type
         self.servers = servers

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -169,7 +169,7 @@ public struct ServerDescription {
         }
 
         for kvp in tagSet {
-            if !serverTags.keys.contains(kvp.key) || !bsonEquals(serverTags[kvp.key]!, kvp.value!) {
+            if !serverTags.keys.contains(kvp.key) || !bsonEquals(serverTags[kvp.key]!, kvp.value) {
                 return false
             }
         }

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -178,18 +178,16 @@ public struct ServerDescription {
     }
 
     /// An internal initializer to create a `ServerDescription` for testing purposes.
-    internal init(_ connectionId: ConnectionId, _ rtt: Int64, _ isMaster: Document, _ type: ServerType,
-                  _ updateTime: Date?) {
+    internal init(connectionId: ConnectionId, type: ServerType, isMaster: Document, updateTime: Date?) {
         self.connectionId = connectionId
-        self.roundTripTime = rtt
-        self.parseIsMaster(isMaster)
         self.type = type
+        self.parseIsMaster(isMaster)
         self.lastUpdateTime = updateTime // TODO: get lastUpdateTime from mongoc_server_description_t after CDRIVER-2896
     }
 
     /// An internal initializer to create a `ServerDescription` from an OpaquePointer to a
     /// mongoc_server_description_t.
-    internal init(_ description: OpaquePointer, _ updateTime: Date?) {
+    internal init(_ description: OpaquePointer, updateTime: Date? = nil) {
         self.lastUpdateTime = updateTime // TODO: get lastUpdateTime from mongoc_server_description_t after CDRIVER-2896
         self.connectionId = ConnectionId(mongoc_server_description_host(description))
         self.roundTripTime = mongoc_server_description_round_trip_time(description)
@@ -317,7 +315,7 @@ public struct TopologyDescription {
     }
 
     /// Returns `true` if the topology has a readable server available, and `false` otherwise.
-    public func hasReadableServer(_ readPref: ReadPreference = ReadPreference(ReadPreference.Mode.primary)) -> Bool {
+    public func hasReadableServer(_ readPref: ReadPreference = ReadPreference(.primary)) -> Bool {
         switch self.type {
         case .unknown:
             return false
@@ -342,7 +340,7 @@ public struct TopologyDescription {
     }
 
     /// An internal initializer to create a `TopologyDescription` for testing purposes
-    internal init(_ type: TopologyType, _ servers: [ServerDescription]) {
+    internal init(type: TopologyType, servers: [ServerDescription]) {
         self.type = type
         self.servers = servers
     }
@@ -358,7 +356,7 @@ public struct TopologyDescription {
         let serverData = mongoc_topology_description_get_servers(description, &size)
         let buffer = UnsafeBufferPointer(start: serverData, count: size)
         if size > 0 {
-            self.servers = Array(buffer).map { ServerDescription($0!, updateTime) }
+            self.servers = Array(buffer).map { ServerDescription($0!, updateTime: updateTime) }
         }
     }
 }

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -172,24 +172,24 @@ final class SDAMTests: MongoSwiftTestCase {
         let servers: [ServerDescription] = [
             ServerDescription(
                     connectionId: ConnectionId(hosts[0]),
-                    type: ServerType.rsPrimary,
+                    type: .rsPrimary,
                     isMaster: isMasterPrimary,
                     updateTime: primaryLastWrite + 10),
             ServerDescription(
                     connectionId: ConnectionId(hosts[1]),
-                    type: ServerType.rsSecondary,
+                    type: .rsSecondary,
                     isMaster: isMasterSecondary,
                     updateTime: primaryLastWrite + 600),
             ServerDescription(
                     connectionId: ConnectionId(hosts[1]),
-                    type: ServerType.rsSecondary,
+                    type: .rsSecondary,
                     isMaster: isMasterSecondary1,
                     updateTime: primaryLastWrite + 10)
         ]
 
         let serversNoPrimary: [ServerDescription] = Array(servers[1...])
 
-        let topology1 = TopologyDescription(type: TopologyType.replicaSetWithPrimary, servers: servers)
+        let topology1 = TopologyDescription(type: .replicaSetWithPrimary, servers: servers)
         let case1: [(ReadPreference, Bool)] = [
             (ReadPreference(.primary), true),
             (ReadPreference(.secondary), true),
@@ -202,7 +202,7 @@ final class SDAMTests: MongoSwiftTestCase {
         ]
         runHasReadableAsserts(topology1, case1)
 
-        let topology2 = TopologyDescription(type: TopologyType.replicaSetNoPrimary, servers: serversNoPrimary)
+        let topology2 = TopologyDescription(type: .replicaSetNoPrimary, servers: serversNoPrimary)
         let case2: [(ReadPreference, Bool)] = [
             (ReadPreference(.primary), false),
             (ReadPreference(.secondary), true),
@@ -212,7 +212,7 @@ final class SDAMTests: MongoSwiftTestCase {
         ]
         runHasReadableAsserts(topology2, case2)
 
-        let topology3 = TopologyDescription(type: TopologyType.replicaSetWithPrimary, servers: servers)
+        let topology3 = TopologyDescription(type: .replicaSetWithPrimary, servers: servers)
         let case3: [(ReadPreference, Bool)] = [
             (ReadPreference(.primary), true),
             (ReadPreference(.secondary), true),
@@ -222,7 +222,7 @@ final class SDAMTests: MongoSwiftTestCase {
         ]
         runHasReadableAsserts(topology3, case3)
 
-        let topology4 = TopologyDescription(type: TopologyType.replicaSetNoPrimary, servers: serversNoPrimary)
+        let topology4 = TopologyDescription(type: .replicaSetNoPrimary, servers: serversNoPrimary)
         let case4: [(ReadPreference, Bool)] = [
             (ReadPreference(.primary), false),
             (try ReadPreference(.primaryPreferred, tagSets: [tags]), true),

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -7,7 +7,8 @@ import XCTest
 final class SDAMTests: MongoSwiftTestCase {
     static var allTests: [(String, (SDAMTests) -> () throws -> Void)] {
         return [
-            ("testMonitoring", testMonitoring)
+            ("testMonitoring", testMonitoring),
+            ("testHasReadableServers", testHasReadableServers)
         ]
     }
 
@@ -169,24 +170,26 @@ final class SDAMTests: MongoSwiftTestCase {
         ]
 
         let servers: [ServerDescription] = [
-            ServerDescription(ConnectionId(hosts[0]), 12, isMasterPrimary, ServerType.rsPrimary, primaryLastWrite + 10),
-            ServerDescription(ConnectionId(
-                    hosts[1]),
-                    12,
-                    isMasterSecondary,
-                    ServerType.rsSecondary,
-                    primaryLastWrite + 600),
-            ServerDescription(ConnectionId(
-                    hosts[2]),
-                    12,
-                    isMasterSecondary1,
-                    ServerType.rsSecondary,
-                    primaryLastWrite + 10)
+            ServerDescription(
+                    connectionId: ConnectionId(hosts[0]),
+                    type: ServerType.rsPrimary,
+                    isMaster: isMasterPrimary,
+                    updateTime: primaryLastWrite + 10),
+            ServerDescription(
+                    connectionId: ConnectionId(hosts[1]),
+                    type: ServerType.rsSecondary,
+                    isMaster: isMasterSecondary,
+                    updateTime: primaryLastWrite + 600),
+            ServerDescription(
+                    connectionId: ConnectionId(hosts[1]),
+                    type: ServerType.rsSecondary,
+                    isMaster: isMasterSecondary1,
+                    updateTime: primaryLastWrite + 10)
         ]
 
         let serversNoPrimary: [ServerDescription] = Array(servers[1...])
 
-        let topology1 = TopologyDescription(TopologyType.replicaSetWithPrimary, servers)
+        let topology1 = TopologyDescription(type: TopologyType.replicaSetWithPrimary, servers: servers)
         let case1: [(ReadPreference, Bool)] = [
             (ReadPreference(.primary), true),
             (ReadPreference(.secondary), true),
@@ -199,7 +202,7 @@ final class SDAMTests: MongoSwiftTestCase {
         ]
         runHasReadableAsserts(topology1, case1)
 
-        let topology2 = TopologyDescription(TopologyType.replicaSetNoPrimary, serversNoPrimary)
+        let topology2 = TopologyDescription(type: TopologyType.replicaSetNoPrimary, servers: serversNoPrimary)
         let case2: [(ReadPreference, Bool)] = [
             (ReadPreference(.primary), false),
             (ReadPreference(.secondary), true),
@@ -209,7 +212,7 @@ final class SDAMTests: MongoSwiftTestCase {
         ]
         runHasReadableAsserts(topology2, case2)
 
-        let topology3 = TopologyDescription(TopologyType.replicaSetWithPrimary, servers)
+        let topology3 = TopologyDescription(type: TopologyType.replicaSetWithPrimary, servers: servers)
         let case3: [(ReadPreference, Bool)] = [
             (ReadPreference(.primary), true),
             (ReadPreference(.secondary), true),
@@ -219,7 +222,7 @@ final class SDAMTests: MongoSwiftTestCase {
         ]
         runHasReadableAsserts(topology3, case3)
 
-        let topology4 = TopologyDescription(TopologyType.replicaSetNoPrimary, serversNoPrimary)
+        let topology4 = TopologyDescription(type: TopologyType.replicaSetNoPrimary, servers: serversNoPrimary)
         let case4: [(ReadPreference, Bool)] = [
             (ReadPreference(.primary), false),
             (try ReadPreference(.primaryPreferred, tagSets: [tags]), true),

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -8,6 +8,7 @@ final class SDAMTests: MongoSwiftTestCase {
     static var allTests: [(String, (SDAMTests) -> () throws -> Void)] {
         return [
             ("testMonitoring", testMonitoring),
+            ("testMaxStaleness", testMaxStaleness),
             ("testHasReadableServers", testHasReadableServers)
         ]
     }

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -238,8 +238,8 @@ final class SDAMTests: MongoSwiftTestCase {
             "c:3"
         ]
 
-        let tags: Document = ["dog": 1, "cat": "two"]
-        let tags1: Document = ["sdaf": "sadfsf", "f": 2]
+        let tags: Document = ["dog": "1", "cat": "two"]
+        let tags1: Document = ["sdaf": "sadfsf", "f": "2"]
         let wrongTags: Document = ["a": "b"]
 
         let primaryLastWrite = Date() - 600

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -169,7 +169,7 @@ final class SDAMTests: MongoSwiftTestCase {
             "lastWrite": lw
         ]
 
-        let servers: [ServerDescription] = [
+        let servers = [
             ServerDescription(
                     connectionId: ConnectionId(hosts[0]),
                     type: .rsPrimary,
@@ -187,10 +187,10 @@ final class SDAMTests: MongoSwiftTestCase {
                     updateTime: primaryLastWrite + 10)
         ]
 
-        let serversNoPrimary: [ServerDescription] = Array(servers[1...])
+        let serversNoPrimary = Array(servers[1...])
 
         let topology1 = TopologyDescription(type: .replicaSetWithPrimary, servers: servers)
-        let case1: [(ReadPreference, Bool)] = [
+        let case1 = [
             (ReadPreference(.primary), true),
             (ReadPreference(.secondary), true),
             (ReadPreference(.primaryPreferred), true),
@@ -203,7 +203,7 @@ final class SDAMTests: MongoSwiftTestCase {
         runHasReadableAsserts(topology1, case1)
 
         let topology2 = TopologyDescription(type: .replicaSetNoPrimary, servers: serversNoPrimary)
-        let case2: [(ReadPreference, Bool)] = [
+        let case2 = [
             (ReadPreference(.primary), false),
             (ReadPreference(.secondary), true),
             (ReadPreference(.primaryPreferred), true),
@@ -213,7 +213,7 @@ final class SDAMTests: MongoSwiftTestCase {
         runHasReadableAsserts(topology2, case2)
 
         let topology3 = TopologyDescription(type: .replicaSetWithPrimary, servers: servers)
-        let case3: [(ReadPreference, Bool)] = [
+        let case3 = [
             (ReadPreference(.primary), true),
             (ReadPreference(.secondary), true),
             (try ReadPreference(.secondary, tagSets: [wrongTags, tags]), true),
@@ -223,7 +223,7 @@ final class SDAMTests: MongoSwiftTestCase {
         runHasReadableAsserts(topology3, case3)
 
         let topology4 = TopologyDescription(type: .replicaSetNoPrimary, servers: serversNoPrimary)
-        let case4: [(ReadPreference, Bool)] = [
+        let case4 = [
             (ReadPreference(.primary), false),
             (try ReadPreference(.primaryPreferred, tagSets: [tags]), true),
             (try ReadPreference(.primaryPreferred, tagSets: [wrongTags]), false)


### PR DESCRIPTION
[SWIFT-244](https://jira.mongodb.org/browse/SWIFT-244)

This PR adds an optional read preference to `TopologyDescription.hasReadableServer`. 

In order to fully support the max staleness option of read preferences, we needed to basically perform server selection, which relies on two fields that libmongoc does not expose: `lastUpdateTime` from `mongoc_server_description_t` and `heartbeatFrequencyMS` from `mongoc_topology_description_t`. For the former, I filed a ticket (https://jira.mongodb.org/browse/CDRIVER-2896) to add the necessary getter. In the meantime, it can be estimated using the system clock in the Swift driver. The latter has a spec-defined default value and is configured via the connection string, so I just set it from there. 
