### PR TITLE
SWIFT-253 Make test database name accessible from the base class

### DIFF
--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -16,7 +16,7 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
         self.continueAfterFailure = false
     }
 
-    override class func testDatabase() -> String {
+    override internal class var testDatabase: String {
         return "commandTest"
     }
 
@@ -88,7 +88,7 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
 
     func testAlternateNotificationCenters() throws {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
-        let db = try client.db(type(of: self).testDatabase())
+        let db = try client.db(type(of: self).testDatabase)
         let collection = try db.createCollection("coll1")
         let customCenter = NotificationCenter()
         client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -16,6 +16,10 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
         self.continueAfterFailure = false
     }
 
+    override class func testDatabase() -> String {
+        return "commandTest"
+    }
+
     func testCommandMonitoring() throws {
         let decoder = BSONDecoder()
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
@@ -84,7 +88,7 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
 
     func testAlternateNotificationCenters() throws {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
-        let db = try client.db("commandTest")
+        let db = try client.db(type(of: self).testDatabase())
         let collection = try db.createCollection("coll1")
         let customCenter = NotificationCenter()
         client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -16,10 +16,6 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
         self.continueAfterFailure = false
     }
 
-    override internal class var testDatabase: String {
-        return "commandTest"
-    }
-
     func testCommandMonitoring() throws {
         let decoder = BSONDecoder()
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -19,20 +19,24 @@ final class CrudTests: MongoSwiftTestCase {
         ]
     }
 
+    override class func testDatabase() -> String {
+        return "crudTests"
+    }
+
     // Teardown at the very end of the suite by dropping the "crudTests" db.
     override class func tearDown() {
         super.tearDown()
         do {
-            try MongoClient().db("crudTests").drop()
+            try MongoClient().db(testDatabase()).drop()
         } catch {
-            print("Dropping test db crudTests failed: \(error)")
+            print("Dropping test db \(testDatabase()) failed: \(error)")
         }
     }
 
     // Run tests for .json files at the provided path
     func doTests(forPath: String) throws {
         let client = try MongoClient()
-        let db = try client.db("crudTests")
+        let db = try client.db(type(of: self).testDatabase())
         for (filename, file) in try parseFiles(atPath: forPath) {
 
             if try !client.serverVersionIsInRange(file.minServerVersion, file.maxServerVersion) {

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -19,7 +19,7 @@ final class CrudTests: MongoSwiftTestCase {
         ]
     }
 
-    // Teardown at the very end of the suite by dropping the "crudTests" db.
+    // Teardown at the very end of the suite by dropping the db we tested on.
     override class func tearDown() {
         super.tearDown()
         do {

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -19,7 +19,7 @@ final class CrudTests: MongoSwiftTestCase {
         ]
     }
 
-    override class func testDatabase() -> String {
+    override internal class var testDatabase: String {
         return "crudTests"
     }
 
@@ -27,16 +27,16 @@ final class CrudTests: MongoSwiftTestCase {
     override class func tearDown() {
         super.tearDown()
         do {
-            try MongoClient().db(testDatabase()).drop()
+            try MongoClient().db(testDatabase).drop()
         } catch {
-            print("Dropping test db \(testDatabase()) failed: \(error)")
+            print("Dropping test db \(testDatabase) failed: \(error)")
         }
     }
 
     // Run tests for .json files at the provided path
     func doTests(forPath: String) throws {
         let client = try MongoClient()
-        let db = try client.db(type(of: self).testDatabase())
+        let db = try client.db(type(of: self).testDatabase)
         for (filename, file) in try parseFiles(atPath: forPath) {
 
             if try !client.serverVersionIsInRange(file.minServerVersion, file.maxServerVersion) {

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -23,9 +23,9 @@ final class CrudTests: MongoSwiftTestCase {
     override class func tearDown() {
         super.tearDown()
         do {
-            try MongoClient().db(testDatabase).drop()
+            try MongoClient().db(self.testDatabase).drop()
         } catch {
-            print("Dropping test db \(testDatabase) failed: \(error)")
+            print("Dropping test db \(self.testDatabase) failed: \(error)")
         }
     }
 

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -19,10 +19,6 @@ final class CrudTests: MongoSwiftTestCase {
         ]
     }
 
-    override internal class var testDatabase: String {
-        return "crudTests"
-    }
-
     // Teardown at the very end of the suite by dropping the "crudTests" db.
     override class func tearDown() {
         super.tearDown()

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -30,7 +30,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         }
 
         let client = MongoClient(fromPointer: client_t)
-        let db = try client.db(type(of: self).testDatabase())
+        let db = try client.db(type(of: self).testDatabase)
         let coll = try db.collection("foo")
         let insertResult = try coll.insertOne([ "test": 42 ])
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -30,7 +30,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         }
 
         let client = MongoClient(fromPointer: client_t)
-        let db = try client.db("test")
+        let db = try client.db(type(of: self).testDatabase())
         let coll = try db.collection("foo")
         let insertResult = try coll.insertOne([ "test": 42 ])
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -17,10 +17,6 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
     static var client: MongoClient?
     var coll: MongoCollection<Document>!
 
-    override internal class var testDatabase: String {
-        return "collectionTest"
-    }
-
     /// Set up the entire suite - run once before all tests
     override class func setUp() {
         super.setUp()

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -17,6 +17,10 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
     static var client: MongoClient?
     var coll: MongoCollection<Document>!
 
+    override class func testDatabase() -> String {
+        return "collectionTest"
+    }
+
     /// Set up the entire suite - run once before all tests
     override class func setUp() {
         super.setUp()
@@ -39,7 +43,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         let collectionName = String(describing: self)
 
         do {
-            coll = try client.db("collectionTest").collection(collectionName)
+            coll = try client.db(type(of: self).testDatabase()).collection(collectionName)
         } catch {
             return XCTFail("Setup failed: \(error)")
         }

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -17,7 +17,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
     static var client: MongoClient?
     var coll: MongoCollection<Document>!
 
-    override class func testDatabase() -> String {
+    override internal class var testDatabase: String {
         return "collectionTest"
     }
 
@@ -43,7 +43,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         let collectionName = String(describing: self)
 
         do {
-            coll = try client.db(type(of: self).testDatabase()).collection(collectionName)
+            coll = try client.db(type(of: self).testDatabase).collection(collectionName)
         } catch {
             return XCTFail("Setup failed: \(error)")
         }

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -90,7 +90,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
                 print("Invalid client")
                 return
             }
-            try client.db(testDatabase).drop()
+            try client.db(self.testDatabase).drop()
         } catch {
             print("Dropping test database collectionTest failed: \(error)")
         }

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -65,7 +65,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
                 XCTFail("Invalid client")
                 return
             }
-            coll = try client.db(type(of: self).testDatabase()).createCollection("coll1")
+            coll = try client.db(type(of: self).testDatabase).createCollection("coll1")
             try coll.insertMany([doc1, doc2])
         } catch {
             XCTFail("Setup failed: \(error)")
@@ -90,7 +90,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
                 print("Invalid client")
                 return
             }
-            try client.db(testDatabase()).drop()
+            try client.db(testDatabase).drop()
         } catch {
             print("Dropping test database collectionTest failed: \(error)")
         }
@@ -358,7 +358,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
     func testCodableCollection() throws {
         let client = try MongoClient()
-        let db = try client.db(type(of: self).testDatabase())
+        let db = try client.db(type(of: self).testDatabase)
         let coll1 = try db.createCollection("codablecoll", withType: Basic.self)
         defer { try? coll1.drop() }
 

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -65,7 +65,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
                 XCTFail("Invalid client")
                 return
             }
-            coll = try client.db("collectionTest").createCollection("coll1")
+            coll = try client.db(type(of: self).testDatabase()).createCollection("coll1")
             try coll.insertMany([doc1, doc2])
         } catch {
             XCTFail("Setup failed: \(error)")
@@ -90,7 +90,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
                 print("Invalid client")
                 return
             }
-            try client.db("collectionTest").drop()
+            try client.db(testDatabase()).drop()
         } catch {
             print("Dropping test database collectionTest failed: \(error)")
         }
@@ -358,9 +358,9 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
     func testCodableCollection() throws {
         let client = try MongoClient()
-        let db = try client.db("codable")
-        defer { try? db.drop() }
-        let coll1 = try db.createCollection("coll1", withType: Basic.self)
+        let db = try client.db(type(of: self).testDatabase())
+        let coll1 = try db.createCollection("codablecoll", withType: Basic.self)
+        defer { try? coll1.drop() }
 
         let b1 = Basic(x: 1, y: "hi")
         let b2 = Basic(x: 2, y: "hello")

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -5,11 +5,11 @@ import XCTest
 final class MongoDatabaseTests: MongoSwiftTestCase {
     static var allTests: [(String, (MongoDatabaseTests) -> () throws -> Void)] {
         return [
-            ("testDatabase", testDatabase)
+            ("testDatabase", testMongoDatabase)
         ]
     }
 
-    override class func testDatabase() -> String {
+    override internal class var testDatabase: String {
         return "testDB"
     }
 
@@ -17,9 +17,9 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         continueAfterFailure = false
     }
 
-    func testDatabase() throws {
+    func testMongoDatabase() throws {
         let client = try MongoClient(connectionString: MongoSwiftTestCase.connStr)
-        let db = try client.db(type(of: self).testDatabase())
+        let db = try client.db(type(of: self).testDatabase)
 
         let command: Document = ["create": "coll1"]
         expect(try db.runCommand(command)).to(equal(["ok": 1.0]))
@@ -35,8 +35,8 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         expect(try db.drop()).toNot(throwError())
         let dbs = try client.listDatabases(options: ListDatabasesOptions(nameOnly: true))
         let names = (Array(dbs) as [Document]).map { $0["name"] as? String ?? "" }
-        expect(names).toNot(contain([type(of: self).testDatabase()]))
+        expect(names).toNot(contain([type(of: self).testDatabase]))
 
-        expect(db.name).to(equal(type(of: self).testDatabase()))
+        expect(db.name).to(equal(type(of: self).testDatabase))
     }
 }

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -9,13 +9,17 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         ]
     }
 
+    override class func testDatabase() -> String {
+        return "testDB"
+    }
+
     override func setUp() {
         continueAfterFailure = false
     }
 
     func testDatabase() throws {
         let client = try MongoClient(connectionString: MongoSwiftTestCase.connStr)
-        let db = try client.db("testDB")
+        let db = try client.db(type(of: self).testDatabase())
 
         let command: Document = ["create": "coll1"]
         expect(try db.runCommand(command)).to(equal(["ok": 1.0]))
@@ -31,8 +35,8 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         expect(try db.drop()).toNot(throwError())
         let dbs = try client.listDatabases(options: ListDatabasesOptions(nameOnly: true))
         let names = (Array(dbs) as [Document]).map { $0["name"] as? String ?? "" }
-        expect(names).toNot(contain(["testDB"]))
+        expect(names).toNot(contain([type(of: self).testDatabase()]))
 
-        expect(db.name).to(equal("testDB"))
+        expect(db.name).to(equal(type(of: self).testDatabase()))
     }
 }

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class MongoDatabaseTests: MongoSwiftTestCase {
     static var allTests: [(String, (MongoDatabaseTests) -> () throws -> Void)] {
         return [
-            ("testDatabase", testMongoDatabase)
+            ("testMongoDatabase", testMongoDatabase)
         ]
     }
 

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -9,10 +9,6 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         ]
     }
 
-    override internal class var testDatabase: String {
-        return "testDB"
-    }
-
     override func setUp() {
         continueAfterFailure = false
     }

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -88,11 +88,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern).to(beNil())
 
             // expect that a DB created from this client inherits its unset RC 
-            let db1 = try client.db(type(of: self).testDatabase())
+            let db1 = try client.db(type(of: self).testDatabase)
             expect(db1.readConcern).to(beNil())
 
             // expect that a DB created from this client can override the client's unset RC
-            let db2 = try client.db(type(of: self).testDatabase(), options: DatabaseOptions(readConcern: majority))
+            let db2 = try client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
             expect(db2.readConcern?.level).to(equal("majority"))
         }
 
@@ -103,11 +103,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern?.level).to(equal("local"))
 
             // expect that a DB created from this client inherits its local RC 
-            let db1 = try client.db(type(of: self).testDatabase())
+            let db1 = try client.db(type(of: self).testDatabase)
             expect(db1.readConcern?.level).to(equal("local"))
 
             // expect that a DB created from this client can override the client's local RC
-            let db2 = try client.db(type(of: self).testDatabase(), options: DatabaseOptions(readConcern: majority))
+            let db2 = try client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
             expect(db2.readConcern?.level).to(equal("majority"))
         }
 
@@ -117,7 +117,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern?.level).to(equal("majority"))
 
             // expect that a DB created from this client can override the client's majority RC with an unset one
-            let db = try client.db(type(of: self).testDatabase(), options: DatabaseOptions(readConcern: ReadConcern()))
+            let db = try client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: ReadConcern()))
             expect(db.readConcern).to(beNil())
         }
     }
@@ -134,11 +134,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client1.writeConcern).to(beNil())
 
             // expect that a DB created from this client inherits its default WC
-            let db1 = try client1.db(type(of: self).testDatabase())
+            let db1 = try client1.db(type(of: self).testDatabase)
             expect(db1.writeConcern).to(beNil())
 
             // expect that a DB created from this client can override the client's default WC
-            let db2 = try client1.db(type(of: self).testDatabase(), options: DatabaseOptions(writeConcern: wc2))
+            let db2 = try client1.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc2))
             expect(db2.writeConcern?.w).to(equal(w2))
         }
 
@@ -149,11 +149,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client2.writeConcern?.w).to(equal(w1))
 
             // expect that a DB created from this client inherits its WC
-            let db3 = try client2.db(type(of: self).testDatabase())
+            let db3 = try client2.db(type(of: self).testDatabase)
             expect(db3.writeConcern?.w).to(equal(w1))
 
             // expect that a DB created from this client can override the client's WC
-            let db4 = try client2.db(type(of: self).testDatabase(), options: DatabaseOptions(writeConcern: wc2))
+            let db4 = try client2.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc2))
             expect(db4.writeConcern?.w).to(equal(w2))
         }
 
@@ -164,7 +164,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
             // expect that a DB created from this client can override the client's WC with an unset one
             let db5 = try client3.db(
-                    type(of: self).testDatabase(),
+                    type(of: self).testDatabase,
                     options: DatabaseOptions(writeConcern: WriteConcern()))
             expect(db5.writeConcern).to(beNil())
         }
@@ -173,7 +173,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testDatabaseReadConcern() throws {
         let client = try MongoClient()
 
-        let db1 = try client.db(type(of: self).testDatabase())
+        let db1 = try client.db(type(of: self).testDatabase)
         defer { try? db1.drop() }
 
         // expect that a collection created from a DB with unset RC also has unset RC
@@ -191,7 +191,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         try db1.drop()
 
         let db2 = try client.db(
-                type(of: self).testDatabase(),
+                type(of: self).testDatabase,
                 options: DatabaseOptions(readConcern: ReadConcern(.local)))
         defer { try? db2.drop() }
 
@@ -211,7 +211,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testDatabaseWriteConcern() throws {
         let client = try MongoClient()
 
-        let db1 = try client.db(type(of: self).testDatabase())
+        let db1 = try client.db(type(of: self).testDatabase)
         defer { try? db1.drop() }
 
         // expect that a collection created from a DB with default WC also has default WC
@@ -231,7 +231,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         try db1.drop()
 
-        let db2 = try client.db(type(of: self).testDatabase(), options: DatabaseOptions(writeConcern: wc1))
+        let db2 = try client.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc1))
         defer { try? db2.drop() }
 
         // expect that a collection created from a DB with w:1 also has w:1
@@ -250,7 +250,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testOperationReadConcerns() throws {
         // setup a collection 
         let client = try MongoClient()
-        let db = try client.db(type(of: self).testDatabase())
+        let db = try client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
         let coll = try db.createCollection("coll1")
 
@@ -284,7 +284,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
     func testOperationWriteConcerns() throws {
         let client = try MongoClient()
-        let db = try client.db(type(of: self).testDatabase())
+        let db = try client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
 
         var counter = 0

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -88,11 +88,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern).to(beNil())
 
             // expect that a DB created from this client inherits its unset RC 
-            let db1 = try client.db("test")
+            let db1 = try client.db(type(of: self).testDatabase())
             expect(db1.readConcern).to(beNil())
 
             // expect that a DB created from this client can override the client's unset RC
-            let db2 = try client.db("test", options: DatabaseOptions(readConcern: majority))
+            let db2 = try client.db(type(of: self).testDatabase(), options: DatabaseOptions(readConcern: majority))
             expect(db2.readConcern?.level).to(equal("majority"))
         }
 
@@ -103,11 +103,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern?.level).to(equal("local"))
 
             // expect that a DB created from this client inherits its local RC 
-            let db1 = try client.db("test")
+            let db1 = try client.db(type(of: self).testDatabase())
             expect(db1.readConcern?.level).to(equal("local"))
 
             // expect that a DB created from this client can override the client's local RC
-            let db2 = try client.db("test", options: DatabaseOptions(readConcern: majority))
+            let db2 = try client.db(type(of: self).testDatabase(), options: DatabaseOptions(readConcern: majority))
             expect(db2.readConcern?.level).to(equal("majority"))
         }
 
@@ -117,7 +117,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern?.level).to(equal("majority"))
 
             // expect that a DB created from this client can override the client's majority RC with an unset one
-            let db = try client.db("test", options: DatabaseOptions(readConcern: ReadConcern()))
+            let db = try client.db(type(of: self).testDatabase(), options: DatabaseOptions(readConcern: ReadConcern()))
             expect(db.readConcern).to(beNil())
         }
     }
@@ -134,11 +134,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client1.writeConcern).to(beNil())
 
             // expect that a DB created from this client inherits its default WC
-            let db1 = try client1.db("test")
+            let db1 = try client1.db(type(of: self).testDatabase())
             expect(db1.writeConcern).to(beNil())
 
             // expect that a DB created from this client can override the client's default WC
-            let db2 = try client1.db("test", options: DatabaseOptions(writeConcern: wc2))
+            let db2 = try client1.db(type(of: self).testDatabase(), options: DatabaseOptions(writeConcern: wc2))
             expect(db2.writeConcern?.w).to(equal(w2))
         }
 
@@ -149,11 +149,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client2.writeConcern?.w).to(equal(w1))
 
             // expect that a DB created from this client inherits its WC
-            let db3 = try client2.db("test")
+            let db3 = try client2.db(type(of: self).testDatabase())
             expect(db3.writeConcern?.w).to(equal(w1))
 
             // expect that a DB created from this client can override the client's WC
-            let db4 = try client2.db("test", options: DatabaseOptions(writeConcern: wc2))
+            let db4 = try client2.db(type(of: self).testDatabase(), options: DatabaseOptions(writeConcern: wc2))
             expect(db4.writeConcern?.w).to(equal(w2))
         }
 
@@ -163,7 +163,9 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client3.writeConcern?.w).to(equal(w2))
 
             // expect that a DB created from this client can override the client's WC with an unset one
-            let db5 = try client3.db("test", options: DatabaseOptions(writeConcern: WriteConcern()))
+            let db5 = try client3.db(
+                    type(of: self).testDatabase(),
+                    options: DatabaseOptions(writeConcern: WriteConcern()))
             expect(db5.writeConcern).to(beNil())
         }
     }
@@ -171,7 +173,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testDatabaseReadConcern() throws {
         let client = try MongoClient()
 
-        let db1 = try client.db("test")
+        let db1 = try client.db(type(of: self).testDatabase())
         defer { try? db1.drop() }
 
         // expect that a collection created from a DB with unset RC also has unset RC
@@ -188,7 +190,9 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         try db1.drop()
 
-        let db2 = try client.db("test", options: DatabaseOptions(readConcern: ReadConcern(.local)))
+        let db2 = try client.db(
+                type(of: self).testDatabase(),
+                options: DatabaseOptions(readConcern: ReadConcern(.local)))
         defer { try? db2.drop() }
 
         // expect that a collection created from a DB with local RC also has local RC
@@ -207,7 +211,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testDatabaseWriteConcern() throws {
         let client = try MongoClient()
 
-        let db1 = try client.db("test")
+        let db1 = try client.db(type(of: self).testDatabase())
         defer { try? db1.drop() }
 
         // expect that a collection created from a DB with default WC also has default WC
@@ -227,7 +231,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         try db1.drop()
 
-        let db2 = try client.db("test", options: DatabaseOptions(writeConcern: wc1))
+        let db2 = try client.db(type(of: self).testDatabase(), options: DatabaseOptions(writeConcern: wc1))
         defer { try? db2.drop() }
 
         // expect that a collection created from a DB with w:1 also has w:1
@@ -246,7 +250,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testOperationReadConcerns() throws {
         // setup a collection 
         let client = try MongoClient()
-        let db = try client.db("test")
+        let db = try client.db(type(of: self).testDatabase())
         defer { try? db.drop() }
         let coll = try db.createCollection("coll1")
 
@@ -280,7 +284,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
     func testOperationWriteConcerns() throws {
         let client = try MongoClient()
-        let db = try client.db("test")
+        let db = try client.db(type(of: self).testDatabase())
         defer { try? db.drop() }
 
         var counter = 0

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -53,7 +53,7 @@ final class SDAMTests: MongoSwiftTestCase {
             receivedEvents.append(event)
         }
         // do some basic operations
-        let db = try client.db("testing")
+        let db = try client.db(type(of: self).testDatabase())
         _ = try db.createCollection("testColl")
         try db.drop()
 

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -53,7 +53,7 @@ final class SDAMTests: MongoSwiftTestCase {
             receivedEvents.append(event)
         }
         // do some basic operations
-        let db = try client.db(type(of: self).testDatabase())
+        let db = try client.db(type(of: self).testDatabase)
         _ = try db.createCollection("testColl")
         try db.drop()
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -13,7 +13,7 @@ class MongoSwiftTestCase: XCTestCase {
     }
 
     /// Gets the name of the database the test case is running against.
-    class func testDatabase() -> String {
+    internal class var testDatabase: String {
         return "test"
     }
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -12,6 +12,11 @@ class MongoSwiftTestCase: XCTestCase {
         MongoSwift.initialize()
     }
 
+    /// Gets the name of the database the test case is running against.
+    class func testDatabase() -> String {
+        return "test"
+    }
+
     /// Gets the path of the directory containing spec files, depending on whether
     /// we're running from XCode or the command line
     static var specsPath: String {


### PR DESCRIPTION
[SWIFT-253](https://jira.mongodb.org/browse/SWIFT-253)

This PR adds new class computed property `testDatabase` to `MongoSwiftTestCase`, which returns the name of the database that particular test case runs against, and replaces all hard-coded database names in tests to use it. 

Since it is static/class, all instances of the same test case share the same test database. It seemed like that was already assumed when the cases were written (e.g. teardown runs in a static context), so I preserved that property here. 