### PR TITLE
SWIFT-255 Conform AnyBSONValue to Hashable

### DIFF
--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -5,19 +5,7 @@ import Foundation
 public struct AnyBSONValue: Codable, Equatable, Hashable {
     // swiftlint:disable:next legacy_hashing
     public var hashValue: Int {
-        if let bool = self.value as? Bool {
-            return bool.hashValue
-        } else if let int = self.value as? Int {
-            return int.hashValue
-        } else if let int32 = self.value as? Int32 {
-            return int32.hashValue
-        } else if let int64 = self.value as? Int64 {
-            return int64.hashValue
-        } else if let double = self.value as? Double {
-            return double.hashValue
-        } else if let date = self.value as? Date {
-            return date.hashValue
-        } else if let doc = self.value as? Document {
+        if let doc = self.value as? Document {
             return doc.extendedJSON.hashValue
         } else {
             let doc: Document = ["value": self.value]

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -21,7 +21,8 @@ public struct AnyBSONValue: Codable, Equatable, Hashable {
             return doc.extendedJSON.hashValue
         } else {
             let doc: Document = ["value": self.value]
-            return doc.extendedJSON.hashValue
+            // need to add some string to the beginning to ensure no collisions with the document case.
+            return ("EXT_JSON" + doc.extendedJSON).hashValue
         }
     }
 

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -5,9 +5,7 @@ import Foundation
 public struct AnyBSONValue: Codable, Equatable, Hashable {
     // swiftlint:disable:next legacy_hashing
     public var hashValue: Int {
-        if let value = self.value as? String {
-            return value.hashValue
-        } else if let bool = self.value as? Bool {
+        if let bool = self.value as? Bool {
             return bool.hashValue
         } else if let int = self.value as? Int {
             return int.hashValue
@@ -17,6 +15,8 @@ public struct AnyBSONValue: Codable, Equatable, Hashable {
             return int64.hashValue
         } else if let double = self.value as? Double {
             return double.hashValue
+        } else if let date = self.value as? Date {
+            return date.hashValue
         } else if let doc = self.value as? Document {
             return doc.extendedJSON.hashValue
         } else {

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -5,6 +5,13 @@ import Foundation
 public struct AnyBSONValue: Codable, Equatable, Hashable {
     // swiftlint:disable:next legacy_hashing
     public var hashValue: Int {
+        if let date = self.value as? Date {
+            return "\(self.value.bsonType)-\(date.hashValue)".hashValue
+        } else if let binary = self.value as? Binary {
+            return "\(self.value.bsonType)-\(binary.data.hashValue)-\(binary.subtype)".hashValue
+        } else if let arr = self.value as? [BSONValue] {
+            return "\(self.value.bsonType)-\((["value": arr] as Document).extendedJSON)".hashValue
+        }
         return "\(self.value.bsonType)-\(self.value)".hashValue
     }
 

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -2,8 +2,30 @@ import Foundation
 
 /// A struct wrapping a `BSONValue` type that allows for encoding/
 /// decoding `BSONValue`s of unknown type.  
-public struct AnyBSONValue: Codable, Equatable {
-    /// The `BSONValue` wrapped by this struct. 
+public struct AnyBSONValue: Codable, Equatable, Hashable {
+    // swiftlint:disable:next legacy_hashing
+    public var hashValue: Int {
+        if let value = self.value as? String {
+            return value.hashValue
+        } else if let bool = self.value as? Bool {
+            return bool.hashValue
+        } else if let int = self.value as? Int {
+            return int.hashValue
+        } else if let int32 = self.value as? Int32 {
+            return int32.hashValue
+        } else if let int64 = self.value as? Int64 {
+            return int64.hashValue
+        } else if let double = self.value as? Double {
+            return double.hashValue
+        } else if let doc = self.value as? Document {
+            return doc.extendedJSON.hashValue
+        } else {
+            let doc: Document = ["value": self.value]
+            return doc.extendedJSON.hashValue
+        }
+    }
+
+    /// The `BSONValue` wrapped by this struct.
     public let value: BSONValue
 
     /// Initializes a new `AnyBSONValue` wrapping the provided `BSONValue`.

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -5,13 +5,7 @@ import Foundation
 public struct AnyBSONValue: Codable, Equatable, Hashable {
     // swiftlint:disable:next legacy_hashing
     public var hashValue: Int {
-        if let doc = self.value as? Document {
-            return doc.extendedJSON.hashValue
-        } else {
-            let doc: Document = ["value": self.value]
-            // need to add some string to the beginning to ensure no collisions with the document case.
-            return ("EXT_JSON" + doc.extendedJSON).hashValue
-        }
+        return "\(self.value.bsonType)-\(self.value)".hashValue
     }
 
     /// The `BSONValue` wrapped by this struct.

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -3,13 +3,20 @@ import Foundation
 /// A struct wrapping a `BSONValue` type that allows for encoding/
 /// decoding `BSONValue`s of unknown type.  
 public struct AnyBSONValue: Codable, Equatable, Hashable {
+    // TODO: conform all `BSONValue` types to `Hashable` (SWIFT-320).
     // swiftlint:disable:next legacy_hashing
     public var hashValue: Int {
+        // A few types need to be handled specifically because their string representations aren't sufficient or
+        // performant.
         if let date = self.value as? Date {
-            return "\(self.value.bsonType)-\(date.hashValue)".hashValue
+            // `Date`'s string conversion omits milliseconds and smaller time units, and using a string formatter is
+            // expensive. Instead, we just include the time interval itself.
+            return "\(self.value.bsonType)-\(date.timeIntervalSince1970)".hashValue
         } else if let binary = self.value as? Binary {
+            // `Binary`'s string representation omits the data itself, so we include its hashValue.
             return "\(self.value.bsonType)-\(binary.data.hashValue)-\(binary.subtype)".hashValue
         } else if let arr = self.value as? [BSONValue] {
+            // To factor in every item in the array, we include the arrays extended JSON representation.
             return "\(self.value.bsonType)-\((["value": arr] as Document).extendedJSON)".hashValue
         }
         return "\(self.value.bsonType)-\(self.value)".hashValue

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -200,11 +200,23 @@ final class BSONValueTests: MongoSwiftTestCase {
         expect(map[abv2]).to(equal(3))
         expect(map[abv3]).to(equal(5))
 
-        let doc = AnyBSONValue(["hello": "world"] as Document)
-        let str = AnyBSONValue((doc.value as! Document).extendedJSON)
+        let str = AnyBSONValue("world")
+        let doc = AnyBSONValue(["value": str.value] as Document)
+        let json = AnyBSONValue((doc.value as! Document).extendedJSON)
 
-        map[doc] = 12
-        map[str] = 13
-        expect(map[doc]).toNot(equal(map[str]))
+        map[str] = 12
+        map[doc] = 13
+        map[json] = 14
+
+        expect(map[str]).to(equal(12))
+        expect(map[doc]).to(equal(13))
+        expect(map[json]).to(equal(14))
+
+        var hashCodes = Set<Int>()
+        hashCodes.insert(str.hashValue)
+        hashCodes.insert(doc.hashValue)
+        hashCodes.insert(json.hashValue)
+
+        expect(hashCodes.count).to(equal(3))
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -176,11 +176,11 @@ final class BSONValueTests: MongoSwiftTestCase {
                 regex: RegularExpression(pattern: "^abc", options: "imx"))
 
         let values = Mirror(reflecting: expected).children.map { child in AnyBSONValue(child.value as! BSONValue) }
-        let set = Set<AnyBSONValue>(values)
+        let valuesSet = Set<AnyBSONValue>(values)
 
-        expect(Set<Int>(set.map { abv in abv.hashValue }).count).to(equal(values.count))
-        expect(set.count).to(equal(values.count))
-        expect(values).to(contain(Array(set)))
+        expect(Set<Int>(valuesSet.map { abv in abv.hashValue }).count).to(equal(values.count))
+        expect(valuesSet.count).to(equal(values.count))
+        expect(values).to(contain(Array(valuesSet)))
 
         let abv1 = AnyBSONValue(Int32(1))
         let abv2 = AnyBSONValue(Int64(1))

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -176,10 +176,9 @@ final class BSONValueTests: MongoSwiftTestCase {
                 regex: RegularExpression(pattern: "^abc", options: "imx"))
 
         let values = Mirror(reflecting: expected).children.map { child in AnyBSONValue(child.value as! BSONValue) }
+        let set = Set<AnyBSONValue>(values)
 
-        var set = Set<AnyBSONValue>()
-        values.forEach { value in set.insert(value) }
-
+        expect(Set<Int>(set.map { abv in abv.hashValue }).count).to(equal(values.count))
         expect(set.count).to(equal(values.count))
         expect(values).to(contain(Array(set)))
 
@@ -187,7 +186,7 @@ final class BSONValueTests: MongoSwiftTestCase {
         let abv2 = AnyBSONValue(Int64(1))
         let abv3 = AnyBSONValue(Int32(5))
 
-        var map: [AnyBSONValue: Int] = [AnyBSONValue(Int32(1)): 1, AnyBSONValue(Int64(1)): 2]
+        var map: [AnyBSONValue: Int] = [abv1: 1, abv2: 2]
 
         expect(map[abv1]).to(equal(1))
         expect(map[abv2]).to(equal(2))
@@ -212,11 +211,6 @@ final class BSONValueTests: MongoSwiftTestCase {
         expect(map[doc]).to(equal(13))
         expect(map[json]).to(equal(14))
 
-        var hashCodes = Set<Int>()
-        hashCodes.insert(str.hashValue)
-        hashCodes.insert(doc.hashValue)
-        hashCodes.insert(json.hashValue)
-
-        expect(hashCodes.count).to(equal(3))
+        expect(Set([str.hashValue, doc.hashValue, json.hashValue]).count).to(equal(3))
     }
 }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -10,7 +10,8 @@ final class BSONValueTests: MongoSwiftTestCase {
             ("testInvalidDecimal128", testInvalidDecimal128),
             ("testUUIDBytes", testUUIDBytes),
             ("testBSONEquals", testBSONEquals),
-            ("testObjectIdRoundTrip", testObjectIdRoundTrip)
+            ("testObjectIdRoundTrip", testObjectIdRoundTrip),
+            ("testHashable", testHashable)
         ]
     }
 
@@ -151,5 +152,32 @@ final class BSONValueTests: MongoSwiftTestCase {
         let objectIdFromString = ObjectId(fromString: oid)
         expect(objectIdFromString.oid).to(equal(oid))
         expect(objectIdFromString.timestamp).to(equal(timestamp))
+    }
+
+    /// Test AnyBSONValue Hashable conformance
+    func testHashable() throws {
+        let values: [AnyBSONValue] = try ([
+            5,
+            Int32(5),
+            Int64(5),
+            "hello world",
+            true,
+            Binary(from: UUID()),
+            BSONNull(),
+            [1],
+            Decimal128("123"),
+            5.5,
+            CodeWithScope(code: "{}"),
+            MaxKey(),
+            MinKey(),
+            ObjectId(),
+            RegularExpression(pattern: "match me", options: "")
+        ] as [BSONValue]).map { AnyBSONValue($0) }
+
+        var set = Set<AnyBSONValue>()
+        values.forEach { value in set.insert(value) }
+
+        expect(set.count).to(equal(values.count))
+        expect(values).to(contain(Array(set)))
     }
 }


### PR DESCRIPTION
[SWIFT-255](https://jira.mongodb.org/browse/SWIFT-255)

This PR adds `Hashable` conformance to `AnyBSONValue` by computing the hashValue of the extended JSON representation of the underlying `BSONValue`. 

I originally tried using the `hashValue` of the wrapped `BSONValue` if it was `Hashable` itself, but I was experiencing some collisions (`hashValue` is only likely to be unique among the same types I guess). Instead, I just resorted to using the extended JSON `hashValue` for everything. It may a bit slower as it has to create a temporary document which is then transformed to JSON, but at least it avoids collisions. There is an argument to be made that tolerating collisions is more performant than converting everything to their extended JSON formats, but I'm not really sure if that is the case or of a good way to quantify that.

We do avoid a copy in the case of the underlying value being a `Document`.