### PR TITLE
SWIFT-316 Add a .dataEncodingStrategy and a .dataDecodingStrategy to support storing Data in BSON binary format

### DIFF
--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -56,8 +56,8 @@ public class BSONEncoder {
     public enum DataEncodingStrategy {
         /// Encode the `Data` by deferring to its default encoding implementation.
         ///
-        /// Note: The default encoding implementation attempts to encode the `Data` as a [UInt8], but because BSON does
-        /// not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int]`.
+        /// Note: The default encoding implementation attempts to encode the `Data` as a `[UInt8]`, but because BSON does
+        /// not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int32]`.
         case deferredToData
 
         /// Encode the `Data` as a BSON binary type (default).

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -361,8 +361,8 @@ extension _BSONEncoder {
     }
 
     fileprivate func handleCustomStrategy<T: Encodable>(
-            encode f: (T, Encoder) throws -> Void,
-            value: T
+            encodeFunc f: (T, Encoder) throws -> Void,
+            forValue value: T
     ) throws -> BSONValue? {
         let depth = self.storage.count
 
@@ -404,7 +404,7 @@ extension _BSONEncoder {
                 throw MongoError.bsonEncodeError(message: "ISO8601DateFormatter is unavailable on this platform.")
             }
         case .custom(let f):
-            return try handleCustomStrategy(encode: f, value: date)
+            return try handleCustomStrategy(encodeFunc: f, forValue: date)
         }
     }
 
@@ -429,7 +429,7 @@ extension _BSONEncoder {
         case .base64:
             return data.base64EncodedString()
         case .custom(let f):
-            return try handleCustomStrategy(encode: f, value: data)
+            return try handleCustomStrategy(encodeFunc: f, forValue: data)
         }
     }
 


### PR DESCRIPTION
[SWIFT-316](https://jira.mongodb.org/browse/SWIFT-316)

This PR adds the `.deferredToData` and `.binary` decoding/encoding strategies to `BSONEncoder`. 

I decided upon using `.binary` as the default because, at least in my reading of the spec, that is the type specified for this exact purpose. Also, the waste concerns mentioned in the original ticket are worth avoiding by default, I think.

I also think that `Data` is a good candidate for the `.custom` encoding/decoding strategy, since users may be aware of some structure of their buffers and want to encode it in their own way. Messing around with buffers like that wouldn't be the most Swift-y way to do things, but I feel like it may be useful to some users, especially if they're interfacing with their own C libraries. 

I also think there may be some value in providing an `.integerArray` encoding/decoding strategy. It would be the same as `.deferredToData`, except that instead of encoding/decoding each byte to/from a 4 byte integer, it would instead encode/decode groups of 4 bytes to 4 byte integers. It would attempt to adhere to the default implementation but without the waste.

I haven't implemented either `.custom` or `.integerArray` yet, as I wanted to get feedback first. Do you all think either are worthwhile?