### PR TITLE
SWIFT-281 Allow .uuidDecodingStrategy and .dateDecodingStrategy to be set for BSONDecoder

### DIFF
--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -58,11 +58,8 @@ public struct AnyBSONValue: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         // short-circuit in the `BSONDecoder` case
         if let bsonDecoder = decoder as? _BSONDecoder {
-            if bsonDecoder.storage.topContainer as? Date != nil {
-                switch bsonDecoder.options.dateDecodingStrategy {
-                case BSONDecoder.DateDecodingStrategy.bsonDateTime:
-                    break
-                default:
+            if bsonDecoder.storage.topContainer is Date {
+                guard case .bsonDateTime = bsonDecoder.options.dateDecodingStrategy else {
                     throw MongoError.bsonDecodeError(message: "Got a BSON datetime but was expecting another format. " +
                             "To decode from BSON datetimes, use the default .bsonDateTime DateDecodingStrategy.")
                 }

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -58,6 +58,15 @@ public struct AnyBSONValue: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         // short-circuit in the `BSONDecoder` case
         if let bsonDecoder = decoder as? _BSONDecoder {
+            if bsonDecoder.storage.topContainer as? Date != nil {
+                switch bsonDecoder.options.dateDecodingStrategy {
+                case BSONDecoder.DateDecodingStrategy.bsonDateTime:
+                    break
+                default:
+                    throw MongoError.bsonDecodeError(message: "Got a BSON datetime but was expecting another format. " +
+                            "To decode from BSON datetimes, use the default .bsonDateTime DateDecodingStrategy.")
+                }
+            }
             self.value = bsonDecoder.storage.topContainer
             return
         }

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -329,8 +329,10 @@ extension _BSONDecoder {
     fileprivate func unbox<T: Decodable>(_ value: BSONValue, as type: T.Type) throws -> T {
         // swiftlint:disable force_cast
         if type == Date.self {
+            // We know T is a Date and unboxDate returns a Date or throws, so this cast will always work
             return try unboxDate(value) as! T
         } else if type == UUID.self {
+            // We know T is a Date and unboxUUID returns a UUID or throws, so this cast will always work
             return try unboxUUID(value) as! T
         }
         // swiftlint:enable force_cast

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -14,7 +14,7 @@ public class BSONDecoder {
     ///
     /// As per the BSON specification, the default strategy is to decode `Date`s from BSON datetime objects.
     ///
-    /// See bsonspec.org for more information.
+    /// - SeeAlso: bsonspec.org
     public enum DateDecodingStrategy {
         /// Decode `Date`s stored as BSON datetimes.
         case bsonDateTime
@@ -44,7 +44,7 @@ public class BSONDecoder {
     /// As per the BSON specification, the default strategy is to decode `UUID`s from BSON binary types with the UUID
     /// subtype.
     ///
-    /// See bsonspec.org for more information.
+    /// - SeeAlso: bsonspec.org
     public enum UUIDDecodingStrategy {
         /// Decode `UUID`s by deferring to their default decoding implementation.
         case deferredToUUID

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -11,6 +11,10 @@ public class BSONDecoder {
     }()
 
     /// Enum representing the different options for decoding `Date`s from BSON.
+    ///
+    /// As per the BSON specification, the default strategy is to decode `Date`s from BSON datetime objects.
+    ///
+    /// See bsonspec.org for more information.
     public enum DateDecodingStrategy {
         /// Decode `Date`s stored as BSON datetimes.
         case bsonDateTime
@@ -36,6 +40,11 @@ public class BSONDecoder {
     }
 
     /// Enum representing the different options for decoding `UUID`s from BSON.
+    ///
+    /// As per the BSON specification, the default strategy is to decode `UUID`s from BSON binary types with the UUID
+    /// subtype.
+    ///
+    /// See bsonspec.org for more information.
     public enum UUIDDecodingStrategy {
         /// Decode `UUID`s by deferring to their default decoding implementation.
         case deferredToUUID

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -41,7 +41,7 @@ public class BSONDecoder {
         case deferredToUUID
 
         /// Decode `UUID`s stored as the BSON `Binary` type.
-        case fromBinary
+        case binary
     }
 
     /// Contextual user-provided information for use during decoding.
@@ -51,7 +51,7 @@ public class BSONDecoder {
     public var dateDecodingStrategy: DateDecodingStrategy = .bsonDateTime
 
     /// The strategy used for decoding `UUID`s with this instance.
-    public var uuidDecodingStrategy: UUIDDecodingStrategy = .fromBinary
+    public var uuidDecodingStrategy: UUIDDecodingStrategy = .binary
 
     /// Options set on the top-level decoder to pass down the decoding hierarchy.
     fileprivate struct _Options {
@@ -310,7 +310,7 @@ extension _BSONDecoder {
             self.storage.push(container: value)
             defer { self.storage.popContainer() }
             return try UUID(from: self)
-        case .fromBinary:
+        case .binary:
             let binary = try self.unbox(value, as: Binary.self)
             return try UUID(fromBinary: binary)
         }

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -3,7 +3,7 @@ import Foundation
 /// `BSONDecoder` facilitates the decoding of BSON into semantic `Decodable` types.
 public class BSONDecoder {
 
-    @available(OSX 10.12, *)
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     internal static var iso8601Formatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = .withInternetDateTime
@@ -28,7 +28,7 @@ public class BSONDecoder {
         case deferredToDate
 
         /// Decoding `Date`s represented by ISO8601 formatted strings
-        @available(OSX 10.12, *)
+        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
         /// Decoding `Date`s stored as strings parsable by the given formatter
@@ -276,7 +276,7 @@ extension _BSONDecoder {
             let val = try self.unbox(value, as: Int64.self)
             return Date(timeIntervalSince1970: TimeInterval(val))
         case .iso8601:
-            if #available(OSX 10.12, *) {
+            if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
                 let isoString = try self.unbox(value, as: String.self)
                 guard let date = BSONDecoder.iso8601Formatter.date(from: isoString) else {
                     throw MongoError.bsonDecodeError(message: "Improperly formatted ISO 8601 Date string")
@@ -313,8 +313,8 @@ extension _BSONDecoder {
             }
             return uuid
         case .fromBinary:
-            let val: Binary = try self.unbox(value, as: Binary.self)
-            return try UUID(fromBinary: val)
+            let binary = try self.unbox(value, as: Binary.self)
+            return try UUID(fromBinary: binary)
         }
     }
 

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -10,43 +10,43 @@ public class BSONDecoder {
         return formatter
     }()
 
-    /// Enum representing the different options for decoding `Date`s from BSON
+    /// Enum representing the different options for decoding `Date`s from BSON.
     public enum DateDecodingStrategy {
-        /// Decoding `Date`s stored as 64 bit integers counting the number of milliseconds since January 1, 1970
+        /// Decode `Date`s stored as 64 bit integers counting the number of milliseconds since January 1, 1970.
         case millisecondsSince1970Int64
 
-        /// Decoding `Date`s stored as 64 bit integers counting the number of seconds since January 1, 1970
+        /// Decode `Date`s stored as 64 bit integers counting the number of seconds since January 1, 1970.
         case secondsSince1970Int64
 
-        /// Decoding `Date`s stored as `Double`s counting the number of seconds since January 1, 1970
+        /// Decode `Date`s stored as `Double`s counting the number of seconds since January 1, 1970.
         case millisecondsSince1970
 
-        /// Decoding `Date`s stored as `Double`s counting the number of milliseconds since January 1, 1970
+        /// Decode `Date`s stored as BSON doubles counting the number of milliseconds since January 1, 1970.
         case secondsSince1970
 
-        /// Decoding `Date`s by deferring to their default decoding implementation
+        /// Decode `Date`s by deferring to their default decoding implementation.
         case deferredToDate
 
-        /// Decoding `Date`s represented by ISO8601 formatted strings
+        /// Decode `Date`s represented by ISO8601 formatted strings.
         @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
-        /// Decoding `Date`s stored as strings parsable by the given formatter
+        /// Decode `Date`s stored as strings parsable by the given formatter.
         case formatted(DateFormatter)
 
-        /// Decoding `Date`s using the provided closure
+        /// Decode `Date`s using the provided closure.
         case custom((_ decoder: Decoder) throws -> Date)
     }
 
-    /// Enum representing the different options for decoding `UUID`s from BSON
+    /// Enum representing the different options for decoding `UUID`s from BSON.
     public enum UUIDDecodingStrategy {
-        /// Decoding `UUID`s by deferring to their default decoding implementation
+        /// Decode `UUID`s by deferring to their default decoding implementation.
         case deferredToUUID
 
-        /// Decoding `UUID`s from strings
+        /// Decode `UUID`s from strings.
         case fromString
 
-        /// Decoding `UUID`s from the BSON `Binary` type
+        /// Decode `UUID`s from the BSON `Binary` type.
         case fromBinary
     }
 
@@ -56,7 +56,7 @@ public class BSONDecoder {
     /// The strategy used for decoding dates with this instance.
     public var dateDecodingStrategy: DateDecodingStrategy = .millisecondsSince1970Int64
 
-    /// The strategy used for decoding UUIDs with this instance
+    /// The strategy used for decoding UUIDs with this instance.
     public var uuidDecodingStrategy: UUIDDecodingStrategy = .fromBinary
 
     /// Options set on the top-level decoder to pass down the decoding hierarchy.
@@ -255,7 +255,7 @@ extension _BSONDecoder {
         return primitive
     }
 
-    /// Private helper function used specifically for decoding dates
+    /// Private helper function used specifically for decoding dates.
     // swiftlint:disable cyclomatic_complexity
     fileprivate func unboxDate(_ value: BSONValue) throws -> Date {
         switch self.options.dateDecodingStrategy {
@@ -299,7 +299,7 @@ extension _BSONDecoder {
     }
     // swiftlint:enable cyclomatic_complexity
 
-    /// Private helper used specifically for decoding UUIDs
+    /// Private helper used specifically for decoding UUIDs.
     fileprivate func unboxUUID(_ value: BSONValue) throws -> UUID {
         switch self.options.uuidDecodingStrategy {
         case .deferredToUUID:

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -40,9 +40,6 @@ public class BSONDecoder {
         /// Decode `UUID`s by deferring to their default decoding implementation.
         case deferredToUUID
 
-        /// Decode `UUID`s stored as strings.
-        case fromString
-
         /// Decode `UUID`s stored as the BSON `Binary` type.
         case fromBinary
     }
@@ -313,16 +310,6 @@ extension _BSONDecoder {
             self.storage.push(container: value)
             defer { self.storage.popContainer() }
             return try UUID(from: self)
-        case .fromString:
-            let uuidString = try self.unbox(value, as: String.self)
-             guard let uuid = UUID(uuidString: uuidString) else {
-                 throw DecodingError.dataCorrupted(
-                         DecodingError.Context(
-                                 codingPath: self.codingPath,
-                                 debugDescription: "Could not decode UUID from string \"\(uuidString)\"")
-                 )
-            }
-            return uuid
         case .fromBinary:
             let binary = try self.unbox(value, as: Binary.self)
             return try UUID(fromBinary: binary)

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -293,7 +293,7 @@ extension _BSONDecoder {
                         DecodingError.Context(
                                 codingPath: self.codingPath,
                                 debugDescription: "String \"\(isoString)\" is not a properly formatted " +
-                                        "ISO 8601 Date string"
+                                        "ISO 8601 Date string."
                         )
                 )
             }
@@ -344,10 +344,10 @@ extension _BSONDecoder {
     fileprivate func unbox<T: Decodable>(_ value: BSONValue, as type: T.Type) throws -> T {
         // swiftlint:disable force_cast
         if type == Date.self {
-            // We know T is a Date and unboxDate returns a Date or throws, so this cast will always work
+            // We know T is a Date and unboxDate returns a Date or throws, so this cast will always work.
             return try unboxDate(value) as! T
         } else if type == UUID.self {
-            // We know T is a Date and unboxUUID returns a UUID or throws, so this cast will always work
+            // We know T is a Date and unboxUUID returns a UUID or throws, so this cast will always work.
             return try unboxUUID(value) as! T
         }
         // swiftlint:enable force_cast

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -335,7 +335,7 @@ extension _BSONDecoder {
             // We know T is a Date and unboxDate returns a Date or throws, so this cast will always work.
             return try unboxDate(value) as! T
         } else if type == UUID.self {
-            // We know T is a Date and unboxUUID returns a UUID or throws, so this cast will always work.
+            // We know T is a UUID and unboxUUID returns a UUID or throws, so this cast will always work.
             return try unboxUUID(value) as! T
         }
         // swiftlint:enable force_cast

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -63,7 +63,7 @@ public class BSONDecoder {
     public var uuidDecodingStrategy: UUIDDecodingStrategy = .binary
 
     /// Options set on the top-level decoder to pass down the decoding hierarchy.
-    fileprivate struct _Options {
+    internal struct _Options {
         let userInfo: [CodingUserInfoKey: Any]
         let dateDecodingStrategy: DateDecodingStrategy
         let uuidDecodingStrategy: UUIDDecodingStrategy
@@ -144,7 +144,7 @@ internal class _BSONDecoder: Decoder {
     internal var storage: _BSONDecodingStorage
 
     /// Options set on the top-level decoder.
-    fileprivate let options: BSONDecoder._Options
+    internal let options: BSONDecoder._Options
 
     /// The path to the current point in decoding.
     public fileprivate(set) var codingPath: [CodingKey]

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -312,7 +312,7 @@ extension _BSONDecoder {
             return try UUID(from: self)
         case .binary:
             let binary = try self.unbox(value, as: Binary.self)
-            return try UUID(fromBinary: binary)
+            return try UUID(from: binary)
         }
     }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -653,7 +653,7 @@ extension UUID {
         }
         guard binary.subtype == Binary.Subtype.uuid.rawValue else {
             throw MongoError.bsonDecodeError(message: "Expected a UUID binary type " +
-                    "(\(Binary.Subtype.uuidDeprecated)), got \(binary.subtype) instead.")
+                    "(\(Binary.Subtype.uuid)), got \(binary.subtype) instead.")
         }
 
         let data = binary.data

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -644,7 +644,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 
 /// Extension to allow a UUID to be initialized from a Binary BSONValue.
 extension UUID {
-    // TODO: fill the rest of this out for full BSONValue conformance.
+    // TODO: fill the rest of this out for full BSONValue conformance (SWIFT-295).
 
     internal init(fromBinary binary: Binary) throws {
         guard binary.subtype != Binary.Subtype.uuidDeprecated.rawValue else {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -646,7 +646,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 extension UUID {
     // TODO: fill the rest of this out for full BSONValue conformance (SWIFT-295).
 
-    internal init(fromBinary binary: Binary) throws {
+    internal init(from binary: Binary) throws {
         guard binary.subtype != Binary.Subtype.uuidDeprecated.rawValue else {
             throw MongoError.bsonDecodeError(message: "Binary subtype \(binary.subtype) is deprecated, " +
                     "use \(Binary.Subtype.uuid) instead.")

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -642,18 +642,18 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 
 }
 
-/// Extension to allow a UUID to be initialized from a Binary BSONValue
+/// Extension to allow a UUID to be initialized from a Binary BSONValue.
 extension UUID {
-    // TODO: fill the rest of this out for full BSONValue conformance
+    // TODO: fill the rest of this out for full BSONValue conformance.
 
     internal init(fromBinary binary: Binary) throws {
         guard binary.subtype != Binary.Subtype.uuidDeprecated.rawValue else {
             throw MongoError.bsonDecodeError(message: "Binary subtype \(binary.subtype) is deprecated, " +
-                    "use \(Binary.Subtype.uuid) instead")
+                    "use \(Binary.Subtype.uuid) instead.")
         }
         guard binary.subtype == Binary.Subtype.uuid.rawValue else {
             throw MongoError.bsonDecodeError(message: "Expected a UUID binary type " +
-                    "(\(Binary.Subtype.uuidDeprecated)), got \(binary.subtype) instead")
+                    "(\(Binary.Subtype.uuidDeprecated)), got \(binary.subtype) instead.")
         }
 
         let data = binary.data

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -647,8 +647,13 @@ extension UUID {
     // TODO: fill the rest of this out for full BSONValue conformance
 
     internal init(fromBinary binary: Binary) throws {
+        guard binary.subtype != Binary.Subtype.uuidDeprecated.rawValue else {
+            throw MongoError.bsonDecodeError(message: "Binary subtype \(binary.subtype) is deprecated, " +
+                    "use \(Binary.Subtype.uuid) instead")
+        }
         guard binary.subtype == Binary.Subtype.uuid.rawValue else {
-            throw MongoError.bsonDecodeError(message: "Expected a UUID binary type, got \(binary.subtype) instead")
+            throw MongoError.bsonDecodeError(message: "Expected a UUID binary type " +
+                    "(\(Binary.Subtype.uuidDeprecated)), got \(binary.subtype) instead")
         }
 
         let data = binary.data

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -651,12 +651,7 @@ extension UUID {
             throw MongoError.bsonDecodeError(message: "Expected a UUID binary type, got \(binary.subtype) instead")
         }
 
-        guard binary.data.count == 16 else {
-            throw MongoError.bsonDecodeError(message: "UUIDs must be exactly 16 bytes")
-        }
-
         let data = binary.data
-
         let uuid: uuid_t = (
                 data[0], data[1], data[2], data[3],
                 data[4], data[5], data[6], data[7],

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -642,6 +642,32 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 
 }
 
+/// Extension to allow a UUID to be initialized from a Binary BSONValue
+extension UUID {
+    // TODO: fill the rest of this out for full BSONValue conformance
+
+    internal init(fromBinary binary: Binary) throws {
+        guard binary.subtype == Binary.Subtype.uuid.rawValue else {
+            throw MongoError.bsonDecodeError(message: "Expected a UUID binary type, got \(binary.subtype) instead")
+        }
+
+        guard binary.data.count == 16 else {
+            throw MongoError.bsonDecodeError(message: "UUIDs must be exactly 16 bytes")
+        }
+
+        let data = binary.data
+
+        let uuid: uuid_t = (
+                data[0], data[1], data[2], data[3],
+                data[4], data[5], data[6], data[7],
+                data[8], data[9], data[10], data[11],
+                data[12], data[13], data[14], data[15]
+        )
+
+        self.init(uuid: uuid)
+    }
+}
+
 // A mapping of regex option characters to their equivalent `NSRegularExpression` option.
 // note that there is a BSON regexp option 'l' that `NSRegularExpression`
 // doesn't support. The flag will be dropped if BSON containing it is parsed,

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -616,6 +616,10 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(AnyBSONStruct.self,
                                   from: wrappedDate.canonicalExtendedJSON).x.value).to(bsonEqual(date))
 
+        let dateDecoder = BSONDecoder()
+        dateDecoder.dateDecodingStrategy = .millisecondsSince1970
+        expect(try dateDecoder.decode(AnyBSONStruct.self, from: wrappedDate)).to(throwError())
+
         // regex
         let regex = RegularExpression(pattern: "abc", options: "imx")
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -707,11 +707,6 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(deferredStruct.uuid).to(equal(uuid))
         expect(try decoder.decode(UUIDWrapper.self, from: badString)).to(throwError())
 
-        decoder.uuidDecodingStrategy = .fromString
-        let stringStruct = try decoder.decode(UUIDWrapper.self, from: stringDoc)
-        expect(stringStruct.uuid).to(equal(uuid))
-        expect(try decoder.decode(UUIDWrapper.self, from: badString)).to(throwError())
-
         decoder.uuidDecodingStrategy = .fromBinary
         let uuidt = uuid.uuid
         let bytes = Data(bytes: [
@@ -755,7 +750,7 @@ final class DocumentTests: MongoSwiftTestCase {
         let msInt64Struct = try decoder.decode(DateWrapper.self, from: msInt64)
         expect(msInt64Struct.date).to(equal(date))
 
-        let msDouble: Document = ["date": TimeInterval(date.msSinceEpoch)]
+        let msDouble: Document = ["date": Double(date.msSinceEpoch)]
         let msDoubleStruct = try decoder.decode(DateWrapper.self, from: msDouble)
         expect(msDoubleStruct.date).to(equal(date))
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -694,7 +694,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
         // randomly generated uuid
         guard let uuid = UUID(uuidString: "2c380a6c-7bc5-48cb-84a2-b26777a72276") else {
-            throw MongoError.bsonDecodeError(message: "Cant create URI")
+            throw MongoError.bsonDecodeError(message: "Cant create UUID.")
         }
 
         let decoder = BSONDecoder()

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -750,17 +750,11 @@ final class DocumentTests: MongoSwiftTestCase {
         let bsonDateStruct = try decoder.decode(DateWrapper.self, from: bsonDate)
         expect(bsonDateStruct.date).to(equal(date))
 
-        decoder.dateDecodingStrategy = .millisecondsSince1970Int64
+        decoder.dateDecodingStrategy = .millisecondsSince1970
         let msInt64: Document = ["date": date.msSinceEpoch]
         let msInt64Struct = try decoder.decode(DateWrapper.self, from: msInt64)
         expect(msInt64Struct.date).to(equal(date))
 
-        decoder.dateDecodingStrategy = .secondsSince1970Int64
-        let sInt64: Document = ["date": Int64(date.timeIntervalSince1970)]
-        let sInt64Struct = try decoder.decode(DateWrapper.self, from: sInt64)
-        expect(sInt64Struct.date).to(equal(date))
-
-        decoder.dateDecodingStrategy = .millisecondsSince1970
         let msDouble: Document = ["date": TimeInterval(date.msSinceEpoch)]
         let msDoubleStruct = try decoder.decode(DateWrapper.self, from: msDouble)
         expect(msDoubleStruct.date).to(equal(date))
@@ -769,6 +763,10 @@ final class DocumentTests: MongoSwiftTestCase {
         let sDouble: Document = ["date": date.timeIntervalSince1970]
         let sDoubleStruct = try decoder.decode(DateWrapper.self, from: sDouble)
         expect(sDoubleStruct.date).to(equal(date))
+
+        let sInt64: Document = ["date": Int64(date.timeIntervalSince1970)]
+        let sInt64Struct = try decoder.decode(DateWrapper.self, from: sInt64)
+        expect(sInt64Struct.date).to(equal(date))
 
         let formatter = DateFormatter()
         formatter.dateStyle = .short
@@ -782,7 +780,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(formattedStruct.date).to(equal(date))
         expect(try decoder.decode(DateWrapper.self, from: badlyFormatted)).to(throwError())
 
-        if #available(macOS 10.12, *) {
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
             decoder.dateDecodingStrategy = .iso8601
             let isoDoc: Document = ["date": BSONDecoder.iso8601Formatter.string(from: date)]
             let isoStruct = try decoder.decode(DateWrapper.self, from: isoDoc)

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -707,7 +707,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(deferredStruct.uuid).to(equal(uuid))
         expect(try decoder.decode(UUIDWrapper.self, from: badString)).to(throwError())
 
-        decoder.uuidDecodingStrategy = .fromBinary
+        decoder.uuidDecodingStrategy = .binary
         let uuidt = uuid.uuid
         let bytes = Data(bytes: [
             uuidt.0, uuidt.1, uuidt.2, uuidt.3,


### PR DESCRIPTION
[SWIFT-281](https://jira.mongodb.org/browse/SWIFT-281)

This PR adds two options for specifying a `DateDecodingStrategy` and a `UUIDDecodingStrategy` on a given `BSONDecoder`. 

For `Date`, I mimicked the functionality of `JSONDecoder`'s [strategies](https://developer.apple.com/documentation/foundation/jsondecoder/datedecodingstrategy). I also added a `.bsonDateTime` strategy for when the date is encoded as a BSON datetime. 
The default strategy is `.bsonDateTime`.

For `UUID`, I added the following strategies:

- `.defferredToUUID`: uses `UUID`'s implementation of `init(from: decoder)`
- `.binary`: decodes from a BSON binary type

The default is `.binary` as per the encoding in #162 .

The ticket mentions changing the decoder from `public` to `open`, but I didn't see why that is necessary. Openness really just means the class can subclassed / its properties and functions can be overridden outside of the MongoSwift module. Does the introduction of these strategies necessitate that?