### PR TITLE
SWIFT-279 Fix loss of precision when initializing Date BSONValue from msSinceEpoch

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -244,7 +244,7 @@ extension Bool: BSONValue {
     }
 }
 
-/// An extension of `Date` to represent the BSON Datetime type.
+/// An extension of `Date` to represent the BSON Datetime type. Supports millisecond level precision.
 extension Date: BSONValue {
 
     public var bsonType: BSONType { return .dateTime }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -252,15 +252,14 @@ extension Date: BSONValue {
     /// Initializes a new `Date` representing the instance `msSinceEpoch` milliseconds
     /// since the Unix epoch.
     public init(msSinceEpoch: Int64) {
-        self.init(timeIntervalSince1970: Double(msSinceEpoch / 1000))
+        self.init(timeIntervalSince1970: TimeInterval(msSinceEpoch) / 1000.0)
     }
 
     /// The number of milliseconds after the Unix epoch that this `Date` occurs.
-    public var msSinceEpoch: Int64 { return Int64(self.timeIntervalSince1970 * 1000) }
+    public var msSinceEpoch: Int64 { return Int64((self.timeIntervalSince1970 * 1000.0).rounded()) }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        let seconds = self.timeIntervalSince1970 * 1000
-        guard bson_append_date_time(storage.pointer, key, Int32(key.count), Int64(seconds)) else {
+        guard bson_append_date_time(storage.pointer, key, Int32(key.count), self.msSinceEpoch) else {
             throw bsonEncodeError(value: self, forKey: key)
         }
     }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -72,7 +72,7 @@ final class DocumentTests: MongoSwiftTestCase {
             "decimal128": Decimal128("1.2E+10"),
             "minkey": MinKey(),
             "maxkey": MaxKey(),
-            "date": Date(timeIntervalSince1970: 5000),
+            "date": Date(timeIntervalSince1970: 500.004),
             "timestamp": Timestamp(timestamp: 5, inc: 10),
             "nestedarray": [[1, 2], [Int32(3), Int32(4)]] as [[Int32]],
             "nesteddoc": ["a": 1, "b": 2, "c": false, "d": [3, 4]] as Document,
@@ -123,7 +123,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["decimal128"] as? Decimal128).to(equal(Decimal128("1.2E+10")))
         expect(doc["minkey"] as? MinKey).to(beAnInstanceOf(MinKey.self))
         expect(doc["maxkey"] as? MaxKey).to(beAnInstanceOf(MaxKey.self))
-        expect(doc["date"] as? Date).to(equal(Date(timeIntervalSince1970: 5000)))
+        expect(doc["date"] as? Date).to(equal(Date(timeIntervalSince1970: 500.004)))
         expect(doc["timestamp"] as? Timestamp).to(equal(Timestamp(timestamp: 5, inc: 10)))
         expect(doc["oid"] as? ObjectId).to(equal(ObjectId(fromString: "507f1f77bcf86cd799439011")))
 


### PR DESCRIPTION
[SWIFT-279](https://jira.mongodb.org/browse/SWIFT-279)

Swift `Date`s use `TimeInterval`s to represent units of time. `TimeInterval` is simply a typealias of `Double` and is stored in terms of seconds. Our `BSONValue` Dates convert to milliseconds for interoperability with the BSON date type, but it loses precision when doing so in a couple of places. This PR fixes those precision errors.