### PR TITLE
SWIFT-278 BSONValue.from(iterator) should return Self, not BSONValue

### DIFF
--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -67,7 +67,7 @@ public struct AnyBSONValue: Codable, Equatable {
         // since we aren't sure which BSON type this is, just try decoding
         // to each of them and go with the first one that succeeds
         if container.decodeNil() {
-            self.value = NSNull()
+            self.value = BSONNull()
         } else if let value = try? container.decode(String.self) {
             self.value = value
         } else if let value = try? container.decode(Binary.self) {

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -177,8 +177,8 @@ internal struct _BSONDecodingStorage {
 extension _BSONDecoder {
 
     fileprivate func unboxBSONValue<T: BSONValue>(_ value: BSONValue, as type: T.Type) throws -> T {
-        // We throw in the case of NSNull because nulls should be requested through decodeNil().
-        guard !(value is NSNull) else {
+        // We throw in the case of BSONNull because nulls should be requested through decodeNil().
+        guard !(value is BSONNull) else {
             throw DecodingError.valueNotFound(
                 type,
                 DecodingError.Context(codingPath: self.codingPath,
@@ -290,7 +290,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
         let entry = try getValue(forKey: key)
         return try self.decoder.with(pushedKey: key) {
             let value = try decoder.unbox(entry, as: type)
-            guard !(value is NSNull) else {
+            guard !(value is BSONNull) else {
                 throw DecodingError.valueNotFound(
                     type,
                     DecodingError.Context(codingPath: self.decoder.codingPath,
@@ -310,7 +310,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
                 DecodingError.Context(codingPath: self.decoder.codingPath,
                                       debugDescription: "Key \(_errorDescription(of: key)) not found."))
         }
-        return try self.container.getValue(for: key.stringValue) is NSNull
+        return try self.container.getValue(for: key.stringValue) is BSONNull
     }
 
     // swiftlint:disable line_length
@@ -447,7 +447,7 @@ private struct _BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         try self.checkAtEnd()
         return try self.decoder.with(pushedKey: _BSONKey(index: self.currentIndex)) {
             let decoded = try self.decoder.unbox(self.container[currentIndex], as: T.self)
-            guard !(decoded is NSNull) else {
+            guard !(decoded is BSONNull) else {
                 throw DecodingError.valueNotFound(
                     type,
                     DecodingError.Context(
@@ -463,7 +463,7 @@ private struct _BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     public mutating func decodeNil() throws -> Bool {
         try self.checkAtEnd()
 
-        if self.container[self.currentIndex] is NSNull {
+        if self.container[self.currentIndex] is BSONNull {
             self.currentIndex += 1
             return true
         }
@@ -551,7 +551,7 @@ extension _BSONDecoder: SingleValueDecodingContainer {
     }
 
     /// Decode a null value from this container.
-    public func decodeNil() -> Bool { return self.storage.topContainer is NSNull }
+    public func decodeNil() -> Bool { return self.storage.topContainer is BSONNull }
 
     /// Decode all the required types from this container using the helpers defined above.
     public func decode(_ type: Bool.Type) throws -> Bool { return try decodeBSONType(type) }

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -324,7 +324,7 @@ private struct _BSONKeyedEncodingContainer<K: CodingKey> : KeyedEncodingContaine
         self.container = container
     }
 
-    public mutating func encodeNil(forKey key: Key) throws { self.container[key.stringValue] = NSNull() }
+    public mutating func encodeNil(forKey key: Key) throws { self.container[key.stringValue] = BSONNull() }
     public mutating func encode(_ value: Bool, forKey key: Key) throws { self.container[key.stringValue] = value }
     public mutating func encode(_ value: Int, forKey key: Key) throws { self.container[key.stringValue] = value }
     public mutating func encode(_ value: Int8, forKey key: Key) throws { try self.encodeNumber(value, forKey: key) }
@@ -409,7 +409,7 @@ private struct _BSONUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         self.container = container
     }
 
-    public mutating func encodeNil() throws { self.container.add(NSNull()) }
+    public mutating func encodeNil() throws { self.container.add(BSONNull()) }
     public mutating func encode(_ value: Bool) throws { self.container.add(value) }
     public mutating func encode(_ value: Int) throws { self.container.add(value) }
     public mutating func encode(_ value: Int8) throws { try self.encodeNumber(value) }
@@ -476,7 +476,7 @@ extension _BSONEncoder: SingleValueEncodingContainer {
 
     public func encodeNil() throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: NSNull())
+        self.storage.push(container: BSONNull())
     }
 
     public func encode(_ value: Bool) throws { try self.encodeBSONType(value) }
@@ -537,7 +537,7 @@ private class MutableArray: BSONValue {
 
     /// methods required by the BSONValue protocol that we don't actually need/use. MutableArray
     /// is just a BSONValue to simplify usage alongside true BSONValues within the encoder.
-    public static func from(iterator iter: DocumentIterator) -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) -> Self {
         fatalError("`MutableArray` is not meant to be initialized from a `DocumentIterator`")
     }
     func encode(to encoder: Encoder) throws {
@@ -593,7 +593,7 @@ private class MutableDictionary: BSONValue {
 
     /// methods required by the BSONValue protocol that we don't actually need/use. MutableDictionary
     /// is just a BSONValue to simplify usage alongside true BSONValues within the encoder.
-    public static func from(iterator iter: DocumentIterator) -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) -> Self {
         fatalError("`MutableDictionary` is not meant to be initialized from a `DocumentIterator`")
     }
     func encode(to encoder: Encoder) throws {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -68,7 +68,7 @@ public protocol BSONValue {
     * Given a `DocumentIterator` known to have a next value of this type,
     * initializes the value.
     */
-    static func from(iterator iter: DocumentIterator) throws -> BSONValue
+    static func from(iterator iter: DocumentIterator) throws -> Self
 }
 
 /// An extension of `Array` to represent the BSON array type.
@@ -76,7 +76,7 @@ extension Array: BSONValue {
 
     public var bsonType: BSONType { return .array }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Array {
         var length: UInt32 = 0
         let array = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
         defer {
@@ -119,11 +119,11 @@ extension Array: BSONValue {
     }
 }
 
-/// An extension of `NSNull` to represent BSON null values.
-extension NSNull: BSONValue {
+/// A class to represent the BSON null type
+public struct BSONNull: BSONValue, Codable {
     public var bsonType: BSONType { return .null }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue { return NSNull() }
+    public static func from(iterator iter: DocumentIterator) throws -> BSONNull { return BSONNull() }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         guard bson_append_null(storage.pointer, key, Int32(key.count)) else {
@@ -205,7 +205,7 @@ public struct Binary: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Binary {
         var subtype = bson_subtype_t(rawValue: 0)
         var length: UInt32 = 0
         let dataPointer = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
@@ -239,7 +239,7 @@ extension Bool: BSONValue {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Bool {
         return self.init(bson_iter_bool(&iter.iter))
     }
 }
@@ -264,7 +264,7 @@ extension Date: BSONValue {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Date {
         return self.init(msSinceEpoch: bson_iter_date_time(&iter.iter))
     }
 }
@@ -279,7 +279,7 @@ internal struct DBPointer: BSONValue {
         throw MongoError.bsonEncodeError(message: "`DBPointer`s are deprecated; use a DBRef document instead")
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> DBPointer {
         throw MongoError.bsonDecodeError(message:
             "`DBPointer`s are deprecated; use `DBPointer.asDocument` to create a DBRef document instead")
     }
@@ -364,7 +364,7 @@ public struct Decimal128: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Decimal128 {
         var value = bson_decimal128_t()
         guard bson_iter_decimal128(&iter.iter, &value) else {
             throw MongoError.bsonDecodeError(message: "Failed to retrieve Decimal128 value from iterator")
@@ -390,7 +390,7 @@ extension Double: BSONValue {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Double {
         return self.init(bson_iter_double(&iter.iter))
     }
 }
@@ -415,7 +415,7 @@ extension Int: BSONValue {
         throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Int {
         return self.init(Int(bson_iter_int32(&iter.iter)))
     }
 }
@@ -431,7 +431,7 @@ extension Int32: BSONValue {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Int32 {
         return self.init(bson_iter_int32(&iter.iter))
     }
 }
@@ -447,7 +447,7 @@ extension Int64: BSONValue {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Int64 {
         return self.init(bson_iter_int64(&iter.iter))
     }
 }
@@ -482,7 +482,7 @@ public struct CodeWithScope: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> CodeWithScope {
 
         var length: UInt32 = 0
 
@@ -528,7 +528,7 @@ public struct MaxKey: BSONValue, Equatable, Codable {
     /// Initializes a new `MaxKey` instance.
     public init() {}
 
-    public static func from(iterator iter: DocumentIterator) -> BSONValue { return self.init() }
+    public static func from(iterator iter: DocumentIterator) -> MaxKey { return self.init() }
 
     public static func == (lhs: MaxKey, rhs: MaxKey) -> Bool { return true }
 }
@@ -549,7 +549,7 @@ public struct MinKey: BSONValue, Equatable, Codable {
     /// Initializes a new `MinKey` instance.
     public init() {}
 
-    public static func from(iterator iter: DocumentIterator) -> BSONValue { return self.init() }
+    public static func from(iterator iter: DocumentIterator) -> MinKey { return self.init() }
 
     public static func == (lhs: MinKey, rhs: MinKey) -> Bool { return true }
 }
@@ -622,7 +622,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> ObjectId {
         guard let oid = bson_iter_oid(&iter.iter) else {
             throw MongoError.bsonDecodeError(message: "Failed to retrieve ObjectID value")
         }
@@ -702,7 +702,7 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> RegularExpression {
         let options = UnsafeMutablePointer<UnsafePointer<Int8>?>.allocate(capacity: 1)
         defer {
             options.deinitialize(count: 1)
@@ -752,7 +752,7 @@ extension String: BSONValue {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> String {
         var length: UInt32 = 0
         guard let strValue = bson_iter_utf8(&iter.iter, &length) else {
            throw MongoError.bsonDecodeError(message: retrieveErrorMsg(type: "UTF-8", key: iter.currentKey))
@@ -771,7 +771,7 @@ internal struct Symbol: BSONValue {
         throw MongoError.bsonEncodeError(message: "Symbols are deprecated; use a string instead")
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Symbol {
         throw MongoError.bsonDecodeError(message:
             "`Symbol`s are deprecated; use `Symbol.asString` to parse as a string instead")
 
@@ -815,7 +815,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Timestamp {
         var t: UInt32 = 0
         var i: UInt32 = 0
         bson_iter_timestamp(&iter.iter, &t, &i)
@@ -864,7 +864,7 @@ func bsonEquals(_ lhs: BSONValue, _ rhs: BSONValue) -> Bool {
     case (let l as ObjectId, let r as ObjectId): return l == r
     case (let l as CodeWithScope, let r as CodeWithScope): return l == r
     case (let l as Binary, let r as Binary): return l == r
-    case (_ as NSNull, _ as NSNull): return true
+    case (_ as BSONNull, _ as BSONNull): return true
     case (let l as Document, let r as Document): return l == r
     case (let l as [BSONValue], let r as [BSONValue]): // TODO: SWIFT-242
         return zip(l, r).reduce(true, {prev, next in bsonEquals(next.0, next.1) && prev})

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -119,7 +119,7 @@ extension Array: BSONValue {
     }
 }
 
-/// A class to represent the BSON null type
+/// A struct to represent the BSON null type.
 public struct BSONNull: BSONValue, Codable {
     public var bsonType: BSONType { return .null }
 

--- a/Sources/MongoSwift/BSON/Document+Codable.swift
+++ b/Sources/MongoSwift/BSON/Document+Codable.swift
@@ -15,7 +15,7 @@ extension Document: Codable {
         var container = encoder.container(keyedBy: _BSONKey.self)
         for (k, v) in self {
             let key = _BSONKey(stringValue: k)!
-            if v is NSNull {
+            if v is BSONNull {
                 try container.encodeNil(forKey: key)
             } else {
                 let val = AnyBSONValue(v)
@@ -47,7 +47,7 @@ extension Document: Codable {
         for key in container.allKeys {
             let k = key.stringValue
             if try container.decodeNil(forKey: key) {
-                try output.setValue(for: k, to: NSNull())
+                try output.setValue(for: k, to: BSONNull())
             } else {
                 let val = try container.decode(AnyBSONValue.self, forKey: key).value
                 try output.setValue(for: k, to: val)

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -320,6 +320,6 @@ public class DocumentIterator: IteratorProtocol {
         .decimal128: Decimal128.self,
         .minKey: MinKey.self,
         .maxKey: MaxKey.self,
-        .null: NSNull.self
+        .null: BSONNull.self
     ]
 }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -323,7 +323,7 @@ extension Document {
      *  print(d["a"]) // prints 1
      *  ```
      * A nil return suggests that the subscripted key does not exist in the `Document`. A true BSON null is returned as
-     * an `NSNull`.
+     * a `BSONNull`.
      */
     public subscript(key: String) -> BSONValue? {
         // TODO: This `get` method _should_ guarantee constant-time O(1) access, and it is possible to make it do so.
@@ -378,7 +378,7 @@ extension Document: BSONValue {
         }
     }
 
-    public static func from(iterator iter: DocumentIterator) throws -> BSONValue {
+    public static func from(iterator iter: DocumentIterator) throws -> Document {
         var length: UInt32 = 0
         let document = UnsafeMutablePointer<UnsafePointer<UInt8>?>.allocate(capacity: 1)
         defer {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -353,7 +353,7 @@ extension Document {
      *  print(d.a) // prints 1
      *  ```
      * A nil return suggests that the key does not exist in the `Document`. A true BSON null is returned as
-     * an `NSNull`.
+     * a `BSONNull`.
      *
      * Only available in Swift 4.2+.
      */

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -142,8 +142,8 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try encoder.encode(s2)).to(equal(s2Doc1))
         expect(try decoder.decode(OptionalsStruct.self, from: s2Doc1)).to(equal(s2))
 
-        // test with key in doc explicitly set to NSNull
-        let s2Doc2: Document = ["int": NSNull(), "bool": true, "string": "hi"]
+        // test with key in doc explicitly set to BSONNull
+        let s2Doc2: Document = ["int": BSONNull(), "bool": true, "string": "hi"]
         expect(try decoder.decode(OptionalsStruct.self, from: s2Doc2)).to(equal(s2))
     }
 
@@ -562,7 +562,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(decodedWrapped?[2]).to(bsonEqual("hello"))
 
         // an array with a non-BSONValue
-        let arrWithNonBSONValue: [Any?] = [1, "hi", NSNull(), Int16(4)]
+        let arrWithNonBSONValue: [Any?] = [1, "hi", BSONNull(), Int16(4)]
         expect(try arrWithNonBSONValue.encode(to: DocumentStorage(), forKey: "arrWithNonBSONValue")).to(throwError())
 
         // binary
@@ -719,12 +719,12 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(AnyBSONStruct.self,
                                   from: wrappedMinKey.canonicalExtendedJSON).x.value).to(bsonEqual(minKey))
 
-        // NSNull
+        // BSONNull
         expect(
-            try decoder.decode(AnyBSONStruct.self, from: ["x": NSNull()]).x
-        ).to(equal(AnyBSONValue(NSNull())))
+            try decoder.decode(AnyBSONStruct.self, from: ["x": BSONNull()]).x
+        ).to(equal(AnyBSONValue(BSONNull())))
 
-        expect(try encoder.encode(AnyBSONStruct(NSNull()))).to(equal(["x": NSNull()]))
+        expect(try encoder.encode(AnyBSONStruct(BSONNull()))).to(equal(["x": BSONNull()]))
     }
 
     fileprivate struct IncorrectTopLevelEncode: Encodable {
@@ -762,8 +762,8 @@ final class CodecTests: MongoSwiftTestCase {
 
         // A top-level `encode()` problem should throw an error, but any such issues deeper in the recursion should not.
         // These tests are to ensure that we handle incorrect encode() implementations in the same way as JSONEncoder.
-        expect(try encoder.encode(IncorrectTopLevelEncode(NSNull()))).to(throwError())
-        expect(try encoder.encode(CorrectTopLevelEncode(NSNull()))).to(equal(["x": Document()]))
+        expect(try encoder.encode(IncorrectTopLevelEncode(BSONNull()))).to(throwError())
+        expect(try encoder.encode(CorrectTopLevelEncode(BSONNull()))).to(equal(["x": Document()]))
 
     }
 }

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -209,7 +209,7 @@ private class CrudTest {
             return
         }
 
-        if self.result is NSNull {
+        if self.result is BSONNull {
             expect(result).to(beNil())
         } else {
             expect(result).to(equal(self.result as? Document))

--- a/Tests/MongoSwiftTests/Document+SequenceTests.swift
+++ b/Tests/MongoSwiftTests/Document+SequenceTests.swift
@@ -96,14 +96,14 @@ final class Document_SequenceTests: MongoSwiftTestCase {
     }
 
     func testMapFilter() throws {
-        let doc1: Document = ["a": 1, "b": NSNull(), "c": 3, "d": 4, "e": NSNull()]
-        expect(doc1.mapValues { $0 is NSNull ? 1 : $0 }).to(equal(["a": 1, "b": 1, "c": 3, "d": 4, "e": 1]))
+        let doc1: Document = ["a": 1, "b": BSONNull(), "c": 3, "d": 4, "e": BSONNull()]
+        expect(doc1.mapValues { $0 is BSONNull ? 1 : $0 }).to(equal(["a": 1, "b": 1, "c": 3, "d": 4, "e": 1]))
         let output1 = doc1.mapValues { val in
             if let int = val as? Int { return int + 1 }
             return val
         }
-        expect(output1).to(equal(["a": 2, "b": NSNull(), "c": 4, "d": 5, "e": NSNull()]))
-        expect(doc1.filter { !($0.value is NSNull) }).to(equal(["a": 1, "c": 3, "d": 4]))
+        expect(output1).to(equal(["a": 2, "b": BSONNull(), "c": 4, "d": 5, "e": BSONNull()]))
+        expect(doc1.filter { !($0.value is BSONNull) }).to(equal(["a": 1, "c": 3, "d": 4]))
 
         let doc2: Document = ["a": 1, "b": "hello", "c": [1, 2] as [Int]]
         expect(doc2.filter { $0.value is String }).to(equal(["b": "hello"]))
@@ -128,11 +128,11 @@ final class Document_SequenceTests: MongoSwiftTestCase {
     // shared docs for subsequence tests
     let emptyDoc = Document()
     let smallDoc: Document = ["x": 1]
-    let doc: Document = ["a": 1, "b": "hi", "c": [1, 2] as [Int], "d": false, "e": NSNull(), "f": MinKey(), "g": 10]
+    let doc: Document = ["a": 1, "b": "hi", "c": [1, 2] as [Int], "d": false, "e": BSONNull(), "f": MinKey(), "g": 10]
 
     // shared predicates for subsequence tests
     func isInt(_ pair: Document.KeyValuePair) -> Bool { return pair.value is Int }
-    func isNotNil(_ pair: Document.KeyValuePair) -> Bool { return !(pair.value is NSNull) }
+    func isNotNil(_ pair: Document.KeyValuePair) -> Bool { return !(pair.value is BSONNull) }
     func is10(_ pair: Document.KeyValuePair) -> Bool {
         if let int = pair.value as? Int { return int == 10 } else { return false }
     }
@@ -151,11 +151,11 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             "b": "hi",
             "c": [1, 2] as [Int],
             "d": false,
-            "e": NSNull(),
+            "e": BSONNull(),
             "f": MinKey(),
             "g": 10
         ]))
-        expect(self.doc.dropFirst(4)).to(equal(["e": NSNull(), "f": MinKey(), "g": 10]))
+        expect(self.doc.dropFirst(4)).to(equal(["e": BSONNull(), "f": MinKey(), "g": 10]))
         expect(self.doc.dropFirst(7)).to(equal([:]))
         expect(self.doc.dropFirst(8)).to(equal([:]))
     }
@@ -174,7 +174,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             "b": "hi",
             "c": [1, 2] as [Int],
             "d": false,
-            "e": NSNull(),
+            "e": BSONNull(),
             "f": MinKey()
         ]))
         expect(self.doc.dropLast(4)).to(equal(["a": 1, "b": "hi", "c": [1, 2] as [Int]]))
@@ -189,14 +189,14 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             "b": "hi",
             "c": [1, 2] as [Int],
             "d": false,
-            "e": NSNull(),
+            "e": BSONNull(),
             "f": MinKey(),
             "g": 10
         ]))
 
         expect(self.emptyDoc.drop(while: self.isNotNil)).to(equal([:]))
         expect(self.smallDoc.drop(while: self.isNotNil)).to(equal([:]))
-        expect(self.doc.drop(while: self.isNotNil)).to(equal(["e": NSNull(), "f": MinKey(), "g": 10]))
+        expect(self.doc.drop(while: self.isNotNil)).to(equal(["e": BSONNull(), "f": MinKey(), "g": 10]))
 
         expect(self.emptyDoc.drop(while: self.isNot10)).to(equal([:]))
         expect(self.smallDoc.drop(while: self.isNot10)).to(equal([:]))
@@ -239,7 +239,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             "b": "hi",
             "c": [1, 2] as [Int],
             "d": false,
-            "e": NSNull(),
+            "e": BSONNull(),
             "f": MinKey()
         ]))
 
@@ -261,7 +261,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
         expect(self.doc.suffix(0)).to(equal([]))
         expect(self.doc.suffix(1)).to(equal(["g": 10]))
         expect(self.doc.suffix(2)).to(equal(["f": MinKey(), "g": 10]))
-        expect(self.doc.suffix(4)).to(equal(["d": false, "e": NSNull(), "f": MinKey(), "g": 10]))
+        expect(self.doc.suffix(4)).to(equal(["d": false, "e": BSONNull(), "f": MinKey(), "g": 10]))
         expect(self.doc.suffix(7)).to(equal(doc))
         expect(self.doc.suffix(8)).to(equal(doc))
     }
@@ -273,7 +273,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             "b": "hi",
             "c": [1, 2] as [Int],
             "d": false,
-            "e": NSNull(),
+            "e": BSONNull(),
             "f": MinKey()
         ]]))
 
@@ -283,12 +283,12 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             "b": "hi",
             "c": [1, 2] as [Int],
             "d": false,
-            "e": NSNull(),
+            "e": BSONNull(),
             "f": MinKey()
         ], [:]]))
 
         expect(self.doc.split(maxSplits: 1, omittingEmptySubsequences: false, whereSeparator: self.isInt))
-            .to(equal([[:], ["b": "hi", "c": [1, 2] as [Int], "d": false, "e": NSNull(), "f": MinKey(), "g": 10]]))
+            .to(equal([[:], ["b": "hi", "c": [1, 2] as [Int], "d": false, "e": BSONNull(), "f": MinKey(), "g": 10]]))
 
     }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -192,7 +192,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
         expect(DocumentTests.testDoc.array1).to(bsonEqual([1, 2]))
         expect(DocumentTests.testDoc.array2).to(bsonEqual(["string1", "string2"]))
-        expect(DocumentTests.testDoc.null).to(bsonEqual(NSNull()))
+        expect(DocumentTests.testDoc.null).to(bsonEqual(BSONNull()))
 
         let regex = DocumentTests.testDoc.regex as? RegularExpression
         expect(regex).to(equal(RegularExpression(pattern: "^abc", options: "imx")))

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -69,7 +69,7 @@ final class DocumentTests: MongoSwiftTestCase {
         "regex": RegularExpression(pattern: "^abc", options: "imx"),
         "array1": [1, 2],
         "array2": ["string1", "string2"],
-        "null": NSNull(),
+        "null": BSONNull(),
         "code": CodeWithScope(code: "console.log('hi');"),
         "codewscope": CodeWithScope(code: "console.log(x);", scope: ["x": 2])
     ]
@@ -139,7 +139,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
         expect(doc["array1"]).to(bsonEqual([1, 2]))
         expect(doc["array2"]).to(bsonEqual(["string1", "string2"]))
-        expect(doc["null"]).to(bsonEqual(NSNull()))
+        expect(doc["null"]).to(bsonEqual(BSONNull()))
 
         let code = doc["code"] as? CodeWithScope
         expect(code?.code).to(equal("console.log('hi');"))
@@ -229,20 +229,20 @@ final class DocumentTests: MongoSwiftTestCase {
     }
 
     func testDocumentFromArray() {
-       let doc1: Document = ["foo", MinKey(), NSNull()]
+       let doc1: Document = ["foo", MinKey(), BSONNull()]
 
        expect(doc1.keys).to(equal(["0", "1", "2"]))
        expect(doc1["0"]).to(bsonEqual("foo"))
        expect(doc1["1"]).to(bsonEqual(MinKey()))
-       expect(doc1["2"]).to(bsonEqual(NSNull()))
+       expect(doc1["2"]).to(bsonEqual(BSONNull()))
 
-       let elements: [BSONValue] = ["foo", MinKey(), NSNull()]
+       let elements: [BSONValue] = ["foo", MinKey(), BSONNull()]
        let doc2 = Document(elements)
 
        expect(doc2.keys).to(equal(["0", "1", "2"]))
        expect(doc2["0"]).to(bsonEqual("foo"))
        expect(doc2["1"]).to(bsonEqual(MinKey()))
-       expect(doc2["2"]).to(bsonEqual(NSNull()))
+       expect(doc2["2"]).to(bsonEqual(BSONNull()))
     }
 
     func testEquatable() {
@@ -416,8 +416,8 @@ final class DocumentTests: MongoSwiftTestCase {
     }
 
     func testNilInNestedArray() throws {
-        let arr1: [BSONValue] = ["a", "b", "c", NSNull()]
-        let arr2: [BSONValue] = ["d", "e", NSNull(), "f"]
+        let arr1: [BSONValue] = ["a", "b", "c", BSONNull()]
+        let arr2: [BSONValue] = ["d", "e", BSONNull(), "f"]
 
         let doc = ["a1": arr1, "a2": arr2]
 
@@ -439,7 +439,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
     static let nonOverwritables: Document = [
         "string": "hello",
-        "nil": NSNull(),
+        "nil": BSONNull(),
         "doc": ["x": 1] as Document,
         "arr": [1, 2] as [Int]
     ]
@@ -538,7 +538,7 @@ final class DocumentTests: MongoSwiftTestCase {
             pointer = doc.data
         }
 
-        expect(doc).to(equal(["string": "hi", "nil": NSNull(), "doc": newDoc, "arr": [3, 4] as [Int]]))
+        expect(doc).to(equal(["string": "hi", "nil": BSONNull(), "doc": newDoc, "arr": [3, 4] as [Int]]))
     }
 
     // test replacing both overwritable and nonoverwritable values with values of different types
@@ -601,7 +601,7 @@ final class DocumentTests: MongoSwiftTestCase {
         var overwritablePointer = overwritableDoc.data
 
         ["double", "int32", "int64", "bool", "decimal", "oid", "timestamp", "datetime"].forEach {
-            overwritableDoc[$0] = NSNull()
+            overwritableDoc[$0] = BSONNull()
             // the storage should change every time 
             expect(overwritableDoc.data).toNot(equal(overwritablePointer))
             overwritablePointer = overwritableDoc.data
@@ -611,23 +611,24 @@ final class DocumentTests: MongoSwiftTestCase {
         var nonOverwritablePointer = nonOverwritableDoc.data
 
         ["string", "doc", "arr"].forEach {
-            nonOverwritableDoc[$0] = NSNull()
+            nonOverwritableDoc[$0] = BSONNull()
             // the storage should change every time 
             expect(nonOverwritableDoc.data).toNot(equal(nonOverwritablePointer))
             nonOverwritablePointer = nonOverwritableDoc.data
         }
 
-        expect(nonOverwritableDoc).to(equal(["string": NSNull(), "nil": NSNull(), "doc": NSNull(), "arr": NSNull()]))
+        expect(nonOverwritableDoc).to(
+                equal(["string": BSONNull(), "nil": BSONNull(), "doc": BSONNull(), "arr": BSONNull()]))
     }
 
     // Test types where replacing them with an instance of their own type is a no-op
     func testReplaceValueNoop() throws {
-        var noops: Document = ["null": NSNull(), "maxkey": MaxKey(), "minkey": MinKey()]
+        var noops: Document = ["null": BSONNull(), "maxkey": MaxKey(), "minkey": MinKey()]
 
         var pointer = noops.data
 
         // replace values with own types. these should all be no-ops
-        let newPairs1: [(String, BSONValue)] = [("null", NSNull()), ("maxkey", MaxKey()), ("minkey", MinKey())]
+        let newPairs1: [(String, BSONValue)] = [("null", BSONNull()), ("maxkey", MaxKey()), ("minkey", MinKey())]
 
         newPairs1.forEach { (k, v) in
             noops[k] = v
@@ -636,7 +637,7 @@ final class DocumentTests: MongoSwiftTestCase {
         }
 
         // we should still have exactly the same document we started with
-        expect(noops).to(equal(["null": NSNull(), "maxkey": MaxKey(), "minkey": MinKey()]))
+        expect(noops).to(equal(["null": BSONNull(), "maxkey": MaxKey(), "minkey": MinKey()]))
 
         // now try replacing them with values of different types that do require replacing storage
         let newPairs2: [(String, BSONValue)] = [("null", 5), ("maxkey", "hi"), ("minkey", false)]
@@ -652,8 +653,8 @@ final class DocumentTests: MongoSwiftTestCase {
     }
 
     func testDocumentDictionarySimilarity() throws {
-        var doc: Document = ["hello": "world", "swift": 4.2, "null": NSNull(), "remove_me": "please"]
-        var dict: [String: BSONValue] = ["hello": "world", "swift": 4.2, "null": NSNull(), "remove_me": "please"]
+        var doc: Document = ["hello": "world", "swift": 4.2, "null": BSONNull(), "remove_me": "please"]
+        var dict: [String: BSONValue] = ["hello": "world", "swift": 4.2, "null": BSONNull(), "remove_me": "please"]
 
         expect(doc["hello"]).to(bsonEqual(dict["hello"]))
         expect(doc["swift"]).to(bsonEqual(dict["swift"]))

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -235,11 +235,11 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.distinct(fieldName: "abc", filter: [:])).to(beEmpty())
 
         // test a null distinct value
-        try coll.insertOne(["cat": NSNull()])
+        try coll.insertOne(["cat": BSONNull()])
         let distinct2 = try coll.distinct(fieldName: "cat", filter: [:])
         expect(distinct2).to(haveCount(3))
         // swiftlint:disable trailing_closure
-        expect(distinct2).to(containElementSatisfying({ $0 is NSNull }))
+        expect(distinct2).to(containElementSatisfying({ $0 is BSONNull }))
         // swiftlint:enable trailing_closure
     }
 
@@ -493,15 +493,15 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     }
 
     func testNullIds() throws {
-        let result1 = try self.coll.insertOne(["_id": NSNull(), "hi": "hello"])
+        let result1 = try self.coll.insertOne(["_id": BSONNull(), "hi": "hello"])
         expect(result1).toNot(beNil())
-        expect(result1?.insertedId).to(bsonEqual(NSNull()))
+        expect(result1?.insertedId).to(bsonEqual(BSONNull()))
 
-        try self.coll.deleteOne(["_id": NSNull()])
+        try self.coll.deleteOne(["_id": BSONNull()])
 
-        let result2 = try self.coll.insertMany([["_id": NSNull()], ["_id": 20]])
+        let result2 = try self.coll.insertMany([["_id": BSONNull()], ["_id": 20]])
         expect(result2).toNot(beNil())
-        expect(result2?.insertedIds[0]).to(bsonEqual(NSNull()))
+        expect(result2?.insertedIds[0]).to(bsonEqual(BSONNull()))
         expect(result2?.insertedIds[1]).to(bsonEqual(20))
     }
 }


### PR DESCRIPTION
[SWIFT-278](url)

This PR updates `BSONValue.from(iterator)` to return `Self` instead of `BSONValue`, which is semantically nicer. Originally, we returned `BSONValue` to facilitate conversion of deprecated BSON 
types to other ones, but that is handled elsewhere now.

Due to some weird issues involving `NSNull` on Linux, this PR also introduces a new type to represent BSON null values: `BSONNull`. 