### PR TITLE
SWIFT-241 Replace pre-existing test code to use the new bsonEqual Nimble matcher

### DIFF
--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -515,51 +515,51 @@ final class CodecTests: MongoSwiftTestCase {
         // standalone document
         let doc: Document = ["y": 1]
         expect(try encoder.encode(AnyBSONValue(doc))).to(equal(doc))
-        expect(try decoder.decode(AnyBSONValue.self, from: doc).value as? Document).to(equal(doc))
-        expect(try decoder.decode(AnyBSONValue.self, from: doc.canonicalExtendedJSON).value as? Document).to(equal(doc))
+        expect(try decoder.decode(AnyBSONValue.self, from: doc).value).to(bsonEqual(doc))
+        expect(try decoder.decode(AnyBSONValue.self, from: doc.canonicalExtendedJSON).value).to(bsonEqual(doc))
         // doc wrapped in a struct
 
         let wrappedDoc: Document = ["x": doc]
         expect(try encoder.encode(AnyBSONStruct(doc))).to(equal(wrappedDoc))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDoc).x.value as? Document).to(equal(doc))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDoc).x.value).to(bsonEqual(doc))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedDoc.canonicalExtendedJSON).x.value as? Document).to(equal(doc))
+                                  from: wrappedDoc.canonicalExtendedJSON).x.value).to(bsonEqual(doc))
 
         // values wrapped in an `AnyBSONStruct`
         let double = 42.0
         expect(try decoder.decode(AnyBSONValue.self,
-                                  from: "{\"$numberDouble\": \"42\"}").value as? Double).to(equal(double))
+                                  from: "{\"$numberDouble\": \"42\"}").value).to(bsonEqual(double))
 
         let wrappedDouble: Document = ["x": double]
         expect(try encoder.encode(AnyBSONStruct(double))).to(equal(wrappedDouble))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDouble).x.value as? Double).to(equal(double))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDouble).x.value).to(bsonEqual(double))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedDouble.canonicalExtendedJSON).x.value as? Double).to(equal(double))
+                                  from: wrappedDouble.canonicalExtendedJSON).x.value).to(bsonEqual(double))
 
         // string
         let string = "hi"
-        expect(try decoder.decode(AnyBSONValue.self, from: "\"hi\"").value as? String).to(equal(string))
+        expect(try decoder.decode(AnyBSONValue.self, from: "\"hi\"").value).to(bsonEqual(string))
 
         let wrappedString: Document = ["x": string]
         expect(try encoder.encode(AnyBSONStruct(string))).to(equal(wrappedString))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedString).x.value as? String).to(equal(string))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedString).x.value).to(bsonEqual(string))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedString.canonicalExtendedJSON).x.value as? String).to(equal(string))
+                                  from: wrappedString.canonicalExtendedJSON).x.value).to(bsonEqual(string))
 
         // array
         let array: [BSONValue] = [1, 2, "hello"]
 
         let decodedArray = try decoder.decode(AnyBSONValue.self, from: "[1, 2, \"hello\"]").value as? [BSONValue]
-        expect(decodedArray?[0] as? Int).to(equal(1))
-        expect(decodedArray?[1] as? Int).to(equal(2))
-        expect(decodedArray?[2] as? String).to(equal("hello"))
+        expect(decodedArray?[0]).to(bsonEqual(1))
+        expect(decodedArray?[1]).to(bsonEqual(2))
+        expect(decodedArray?[2]).to(bsonEqual("hello"))
 
         let wrappedArray: Document = ["x": array]
         expect(try encoder.encode(AnyBSONStruct(array))).to(equal(wrappedArray))
         let decodedWrapped = try decoder.decode(AnyBSONStruct.self, from: wrappedArray).x.value as? [BSONValue]
-        expect(decodedWrapped?[0] as? Int).to(equal(1))
-        expect(decodedWrapped?[1] as? Int).to(equal(2))
-        expect(decodedWrapped?[2] as? String).to(equal("hello"))
+        expect(decodedWrapped?[0]).to(bsonEqual(1))
+        expect(decodedWrapped?[1]).to(bsonEqual(2))
+        expect(decodedWrapped?[2]).to(bsonEqual("hello"))
 
         // an array with a non-BSONValue
         let arrWithNonBSONValue: [Any?] = [1, "hi", NSNull(), Int16(4)]
@@ -575,32 +575,32 @@ final class CodecTests: MongoSwiftTestCase {
 
         let wrappedBinary: Document = ["x": binary]
         expect(try encoder.encode(AnyBSONStruct(binary))).to(equal(wrappedBinary))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBinary).x.value as? Binary).to(equal(binary))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBinary).x.value).to(bsonEqual(binary))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedBinary.canonicalExtendedJSON).x.value as? Binary).to(equal(binary))
+                                  from: wrappedBinary.canonicalExtendedJSON).x.value).to(bsonEqual(binary))
 
         // objectid
         let oid = ObjectId()
 
         expect(try decoder.decode(AnyBSONValue.self,
-                                  from: "{\"$oid\": \"\(oid.oid)\"}").value as? ObjectId).to(equal(oid))
+                                  from: "{\"$oid\": \"\(oid.oid)\"}").value).to(bsonEqual(oid))
 
         let wrappedOid: Document = ["x": oid]
         expect(try encoder.encode(AnyBSONStruct(oid))).to(equal(wrappedOid))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedOid).x.value as? ObjectId).to(equal(oid))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedOid).x.value).to(bsonEqual(oid))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedOid.canonicalExtendedJSON).x.value as? ObjectId).to(equal(oid))
+                                  from: wrappedOid.canonicalExtendedJSON).x.value).to(bsonEqual(oid))
 
         // bool
         let bool = true
 
-        expect(try decoder.decode(AnyBSONValue.self, from: "true").value as? Bool).to(equal(bool))
+        expect(try decoder.decode(AnyBSONValue.self, from: "true").value).to(bsonEqual(bool))
 
         let wrappedBool: Document = ["x": bool]
         expect(try encoder.encode(AnyBSONStruct(bool))).to(equal(wrappedBool))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBool).x.value as? Bool).to(equal(bool))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBool).x.value).to(bsonEqual(bool))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedBool.canonicalExtendedJSON).x.value as? Bool).to(equal(bool))
+                                  from: wrappedBool.canonicalExtendedJSON).x.value).to(bsonEqual(bool))
 
         // date
         let date = Date(timeIntervalSince1970: 5000)
@@ -612,21 +612,21 @@ final class CodecTests: MongoSwiftTestCase {
 
         let wrappedDate: Document = ["x": date]
         expect(try encoder.encode(AnyBSONStruct(date))).to(equal(wrappedDate))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDate).x.value as? Date).to(equal(date))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDate).x.value).to(bsonEqual(date))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedDate.canonicalExtendedJSON).x.value as? Date).to(equal(date))
+                                  from: wrappedDate.canonicalExtendedJSON).x.value).to(bsonEqual(date))
 
         // regex
         let regex = RegularExpression(pattern: "abc", options: "imx")
 
         expect(try decoder.decode(AnyBSONValue.self,
                                   from: "{ \"$regularExpression\" : { \"pattern\" : \"abc\", \"options\" : \"imx\" } }")
-            .value as? RegularExpression).to(equal(regex))
+            .value).to(bsonEqual(regex))
 
         let wrappedRegex: Document = ["x": regex]
         expect(try encoder.encode(AnyBSONStruct(regex))).to(equal(wrappedRegex))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedRegex).x.value as? RegularExpression).to(equal(regex))
+                                  from: wrappedRegex).x.value).to(bsonEqual(regex))
         expect(
             try decoder.decode(AnyBSONStruct.self,
                                from: wrappedRegex.canonicalExtendedJSON).x.value as? RegularExpression
@@ -644,32 +644,32 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedCode: Document = ["x": code]
         expect(try encoder.encode(AnyBSONStruct(code))).to(equal(wrappedCode))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedCode).x.value as? CodeWithScope).to(equal(code))
+                                  from: wrappedCode).x.value).to(bsonEqual(code))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedCode.canonicalExtendedJSON).x.value as? CodeWithScope).to(equal(code))
+                                  from: wrappedCode.canonicalExtendedJSON).x.value).to(bsonEqual(code))
 
         // int32
         let int32 = Int32(5)
 
-        expect(try decoder.decode(AnyBSONValue.self, from: "{ \"$numberInt\" : \"5\" }").value as? Int).to(equal(5))
+        expect(try decoder.decode(AnyBSONValue.self, from: "{ \"$numberInt\" : \"5\" }").value).to(bsonEqual(5))
 
         let wrappedInt32: Document = ["x": int32]
         expect(try encoder.encode(AnyBSONStruct(int32))).to(equal(wrappedInt32))
         // as int because we convert Int32 -> Int when decoding
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt32).x.value as? Int).to(equal(5))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt32).x.value).to(bsonEqual(5))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedInt32.canonicalExtendedJSON).x.value as? Int).to(equal(5))
+                                  from: wrappedInt32.canonicalExtendedJSON).x.value).to(bsonEqual(5))
 
         // int
         let int = 5
 
-        expect(try decoder.decode(AnyBSONValue.self, from: "{ \"$numberInt\" : \"5\" }").value as? Int).to(equal(int))
+        expect(try decoder.decode(AnyBSONValue.self, from: "{ \"$numberInt\" : \"5\" }").value).to(bsonEqual(int))
 
         let wrappedInt: Document = ["x": int]
         expect(try encoder.encode(AnyBSONStruct(int))).to(equal(wrappedInt))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt).x.value as? Int).to(equal(int))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt).x.value).to(bsonEqual(int))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedInt.canonicalExtendedJSON).x.value as? Int).to(equal(int))
+                                  from: wrappedInt.canonicalExtendedJSON).x.value).to(bsonEqual(int))
 
         // int64
         let int64 = Int64(5)
@@ -680,9 +680,9 @@ final class CodecTests: MongoSwiftTestCase {
 
         let wrappedInt64: Document = ["x": int64]
         expect(try encoder.encode(AnyBSONStruct(Int64(5)))).to(equal(wrappedInt64))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64).x.value as? Int64).to(equal(int64))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64).x.value).to(bsonEqual(int64))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedInt64.canonicalExtendedJSON).x.value as? Int64).to(equal(int64))
+                                  from: wrappedInt64.canonicalExtendedJSON).x.value).to(bsonEqual(int64))
 
         // decimal128
         let decimal = Decimal128("1.2E+10")
@@ -693,31 +693,31 @@ final class CodecTests: MongoSwiftTestCase {
 
         let wrappedDecimal: Document = ["x": decimal]
         expect(try encoder.encode(AnyBSONStruct(decimal))).to(equal(wrappedDecimal))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDecimal).x.value as? Decimal128).to(equal(decimal))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDecimal).x.value).to(bsonEqual(decimal))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedDecimal.canonicalExtendedJSON).x.value as? Decimal128).to(equal(decimal))
+                                  from: wrappedDecimal.canonicalExtendedJSON).x.value).to(bsonEqual(decimal))
 
         // maxkey
         let maxKey = MaxKey()
 
-        expect(try decoder.decode(AnyBSONValue.self, from: "{ \"$maxKey\" : 1 }").value as? MaxKey).to(equal(maxKey))
+        expect(try decoder.decode(AnyBSONValue.self, from: "{ \"$maxKey\" : 1 }").value).to(bsonEqual(maxKey))
 
         let wrappedMaxKey: Document = ["x": maxKey]
         expect(try encoder.encode(AnyBSONStruct(maxKey))).to(equal(wrappedMaxKey))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMaxKey).x.value as? MaxKey).to(equal(maxKey))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMaxKey).x.value).to(bsonEqual(maxKey))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedMaxKey.canonicalExtendedJSON).x.value as? MaxKey).to(equal(maxKey))
+                                  from: wrappedMaxKey.canonicalExtendedJSON).x.value).to(bsonEqual(maxKey))
 
         // minkey
         let minKey = MinKey()
 
-        expect(try decoder.decode(AnyBSONValue.self, from: "{ \"$minKey\" : 1 }").value as? MinKey).to(equal(minKey))
+        expect(try decoder.decode(AnyBSONValue.self, from: "{ \"$minKey\" : 1 }").value).to(bsonEqual(minKey))
 
         let wrappedMinKey: Document = ["x": minKey]
         expect(try encoder.encode(AnyBSONStruct(minKey))).to(equal(wrappedMinKey))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMinKey).x.value as? MinKey).to(equal(minKey))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMinKey).x.value).to(bsonEqual(minKey))
         expect(try decoder.decode(AnyBSONStruct.self,
-                                  from: wrappedMinKey.canonicalExtendedJSON).x.value as? MinKey).to(equal(minKey))
+                                  from: wrappedMinKey.canonicalExtendedJSON).x.value).to(bsonEqual(minKey))
 
         // NSNull
         expect(

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -274,8 +274,8 @@ private struct CommandStartedExpectation: ExpectationType, Decodable {
             // verify that the getMore ID matches the stored cursor ID for this test
             expect(event.command["getMore"]).to(bsonEqual(testContext["cursorId"] as? Int64))
             // compare collection and batchSize fields
-            expect(event.command["collection"]).to(bsonEqual(self.command["collection"] as? String))
-            expect(event.command["batchSize"]).to(bsonEqual(self.command["batchSize"] as? Int64))
+            expect(event.command["collection"]).to(bsonEqual(self.command["collection"]))
+            expect(event.command["batchSize"]).to(bsonEqual(self.command["batchSize"]))
         } else {
             // remove fields from the command we received that are not in the expected
             // command, and reorder them, so we can do a direct comparison of the documents
@@ -413,7 +413,7 @@ private struct CommandSucceededExpectation: ExpectationType, Decodable {
     /// (handled in `compare` because we need the test context).
     func compareCursors(expected: Document, actual: Document) {
         let ordered = rearrangeDoc(actual, toLookLike: expected)
-        expect(ordered["ns"]).to(bsonEqual(expected["ns"] as? String))
+        expect(ordered["ns"]).to(bsonEqual(expected["ns"]))
         if let firstBatch = expected["firstBatch"] as? [Document] {
             expect(ordered["firstBatch"]).to(bsonEqual(firstBatch))
         } else if let nextBatch = expected["nextBatch"] as? [Document] {

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -272,10 +272,10 @@ private struct CommandStartedExpectation: ExpectationType, Decodable {
         // if it's a getMore, we can't directly compare the results
         if commandName == "getMore" {
             // verify that the getMore ID matches the stored cursor ID for this test
-            expect(event.command["getMore"] as? Int64).to(equal(testContext["cursorId"] as? Int64))
+            expect(event.command["getMore"]).to(bsonEqual(testContext["cursorId"] as? Int64))
             // compare collection and batchSize fields
-            expect(event.command["collection"] as? String).to(equal(self.command["collection"] as? String))
-            expect(event.command["batchSize"] as? Int64).to(equal(self.command["batchSize"] as? Int64))
+            expect(event.command["collection"]).to(bsonEqual(self.command["collection"] as? String))
+            expect(event.command["batchSize"]).to(bsonEqual(self.command["batchSize"] as? Int64))
         } else {
             // remove fields from the command we received that are not in the expected
             // command, and reorder them, so we can do a direct comparison of the documents
@@ -413,11 +413,11 @@ private struct CommandSucceededExpectation: ExpectationType, Decodable {
     /// (handled in `compare` because we need the test context).
     func compareCursors(expected: Document, actual: Document) {
         let ordered = rearrangeDoc(actual, toLookLike: expected)
-        expect(ordered["ns"] as? String).to(equal(expected["ns"] as? String))
+        expect(ordered["ns"]).to(bsonEqual(expected["ns"] as? String))
         if let firstBatch = expected["firstBatch"] as? [Document] {
-            expect(ordered["firstBatch"] as? [Document]).to(equal(firstBatch))
+            expect(ordered["firstBatch"]).to(bsonEqual(firstBatch))
         } else if let nextBatch = expected["nextBatch"] as? [Document] {
-            expect(ordered["nextBatch"] as? [Document]).to(equal(nextBatch))
+            expect(ordered["nextBatch"]).to(bsonEqual(nextBatch))
         }
     }
 }

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -523,7 +523,7 @@ private class InsertOneTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let doc: Document = try self.args.get("document")
         let result = try coll.insertOne(doc)
-        expect(doc["_id"]).to(bsonEqual(result?.insertedId as? Int))
+        expect(doc["_id"]).to(bsonEqual(result?.insertedId))
     }
 }
 

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -523,7 +523,7 @@ private class InsertOneTest: CrudTest {
     override func execute(usingCollection coll: MongoCollection<Document>) throws {
         let doc: Document = try self.args.get("document")
         let result = try coll.insertOne(doc)
-        expect(doc["_id"] as? Int).to(equal(result?.insertedId as? Int))
+        expect(doc["_id"]).to(bsonEqual(result?.insertedId as? Int))
     }
 }
 

--- a/Tests/MongoSwiftTests/Document+SequenceTests.swift
+++ b/Tests/MongoSwiftTests/Document+SequenceTests.swift
@@ -39,47 +39,47 @@ final class Document_SequenceTests: MongoSwiftTestCase {
 
         let stringTup = iter.next()!
         expect(stringTup.key).to(equal("string"))
-        expect(stringTup.value as? String).to(equal("test string"))
+        expect(stringTup.value).to(bsonEqual("test string"))
 
         let trueTup = iter.next()!
         expect(trueTup.key).to(equal("true"))
-        expect(trueTup.value as? Bool).to(beTrue())
+        expect(trueTup.value).to(bsonEqual(true))
 
         let falseTup = iter.next()!
         expect(falseTup.key).to(equal("false"))
-        expect(falseTup.value as? Bool).to(beFalse())
+        expect(falseTup.value).to(bsonEqual(false))
 
         let intTup = iter.next()!
         expect(intTup.key).to(equal("int"))
-        expect(intTup.value as? Int).to(equal(25))
+        expect(intTup.value).to(bsonEqual(25))
 
         let int32Tup = iter.next()!
         expect(int32Tup.key).to(equal("int32"))
-        expect(int32Tup.value as? Int).to(equal(5))
+        expect(int32Tup.value).to(bsonEqual(5))
 
         let doubleTup = iter.next()!
         expect(doubleTup.key).to(equal("double"))
-        expect(doubleTup.value as? Double).to(equal(15))
+        expect(doubleTup.value).to(bsonEqual(15.0))
 
         let decimalTup = iter.next()!
         expect(decimalTup.key).to(equal("decimal128"))
-        expect(decimalTup.value as? Decimal128).to(equal(Decimal128("1.2E+10")))
+        expect(decimalTup.value).to(bsonEqual(Decimal128("1.2E+10")))
 
         let minTup = iter.next()!
         expect(minTup.key).to(equal("minkey"))
-        expect(minTup.value as? MinKey).to(equal(MinKey()))
+        expect(minTup.value).to(bsonEqual(MinKey()))
 
         let maxTup = iter.next()!
         expect(maxTup.key).to(equal("maxkey"))
-        expect(maxTup.value as? MaxKey).to(equal(MaxKey()))
+        expect(maxTup.value).to(bsonEqual(MaxKey()))
 
         let dateTup = iter.next()!
         expect(dateTup.key).to(equal("date"))
-        expect(dateTup.value as? Date).to(equal(Date(timeIntervalSince1970: 5000)))
+        expect(dateTup.value).to(bsonEqual(Date(timeIntervalSince1970: 5000)))
 
         let timeTup = iter.next()!
         expect(timeTup.key).to(equal("timestamp"))
-        expect(timeTup.value as? Timestamp).to(equal(Timestamp(timestamp: 5, inc: 10)))
+        expect(timeTup.value).to(bsonEqual(Timestamp(timestamp: 5, inc: 10)))
 
         expect(iter.next()).to(beNil())
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -113,19 +113,19 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc.count).to(equal(expectedKeys.count))
         expect(doc.keys).to(equal(expectedKeys))
 
-        expect(doc["string"] as? String).to(equal("test string"))
-        expect(doc["true"] as? Bool).to(beTrue())
-        expect(doc["false"] as? Bool).to(beFalse())
-        expect(doc["int"] as? Int).to(equal(25))
-        expect(doc["int32"] as? Int).to(equal(5))
-        expect(doc["int64"] as? Int64).to(equal(10))
-        expect(doc["double"] as? Double).to(equal(15))
-        expect(doc["decimal128"] as? Decimal128).to(equal(Decimal128("1.2E+10")))
-        expect(doc["minkey"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-        expect(doc["maxkey"] as? MaxKey).to(beAnInstanceOf(MaxKey.self))
-        expect(doc["date"] as? Date).to(equal(Date(timeIntervalSince1970: 500.004)))
-        expect(doc["timestamp"] as? Timestamp).to(equal(Timestamp(timestamp: 5, inc: 10)))
-        expect(doc["oid"] as? ObjectId).to(equal(ObjectId(fromString: "507f1f77bcf86cd799439011")))
+        expect(doc["string"]).to(bsonEqual("test string"))
+        expect(doc["true"]).to(bsonEqual(true))
+        expect(doc["false"]).to(bsonEqual(false))
+        expect(doc["int"]).to(bsonEqual(25))
+        expect(doc["int32"]).to(bsonEqual(5))
+        expect(doc["int64"]).to(bsonEqual(Int64(10)))
+        expect(doc["double"]).to(bsonEqual(15.0))
+        expect(doc["decimal128"]).to(bsonEqual(Decimal128("1.2E+10")))
+        expect(doc["minkey"]).to(bsonEqual(MinKey()))
+        expect(doc["maxkey"]).to(bsonEqual(MaxKey()))
+        expect(doc["date"]).to(bsonEqual(Date(timeIntervalSince1970: 500.004)))
+        expect(doc["timestamp"]).to(bsonEqual(Timestamp(timestamp: 5, inc: 10)))
+        expect(doc["oid"]).to(bsonEqual(ObjectId(fromString: "507f1f77bcf86cd799439011")))
 
         let regex = doc["regex"] as? RegularExpression
         expect(regex).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
@@ -134,9 +134,9 @@ final class DocumentTests: MongoSwiftTestCase {
             options: NSRegularExpression.optionsFromString("imx")
         )))
 
-        expect(doc["array1"] as? [Int]).to(equal([1, 2]))
-        expect(doc["array2"] as? [String]).to(equal(["string1", "string2"]))
-        expect(doc["null"] as? NSNull).to(equal(NSNull()))
+        expect(doc["array1"]).to(bsonEqual([1, 2]))
+        expect(doc["array2"]).to(bsonEqual(["string1", "string2"]))
+        expect(doc["null"]).to(bsonEqual(NSNull()))
 
         let code = doc["code"] as? CodeWithScope
         expect(code?.code).to(equal("console.log('hi');"))
@@ -146,37 +146,37 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(codewscope?.code).to(equal("console.log(x);"))
         expect(codewscope?.scope).to(equal(["x": 2]))
 
-        expect(doc["binary0"] as? Binary).to(equal(try Binary(data: testData, subtype: .generic)))
-        expect(doc["binary1"] as? Binary).to(equal(try Binary(data: testData, subtype: .function)))
-        expect(doc["binary2"] as? Binary).to(equal(try Binary(data: testData, subtype: .binaryDeprecated)))
-        expect(doc["binary3"] as? Binary).to(equal(try Binary(data: uuidData, subtype: .uuidDeprecated)))
-        expect(doc["binary4"] as? Binary).to(equal(try Binary(data: uuidData, subtype: .uuid)))
-        expect(doc["binary5"] as? Binary).to(equal(try Binary(data: testData, subtype: .md5)))
-        expect(doc["binary6"] as? Binary).to(equal(try Binary(data: testData, subtype: .userDefined)))
-        expect(doc["binary7"] as? Binary).to(equal(try Binary(data: testData, subtype: 200)))
+        expect(doc["binary0"]).to(bsonEqual(try Binary(data: testData, subtype: .generic)))
+        expect(doc["binary1"]).to(bsonEqual(try Binary(data: testData, subtype: .function)))
+        expect(doc["binary2"]).to(bsonEqual(try Binary(data: testData, subtype: .binaryDeprecated)))
+        expect(doc["binary3"]).to(bsonEqual(try Binary(data: uuidData, subtype: .uuidDeprecated)))
+        expect(doc["binary4"]).to(bsonEqual(try Binary(data: uuidData, subtype: .uuid)))
+        expect(doc["binary5"]).to(bsonEqual(try Binary(data: testData, subtype: .md5)))
+        expect(doc["binary6"]).to(bsonEqual(try Binary(data: testData, subtype: .userDefined)))
+        expect(doc["binary7"]).to(bsonEqual(try Binary(data: testData, subtype: 200)))
 
         let nestedArray = doc["nestedarray"] as? [[Int]]
         expect(nestedArray?[0]).to(equal([1, 2]))
         expect(nestedArray?[1]).to(equal([3, 4]))
 
-        expect(doc["nesteddoc"] as? Document).to(equal(["a": 1, "b": 2, "c": false, "d": [3, 4]]))
+        expect(doc["nesteddoc"]).to(bsonEqual(["a": 1, "b": 2, "c": false, "d": [3, 4]] as Document))
     }
 
     func testDocumentFromArray() {
        let doc1: Document = ["foo", MinKey(), NSNull()]
 
        expect(doc1.keys).to(equal(["0", "1", "2"]))
-       expect(doc1["0"] as? String).to(equal("foo"))
-       expect(doc1["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       expect(doc1["2"] as? NSNull).to(equal(NSNull()))
+       expect(doc1["0"]).to(bsonEqual("foo"))
+       expect(doc1["1"]).to(bsonEqual(MinKey()))
+       expect(doc1["2"]).to(bsonEqual(NSNull()))
 
        let elements: [BSONValue] = ["foo", MinKey(), NSNull()]
        let doc2 = Document(elements)
 
        expect(doc2.keys).to(equal(["0", "1", "2"]))
-       expect(doc2["0"] as? String).to(equal("foo"))
-       expect(doc2["1"] as? MinKey).to(beAnInstanceOf(MinKey.self))
-       expect(doc2["2"] as? NSNull).to(equal(NSNull()))
+       expect(doc2["0"]).to(bsonEqual("foo"))
+       expect(doc2["1"]).to(bsonEqual(MinKey()))
+       expect(doc2["2"]).to(bsonEqual(NSNull()))
     }
 
     func testEquatable() {
@@ -194,9 +194,9 @@ final class DocumentTests: MongoSwiftTestCase {
         let doc1: Document = ["a": 1]
         var doc2 = doc1
         doc2["b"] = 2
-        XCTAssertEqual(doc2["b"] as? Int, 2)
-        XCTAssertNil(doc1["b"])
-        XCTAssertNotEqual(doc1, doc2)
+        expect(doc2["b"]).to(bsonEqual(2))
+        expect(doc1["b"]).to(beNil())
+        expect(doc1).toNot(equal(doc2))
     }
 
     func testIntEncodesAsInt32OrInt64() {
@@ -214,12 +214,12 @@ final class DocumentTests: MongoSwiftTestCase {
             "int64max": Int(Int64.max)
         ]
 
-        expect(doc["int32min"] as? Int).to(equal(Int(Int32.min)))
-        expect(doc["int32max"] as? Int).to(equal(Int(Int32.max)))
-        expect(doc["int32min-1"] as? Int64).to(equal(int32min_sub1))
-        expect(doc["int32max+1"] as? Int64).to(equal(int32max_add1))
-        expect(doc["int64min"] as? Int64).to(equal(Int64.min))
-        expect(doc["int64max"] as? Int64).to(equal(Int64.max))
+        expect(doc["int32min"]).to(bsonEqual(Int(Int32.min)))
+        expect(doc["int32max"]).to(bsonEqual(Int(Int32.max)))
+        expect(doc["int32min-1"]).to(bsonEqual(int32min_sub1))
+        expect(doc["int32max+1"]).to(bsonEqual(int32max_add1))
+        expect(doc["int64min"]).to(bsonEqual(Int64.min))
+        expect(doc["int64max"]).to(bsonEqual(Int64.max))
     }
 
     // swiftlint:disable:next cyclomatic_complexity
@@ -388,12 +388,12 @@ final class DocumentTests: MongoSwiftTestCase {
 
         // overwrite int32 with int32
         doc["int32"] = Int32(15)
-        expect(doc["int32"] as? Int).to(equal(15))
+        expect(doc["int32"]).to(bsonEqual(15))
         expect(doc.data).to(equal(pointer))
 
         // overwrite int32 with an int that fits into int32s
         doc["int32"] = 20
-        expect(doc["int32"] as? Int).to(equal(20))
+        expect(doc["int32"]).to(bsonEqual(20))
         expect(doc.data).to(equal(pointer))
 
         doc["bool"] = true

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -35,7 +35,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         let insertResult = try coll.insertOne([ "test": 42 ])
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])
         let docs = Array(findResult)
-        expect(docs[0]["test"] as? Int).to(equal(42))
+        expect(docs[0]["test"]).to(bsonEqual(42))
         try db.drop()
     }
 

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -84,7 +84,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         let result: BulkWriteResult! = try self.coll.bulkWrite(requests)
 
         expect(result.insertedCount).to(equal(2))
-        expect(result.insertedIds[0]! as? Int).to(equal(1))
+        expect(result.insertedIds[0]!).to(bsonEqual(1))
         expect(result.insertedIds[1]!).to(beAnInstanceOf(ObjectId.self))
 
         let cursor = try coll.find()
@@ -109,7 +109,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         expect(result.matchedCount).to(equal(5))
         expect(result.modifiedCount).to(equal(5))
         expect(result.upsertedCount).to(equal(2))
-        expect(result.upsertedIds[2]! as? Int).to(equal(5))
+        expect(result.upsertedIds[2]!).to(bsonEqual(5))
         expect(result.upsertedIds[3]!).to(beAnInstanceOf(ObjectId.self))
 
         let cursor = try coll.find()
@@ -153,11 +153,11 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         let result: BulkWriteResult! = try self.coll.bulkWrite(requests)
 
         expect(result.insertedCount).to(equal(1))
-        expect(result.insertedIds[2]! as? Int).to(equal(4))
+        expect(result.insertedIds[2]!).to(bsonEqual(4))
         expect(result.matchedCount).to(equal(3))
         expect(result.modifiedCount).to(equal(3))
         expect(result.upsertedCount).to(equal(1))
-        expect(result.upsertedIds[4]! as? Int).to(equal(4))
+        expect(result.upsertedIds[4]!).to(bsonEqual(4))
         expect(result.deletedCount).to(equal(2))
 
         let cursor = try coll.find()

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -104,8 +104,8 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
     func testInsertOne() throws {
         expect(try self.coll.deleteMany([:])).toNot(beNil())
-        expect(try self.coll.insertOne(self.doc1)?.insertedId as? Int).to(equal(1))
-        expect(try self.coll.insertOne(self.doc2)?.insertedId as? Int).to(equal(2))
+        expect(try self.coll.insertOne(self.doc1)?.insertedId).to(bsonEqual(1))
+        expect(try self.coll.insertOne(self.doc2)?.insertedId).to(bsonEqual(2))
         expect(try self.coll.count()).to(equal(2))
 
         // try inserting a document without an ID to verify one is generated and returned
@@ -247,8 +247,8 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
         let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"] as? String).to(equal("_id_"))
-        expect(indexes.next()?["name"] as? String).to(equal("cat_1"))
+        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+        expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
         expect(indexes.next()).to(beNil())
     }
 
@@ -257,9 +257,9 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         let model2 = IndexModel(keys: ["cat": -1])
         expect( try self.coll.createIndexes([model1, model2]) ).to(equal(["cat_1", "cat_-1"]))
         let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"] as? String).to(equal("_id_"))
-        expect(indexes.next()?["name"] as? String).to(equal("cat_1"))
-        expect(indexes.next()?["name"] as? String).to(equal("cat_-1"))
+        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+        expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
+        expect(indexes.next()?["name"]).to(bsonEqual("cat_-1"))
         expect(indexes.next()).to(beNil())
     }
 
@@ -271,12 +271,12 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.createIndex(model)).to(equal("blah"))
 
         let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"] as? String).to(equal("_id_"))
-        expect(indexes.next()?["name"] as? String).to(equal("cat_1"))
+        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+        expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
 
         let thirdIndex = indexes.next()
-        expect(thirdIndex?["name"] as? String).to(equal("blah"))
-        expect(thirdIndex?["unique"] as? Bool).to(beTrue())
+        expect(thirdIndex?["name"]).to(bsonEqual("blah"))
+        expect(thirdIndex?["unique"]).to(bsonEqual(true))
 
         expect(indexes.next()).to(beNil())
     }
@@ -288,49 +288,49 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"] as? String).to(equal("_id_"))
+        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
         expect(indexes.next()).to(beNil())
     }
 
     func testDropIndexByModel() throws {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
-        expect(try self.coll.dropIndex(model)["ok"] as? Double).to(equal(1.0))
+        expect(try self.coll.dropIndex(model)["ok"]).to(bsonEqual(1.0))
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
         expect(indexes).toNot(beNil())
-        expect(indexes.next()?["name"] as? String).to(equal("_id_"))
+        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
         expect(indexes.next()).to(beNil())
     }
 
     func testDropIndexByKeys() throws {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
-        expect(try self.coll.dropIndex(["cat": 1])["ok"] as? Double).to(equal(1.0))
+        expect(try self.coll.dropIndex(["cat": 1])["ok"]).to(bsonEqual(1.0))
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
         expect(indexes).toNot(beNil())
-        expect(indexes.next()?["name"] as? String).to(equal("_id_"))
+        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
         expect(indexes.next()).to(beNil())
     }
 
     func testDropAllIndexes() throws {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
-        expect(try self.coll.dropIndexes()["ok"] as? Double).to(equal(1.0))
+        expect(try self.coll.dropIndexes()["ok"]).to(bsonEqual(1.0))
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"] as? String).to(equal("_id_"))
+        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
         expect(indexes.next()).to(beNil())
     }
 
     func testListIndexes() throws {
         let indexes = try coll.listIndexes()
         // New collection, so expect just the _id_ index to exist. 
-        expect(indexes.next()?["name"] as? String).to(equal("_id_"))
+        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
         expect(indexes.next()).to(beNil())
     }
 
@@ -495,13 +495,13 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     func testNullIds() throws {
         let result1 = try self.coll.insertOne(["_id": NSNull(), "hi": "hello"])
         expect(result1).toNot(beNil())
-        expect(result1?.insertedId as? NSNull).to(equal(NSNull()))
+        expect(result1?.insertedId).to(bsonEqual(NSNull()))
 
         try self.coll.deleteOne(["_id": NSNull()])
 
         let result2 = try self.coll.insertMany([["_id": NSNull()], ["_id": 20]])
         expect(result2).toNot(beNil())
-        expect(result2?.insertedIds[0] as? NSNull).to(equal(NSNull()))
-        expect(result2?.insertedIds[1] as? Int).to(equal(20))
+        expect(result2?.insertedIds[0]).to(bsonEqual(NSNull()))
+        expect(result2?.insertedIds[1]).to(bsonEqual(20))
     }
 }

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -255,12 +255,12 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         // run command with a valid readConcern
         let options1 = RunCommandOptions(readConcern: ReadConcern(.local))
         let res1 = try db.runCommand(command, options: options1)
-        expect(res1["ok"] as? Double).to(equal(1.0))
+        expect(res1["ok"]).to(bsonEqual(1.0))
 
         // run command with an empty readConcern
         let options2 = RunCommandOptions(readConcern: ReadConcern())
         let res2 = try db.runCommand(command, options: options2)
-        expect(res2["ok"] as? Double).to(equal(1.0))
+        expect(res2["ok"]).to(bsonEqual(1.0))
 
         // running command with an invalid RC level should throw
         let options3 = RunCommandOptions(readConcern: ReadConcern("blah"))
@@ -299,12 +299,12 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         // run command with a valid writeConcern
         let options1 = RunCommandOptions(writeConcern: wc1)
         let res1 = try db.runCommand(command, options: options1)
-        expect(res1["ok"] as? Double).to(equal(1.0))
+        expect(res1["ok"]).to(bsonEqual(1.0))
 
         // run command with an empty writeConcern
         let options2 = RunCommandOptions(writeConcern: wc2)
         let res2 = try db.runCommand(command, options: options2)
-        expect(res2["ok"] as? Double).to(equal(1.0))
+        expect(res2["ok"]).to(bsonEqual(1.0))
 
         expect(try coll.insertOne(nextDoc(), options: InsertOneOptions(writeConcern: wc1))).toNot(throwError())
         expect(try coll.insertOne(nextDoc(), options: InsertOneOptions(writeConcern: wc3))).toNot(throwError())


### PR DESCRIPTION
[SWIFT-241](https://jira.mongodb.org/browse/SWIFT-241)

This PR replaces the standard `equal` Nimble matcher with our custom `bsonEqual` matcher in all existing tests.