### PR TITLE
Add 4.2 version of Package.swift

### DIFF
--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:4.2
+import PackageDescription
+let package = Package(
+    name: "MongoSwift",
+    products: [
+        .library(name: "MongoSwift", targets: ["MongoSwift"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/mongodb/swift-bson", from: "2.0.0"),
+        .package(url: "https://github.com/mongodb/swift-mongoc", from: "2.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "7.3.0")
+    ],
+    targets: [
+        .target(name: "MongoSwift", dependencies: ["mongoc", "bson"]),
+        .testTarget(name: "MongoSwiftTests", dependencies: ["MongoSwift", "Nimble"])
+    ]
+)


### PR DESCRIPTION
Adds a new version-specific `Package.swift`. Without this, `-swift-version 4` is still passed to the compiler, which then thinks we are in 4.1 when we do `#if swift` version checks. what's confusing about this to me is that even without this change, one can still successfully compile and use Swift 4.2 features in the code, for ex. I just tried this with Swift 4.2's new `CaseIterable` protocol. the version checks just don't work as one would expect.

for now anyway, this seems to be the standard way to still support 4.0 while adding support for 4.2. 