### PR TITLE
SWIFT-282 Allow .uuidEncodingStrategy and .dateEncodingStrategy to be set on BSONEncoder

### DIFF
--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -14,7 +14,14 @@ public struct AnyBSONValue: Codable, Equatable {
     public func encode(to encoder: Encoder) throws {
         // short-circuit in the `BSONEncoder` case
         if let bsonEncoder = encoder as? _BSONEncoder {
-            bsonEncoder.storage.containers.append(self.value)
+            // Need to handle `Date`s and `UUID`s separately to respect the encoding strategy choices.
+            if let date = self.value as? Date {
+                try bsonEncoder.encode(date)
+            } else if let uuid = self.value as? UUID {
+                try bsonEncoder.encode(uuid)
+            } else {
+                bsonEncoder.storage.containers.append(self.value)
+            }
             return
         }
 

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -5,6 +5,10 @@ import mongoc
 public class BSONEncoder {
 
     /// Enum representing the various strategies for encoding `Date`s.
+    ///
+    /// As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
+    ///
+    /// See bsonspec.org for more information.
     public enum DateEncodingStrategy {
         /// Encode the `Date` by deferring to its default encoding implementation.
         case deferToDate
@@ -31,6 +35,11 @@ public class BSONEncoder {
     }
 
     /// Enum representing the various strategies for encoding `UUID`s.
+    ///
+    /// As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
+    /// subtype.
+    ///
+    /// See bsonspec.org for more information.
     public enum UUIDEncodingStrategy {
         /// Encode the `UUID` by deferring to its default encoding implementation.
         case deferToUUID

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -29,7 +29,7 @@ public class BSONEncoder {
         case custom((Date) throws -> BSONValue)
     }
 
-    /// Enum representing the various strategies for encoding `UUID`s
+    /// Enum representing the various strategies for encoding `UUID`s.
     public enum UUIDEncodingStrategy {
         /// Encode the `UUID` by deferring to its default encoding implementation.
         case deferToUUID

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -71,13 +71,6 @@ public class BSONEncoder {
                         uuidEncodingStrategy: self.uuidEncodingStrategy)
     }
 
-    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-    internal static let iso8601Formatter: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = .withInternetDateTime
-        return formatter
-    }()
-
     /// Initializes `self`.
     public init() {}
 
@@ -354,7 +347,7 @@ extension _BSONEncoder {
             return formatter.string(from: date)
         case .iso8601:
             if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                return BSONEncoder.iso8601Formatter.string(from: date)
+                return BSONDecoder.iso8601Formatter.string(from: date)
             } else {
                 throw MongoError.bsonEncodeError(message: "ISO8601DateFormatter is unavailable on this platform.")
             }

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -9,7 +9,7 @@ public class BSONEncoder {
         /// Encode the `Date` by deferring to its default encoding implementation.
         case deferToDate
 
-        /// Encode the `Date` as a BSON datetime object.
+        /// Encode the `Date` as a BSON datetime object (default).
         case bsonDate
 
         /// Encode the `Date` as a 64-bit integer counting the number of milliseconds since January 1, 1970.
@@ -62,7 +62,7 @@ public class BSONEncoder {
     }
 
     @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-    internal static var iso8601Formatter: ISO8601DateFormatter = {
+    internal static let iso8601Formatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = .withInternetDateTime
         return formatter
@@ -362,15 +362,11 @@ extension _BSONEncoder {
     }
 
     fileprivate func box_<T: Encodable>(_ value: T) throws -> BSONValue? {
-        // swiftlint:disable force_cast
-        if T.self == Date.self {
-            // We know T is a date, so this force cast works
-            return try boxDate(value as! Date)
-        } else if T.self == UUID.self {
-            // We know T is a UUID, so this force csat works
-            return try boxUUID(value as! UUID)
+        if let date = value as? Date {
+            return try boxDate(date)
+        } else if let uuid = value as? UUID {
+            return try boxUUID(uuid)
         }
-        // swiftlint:enable force_cast
 
         // if it's already a `BSONValue`, just return it, unless if it is an
         // array. technically `[Any]` is a `BSONValue`, but we can only use this

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -4,7 +4,7 @@ import mongoc
 /// `BSONEncoder` facilitates the encoding of `Encodable` values into BSON.
 public class BSONEncoder {
 
-    /// Enum representing the various strategies for encoding `Date`s
+    /// Enum representing the various strategies for encoding `Date`s.
     public enum DateEncodingStrategy {
         /// Encode the `Date` by deferring to its default encoding implementation.
         case deferToDate

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -357,7 +357,7 @@ extension _BSONEncoder {
             try uuid.encode(to: self)
             return self.storage.popContainer()
         case .binary:
-            return try uuid.asBinary()
+            return try Binary(from: uuid)
         }
     }
 

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -8,7 +8,7 @@ public class BSONEncoder {
     ///
     /// As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
     ///
-    /// See bsonspec.org for more information.
+    /// - SeeAlso: bsonspec.org
     public enum DateEncodingStrategy {
         /// Encode the `Date` by deferring to its default encoding implementation.
         case deferToDate
@@ -39,7 +39,7 @@ public class BSONEncoder {
     /// As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
     /// subtype.
     ///
-    /// See bsonspec.org for more information.
+    /// - SeeAlso: bsonspec.org
     public enum UUIDEncodingStrategy {
         /// Encode the `UUID` by deferring to its default encoding implementation.
         case deferToUUID

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -324,10 +324,12 @@ extension _BSONEncoder {
         return number
     }
 
+    /// Returns the value as a `BSONValue` if possible. Otherwise, returns an empty `Document`.
     fileprivate func box<T: Encodable>(_ value: T) throws -> BSONValue {
         return try self.box_(value) ?? Document()
     }
 
+    /// Returns the date as a `BSONValue`, or nil if no values were encoded by the custom encoder strategy.
     fileprivate func boxDate(_ date: Date) throws -> BSONValue? {
         switch self.options.dateEncodingStrategy {
         case .bsonDate:
@@ -359,7 +361,7 @@ extension _BSONEncoder {
                 throw error
             }
 
-            // If they didn't encode anything, will default to empty subdocument
+            // The closure didn't encode anything.
             guard self.storage.count > depth else {
                 return nil
             }
@@ -368,6 +370,7 @@ extension _BSONEncoder {
         }
     }
 
+    /// Returns the uuid as a `BSONValue`.
     fileprivate func boxUUID(_ uuid: UUID) throws -> BSONValue {
         switch self.options.uuidEncodingStrategy {
         case .deferToUUID:
@@ -378,6 +381,7 @@ extension _BSONEncoder {
         }
     }
 
+    /// Returns the value as a `BSONValue` if possible. Otherwise, returns nil.
     fileprivate func box_<T: Encodable>(_ value: T) throws -> BSONValue? {
         if let date = value as? Date {
             return try boxDate(date)

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -14,7 +14,7 @@ public class BSONEncoder {
         case deferToDate
 
         /// Encode the `Date` as a BSON datetime object (default).
-        case bsonDate
+        case bsonDateTime
 
         /// Encode the `Date` as a 64-bit integer counting the number of milliseconds since January 1, 1970.
         case millisecondsSince1970
@@ -49,7 +49,7 @@ public class BSONEncoder {
     }
 
     /// The strategy to use for encoding `Date`s with this instance.
-    public var dateEncodingStrategy: DateEncodingStrategy = .bsonDate
+    public var dateEncodingStrategy: DateEncodingStrategy = .bsonDateTime
 
     /// The strategy to use for encoding `UUID`s with this instance.
     public var uuidEncodingStrategy: UUIDEncodingStrategy = .binary
@@ -341,7 +341,7 @@ extension _BSONEncoder {
     /// Returns the date as a `BSONValue`, or nil if no values were encoded by the custom encoder strategy.
     fileprivate func boxDate(_ date: Date) throws -> BSONValue? {
         switch self.options.dateEncodingStrategy {
-        case .bsonDate:
+        case .bsonDateTime:
             return date
         case .deferToDate:
             try date.encode(to: self)

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -642,6 +642,20 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 
 }
 
+extension UUID {
+    /// Copies this `UUID` into a `Binary`
+    internal func asBinary() throws -> Binary {
+        let uuid = self.uuid
+        let uuidData = Data(bytes: [
+            uuid.0, uuid.1, uuid.2, uuid.3,
+            uuid.4, uuid.5, uuid.6, uuid.7,
+            uuid.8, uuid.9, uuid.10, uuid.11,
+            uuid.12, uuid.13, uuid.14, uuid.15
+        ])
+        return try Binary(data: uuidData, subtype: Binary.Subtype.uuid)
+    }
+}
+
 // A mapping of regex option characters to their equivalent `NSRegularExpression` option.
 // note that there is a BSON regexp option 'l' that `NSRegularExpression`
 // doesn't support. The flag will be dropped if BSON containing it is parsed,

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -643,7 +643,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 }
 
 extension UUID {
-    /// Copies this `UUID` into a `Binary`
+    /// Copies `self` into a `Binary`.
     internal func asBinary() throws -> Binary {
         let uuid = self.uuid
         let uuidData = Data(bytes: [

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -164,6 +164,20 @@ public struct Binary: BSONValue, Equatable, Codable {
         userDefined = 0x80
     }
 
+    /// Initializes a `Binary` instance from a `UUID`.
+    public init(from uuid: UUID) throws {
+        let uuidt = uuid.uuid
+
+        let uuidData = Data(bytes: [
+            uuidt.0, uuidt.1, uuidt.2, uuidt.3,
+            uuidt.4, uuidt.5, uuidt.6, uuidt.7,
+            uuidt.8, uuidt.9, uuidt.10, uuidt.11,
+            uuidt.12, uuidt.13, uuidt.14, uuidt.15
+        ])
+
+        try self.init(data: uuidData, subtype: Binary.Subtype.uuid)
+    }
+
     /// Initializes a `Binary` instance from a `Data` object and a `UInt8` subtype.
     /// Throws an error if the provided data is incompatible with the specified subtype.
     public init(data: Data, subtype: UInt8) throws {
@@ -640,20 +654,6 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         return lhs.oid == rhs.oid
     }
 
-}
-
-extension UUID {
-    /// Copies `self` into a `Binary`.
-    internal func asBinary() throws -> Binary {
-        let uuid = self.uuid
-        let uuidData = Data(bytes: [
-            uuid.0, uuid.1, uuid.2, uuid.3,
-            uuid.4, uuid.5, uuid.6, uuid.7,
-            uuid.8, uuid.9, uuid.10, uuid.11,
-            uuid.12, uuid.13, uuid.14, uuid.15
-        ])
-        return try Binary(data: uuidData, subtype: Binary.Subtype.uuid)
-    }
 }
 
 // A mapping of regex option characters to their equivalent `NSRegularExpression` option.

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -616,6 +616,10 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(AnyBSONStruct.self,
                                   from: wrappedDate.canonicalExtendedJSON).x.value).to(bsonEqual(date))
 
+        let dateEncoder = BSONEncoder()
+        dateEncoder.dateEncodingStrategy = .millisecondsSince1970
+        expect(try dateEncoder.encode(AnyBSONStruct(date))).to(bsonEqual(["x": date.msSinceEpoch] as Document))
+
         // regex
         let regex = RegularExpression(pattern: "abc", options: "imx")
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -696,7 +696,7 @@ final class DocumentTests: MongoSwiftTestCase {
         let defaultEncoding = try encoder.encode(dateStruct)
         expect(defaultEncoding["date"] as? Date).to(equal(date))
 
-        encoder.dateEncodingStrategy = .bsonDate
+        encoder.dateEncodingStrategy = .bsonDateTime
         let bsonDate = try encoder.encode(dateStruct)
         expect(bsonDate["date"] as? Date).to(equal(date))
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -742,7 +742,7 @@ final class DocumentTests: MongoSwiftTestCase {
             throw MongoError.bsonEncodeError(message: "Couldn't create UUID.")
         }
 
-        let binary = try uuid.asBinary()
+        let binary = try Binary(from: uuid)
         let uuidStruct = UUIDWrapper(uuid: uuid)
         let encoder = BSONEncoder()
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -770,7 +770,7 @@ final class DocumentTests: MongoSwiftTestCase {
         if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
             encoder.dateEncodingStrategy = .iso8601
             let iso = try encoder.encode(dateStruct)
-            expect(iso["date"] as? String).to(equal(BSONEncoder.iso8601Formatter.string(from: date)))
+            expect(iso["date"] as? String).to(equal(BSONDecoder.iso8601Formatter.string(from: date)))
         }
 
         let formatter = DateFormatter()


### PR DESCRIPTION
[SWIFT-282](https://jira.mongodb.org/browse/SWIFT-282)

This PR adds the ability to specify encoding strategies for `Date`s and `UUID`s. The strategies for both match their corresponding decoding strategies defined in #176 . 

Also, this PR has some missing comments and has some duplication from the preceding one. Once the other merges, I will rebase this off that and put the pieces together. All of the important implementation is complete.

UPDATE: we now follow `JSONEncoder`'s implementation of the `.custom` date encoding strategy for maintaining interoperability with other encoders. Also, some of the pitfalls of doing it this way were a bit overstated.

Outdated:
However, for the `.custom` strategy, I deviated from the implementation that `JSONEncoder` chose. Ours is defined as `.custom((Date) throws -> BSONValue)`, whereas theirs is `.custom((Date, Encoder) throws -> Void)`. 
From our perspective, it makes more sense due to the context in which the closure is used (i.e. within `box(...) -> BSONValue`). In `JSONEncoder`, they use it in a similar context, so they just pop whatever the user added to the encoder and return it to be added on later anyways. If the user didn't add anything, they return an empty `NSContainer`. For us, we would have to either return a `BSONNull` or throw, both of which I think are unsavory. Also, in the event that the closure throws, they manually clean up the encoder state, which I think is needless overhead.
From the user's perspective, it is also nice that they simply need to supply a closure that translates a `Date` to a `BSONValue` instead of having to deal with encoder logic themselves, and this is closer to the whole point of `.custom` anyways.

The same arguments apply for the decoding version of `.custom` as well. I think, for decoding, `.custom((BSONValue) throws -> Date)` would make more sense than the current `.custom((Decoder) throws -> Date)`, and it would parallel what I've proposed here nicely.

e.g. the following would hold
```
let date = Date()
let wrapper = DateWrapper(date: date)
let decoding: (BSONValue) -> Date = { bv in Date(msSinceEpoch: bv as! Int64) }
let encoding: (Date) -> BSONValue = { date in date.msSinceEpoch }
decoder.dateDecodingStrategy = .custom(decoding)
encoder.dateEncodingStrategy = .custom(encoding)

expect(decoding(encoding(date)).to(equal(date))
expect(try decoder.decode(DateWrapper.self, from: try encoder.encode(wrapper)).date).to(equal(date))
```  

Thoughts on this? I know we generally try to stick to what `JSONDecoder` does, but I think this way has both more value and less headache.