### PR TITLE
Documentation and examples on building `libmongoc` and `libbson`

### DIFF
--- a/Examples/Docker/Dockerfile
+++ b/Examples/Docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+# Getting the tools needed for building from source
+RUN apt-get -qq update && apt-get install -y \
+  git cmake libssl-dev libsasl2-dev \
+  && rm -r /var/lib/apt/lists/*
+
+# Compiling latest libmongoc and libbson
+RUN git clone -b r1.13 https://github.com/mongodb/mongo-c-driver /tmp/libmongoc
+WORKDIR /tmp/libmongoc
+RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr
+RUN make -j8 install
+
+WORKDIR /app

--- a/Examples/Docker/Dockerfile.vapor
+++ b/Examples/Docker/Dockerfile.vapor
@@ -1,0 +1,65 @@
+# ---------------------------------------------------------------------------
+# Builder container
+# ---------------------------------------------------------------------------
+
+# You can set the Swift version to what you need for your app.
+# Versions can be found here: https://hub.docker.com/_/swift
+FROM swift:4.2 as builder
+
+# For local build, add `--build-arg env=docker`
+# In your application, you can use `Environment.custom(name: "docker")` to check if you're in this env
+# ARG env
+
+RUN apt-get -qq update && apt-get -q -y install \
+  tzdata \
+  git cmake libssl-dev libsasl2-dev \
+  && rm -r /var/lib/apt/lists/*
+
+# Compiling latest libmongoc and libbson
+RUN git clone -b r1.13 https://github.com/mongodb/mongo-c-driver /tmp/libmongoc
+WORKDIR /tmp/libmongoc
+RUN cmake \
+  -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+  -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF \
+  -DCMAKE_BUILD_TYPE=Release
+RUN make -j8 install
+
+WORKDIR /app
+COPY . .
+RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so /build/lib
+RUN swift build -c release && mv `swift build -c release --show-bin-path` /build/bin
+
+# ---------------------------------------------------------------------------
+# Production image
+# ---------------------------------------------------------------------------
+
+FROM ubuntu:16.04
+
+RUN apt-get -qq update && apt-get install -y \
+  libicu55 libxml2 libbsd0 libcurl3 libatomic1 \
+  tzdata \
+  git cmake libssl-dev libsasl2-dev \
+  && rm -r /var/lib/apt/lists/*
+
+# Compiling latest libmongoc and libbson
+RUN git clone -b r1.13 https://github.com/mongodb/mongo-c-driver /tmp/libmongoc
+WORKDIR /tmp/libmongoc
+RUN cmake \
+  -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+  -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF \
+  -DCMAKE_BUILD_TYPE=Release
+RUN make -j8 install
+
+WORKDIR /app
+COPY .env.development .env
+COPY --from=builder /build/bin/Run .
+COPY --from=builder /build/lib/* /usr/lib/
+
+# Uncomment the next line if you need to load resources from the `Public` directory
+#COPY --from=builder /app/Public ./Public
+# Uncommand the next line if you are using Leaf
+#COPY --from=builder /app/Resources ./Resources
+# ENV ENVIRONMENT=$env
+
+EXPOSE 8080
+ENTRYPOINT ./Run serve --env production --hostname 0.0.0.0 --port 8080

--- a/Examples/Docker/README.md
+++ b/Examples/Docker/README.md
@@ -1,0 +1,34 @@
+# Building `libmongoc` From Source With Docker
+
+For the `mongo-swift-driver` to run, **the minimum required version of the
+C Driver is 1.13.0**. The easiest way to get the correct version
+of `libmongoc` and `libbson` is to checkout the correct
+[branch](https://github.com/mongodb/mongo-c-driver/tree/r1.13) from git and
+build the sources.
+
+## Dependencies
+
+* Ubuntu 16.04 / 18.04
+* git
+* cmake
+* libssl-dev
+* libsasl2-dev
+
+## Build
+
+```Dockerfile
+RUN git clone -b r1.13 https://github.com/mongodb/mongo-c-driver /tmp/libmongoc
+WORKDIR /tmp/libmongoc
+RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr
+RUN make -j8 install
+```
+
+Further useful `cmake` prefixes are:
+
+- `-DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF` see [reference here](http://mongoc.org/libmongoc/current/init-cleanup.html).
+- `-DCMAKE_BUILD_TYPE=Release` to build a release optimized build.
+
+## Vapor
+
+When building and running Vapor in Docker, the C Driver is needed in both the
+builder and runner containers. See `Dockerfile.vapor` for an example.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The official [MongoDB](https://www.mongodb.com/) driver for Swift.
 - [Documentation](#documentation)
 - [Bugs/Feature Requests](#bugs--feature-requests)
 - [Installation](#installation)
-    - [OS X and Linux](#os-x-and-linux)
+    - [macOS and Linux](#os-x-and-linux)
       - [Step 1: Install the MongoDB C Driver](#step-1-install-the-mongodb-c-driver)
       - [Step 2: Install MongoSwift](#step-2-install-mongoswift)
     - [iOS, tvOS, and watchOS](#ios-tvos-and-watchos)
@@ -36,17 +36,19 @@ Core Server (i.e. SERVER) project are **public**.
 ## Installation
 `MongoSwift` works with Swift 4.0+.
 
-### OS X and Linux
+### macOS and Linux
 
-Installation on OS X and Linux is supported via [Swift Package Manager](https://swift.org/package-manager/).
+Installation on macOS and Linux is supported via [Swift Package Manager](https://swift.org/package-manager/).
 
 #### Step 1: Install the MongoDB C Driver
 The driver wraps the MongoDB C driver, and using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. **The minimum required version of the C Driver is 1.13.0**.
 
-On a Mac, you can install both components at once using [Homebrew](https://brew.sh/):
+*On a Mac*, you can install both components at once using [Homebrew](https://brew.sh/):
 `brew install mongo-c-driver`.
 
-On Linux: please follow the [instructions](http://mongoc.org/libmongoc/current/installing.html#building-on-unix) from `libmongoc`'s documentation. Note that the versions provided by your package manager may be too old, in which case you can follow the instructions for building and installing from source.
+*On Linux*: please follow the [instructions](http://mongoc.org/libmongoc/current/installing.html#building-on-unix) from `libmongoc`'s documentation. Note that the versions provided by your package manager is probably too old, in which case you can follow the instructions for building and installing from source.
+
+See example installation from source on Ubuntu in [Docker](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/Docker).
 
 #### Step 2: Install MongoSwift
 *Please follow the instructions in the previous section on installing the MongoDB C Driver before proceeding.*


### PR DESCRIPTION
Added documentation and examples on building `libmongoc` and `libbson` from source on Ubuntu in Docker.