### PR TITLE
SWIFT-261 Replace preconditions and preconditionFailures with fatalErrors

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -448,10 +448,10 @@ private func postNotification<T: MongoEvent>(type: T.Type,
                                              contextFunc: (OpaquePointer) -> UnsafeMutableRawPointer?
                                             ) where T: InitializableFromOpaquePointer {
     guard let event = _event else {
-        preconditionFailure("Missing event pointer for \(type)")
+        fatalError("Missing event pointer for \(type)")
     }
     guard let context = contextFunc(event) else {
-        preconditionFailure("Missing context for \(type)")
+        fatalError("Missing context for \(type)")
     }
 
     let client = Unmanaged<MongoClient>.fromOpaque(context).takeUnretainedValue()

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -219,7 +219,9 @@ internal struct _BSONDecodingStorage {
 
     /// The container at the top of the stack.
     internal var topContainer: BSONValue {
-        precondition(!self.containers.isEmpty, "Empty container stack.")
+        guard !self.containers.isEmpty else {
+            fatalError("Empty container stack.")
+        }
         // swiftlint:disable:next force_unwrapping - guaranteed safe because of precondition.
         return self.containers.last!
     }
@@ -231,7 +233,9 @@ internal struct _BSONDecodingStorage {
 
     /// Pops the top container from the stack. 
     fileprivate mutating func popContainer() {
-        precondition(!self.containers.isEmpty, "Empty container stack.")
+        guard !self.containers.isEmpty else {
+            fatalError("Empty container stack.")
+        }
         self.containers.removeLast()
     }
 }

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -183,7 +183,7 @@ internal class _BSONEncoder: Encoder {
             topContainer = self.storage.pushKeyedContainer()
         } else {
             guard let container = self.storage.containers.last as? MutableDictionary else {
-                preconditionFailure(
+                fatalError(
                     "Attempt to push new keyed encoding container when already previously encoded at this path.")
             }
             topContainer = container
@@ -201,7 +201,7 @@ internal class _BSONEncoder: Encoder {
             topContainer = self.storage.pushUnkeyedContainer()
         } else {
             guard let container = self.storage.containers.last as? MutableArray else {
-                preconditionFailure(
+                fatalError(
                     "Attempt to push new unkeyed encoding container when already previously encoded at this path.")
             }
             topContainer = container
@@ -244,7 +244,9 @@ internal struct _BSONEncodingStorage {
     }
 
     fileprivate mutating func popContainer() -> BSONValue {
-        precondition(!self.containers.isEmpty, "Empty container stack.")
+        guard !self.containers.isEmpty else {
+            fatalError("Empty container stack.")
+        }
         // swiftlint:disable:next force_unwrapping - guaranteed safe because of precondition.
         return self.containers.popLast()!
     }
@@ -582,8 +584,9 @@ private struct _BSONUnkeyedEncodingContainer: UnkeyedEncodingContainer {
 /// :nodoc:
 extension _BSONEncoder: SingleValueEncodingContainer {
     private func assertCanEncodeNewValue() {
-        precondition(self.canEncodeNewValue,
-                     "Attempt to encode value through single value container when previously value already encoded.")
+        guard self.canEncodeNewValue else {
+            fatalError("Attempt to encode value through single value container when previously value already encoded.")
+        }
     }
 
     public func encodeNil() throws {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -93,7 +93,7 @@ extension Array: BSONValue {
         let arrDoc = Document(fromPointer: arrayData)
 
         guard let arr = arrDoc.values as? Array else {
-            preconditionFailure("Failed to cast values for document \(arrDoc) to array")
+            fatalError("Failed to cast values for document \(arrDoc) to array")
         }
 
        return arr
@@ -759,7 +759,7 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
         do {
             return try NSRegularExpression(pattern: self.pattern, options: opts)
         } catch {
-            preconditionFailure("Failed to initialize NSRegularExpression with " +
+            fatalError("Failed to initialize NSRegularExpression with " +
                 "pattern '\(self.pattern)'' and options '\(self.options)'")
         }
     }
@@ -916,15 +916,15 @@ public func bsonEquals(_ lhs: BSONValue?, _ rhs: BSONValue?) -> Bool {
     return bsonEquals(left, right)
 }
 
-/// A function for catching invalid BSONTypes that should not ever arise, and triggering a preconditionFailure when it
+/// A function for catching invalid BSONTypes that should not ever arise, and triggering a fatalError when it
 /// finds such types.
 private func validateBSONTypes(_ lhs: BSONValue, _ rhs: BSONValue) {
     let invalidTypes: [BSONType] = [.symbol, .dbPointer, .invalid, .undefined]
     guard !invalidTypes.contains(lhs.bsonType) else {
-        preconditionFailure("\(lhs.bsonType) should not be used")
+        fatalError("\(lhs.bsonType) should not be used")
     }
     guard !invalidTypes.contains(rhs.bsonType) else {
-        preconditionFailure("\(rhs.bsonType) should not be used")
+        fatalError("\(rhs.bsonType) should not be used")
     }
 }
 

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -16,10 +16,9 @@ extension Document: Collection {
 
     private func failIndexCheck(_ i: Int) {
         let invalidIndexMsg = "Index \(i) is invalid"
-        if self.isEmpty {
-            preconditionFailure(invalidIndexMsg)
+        guard !self.isEmpty && self.startIndex ... self.endIndex - 1 ~= i else {
+            fatalError(invalidIndexMsg)
         }
-        precondition(self.startIndex ... self.endIndex - 1 ~= i, invalidIndexMsg)
     }
 
     /// Returns the index after the given index for this Document.

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -24,7 +24,7 @@ extension Document: Sequence {
     /// Returns a `DocumentIterator` over the values in this `Document`.
     public func makeIterator() -> DocumentIterator {
         guard let iter = DocumentIterator(forDocument: self) else {
-            preconditionFailure("Failed to initialize an iterator over document \(self)")
+            fatalError("Failed to initialize an iterator over document \(self)")
         }
         return iter
     }
@@ -53,7 +53,7 @@ extension Document: Sequence {
     public func dropFirst(_ n: Int) -> Document {
         switch n {
         case ..<0:
-            preconditionFailure("Can't drop a negative number of elements from a document")
+            fatalError("Can't drop a negative number of elements from a document")
         case 0:
             return self
         default:
@@ -67,7 +67,7 @@ extension Document: Sequence {
     public func dropLast(_ n: Int) -> Document {
         switch n {
         case ..<0:
-            preconditionFailure("Can't drop a negative number of elements from a `Document`")
+            fatalError("Can't drop a negative number of elements from a `Document`")
         case 0:
             return self
         default:
@@ -100,7 +100,7 @@ extension Document: Sequence {
     public func prefix(_ maxLength: Int) -> Document {
         switch maxLength {
         case ..<0:
-            preconditionFailure("Can't retrieve a negative length prefix of a `Document`")
+            fatalError("Can't retrieve a negative length prefix of a `Document`")
         case 0:
             return [:]
         default:
@@ -121,7 +121,7 @@ extension Document: Sequence {
     public func suffix(_ maxLength: Int) -> Document {
         switch maxLength {
         case ..<0:
-            preconditionFailure("Can't retrieve a negative length suffix of a `Document`")
+            fatalError("Can't retrieve a negative length suffix of a `Document`")
         case 0:
             return [:]
         default:
@@ -225,8 +225,8 @@ public class DocumentIterator: IteratorProtocol {
     internal var currentValue: BSONValue {
         do {
             return try self.safeCurrentValue()
-        } catch { // Since properties cannot throw, we need to catch and raise a preconditionFailure.
-            preconditionFailure("Error getting current value from iterator: \(error)")
+        } catch { // Since properties cannot throw, we need to catch and raise a fatalError.
+            fatalError("Error getting current value from iterator: \(error)")
         }
     }
 
@@ -271,7 +271,9 @@ public class DocumentIterator: IteratorProtocol {
     // document. starts at the startIndex-th pair and ends at the end of the document or the (endIndex-1)th index,
     // whichever comes first.
     internal static func subsequence(of doc: Document, startIndex: Int = 0, endIndex: Int = Int.max) -> Document {
-        precondition(endIndex >= startIndex, "endIndex must be >= startIndex")
+        guard endIndex >= startIndex else {
+            fatalError("endIndex must be >= startIndex")
+        }
 
         guard let iter = DocumentIterator(forDocument: doc) else {
             return [:]
@@ -302,8 +304,9 @@ public class DocumentIterator: IteratorProtocol {
     }
 
     internal func overwriteCurrentValue(with newValue: Overwritable) throws {
-        precondition(newValue.bsonType == self.currentType,
-                     "Expected \(newValue) to have BSON type \(self.currentType), but has type \(newValue.bsonType)")
+        guard newValue.bsonType == self.currentType else {
+            fatalError("Expected \(newValue) to have BSON type \(self.currentType), but has type \(newValue.bsonType)")
+        }
         try newValue.writeToCurrentPosition(of: self)
     }
 

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -90,7 +90,7 @@ extension Document {
             do {
                 try self.setValue(for: key, to: value)
             } catch {
-                preconditionFailure("Failed to set the value for \(key) to \(String(describing: value)): \(error)")
+                fatalError("Failed to set the value for \(key) to \(String(describing: value)): \(error)")
             }
         }
     }
@@ -112,7 +112,7 @@ extension Document {
             do {
                 try self.setValue(for: String(i), to: elt, checkForKey: false)
             } catch {
-                preconditionFailure("Failed to set the value for index \(i) to \(String(describing: elt)): \(error)")
+                fatalError("Failed to set the value for index \(i) to \(String(describing: elt)): \(error)")
             }
         }
     }
@@ -344,7 +344,7 @@ extension Document {
                     self = self.filter { $0.key != key }
                 }
             } catch {
-                preconditionFailure("Failed to set the value for key \(key) to \(newValue ?? "nil"): \(error)")
+                fatalError("Failed to set the value for key \(key) to \(newValue ?? "nil"): \(error)")
             }
         }
     }
@@ -446,7 +446,7 @@ extension Document: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral keyValuePairs: (String, BSONValue)...) {
         // make sure all keys are unique
         guard Set(keyValuePairs.map { $0.0 }).count == keyValuePairs.count else {
-            preconditionFailure("Dictionary literal \(keyValuePairs) contains duplicate keys")
+            fatalError("Dictionary literal \(keyValuePairs) contains duplicate keys")
         }
 
         self.storage = DocumentStorage()
@@ -457,7 +457,7 @@ extension Document: ExpressibleByDictionaryLiteral {
             do {
                 try self.setValue(for: key, to: value, checkForKey: false)
             } catch {
-                preconditionFailure("Error setting key \(key) to value \(String(describing: value)): \(error)")
+                fatalError("Error setting key \(key) to value \(String(describing: value)): \(error)")
             }
         }
     }

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -33,7 +33,7 @@ extension MongoCollection {
 
         guard let insertedId = try document.getValue(for: "_id") else {
             // This case should never really happen, since we handle it above and give the document an _id.
-            preconditionFailure("Failed to get value for _id from document")
+            fatalError("Failed to get value for _id from document")
         }
 
         return InsertOneResult(insertedId: insertedId)

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -42,7 +42,7 @@ public final class ReadPreference {
             case MONGOC_READ_NEAREST:
                 self = .nearest
             default:
-                preconditionFailure("Unexpected read preference mode: \(readMode)")
+                fatalError("Unexpected read preference mode: \(readMode)")
             }
         }
     }
@@ -60,7 +60,7 @@ public final class ReadPreference {
     /// The tags of this `ReadPreference`
     public var tagSets: [Document] {
         guard let bson = mongoc_read_prefs_get_tags(self._readPreference) else {
-            preconditionFailure("Failed to retrieve read preference tags")
+            fatalError("Failed to retrieve read preference tags")
         }
 
         let wrapped = Document(fromPointer: bson)


### PR DESCRIPTION
[SWIFT-261](https://jira.mongodb.org/browse/SWIFT-261)

This PR replaces all `precondition`s and `preconditionFailure`s with `fatalErrors`. 

Comparison:

- In a debug build, `preconditionFailure` is the same as `fatalError`
- In a release build, `preconditionFailure` exits, but does not print a message. `fatalError` does both.
- in an `-Ounchecked` build, the `preconditionFailure` may be skipped. `fatalError` behaves the same.

Because of the silent nature of `preconditionFailure` and the possibility that it doesn't get called in `OUnchecked` builds, I think we should only be using `fatalError`. In the cases where we only want to exit when testing, we should use `assert`. AFAIK there are no such cases outside of the tests where the latter is true in the codebase right now.