### PR TITLE
Added public initializer to BSONNull

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -125,6 +125,7 @@ public struct BSONNull: BSONValue, Codable {
 
     public static func from(iterator iter: DocumentIterator) throws -> BSONNull { return BSONNull() }
 
+    /// Initializes a new, empty `BSONNull` instance.
     public init() { }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -125,6 +125,8 @@ public struct BSONNull: BSONValue, Codable {
 
     public static func from(iterator iter: DocumentIterator) throws -> BSONNull { return BSONNull() }
 
+    public init() { }
+
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         guard bson_append_null(storage.pointer, key, Int32(key.count)) else {
             throw bsonEncodeError(value: self, forKey: key)

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -125,7 +125,7 @@ public struct BSONNull: BSONValue, Codable {
 
     public static func from(iterator iter: DocumentIterator) throws -> BSONNull { return BSONNull() }
 
-    /// Initializes a new, empty `BSONNull` instance.
+    /// Initializes a new `BSONNull` instance.
     public init() { }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {


### PR DESCRIPTION
Fixes #174.

#171 deprecates the use of NSNull in favour of BSONNull

Unfortunately, it's not possible to instantiate BSONNull outside the MongoSwift module because the automatically synthesised initialiser is internal.

Adding a simple public init() { } would solve this issue.