### PR TITLE
SWIFT-280, SWIFT-334: Improve handling of documents missing _id in insertOne and insertMany

### DIFF
--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -228,8 +228,8 @@ extension Document {
         }
     }
 
-    /// If the document already has an "_id" field, returns it as-is. Otherwise, returns a new document
-    /// containing all the keys from this document, with an _id field prepended.
+    /// If the document already has an _id, returns it as-is. Otherwise, returns a new document
+    /// containing all the keys from this document, with an _id prepended.
     internal func withID() throws -> Document {
         if self.hasKey("_id") {
             return self

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -227,6 +227,18 @@ extension Document {
             self.storage = DocumentStorage(fromPointer: self.data)
         }
     }
+
+    /// If the document already has an "_id" field, returns it as-is. Otherwise, returns a new document
+    /// containing all the keys from this document, with an _id field prepended.
+    internal func withID() throws -> Document {
+        if self.hasKey("_id") {
+            return self
+        }
+
+        var idDoc: Document = ["_id": ObjectId()]
+        try idDoc.merge(self)
+        return idDoc
+    }
 }
 
 /// An extension of `Document` containing its public API.

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -115,7 +115,7 @@ extension MongoCollection {
 
             guard let insertedId = try document.getValue(for: "_id") else {
                 // we called `withID()`, so this should be present.
-                preconditionFailure("Failed to get value for _id from document")
+                fatalError("Failed to get value for _id from document")
             }
 
             bulk.insertedIds[index] = insertedId

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -420,7 +420,7 @@ public struct WriteError: Codable {
     /// An integer value identifying the error.
     public let code: Int
 
-    /// A description of the error.w
+    /// A description of the error.
     public let message: String
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -93,7 +93,7 @@ extension MongoCollection {
 
     /// A model for an `insertOne` operation within a bulk write.
     public struct InsertOneModel: WriteModel {
-        private let document: CollectionType
+        internal let document: CollectionType
 
         /**
          * Create an `insertOne` operation for a bulk write.
@@ -107,18 +107,18 @@ extension MongoCollection {
 
         /// Adds the `insertOne` operation to a bulk write
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
-            let document = try BSONEncoder().encode(self.document)
-            if !document.hasKey("_id") {
-                try ObjectId().encode(to: document.storage, forKey: "_id")
-            }
-
+            let document = try BSONEncoder().encode(self.document).withID()
             var error = bson_error_t()
-
             guard mongoc_bulk_operation_insert_with_opts(bulk.bulk, document.data, nil, &error) else {
                 throw MongoError.invalidArgument(message: toErrorString(error))
             }
 
-            bulk.insertedIds[index] = document["_id"]
+            guard let insertedId = try document.getValue(for: "_id") else {
+                // we called `withID()`, so this should be present.
+                preconditionFailure("Failed to get value for _id from document")
+            }
+
+            bulk.insertedIds[index] = insertedId
         }
     }
 
@@ -420,7 +420,7 @@ public struct WriteError: Codable {
     /// An integer value identifying the error.
     public let code: Int
 
-    /// A description of the error.
+    /// A description of the error.w
     public let message: String
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -16,10 +16,7 @@ extension MongoCollection {
     @discardableResult
     public func insertOne(_ value: CollectionType, options: InsertOneOptions? = nil) throws -> InsertOneResult? {
         let encoder = BSONEncoder()
-        let document = try encoder.encode(value)
-        if !document.hasKey("_id") {
-            try ObjectId().encode(to: document.storage, forKey: "_id")
-        }
+        let document = try encoder.encode(value).withID()
         let opts = try encoder.encode(options)
         var error = bson_error_t()
         guard mongoc_collection_insert_one(self._collection, document.data, opts?.data, nil, &error) else {
@@ -32,7 +29,7 @@ extension MongoCollection {
         }
 
         guard let insertedId = try document.getValue(for: "_id") else {
-            // This case should never really happen, since we handle it above and give the document an _id.
+            // we called `withID()`, so this should be present.
             preconditionFailure("Failed to get value for _id from document")
         }
 
@@ -61,14 +58,15 @@ extension MongoCollection {
 
         let encoder = BSONEncoder()
         let opts = try encoder.encode(options)
-        let documents = try values.map { try encoder.encode($0) }
+        let documents = try values.map { try encoder.encode($0).withID() }
         var insertedIds: [Int: BSONValue] = [:]
 
         try documents.enumerated().forEach { index, document in
-            if !document.hasKey("_id") {
-                try ObjectId().encode(to: document.storage, forKey: "_id")
+            guard let id = try document.getValue(for: "_id") else {
+                // we called `withID()`, so this should be present.
+                preconditionFailure("Failed to get value for _id from document")
             }
-            insertedIds[index] = document["_id"]
+            insertedIds[index] = id
         }
 
         var docPointers = documents.map { UnsafePointer($0.data) }

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -30,7 +30,7 @@ extension MongoCollection {
 
         guard let insertedId = try document.getValue(for: "_id") else {
             // we called `withID()`, so this should be present.
-            preconditionFailure("Failed to get value for _id from document")
+            fatalError("Failed to get value for _id from document")
         }
 
         return InsertOneResult(insertedId: insertedId)
@@ -64,7 +64,7 @@ extension MongoCollection {
         try documents.enumerated().forEach { index, document in
             guard let id = try document.getValue(for: "_id") else {
                 // we called `withID()`, so this should be present.
-                preconditionFailure("Failed to get value for _id from document")
+                fatalError("Failed to get value for _id from document")
             }
             insertedIds[index] = id
         }

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -85,6 +85,9 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         expect(result.insertedIds[0]!).to(bsonEqual(1))
         expect(result.insertedIds[1]!).to(beAnInstanceOf(ObjectId.self))
 
+        // verify inserted doc without _id was not modified.
+        expect(requests[1].document).to(equal(["x": 22]))
+
         let cursor = try coll.find()
         expect(cursor.next()).to(equal(["_id": 1, "x": 11]))
         expect(cursor.next()).to(equal(["_id": result.insertedIds[1]!, "x": 22]))

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -111,8 +111,12 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.insertOne(self.doc2)?.insertedId).to(bsonEqual(2))
         expect(try self.coll.count()).to(equal(2))
 
-        // try inserting a document without an ID to verify one is generated and returned
-        expect(try self.coll.insertOne(["x": 1])?.insertedId).toNot(beNil())
+        // try inserting a document without an ID
+        let docNoID: Document = ["x": 1]
+        // verify that an _id is returned in the InsertOneResult
+        expect(try self.coll.insertOne(docNoID)?.insertedId).toNot(beNil())
+        // verify that the original document was not modified
+        expect(docNoID).to(equal(["x": 1]))
     }
 
     func testInsertOneWithUnacknowledgedWriteConcern() throws {
@@ -152,6 +156,10 @@ final class MongoCollectionTests: MongoSwiftTestCase {
                 expect(v).to(beAnInstanceOf(ObjectId.self))
             }
         }
+
+        // verify that docs without _ids were not modified.
+        expect(docNoId1).to(equal(["x": 1]))
+        expect(docNoId2).to(equal(["x": 2]))
     }
 
     func testInsertManyWithEmptyValues() {


### PR DESCRIPTION
This makes it so we don't modify the input document(s) in `insertOne` and `insertMany` when they are missing an `_id`. 

Instead, if a doc is missing an `_id`, we make a new document with an `_id` at the start, copy over the data from the original doc, and send the new doc to the server.

