### PR TITLE
Fix Linux + Swift 4.2 failure

### DIFF
--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -89,8 +89,10 @@ final class BSONValueTests: MongoSwiftTestCase {
                 "nested": [ "a": 1, "b": "different" ] as Document
                 ] as Document
         )
-        // Invalid Array type
-        expect(bsonEquals([BSONEncoder()], [BSONEncoder(), BSONEncoder()])).to(beFalse())
+        // Check that when an array contains non-BSONValues, we return false
+        let arr = [[String: Int]()]
+        expect(bsonEquals(arr, arr)).to(beFalse())
+
         // Different types
         expect(4).toNot(bsonEqual("swift"))
     }


### PR DESCRIPTION
for some strange reason, this test was failing on Linux with Swift 4.2. don't know why. @mbroadst looked at it for a bit but I don't think he figured out the issue. 

anyway, this seems like a weird Swift on Linux bug, so I've modified the test to check for basically the same thing but in a different way.

@Utagai, including you so you can verify that I correctly interpreted what this assertion was trying to check?