### PR TITLE
SWIFT-293 Fix bsonEquals not working for arrays of different length

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -870,15 +870,7 @@ func bsonEquals(_ lhs: BSONValue, _ rhs: BSONValue) -> Bool {
     case (_ as BSONNull, _ as BSONNull): return true
     case (let l as Document, let r as Document): return l == r
     case (let l as [BSONValue], let r as [BSONValue]): // TODO: SWIFT-242
-        guard l.count == r.count else {
-            return false
-        }
-        for (lhs, rhs) in zip(l, r) {
-            guard bsonEquals(lhs, rhs) else {
-                return false
-            }
-        }
-        return true
+        return l.count == r.count && zip(l, r).reduce(true, {prev, next in prev && bsonEquals(next.0, next.1)})
     case (_ as [Any], _ as [Any]): return false
     default: return false
     }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -870,7 +870,15 @@ func bsonEquals(_ lhs: BSONValue, _ rhs: BSONValue) -> Bool {
     case (_ as BSONNull, _ as BSONNull): return true
     case (let l as Document, let r as Document): return l == r
     case (let l as [BSONValue], let r as [BSONValue]): // TODO: SWIFT-242
-        return zip(l, r).reduce(true, {prev, next in bsonEquals(next.0, next.1) && prev})
+        guard l.count == r.count else {
+            return false
+        }
+        for (lhs, rhs) in zip(l, r) {
+            guard bsonEquals(lhs, rhs) else {
+                return false
+            }
+        }
+        return true
     case (_ as [Any], _ as [Any]): return false
     default: return false
     }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -97,6 +97,11 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // Different types
         expect(4).toNot(bsonEqual("swift"))
+
+        // Arrays of different sizes should not be equal
+        let b0: [BSONValue] = [1, 2]
+        let b1: [BSONValue] = [1, 2, 3]
+        expect(bsonEquals(b0, b1)).to(beFalse())
     }
 
     /// Test object for ObjectIdRoundTrip


### PR DESCRIPTION
[SWIFT-293](https://jira.mongodb.org/browse/SWIFT-293)

This PR ensures `bsonEquals` checks that the size of two arrays is the same before comparing, fixing a bug where arrays that were prefixes of others could be considered equal.
