### PR TITLE
SWIFT-289 Audit public types to make sure they have public initializers

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -641,11 +641,10 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     }
 }
 
-/// Extension to allow a UUID to be initialized from a Binary BSONValue.
+/// Extension to allow a `UUID` to be initialized from a `Binary` `BSONValue`.
 extension UUID {
-    // TODO: fill the rest of this out for full BSONValue conformance (SWIFT-295).
-
-    internal init(from binary: Binary) throws {
+    /// Initializes a `UUID` instance from a `Binary` `BSONValue`.
+    public init(from binary: Binary) throws {
         guard binary.subtype != Binary.Subtype.uuidDeprecated.rawValue else {
             throw MongoError.bsonDecodeError(message: "Binary subtype \(binary.subtype) is deprecated, " +
                     "use \(Binary.Subtype.uuid) instead.")

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -153,12 +153,22 @@ public struct IndexOptions: Encodable {
 public struct CreateIndexOptions: Encodable {
     /// An optional `WriteConcern` to use for the command
     public let writeConcern: WriteConcern?
+
+    /// Initializer allowing any/all parameters to be omitted.
+    public init(writeConcern: WriteConcern? = nil) {
+        self.writeConcern = writeConcern
+    }
 }
 
 /// Options to use when dropping an index from a `MongoCollection`.
 public struct DropIndexOptions: Encodable {
     /// An optional `WriteConcern` to use for the command
     public let writeConcern: WriteConcern?
+
+    /// Initializer allowing any/all parameters to be omitted.
+    public init(writeConcern: WriteConcern? = nil) {
+        self.writeConcern = writeConcern
+    }
 }
 
 /// An extension of `MongoCollection` encapsulating index management capabilities.

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -79,7 +79,7 @@ extension MongoCollection {
      *
      * - Returns: The count of the documents that matched the filter
      */
-    public func countDocuments(_ filter: Document = [:], options: CountDocumentsOptions? = nil) throws -> Int {
+    private func countDocuments(_ filter: Document = [:], options: CountDocumentsOptions? = nil) throws -> Int {
         // TODO SWIFT-133: implement this https://jira.mongodb.org/browse/SWIFT-133
         throw MongoError.commandError(message: "Unimplemented command")
     }
@@ -92,7 +92,7 @@ extension MongoCollection {
      *
      * - Returns: an estimate of the count of documents in this collection
      */
-    public func estimatedDocumentCount(options: EstimatedDocumentCountOptions? = nil) throws -> Int {
+    private func estimatedDocumentCount(options: EstimatedDocumentCountOptions? = nil) throws -> Int {
         // TODO SWIFT-133: implement this https://jira.mongodb.org/browse/SWIFT-133
         throw MongoError.commandError(message: "Unimplemented command")
     }
@@ -263,10 +263,10 @@ public struct CountOptions: Encodable {
 }
 
 /// The `countDocuments` command takes the same options as the deprecated `count`.
-public typealias CountDocumentsOptions = CountOptions
+private typealias CountDocumentsOptions = CountOptions
 
 /// Options to use when executing an `estimatedDocumentCount` command on a `MongoCollection`.
-public struct EstimatedDocumentCountOptions {
+private struct EstimatedDocumentCountOptions {
     /// The maximum amount of time to allow the query to run.
     public let maxTimeMS: Int64?
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -269,6 +269,11 @@ public typealias CountDocumentsOptions = CountOptions
 public struct EstimatedDocumentCountOptions {
     /// The maximum amount of time to allow the query to run.
     public let maxTimeMS: Int64?
+
+    /// Initializer allowing any/all parameters to be omitted.
+    public init(maxTimeMS: Int64? = nil) {
+        self.maxTimeMS = maxTimeMS
+    }
 }
 
 /// Options to use when executing a `distinct` command on a `MongoCollection`.


### PR DESCRIPTION
[SWIFT-289](https://jira.mongodb.org/browse/SWIFT-289)

This PR adds public initializers to some public types that don't have them. It also exposes `UUID.init(from binary: Binary)`.

It seems the assumption for the other types that do have public initializers is that the default ACL was public, since the docstrings on all those initializers say they're for convenience. 
e.g.
```
/// Convenience initializer allowing any/all parameters to be optional
```
In reality, these initializers are actually very necessary and are not merely conveniences. The docstrings I added are consistently worded with the old ones but omit "convenience". Let me know if you think I should change the older docstrings and/or the newer ones.