### PR TITLE
SWIFT-321 Unify decoding and encoding strategies

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -11,13 +11,13 @@ public class BSONDecoder {
     }()
     // swiftlint:enable explicit_acl
 
-    /// Enum representing the different options for decoding `Date`s from BSON.
+    /// Enum representing the various strategies for decoding `Date`s from BSON.
     ///
     /// As per the BSON specification, the default strategy is to decode `Date`s from BSON datetime objects.
     ///
     /// - SeeAlso: bsonspec.org
     public enum DateDecodingStrategy {
-        /// Decode `Date`s stored as BSON datetimes.
+        /// Decode `Date`s stored as BSON datetimes (default).
         case bsonDateTime
 
         /// Decode `Date`s stored as numbers of seconds since January 1, 1970.
@@ -40,7 +40,7 @@ public class BSONDecoder {
         case custom((_ decoder: Decoder) throws -> Date)
     }
 
-    /// Enum representing the different options for decoding `UUID`s from BSON.
+    /// Enum representing the various strategies for decoding `UUID`s from BSON.
     ///
     /// As per the BSON specification, the default strategy is to decode `UUID`s from BSON binary types with the UUID
     /// subtype.
@@ -50,7 +50,7 @@ public class BSONDecoder {
         /// Decode `UUID`s by deferring to their default decoding implementation.
         case deferredToUUID
 
-        /// Decode `UUID`s stored as the BSON `Binary` type.
+        /// Decode `UUID`s stored as the BSON `Binary` type (default).
         case binary
     }
 

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -10,7 +10,7 @@ public class BSONEncoder {
     /// - SeeAlso: bsonspec.org
     public enum DateEncodingStrategy {
         /// Encode the `Date` by deferring to its default encoding implementation.
-        case deferToDate
+        case deferredToDate
 
         /// Encode the `Date` as a BSON datetime object (default).
         case bsonDateTime
@@ -41,7 +41,7 @@ public class BSONEncoder {
     /// - SeeAlso: bsonspec.org
     public enum UUIDEncodingStrategy {
         /// Encode the `UUID` by deferring to its default encoding implementation.
-        case deferToUUID
+        case deferredToUUID
 
         /// Encode the `UUID` as a BSON binary type (default).
         case binary
@@ -334,7 +334,7 @@ extension _BSONEncoder {
         switch self.options.dateEncodingStrategy {
         case .bsonDateTime:
             return date
-        case .deferToDate:
+        case .deferredToDate:
             try date.encode(to: self)
             return self.storage.popContainer()
         case .millisecondsSince1970:
@@ -373,7 +373,7 @@ extension _BSONEncoder {
     /// Returns the uuid as a `BSONValue`.
     fileprivate func boxUUID(_ uuid: UUID) throws -> BSONValue {
         switch self.options.uuidEncodingStrategy {
-        case .deferToUUID:
+        case .deferredToUUID:
             try uuid.encode(to: self)
             return self.storage.popContainer()
         case .binary:

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -707,7 +707,7 @@ final class DocumentTests: MongoSwiftTestCase {
         let binaryEncoding = try encoder.encode(uuidStruct)
         expect(binaryEncoding["uuid"] as? Binary).to(equal(binary))
 
-        encoder.uuidEncodingStrategy = .deferToUUID
+        encoder.uuidEncodingStrategy = .deferredToUUID
         let deferred = try encoder.encode(uuidStruct)
         expect(deferred["uuid"] as? String).to(equal(uuid.uuidString))
     }
@@ -783,7 +783,7 @@ final class DocumentTests: MongoSwiftTestCase {
         let formatted = try encoder.encode(dateStruct)
         expect(formatted["date"] as? String).to(equal(formatter.string(from: date)))
 
-        encoder.dateEncodingStrategy = .deferToDate
+        encoder.dateEncodingStrategy = .deferredToDate
         let deferred = try encoder.encode(dateStruct)
         expect(deferred["date"] as? TimeInterval).to(equal(date.timeIntervalSinceReferenceDate))
 


### PR DESCRIPTION
[SWIFT-321](https://jira.mongodb.org/browse/SWIFT-321)

This is just a small patch to fix some differences in between the encoding and decoding strategies. The most important change is the refactoring of decoding strategies from `.deferTo<something>` to `.deferredTo<something>`.
