### PR TITLE
SWIFT-206 Use generated collection names for tests

### DIFF
--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -85,7 +85,7 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
     func testAlternateNotificationCenters() throws {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         let db = try client.db(type(of: self).testDatabase)
-        let collection = try db.createCollection("coll1")
+        let collection = try db.createCollection(type(of: self).generateCollectionName())
         let customCenter = NotificationCenter()
         client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)
         var eventCount = 0

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -85,7 +85,7 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
     func testAlternateNotificationCenters() throws {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         let db = try client.db(type(of: self).testDatabase)
-        let collection = try db.createCollection(type(of: self).generateCollectionName())
+        let collection = try db.createCollection(self.generateCollectionName())
         let customCenter = NotificationCenter()
         client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)
         var eventCount = 0

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -85,7 +85,7 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
     func testAlternateNotificationCenters() throws {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         let db = try client.db(type(of: self).testDatabase)
-        let collection = try db.createCollection(self.generateCollectionName())
+        let collection = try db.createCollection(self.getCollectionName())
         let customCenter = NotificationCenter()
         client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)
         var eventCount = 0

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -53,7 +53,7 @@ final class CrudTests: MongoSwiftTestCase {
                 // 3) execute the test according to the type's execute method
                 // 4) verify that expected data is present
                 // 5) drop the collection to clean up
-                let collection = try db.collection(type(of: self).generateCollectionName())
+                let collection = try db.collection(self.generateCollectionName())
                 try collection.insertMany(file.data)
                 try test.execute(usingCollection: collection)
                 try test.verifyData(testCollection: collection, db: db)

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -43,7 +43,7 @@ final class CrudTests: MongoSwiftTestCase {
             print("\n------------\nExecuting tests from file \(forPath)/\(filename)...\n")
 
             // For each file, execute the test cases contained in it
-            for test in file.tests {
+            for (i, test) in file.tests.enumerated() {
 
                 print("Executing test: \(test.description)")
 
@@ -53,7 +53,7 @@ final class CrudTests: MongoSwiftTestCase {
                 // 3) execute the test according to the type's execute method
                 // 4) verify that expected data is present
                 // 5) drop the collection to clean up
-                let collection = try db.collection(self.generateCollectionName())
+                let collection = try db.collection(self.getCollectionName(suffix: i.description))
                 try collection.insertMany(file.data)
                 try test.execute(usingCollection: collection)
                 try test.verifyData(testCollection: collection, db: db)

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -43,7 +43,7 @@ final class CrudTests: MongoSwiftTestCase {
             print("\n------------\nExecuting tests from file \(forPath)/\(filename)...\n")
 
             // For each file, execute the test cases contained in it
-            for (i, test) in file.tests.enumerated() {
+            for test in file.tests {
 
                 print("Executing test: \(test.description)")
 
@@ -53,7 +53,7 @@ final class CrudTests: MongoSwiftTestCase {
                 // 3) execute the test according to the type's execute method
                 // 4) verify that expected data is present
                 // 5) drop the collection to clean up
-                let collection = try db.collection("\(filename)+\(i)")
+                let collection = try db.collection(type(of: self).generateCollectionName())
                 try collection.insertMany(file.data)
                 try test.execute(usingCollection: collection)
                 try test.verifyData(testCollection: collection, db: db)

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -53,7 +53,7 @@ final class CrudTests: MongoSwiftTestCase {
                 // 3) execute the test according to the type's execute method
                 // 4) verify that expected data is present
                 // 5) drop the collection to clean up
-                let collection = try db.collection(self.getCollectionName(suffix: i.description))
+                let collection = try db.collection(self.getCollectionName(suffix: "\(filename)_\(i)"))
                 try collection.insertMany(file.data)
                 try test.execute(usingCollection: collection)
                 try test.verifyData(testCollection: collection, db: db)

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -31,7 +31,7 @@ final class MongoClientTests: MongoSwiftTestCase {
 
         let client = MongoClient(fromPointer: client_t)
         let db = try client.db(type(of: self).testDatabase)
-        let coll = try db.collection(self.generateCollectionName())
+        let coll = try db.collection(self.getCollectionName())
         let insertResult = try coll.insertOne([ "test": 42 ])
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])
         let docs = Array(findResult)

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -31,7 +31,7 @@ final class MongoClientTests: MongoSwiftTestCase {
 
         let client = MongoClient(fromPointer: client_t)
         let db = try client.db(type(of: self).testDatabase)
-        let coll = try db.collection(type(of: self).generateCollectionName())
+        let coll = try db.collection(self.generateCollectionName())
         let insertResult = try coll.insertOne([ "test": 42 ])
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])
         let docs = Array(findResult)

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -31,7 +31,7 @@ final class MongoClientTests: MongoSwiftTestCase {
 
         let client = MongoClient(fromPointer: client_t)
         let db = try client.db(type(of: self).testDatabase)
-        let coll = try db.collection("foo")
+        let coll = try db.collection(type(of: self).generateCollectionName())
         let insertResult = try coll.insertOne([ "test": 42 ])
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])
         let docs = Array(findResult)

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -36,7 +36,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
             return XCTFail("Client is not initialized")
         }
 
-        let collectionName = type(of: self).generateCollectionName()
+        let collectionName = self.generateCollectionName()
 
         do {
             coll = try client.db(type(of: self).testDatabase).collection(collectionName)

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -36,10 +36,8 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
             return XCTFail("Client is not initialized")
         }
 
-        let collectionName = self.generateCollectionName()
-
         do {
-            coll = try client.db(type(of: self).testDatabase).collection(collectionName)
+            coll = try client.db(type(of: self).testDatabase).collection(self.getCollectionName())
         } catch {
             return XCTFail("Setup failed: \(error)")
         }

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -36,7 +36,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
             return XCTFail("Client is not initialized")
         }
 
-        let collectionName = String(describing: self)
+        let collectionName = type(of: self).generateCollectionName()
 
         do {
             coll = try client.db(type(of: self).testDatabase).collection(collectionName)

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -42,6 +42,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         ]
     }
 
+    var collName: String = ""
     var coll: MongoCollection<Document>!
     let doc1: Document = ["_id": 1, "cat": "dog"]
     let doc2: Document = ["_id": 2, "cat": "cat"]
@@ -60,12 +61,14 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     override func setUp() {
         super.setUp()
         self.continueAfterFailure = false
+        self.collName = type(of: self).generateCollectionName()
+
         do {
             guard let client = _client else {
                 XCTFail("Invalid client")
                 return
             }
-            coll = try client.db(type(of: self).testDatabase).createCollection("coll1")
+            coll = try client.db(type(of: self).testDatabase).createCollection(self.collName)
             try coll.insertMany([doc1, doc2])
         } catch {
             XCTFail("Setup failed: \(error)")
@@ -78,7 +81,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         do {
             if coll != nil { try coll.drop() }
         } catch {
-            XCTFail("Dropping test collection collectionTest.coll1 failed: \(error)")
+            XCTFail("Dropping test collection \(type(of: self).testDatabase).\(self.collName) failed: \(error)")
         }
     }
 
@@ -92,7 +95,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
             }
             try client.db(self.testDatabase).drop()
         } catch {
-            print("Dropping test database collectionTest failed: \(error)")
+            print("Dropping test database \(self.testDatabase) failed: \(error)")
         }
     }
 
@@ -335,7 +338,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     }
 
     func testGetName() {
-        expect(self.coll.name).to(equal("coll1"))
+        expect(self.coll.name).to(equal(self.collName))
     }
 
     func testCursorIteration() throws {
@@ -359,7 +362,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     func testCodableCollection() throws {
         let client = try MongoClient()
         let db = try client.db(type(of: self).testDatabase)
-        let coll1 = try db.createCollection("codablecoll", withType: Basic.self)
+        let coll1 = try db.createCollection(type(of: self).generateCollectionName(), withType: Basic.self)
         defer { try? coll1.drop() }
 
         let b1 = Basic(x: 1, y: "hi")

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -61,7 +61,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     override func setUp() {
         super.setUp()
         self.continueAfterFailure = false
-        self.collName = type(of: self).generateCollectionName()
+        self.collName = self.generateCollectionName()
 
         do {
             guard let client = _client else {
@@ -362,7 +362,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     func testCodableCollection() throws {
         let client = try MongoClient()
         let db = try client.db(type(of: self).testDatabase)
-        let coll1 = try db.createCollection(type(of: self).generateCollectionName(), withType: Basic.self)
+        let coll1 = try db.createCollection(self.generateCollectionName(), withType: Basic.self)
         defer { try? coll1.drop() }
 
         let b1 = Basic(x: 1, y: "hi")

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -61,7 +61,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     override func setUp() {
         super.setUp()
         self.continueAfterFailure = false
-        self.collName = self.generateCollectionName()
+        self.collName = self.getCollectionName()
 
         do {
             guard let client = _client else {
@@ -362,7 +362,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     func testCodableCollection() throws {
         let client = try MongoClient()
         let db = try client.db(type(of: self).testDatabase)
-        let coll1 = try db.createCollection(self.generateCollectionName(), withType: Basic.self)
+        let coll1 = try db.createCollection(self.getCollectionName(suffix: "codable"), withType: Basic.self)
         defer { try? coll1.drop() }
 
         let b1 = Basic(x: 1, y: "hi")

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -17,12 +17,12 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         let client = try MongoClient(connectionString: MongoSwiftTestCase.connStr)
         let db = try client.db(type(of: self).testDatabase)
 
-        let command: Document = ["create": "coll1"]
+        let command: Document = ["create": type(of: self).generateCollectionName()]
         expect(try db.runCommand(command)).to(equal(["ok": 1.0]))
-        expect(try db.collection("coll1")).toNot(throwError())
+        expect(try db.collection(command["create"] as! String)).toNot(throwError())
 
         // create collection using createCollection
-        expect(try db.createCollection("coll2")).toNot(throwError())
+        expect(try db.createCollection(type(of: self).generateCollectionName())).toNot(throwError())
         expect(try (Array(db.listCollections()) as [Document]).count).to(equal(2))
 
         let opts = ListCollectionsOptions(filter: ["type": "view"] as Document)

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -17,12 +17,12 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         let client = try MongoClient(connectionString: MongoSwiftTestCase.connStr)
         let db = try client.db(type(of: self).testDatabase)
 
-        let command: Document = ["create": self.generateCollectionName()]
+        let command: Document = ["create": self.getCollectionName(suffix: "1")]
         expect(try db.runCommand(command)).to(equal(["ok": 1.0]))
         expect(try db.collection(command["create"] as! String)).toNot(throwError())
 
         // create collection using createCollection
-        expect(try db.createCollection(self.generateCollectionName())).toNot(throwError())
+        expect(try db.createCollection(self.getCollectionName(suffix: "2"))).toNot(throwError())
         expect(try (Array(db.listCollections()) as [Document]).count).to(equal(2))
 
         let opts = ListCollectionsOptions(filter: ["type": "view"] as Document)

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -17,12 +17,12 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         let client = try MongoClient(connectionString: MongoSwiftTestCase.connStr)
         let db = try client.db(type(of: self).testDatabase)
 
-        let command: Document = ["create": type(of: self).generateCollectionName()]
+        let command: Document = ["create": self.generateCollectionName()]
         expect(try db.runCommand(command)).to(equal(["ok": 1.0]))
         expect(try db.collection(command["create"] as! String)).toNot(throwError())
 
         // create collection using createCollection
-        expect(try db.createCollection(type(of: self).generateCollectionName())).toNot(throwError())
+        expect(try db.createCollection(self.generateCollectionName())).toNot(throwError())
         expect(try (Array(db.listCollections()) as [Document]).count).to(equal(2))
 
         let opts = ListCollectionsOptions(filter: ["type": "view"] as Document)

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -176,7 +176,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         let db1 = try client.db(type(of: self).testDatabase)
         defer { try? db1.drop() }
 
-        let coll1Name = self.generateCollectionName()
+        let coll1Name = self.getCollectionName(suffix: "1")
         // expect that a collection created from a DB with unset RC also has unset RC
         var coll1 = try db1.createCollection(coll1Name)
         expect(coll1.readConcern).to(beNil())
@@ -187,7 +187,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // expect that a collection retrieved from a DB with unset RC can override the DB's RC
         var coll2 = try db1.collection(
-                self.generateCollectionName(),
+                self.getCollectionName(suffix: "2"),
                 options: CollectionOptions(readConcern: ReadConcern(.local))
         )
         expect(coll2.readConcern?.level).to(equal("local"))
@@ -199,7 +199,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
                 options: DatabaseOptions(readConcern: ReadConcern(.local)))
         defer { try? db2.drop() }
 
-        let coll3Name = self.generateCollectionName()
+        let coll3Name = self.getCollectionName(suffix: "3")
         // expect that a collection created from a DB with local RC also has local RC
         var coll3 = try db2.createCollection(coll3Name)
         expect(coll3.readConcern?.level).to(equal("local"))
@@ -210,7 +210,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // expect that a collection retrieved from a DB with local RC can override the DB's RC
         let coll4 = try db2.collection(
-                self.generateCollectionName(),
+                self.getCollectionName(suffix: "4"),
                 options: CollectionOptions(readConcern: ReadConcern(.majority))
         )
         expect(coll4.readConcern?.level).to(equal("majority"))
@@ -223,7 +223,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         defer { try? db1.drop() }
 
         // expect that a collection created from a DB with default WC also has default WC
-        var coll1 = try db1.createCollection(self.generateCollectionName())
+        var coll1 = try db1.createCollection(self.getCollectionName(suffix: "1"))
         expect(coll1.writeConcern).to(beNil())
 
         // expect that a collection retrieved from a DB with default WC also has default WC
@@ -235,7 +235,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // expect that a collection retrieved from a DB with default WC can override the DB's WC
         var coll2 = try db1.collection(
-                self.generateCollectionName(),
+                self.getCollectionName(suffix: "2"),
                 options: CollectionOptions(writeConcern: wc1)
         )
         expect(coll2.writeConcern?.w).to(equal(wc1.w))
@@ -246,7 +246,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         defer { try? db2.drop() }
 
         // expect that a collection created from a DB with w:1 also has w:1
-        var coll3 = try db2.createCollection(self.generateCollectionName())
+        var coll3 = try db2.createCollection(self.getCollectionName(suffix: "3"))
         expect(coll3.writeConcern?.w).to(equal(wc1.w))
 
         // expect that a collection retrieved from a DB with w:1 also has w:1
@@ -255,7 +255,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // expect that a collection retrieved from a DB with w:1 can override the DB's WC
         let coll4 = try db2.collection(
-                self.generateCollectionName(),
+                self.getCollectionName(suffix: "4"),
                 options: CollectionOptions(writeConcern: wc2))
         expect(coll4.writeConcern?.w).to(equal(wc2.w))
     }
@@ -265,7 +265,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         let client = try MongoClient()
         let db = try client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
-        let coll = try db.createCollection(self.generateCollectionName())
+        let coll = try db.createCollection(self.getCollectionName())
 
         let command: Document = ["count": coll.name]
 
@@ -306,7 +306,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             return ["x": counter]
         }
 
-        let coll = try db.createCollection(self.generateCollectionName())
+        let coll = try db.createCollection(self.getCollectionName())
         let wc1 = try WriteConcern(w: .number(1))
         let wc2 = WriteConcern()
         let wc3 = try WriteConcern(journal: true)
@@ -341,7 +341,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         expect(try coll.updateMany(filter: ["x": 4], update: ["$set": nextDoc()],
                                    options: UpdateOptions(writeConcern: wc3))).toNot(throwError())
 
-        let coll2 = try db.createCollection(self.generateCollectionName())
+        let coll2 = try db.createCollection(self.getCollectionName(suffix: "2"))
         defer { try? coll2.drop() }
         let pipeline: [Document] = [["$out": "\(db.name).\(coll2.name)"]]
         expect(try coll.aggregate(pipeline, options: AggregateOptions(writeConcern: wc1))).toNot(throwError())

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -176,7 +176,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         let db1 = try client.db(type(of: self).testDatabase)
         defer { try? db1.drop() }
 
-        let coll1Name = type(of: self).generateCollectionName()
+        let coll1Name = self.generateCollectionName()
         // expect that a collection created from a DB with unset RC also has unset RC
         var coll1 = try db1.createCollection(coll1Name)
         expect(coll1.readConcern).to(beNil())
@@ -187,7 +187,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // expect that a collection retrieved from a DB with unset RC can override the DB's RC
         var coll2 = try db1.collection(
-                type(of: self).generateCollectionName(),
+                self.generateCollectionName(),
                 options: CollectionOptions(readConcern: ReadConcern(.local))
         )
         expect(coll2.readConcern?.level).to(equal("local"))
@@ -199,7 +199,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
                 options: DatabaseOptions(readConcern: ReadConcern(.local)))
         defer { try? db2.drop() }
 
-        let coll3Name = type(of: self).generateCollectionName()
+        let coll3Name = self.generateCollectionName()
         // expect that a collection created from a DB with local RC also has local RC
         var coll3 = try db2.createCollection(coll3Name)
         expect(coll3.readConcern?.level).to(equal("local"))
@@ -210,7 +210,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // expect that a collection retrieved from a DB with local RC can override the DB's RC
         let coll4 = try db2.collection(
-                type(of: self).generateCollectionName(),
+                self.generateCollectionName(),
                 options: CollectionOptions(readConcern: ReadConcern(.majority))
         )
         expect(coll4.readConcern?.level).to(equal("majority"))
@@ -223,7 +223,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         defer { try? db1.drop() }
 
         // expect that a collection created from a DB with default WC also has default WC
-        var coll1 = try db1.createCollection(type(of: self).generateCollectionName())
+        var coll1 = try db1.createCollection(self.generateCollectionName())
         expect(coll1.writeConcern).to(beNil())
 
         // expect that a collection retrieved from a DB with default WC also has default WC
@@ -235,7 +235,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // expect that a collection retrieved from a DB with default WC can override the DB's WC
         var coll2 = try db1.collection(
-                type(of: self).generateCollectionName(),
+                self.generateCollectionName(),
                 options: CollectionOptions(writeConcern: wc1)
         )
         expect(coll2.writeConcern?.w).to(equal(wc1.w))
@@ -246,7 +246,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         defer { try? db2.drop() }
 
         // expect that a collection created from a DB with w:1 also has w:1
-        var coll3 = try db2.createCollection(type(of: self).generateCollectionName())
+        var coll3 = try db2.createCollection(self.generateCollectionName())
         expect(coll3.writeConcern?.w).to(equal(wc1.w))
 
         // expect that a collection retrieved from a DB with w:1 also has w:1
@@ -255,7 +255,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // expect that a collection retrieved from a DB with w:1 can override the DB's WC
         let coll4 = try db2.collection(
-                type(of: self).generateCollectionName(),
+                self.generateCollectionName(),
                 options: CollectionOptions(writeConcern: wc2))
         expect(coll4.writeConcern?.w).to(equal(wc2.w))
     }
@@ -265,7 +265,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         let client = try MongoClient()
         let db = try client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
-        let coll = try db.createCollection(type(of: self).generateCollectionName())
+        let coll = try db.createCollection(self.generateCollectionName())
 
         let command: Document = ["count": coll.name]
 
@@ -306,7 +306,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             return ["x": counter]
         }
 
-        let coll = try db.createCollection(type(of: self).generateCollectionName())
+        let coll = try db.createCollection(self.generateCollectionName())
         let wc1 = try WriteConcern(w: .number(1))
         let wc2 = WriteConcern()
         let wc3 = try WriteConcern(journal: true)
@@ -341,7 +341,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         expect(try coll.updateMany(filter: ["x": 4], update: ["$set": nextDoc()],
                                    options: UpdateOptions(writeConcern: wc3))).toNot(throwError())
 
-        let coll2 = try db.createCollection(type(of: self).generateCollectionName())
+        let coll2 = try db.createCollection(self.generateCollectionName())
         defer { try? coll2.drop() }
         let pipeline: [Document] = [["$out": "\(db.name).\(coll2.name)"]]
         expect(try coll.aggregate(pipeline, options: AggregateOptions(writeConcern: wc1))).toNot(throwError())

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -54,7 +54,7 @@ final class SDAMTests: MongoSwiftTestCase {
         }
         // do some basic operations
         let db = try client.db(type(of: self).testDatabase)
-        _ = try db.createCollection(self.generateCollectionName())
+        _ = try db.createCollection(self.getCollectionName())
         try db.drop()
 
         center.removeObserver(observer)

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -54,7 +54,7 @@ final class SDAMTests: MongoSwiftTestCase {
         }
         // do some basic operations
         let db = try client.db(type(of: self).testDatabase)
-        _ = try db.createCollection(type(of: self).generateCollectionName())
+        _ = try db.createCollection(self.generateCollectionName())
         try db.drop()
 
         center.removeObserver(observer)

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -54,7 +54,7 @@ final class SDAMTests: MongoSwiftTestCase {
         }
         // do some basic operations
         let db = try client.db(type(of: self).testDatabase)
-        _ = try db.createCollection("testColl")
+        _ = try db.createCollection(type(of: self).generateCollectionName())
         try db.drop()
 
         center.removeObserver(observer)

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -45,9 +45,12 @@ class MongoSwiftTestCase: XCTestCase {
     // See: https://forums.swift.org/t/how-can-i-condition-on-the-size-of-int/9080/4 */
     static let is32Bit = MemoryLayout<Int>.size == 4
 
-    /// Generates a unique collection name of the format "-[<Test Case> <Test Name>]-<timestamp>".
-    internal func generateCollectionName() -> String {
-        return "\(self.name)-\(Date().timeIntervalSinceReferenceDate)"
+    /// Generates a unique collection name of the format "<Test Suite>_<Test Name>_<suffix>". If no suffix is provided,
+    /// the last underscore is omitted.
+    internal func getCollectionName(suffix: String = "") -> String {
+        let firstPart = self.name.replacingOccurrences(of: "[\\[\\]-]", with: "", options: [.regularExpression])
+        let bothParts = suffix.count > 0 ? "\(firstPart)_\(suffix)" : firstPart
+        return bothParts.replacingOccurrences(of: "[ \\+\\$]", with: "_", options: [.regularExpression])
     }
 }
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -14,7 +14,7 @@ class MongoSwiftTestCase: XCTestCase {
 
     /// Gets the name of the database the test case is running against.
     internal class var testDatabase: String {
-        return String(describing: self)
+        return "test"
     }
 
     /// Gets the path of the directory containing spec files, depending on whether

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -48,11 +48,11 @@ class MongoSwiftTestCase: XCTestCase {
     /// Generates a unique collection name of the format "<Test Suite>_<Test Name>_<suffix>". If no suffix is provided,
     /// the last underscore is omitted.
     internal func getCollectionName(suffix: String? = nil) -> String {
-        let name = self.name.replacingOccurrences(of: "[\\[\\]-]", with: "", options: [.regularExpression])
-
-        return [name, suffix].compactMap { $0 }
-                .joined(separator: "_")
-                .replacingOccurrences(of: "[ \\+\\$]", with: "_", options: [.regularExpression])
+        var name = self.name.replacingOccurrences(of: "[\\[\\]-]", with: "", options: [.regularExpression])
+        if let suf = suffix {
+            name += "_" + suf
+        }
+        return name.replacingOccurrences(of: "[ \\+\\$]", with: "_", options: [.regularExpression])
     }
 }
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -14,7 +14,7 @@ class MongoSwiftTestCase: XCTestCase {
 
     /// Gets the name of the database the test case is running against.
     internal class var testDatabase: String {
-        return "test"
+        return String(describing: self)
     }
 
     /// Gets the path of the directory containing spec files, depending on whether
@@ -44,6 +44,12 @@ class MongoSwiftTestCase: XCTestCase {
     // Use MemoryLayout instead of Int.bitWidth to avoid a compiler warning.
     // See: https://forums.swift.org/t/how-can-i-condition-on-the-size-of-int/9080/4 */
     static let is32Bit = MemoryLayout<Int>.size == 4
+
+    /// Generates a unique collection name. Not guaranteed to be unique if tests are run in parallel. Pass in custom
+    /// salt to guarantee uniqueness in a multithreaded context.
+    internal class func generateCollectionName(salt: String = "\(Float.random(in: 0 ..< 1))") -> String {
+        return "\(self.className)-\(salt)-\(Date().msSinceEpoch)"
+    }
 }
 
 extension MongoClient {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -45,10 +45,9 @@ class MongoSwiftTestCase: XCTestCase {
     // See: https://forums.swift.org/t/how-can-i-condition-on-the-size-of-int/9080/4 */
     static let is32Bit = MemoryLayout<Int>.size == 4
 
-    /// Generates a unique collection name. Not guaranteed to be unique if tests are run in parallel. Pass in custom
-    /// salt to guarantee uniqueness in a multithreaded context.
-    internal class func generateCollectionName(salt: String = "\(Float.random(in: 0 ..< 1))") -> String {
-        return "\(self.className)-\(salt)-\(Date().msSinceEpoch)"
+    /// Generates a unique collection name of the format "-[<Test Case> <Test Name>]-<timestamp>".
+    internal func generateCollectionName() -> String {
+        return "\(self.name)-\(Date().timeIntervalSinceReferenceDate)"
     }
 }
 

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -47,10 +47,12 @@ class MongoSwiftTestCase: XCTestCase {
 
     /// Generates a unique collection name of the format "<Test Suite>_<Test Name>_<suffix>". If no suffix is provided,
     /// the last underscore is omitted.
-    internal func getCollectionName(suffix: String = "") -> String {
-        let firstPart = self.name.replacingOccurrences(of: "[\\[\\]-]", with: "", options: [.regularExpression])
-        let bothParts = suffix.count > 0 ? "\(firstPart)_\(suffix)" : firstPart
-        return bothParts.replacingOccurrences(of: "[ \\+\\$]", with: "_", options: [.regularExpression])
+    internal func getCollectionName(suffix: String? = nil) -> String {
+        let name = self.name.replacingOccurrences(of: "[\\[\\]-]", with: "", options: [.regularExpression])
+
+        return [name, suffix].compactMap { $0 }
+                .joined(separator: "_")
+                .replacingOccurrences(of: "[ \\+\\$]", with: "_", options: [.regularExpression])
     }
 }
 


### PR DESCRIPTION
[SWIFT-206](https://jira.mongodb.org/browse/SWIFT-206)

This PR adds a function to `MongoSwiftTestCase` for generating collection names of the format "`<Test Case>_<Test Name>_<optional suffix>`".

e.g. a namespace for `testListDatabases` would be `test.MongoClientTests_testListDatabases`