### PR TITLE
Update CRUD API errors to match the new hierarchy

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -132,7 +132,7 @@ public struct CommandFailedEvent: MongoEvent, InitializableFromOpaquePointer {
         self.commandName = String(cString: mongoc_apm_command_failed_get_command_name(event))
         var error = bson_error_t()
         mongoc_apm_command_failed_get_error(event, &error)
-        self.failure = parseMongocError(error: error) // should always return a ServerError.commandError
+        self.failure = parseMongocError(error) // should always return a ServerError.commandError
         self.requestId = mongoc_apm_command_failed_get_request_id(event)
         self.operationId = mongoc_apm_command_failed_get_operation_id(event)
         self.connectionId = ConnectionId(mongoc_apm_command_failed_get_host(event))
@@ -347,7 +347,7 @@ public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePoi
         self.duration = mongoc_apm_server_heartbeat_failed_get_duration(event)
         var error = bson_error_t()
         mongoc_apm_server_heartbeat_failed_get_error(event, &error)
-        self.failure = parseMongocError(error: error)
+        self.failure = parseMongocError(error)
         self.connectionId = ConnectionId(mongoc_apm_server_heartbeat_failed_get_host(event))
     }
 }

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -113,8 +113,8 @@ public struct CommandFailedEvent: MongoEvent, InitializableFromOpaquePointer {
     /// The command name.
     public let commandName: String
 
-    /// The failure, represented as a MongoError.
-    public let failure: MongoError
+    /// The failure, represented as a MongoSwiftError.
+    public let failure: MongoSwiftError
 
     /// The client generated request id.
     public let requestId: Int64
@@ -132,7 +132,7 @@ public struct CommandFailedEvent: MongoEvent, InitializableFromOpaquePointer {
         self.commandName = String(cString: mongoc_apm_command_failed_get_command_name(event))
         var error = bson_error_t()
         mongoc_apm_command_failed_get_error(event, &error)
-        self.failure = MongoError.commandError(message: toErrorString(error))
+        self.failure = parseMongocError(error: error) // should always return a ServerError.commandError
         self.requestId = mongoc_apm_command_failed_get_request_id(event)
         self.operationId = mongoc_apm_command_failed_get_operation_id(event)
         self.connectionId = ConnectionId(mongoc_apm_command_failed_get_host(event))
@@ -337,7 +337,7 @@ public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePoi
     public let duration: Int64
 
     /// The failure.
-    public let failure: MongoError
+    public let failure: MongoSwiftError
 
     /// The connection ID (host/port pair) of the server.
     public let connectionId: ConnectionId
@@ -347,7 +347,7 @@ public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePoi
         self.duration = mongoc_apm_server_heartbeat_failed_get_duration(event)
         var error = bson_error_t()
         mongoc_apm_server_heartbeat_failed_get_error(event, &error)
-        self.failure = MongoError.commandError(message: toErrorString(error))
+        self.failure = parseMongocError(error: error)
         self.connectionId = ConnectionId(mongoc_apm_server_heartbeat_failed_get_host(event))
     }
 }

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -164,6 +164,20 @@ public class BSONDecoder {
                                   debugDescription: "Unable to parse JSON string \(json)"))
     }
 
+    /// Internal function used to  convert encountered `DecodingError`s to `.internalErrors`. Use this when using the
+    /// decoder internally on non-user-modified types.
+    public func internalDecode<T: Decodable>(
+            _ type: T.Type,
+            from document: Document,
+            withError errMsg: String = "Failed to decode \(T.self)")
+    throws -> T {
+        do {
+            return try self.decode(type, from: document)
+        } catch is DecodingError {
+            throw RuntimeError.internalError(message: errMsg)
+        }
+    }
+
     /// A struct to wrap a `Decodable` type, allowing us to support decoding to types that
     /// are not inside a wrapping object (for ex., Int or String).
     private struct DecodableWrapper<T: Decodable>: Decodable {

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -164,9 +164,9 @@ public class BSONDecoder {
                                   debugDescription: "Unable to parse JSON string \(json)"))
     }
 
-    /// Internal function used to  convert encountered `DecodingError`s to `.internalErrors`. Use this when using the
+    /// Internal version of decode that throws `.internalErrors` instead of `DecodingErrors`. Use this when using the
     /// decoder internally on non-user-modified types.
-    public func internalDecode<T: Decodable>(
+    internal func internalDecode<T: Decodable>(
             _ type: T.Type,
             from document: Document,
             withError errMsg: String = "Failed to decode \(T.self)")

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -203,7 +203,7 @@ extension Document {
     internal mutating func merge(_ doc: Document) throws {
         self.copyStorageIfRequired()
         guard bson_concat(self.data, doc.data) else {
-            throw MongoError.bsonEncodeError(message: "Failed to merge \(doc) with \(self). This is likely due to " +
+            throw RuntimeError.internalError(message: "Failed to merge \(doc) with \(self). This is likely due to " +
                     "the merged document being too large.")
         }
         self.count += doc.count

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -150,6 +150,7 @@ public class MongoClient {
         if options?.eventMonitoring == true { self.initializeMonitoring() }
 
         guard mongoc_client_set_error_api(self._client, MONGOC_ERROR_API_VERSION_2) else {
+            close()
             throw RuntimeError.internalError(message: "Could not configure error handling on client")
         }
     }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -150,7 +150,7 @@ public class MongoClient {
         if options?.eventMonitoring == true { self.initializeMonitoring() }
 
         guard mongoc_client_set_error_api(self._client, MONGOC_ERROR_API_VERSION_2) else {
-            close()
+            self.close()
             throw RuntimeError.internalError(message: "Could not configure error handling on client")
         }
     }

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -6,8 +6,8 @@ extension MongoCollection {
      * Execute multiple write operations.
      *
      * - Parameters:
-     *   - requests: a `[WriteModel]` containing the writes to perform
-     *   - options: optional `BulkWriteOptions` to use while executing the operation
+     *   - requests: a `[WriteModel]` containing the writes to perform.
+     *   - options: optional `BulkWriteOptions` to use while executing the operation.
      *
      * - Returns: a `BulkWriteResult`, or `nil` if the write concern is unacknowledged.
      *
@@ -47,8 +47,8 @@ extension MongoCollection {
          * Create a `deleteOne` operation for a bulk write.
          *
          * - Parameters:
-         *   - filter: A `Document` representing the match criteria
-         *   - collation: Specifies a collation to use
+         *   - filter: A `Document` representing the match criteria.
+         *   - collation: Specifies a collation to use.
          */
         public init(_ filter: Document, collation: Document? = nil) {
             self.filter = filter
@@ -56,7 +56,7 @@ extension MongoCollection {
         }
 
         /**
-         * Adds the `deleteOne` operation to a bulk write
+         * Adds the `deleteOne` operation to a bulk write.
          *
          * - Throws:
          *   - `UserError.invalidArgumentError` if the options form an invalid combination.
@@ -82,8 +82,8 @@ extension MongoCollection {
          * Create a `deleteMany` operation for a bulk write.
          *
          * - Parameters:
-         *   - filter: A `Document` representing the match criteria
-         *   - collation: Specifies a collation to use
+         *   - filter: A `Document` representing the match criteria.
+         *   - collation: Specifies a collation to use.
          */
         public init(_ filter: Document, collation: Document? = nil) {
             self.filter = filter
@@ -91,7 +91,7 @@ extension MongoCollection {
         }
 
         /**
-         * Adds the `deleteMany` operation to a bulk write
+         * Adds the `deleteMany` operation to a bulk write.
          *
          * - Throws:
          *   - `UserError.invalidArgumentError` if the options form an invalid combination.
@@ -115,13 +115,13 @@ extension MongoCollection {
          * Create an `insertOne` operation for a bulk write.
          *
          * - Parameters:
-         *   - document: The `CollectionType` to insert
+         *   - document: The `CollectionType` to insert.
          */
         public init(_ document: CollectionType) {
             self.document = document
         }
 
-        /** Adds the `insertOne` operation to a bulk write
+        /** Adds the `insertOne` operation to a bulk write.
          *
          * - Throws:
          *   - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
@@ -158,10 +158,10 @@ extension MongoCollection {
          * Create a `replaceOne` operation for a bulk write.
          *
          * - Parameters:
-         *   - filter: A `Document` representing the match criteria
-         *   - replacement: The `CollectionType` to use as the replacement value
-         *   - collation: Specifies a collation to use
-         *   - upsert: When `true`, creates a new document if no document matches the query
+         *   - filter: A `Document` representing the match criteria.
+         *   - replacement: The `CollectionType` to use as the replacement value.
+         *   - collation: Specifies a collation to use.
+         *   - upsert: When `true`, creates a new document if no document matches the query.
          */
         public init(filter: Document, replacement: CollectionType, collation: Document? = nil, upsert: Bool? = nil) {
             self.filter = filter
@@ -169,7 +169,7 @@ extension MongoCollection {
             self.options = ReplaceOneModelOptions(collation: collation, upsert: upsert)
         }
 
-        /** Adds the `replaceOne` operation to a bulk write
+        /** Adds the `replaceOne` operation to a bulk write.
          *
          * - Throws:
          *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
@@ -207,11 +207,11 @@ extension MongoCollection {
          * Create an `updateOne` operation for a bulk write.
          *
          * - Parameters:
-         *   - filter: A `Document` representing the match criteria
-         *   - update: A `Document` containing update operators
-         *   - arrayFilters: A set of filters specifying to which array elements an update should apply
-         *   - collation: Specifies a collation to use
-         *   - upsert: When `true`, creates a new document if no document matches the query
+         *   - filter: A `Document` representing the match criteria.
+         *   - update: A `Document` containing update operators.
+         *   - arrayFilters: A set of filters specifying to which array elements an update should apply.
+         *   - collation: Specifies a collation to use.
+         *   - upsert: When `true`, creates a new document if no document matches the query.
          */
         public init(filter: Document,
                     update: Document,
@@ -253,11 +253,11 @@ extension MongoCollection {
          * Create a `updateMany` operation for a bulk write.
          *
          * - Parameters:
-         *   - filter: A `Document` representing the match criteria
-         *   - update: A `Document` containing update operators
-         *   - arrayFilters: A set of filters specifying to which array elements an update should apply
-         *   - collation: Specifies a collation to use
-         *   - upsert: When `true`, creates a new document if no document matches the query
+         *   - filter: A `Document` representing the match criteria.
+         *   - update: A `Document` containing update operators.
+         *   - arrayFilters: A set of filters specifying to which array elements an update should apply.
+         *   - collation: Specifies a collation to use.
+         *   - upsert: When `true`, creates a new document if no document matches the query.
          */
         public init(filter: Document,
                     update: Document,
@@ -270,7 +270,7 @@ extension MongoCollection {
         }
 
         /**
-         * Adds the `updateMany` operation to a bulk write
+         * Adds the `updateMany` operation to a bulk write.
          *
          * - Throws:
          *   - `EncodingError` if an error occurs while encoding the options to BSON.
@@ -301,8 +301,8 @@ public protocol WriteModel {
      * `MongoCollection.bulkWrite`.
      *
      * - Parameters:
-     *   - bulk: A `BulkWriteOperation`
-     *   - index: Index of the operation within the `MongoCollection.bulkWrite` `requests` array
+     *   - bulk: A `BulkWriteOperation`.
+     *   - index: Index of the operation within the `MongoCollection.bulkWrite` `requests` array.
      */
     func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws
 }
@@ -329,7 +329,7 @@ public class BulkWriteOperation {
     }
 
     /// Executes the bulk write operation and returns a `BulkWriteResult` or
-    /// `nil` is the write concern is unacknowledged
+    /// `nil` is the write concern is unacknowledged.
     fileprivate func execute() throws -> BulkWriteResult? {
         let reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -97,7 +97,7 @@ extension MongoCollection {
          *   - `EncodingError` if an error occurs while encoding the options to BSON.
          */
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
-            let opts = try BSONEncoder().encode(options)
+            let opts = try BSONEncoder().encode(self.options)
             var error = bson_error_t()
 
             guard mongoc_bulk_operation_remove_many_with_opts(bulk.bulk, self.filter.data, opts.data, &error) else {

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -28,7 +28,6 @@ extension MongoCollection {
 
         try requests.enumerated().forEach { index, model in
             try model.addToBulkWrite(bulk: bulk, index: index)
-            bulk.requests[index] = model
         }
 
         return try bulk.execute()
@@ -312,7 +311,6 @@ public class BulkWriteOperation {
     fileprivate var bulk: OpaquePointer?
     fileprivate var insertedIds: [Int: BSONValue] = [:]
 
-    internal var requests: [Int: WriteModel] = [:]
     internal let opts: Document?
 
     /// Indicates whether this bulk operation used an acknowledged write concern.

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -55,18 +55,20 @@ extension MongoCollection {
             self.options = DeleteModelOptions(collation: collation)
         }
 
-        /// Adds the `deleteOne` operation to a bulk write
-        ///
-        /// - Throws:
-        ///   - `UserError.invalidArgumentError` if the options form an invalid combination.
-        ///   - `EncodingError` if an error occurs while encoding the options to BSON.
+        /**
+         * Adds the `deleteOne` operation to a bulk write
+         *
+         * - Throws:
+         *   - `UserError.invalidArgumentError` if the options form an invalid combination.
+         *   - `EncodingError` if an error occurs while encoding the options to BSON.
+         */
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
-            let opts = try BSONEncoder().encode(options)
+            let opts = try BSONEncoder().encode(self.options)
 
             var error = bson_error_t()
 
             guard mongoc_bulk_operation_remove_one_with_opts(bulk.bulk, self.filter.data, opts.data, &error) else {
-                throw UserError.invalidArgumentError(message: toErrorString(error))
+                throw parseMongocError(error) // Should be invalidArgumentError
             }
         }
     }
@@ -88,17 +90,19 @@ extension MongoCollection {
             self.options = DeleteModelOptions(collation: collation)
         }
 
-        /// Adds the `deleteMany` operation to a bulk write
-        ///
-        /// - Throws:
-        ///   - `UserError.invalidArgumentError` if the options form an invalid combination.
-        ///   - `EncodingError` if an error occurs while encoding the options to BSON.
+        /**
+         * Adds the `deleteMany` operation to a bulk write
+         *
+         * - Throws:
+         *   - `UserError.invalidArgumentError` if the options form an invalid combination.
+         *   - `EncodingError` if an error occurs while encoding the options to BSON.
+         */
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
             let opts = try BSONEncoder().encode(options)
             var error = bson_error_t()
 
             guard mongoc_bulk_operation_remove_many_with_opts(bulk.bulk, self.filter.data, opts.data, &error) else {
-                throw UserError.invalidArgumentError(message: toErrorString(error))
+                throw parseMongocError(error) // should be invalidArgumentError
             }
         }
     }
@@ -117,16 +121,17 @@ extension MongoCollection {
             self.document = document
         }
 
-        /// Adds the `insertOne` operation to a bulk write
-        ///
-        /// - Throws:
-        ///   - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
-        ///   - `UserError.invalidArgumentError` if the options form an invalid combination.
+        /** Adds the `insertOne` operation to a bulk write
+         *
+         * - Throws:
+         *   - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
+         *   - `UserError.invalidArgumentError` if the options form an invalid combination.
+         */
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
             let document = try BSONEncoder().encode(self.document).withID()
             var error = bson_error_t()
             guard mongoc_bulk_operation_insert_with_opts(bulk.bulk, document.data, nil, &error) else {
-                throw UserError.invalidArgumentError(message: toErrorString(error))
+                throw parseMongocError(error) // should be invalidArgumentError
             }
 
             guard let insertedId = try document.getValue(for: "_id") else {
@@ -164,11 +169,12 @@ extension MongoCollection {
             self.options = ReplaceOneModelOptions(collation: collation, upsert: upsert)
         }
 
-        /// Adds the `replaceOne` operation to a bulk write
-        ///
-        /// - Throws:
-        ///   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
-        ///   - `UserError.invalidArgumentError` if the options form an invalid combination.
+        /** Adds the `replaceOne` operation to a bulk write
+         *
+         * - Throws:
+         *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
+         *   - `UserError.invalidArgumentError` if the options form an invalid combination.
+         */
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
             let encoder = BSONEncoder()
             let replacement = try encoder.encode(self.replacement)
@@ -180,7 +186,7 @@ extension MongoCollection {
                                                               replacement.data,
                                                               opts.data,
                                                               &error) else {
-                throw UserError.invalidArgumentError(message: toErrorString(error))
+                throw parseMongocError(error) // should be invalidArgumentError
             }
         }
     }
@@ -217,11 +223,12 @@ extension MongoCollection {
             self.options = UpdateModelOptions(arrayFilters: arrayFilters, collation: collation, upsert: upsert)
         }
 
-        /// Adds the `updateOne` operation to a bulk write.
-        ///
-        /// - Throws:
-        ///   - `EncodingError` if an error occurs while encoding the options to BSON.
-        ///   - `UserError.invalidArgumentError` if the options form an invalid combination.
+        /** Adds the `updateOne` operation to a bulk write.
+         *
+         * - Throws:
+         *   - `EncodingError` if an error occurs while encoding the options to BSON.
+         *   - `UserError.invalidArgumentError` if the options form an invalid combination.
+         */
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
             let opts = try BSONEncoder().encode(self.options)
             var error = bson_error_t()
@@ -231,7 +238,7 @@ extension MongoCollection {
                                                              self.update.data,
                                                              opts.data,
                                                              &error) else {
-                throw UserError.invalidArgumentError(message: toErrorString(error))
+                throw parseMongocError(error) // should be invalidArgumentError
             }
         }
     }
@@ -262,11 +269,13 @@ extension MongoCollection {
             self.options = UpdateModelOptions(arrayFilters: arrayFilters, collation: collation, upsert: upsert)
         }
 
-        /// Adds the `updateMany` operation to a bulk write
-        ///
-        /// - Throws:
-        ///   - `EncodingError` if an error occurs while encoding the options to BSON.
-        ///   - `UserError.invalidArgumentError` if the options form an invalid combination.
+        /**
+         * Adds the `updateMany` operation to a bulk write
+         *
+         * - Throws:
+         *   - `EncodingError` if an error occurs while encoding the options to BSON.
+         *   - `UserError.invalidArgumentError` if the options form an invalid combination.
+         */
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
             let opts = try BSONEncoder().encode(self.options)
             var error = bson_error_t()
@@ -276,7 +285,7 @@ extension MongoCollection {
                                                               self.update.data,
                                                               opts.data,
                                                               &error) else {
-                throw UserError.invalidArgumentError(message: toErrorString(error))
+                throw parseMongocError(error) // should be invalidArgumentError
             }
         }
     }

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -12,9 +12,10 @@ extension MongoCollection {
      * - Returns: The deleted document, represented as a `CollectionType`, or `nil` if no document was deleted.
      *
      * - Throws:
-     *   - `MongoError.invalidArgument` if any of the provided options are invalid
-     *   - `MongoError.commandError` if there are any errors executing the command.
-     *   - A `DecodingError` if the deleted document cannot be decoded to a `CollectionType` value
+     *   - `UserError.invalidArgumentError` if any of the provided options are invalid.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `ServerError.writeError` if an error occurs while executing the command.
+     *   - `DecodingError` if the deleted document cannot be decoded to a `CollectionType` value.
      */
     @discardableResult
     public func findOneAndDelete(_ filter: Document,
@@ -36,10 +37,11 @@ extension MongoCollection {
      *      depending on selected options, or `nil` if there was no match.
      *
      * - Throws:
-     *   - `MongoError.invalidArgument` if any of the provided options are invalid
-     *   - `MongoError.commandError` if there are any errors executing the command.
-     *   - An `EncodingError` if `replacement` cannot be encoded to a `Document`
-     *   - A `DecodingError` if the replaced document cannot be decoded to a `CollectionType` value
+     *   - `UserError.invalidArgumentError` if any of the provided options are invalid.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `ServerError.writeError` if an error occurs while executing the command.
+     *   - `DecodingError` if the replaced document cannot be decoded to a `CollectionType` value.
+     *   - `EncodingError` if `replacement` cannot be encoded to a `Document`.
      */
     @discardableResult
     public func findOneAndReplace(filter: Document,
@@ -61,9 +63,10 @@ extension MongoCollection {
      *      depending on selected options, or `nil` if there was no match.
      *
      * - Throws:
-     *   - `MongoError.invalidArgument` if any of the provided options are invalid
-     *   - `MongoError.commandError` if there are any errors executing the command.
-     *   - A `DecodingError` if the updated document cannot be decoded to a `CollectionType` value
+     *   - `UserError.invalidArgumentError` if any of the provided options are invalid.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `ServerError.writeError` if an error occurs while executing the command.
+     *   - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
      */
     @discardableResult
     public func findOneAndUpdate(filter: Document,

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -276,7 +276,7 @@ extension MongoCollection {
         let opts = try BSONEncoder().encode(options)
         var error = bson_error_t()
         guard mongoc_collection_drop_index_with_opts(self._collection, name, opts?.data, &error) else {
-            throw parseMongocError(error: error)
+            throw parseMongocError(error)
         }
     }
 

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -184,7 +184,7 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `ServerError.writeError` if an error occurs while performing the write.
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the index specification or options.
      */
@@ -205,7 +205,7 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `ServerError.writeError` if an error occurs while performing the write.
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the index specification or options.
      */
@@ -227,7 +227,7 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `ServerError.writeError` if an error occurs while performing the write.
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the index specifications or options.
      */
@@ -269,7 +269,7 @@ extension MongoCollection {
      *   - writeConcern: An optional WriteConcern to use for the command
      *
      * - Throws:
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      */
     public func dropIndex(_ name: String, options: DropIndexOptions? = nil) throws {
@@ -292,7 +292,7 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `ServerError.writeError` if an error occurs while performing the command.
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the options.
      */
@@ -314,7 +314,7 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `ServerError.writeError` if an error occurs while performing the command.
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the options.
      */
@@ -333,7 +333,7 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `ServerError.writeError` if an error occurs while performing the command.
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the options.
      */

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -70,7 +70,7 @@ extension MongoCollection {
         let count = mongoc_collection_count_with_opts(
             self._collection, MONGOC_QUERY_NONE, filter.data, 0, 0, opts?.data, rp, &error)
 
-        if count == -1 { throw parseMongocError(error: error) }
+        if count == -1 { throw parseMongocError(error) }
 
         return Int(count)
     }
@@ -133,7 +133,7 @@ extension MongoCollection {
         var error = bson_error_t()
         guard mongoc_collection_read_command_with_opts(
             self._collection, command.data, rp, opts?.data, reply.data, &error) else {
-            throw parseMongocError(error: error, errorLabels: reply["errorLabels"] as? [String])
+            throw parseMongocError(error, errorLabels: reply["errorLabels"] as? [String])
         }
 
         guard let values = try reply.getValue(for: "values") as? [BSONValue] else {

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -55,6 +55,11 @@ extension MongoCollection {
      *   - options: Optional `CountOptions` to use when executing the command
      *
      * - Returns: The count of the documents that matched the filter
+     *
+     * - Throws:
+     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the write.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func count(_ filter: Document = [:], options: CountOptions? = nil) throws -> Int {
         let opts = try BSONEncoder().encode(options)
@@ -65,7 +70,7 @@ extension MongoCollection {
         let count = mongoc_collection_count_with_opts(
             self._collection, MONGOC_QUERY_NONE, filter.data, 0, 0, opts?.data, rp, &error)
 
-        if count == -1 { throw MongoError.commandError(message: toErrorString(error)) }
+        if count == -1 { throw parseMongocError(error: error) }
 
         return Int(count)
     }
@@ -81,7 +86,7 @@ extension MongoCollection {
      */
     private func countDocuments(_ filter: Document = [:], options: CountDocumentsOptions? = nil) throws -> Int {
         // TODO SWIFT-133: implement this https://jira.mongodb.org/browse/SWIFT-133
-        throw MongoError.commandError(message: "Unimplemented command")
+        throw UserError.logicError(message: "Unimplemented command")
     }
 
     /**
@@ -94,7 +99,7 @@ extension MongoCollection {
      */
     private func estimatedDocumentCount(options: EstimatedDocumentCountOptions? = nil) throws -> Int {
         // TODO SWIFT-133: implement this https://jira.mongodb.org/browse/SWIFT-133
-        throw MongoError.commandError(message: "Unimplemented command")
+        throw UserError.logicError(message: "Unimplemented command")
     }
 
     /**
@@ -106,6 +111,11 @@ extension MongoCollection {
      *   - options: Optional `DistinctOptions` to use when executing the command
      *
      * - Returns: A `[BSONValue]` containing the distinct values for the specified criteria
+     *
+     * - Throws:
+     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func distinct(fieldName: String,
                          filter: Document = [:],
@@ -123,11 +133,11 @@ extension MongoCollection {
         var error = bson_error_t()
         guard mongoc_collection_read_command_with_opts(
             self._collection, command.data, rp, opts?.data, reply.data, &error) else {
-            throw MongoError.commandError(message: toErrorString(error))
+            throw parseMongocError(error: error, errorLabels: reply["errorLabels"] as? [String])
         }
 
         guard let values = try reply.getValue(for: "values") as? [BSONValue] else {
-            throw MongoError.commandError(message:
+            throw RuntimeError.internalError(message:
                 "expected server reply \(reply) to contain an array of distinct values")
         }
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -113,7 +113,7 @@ extension MongoCollection {
      * - Returns: A `[BSONValue]` containing the distinct values for the specified criteria
      *
      * - Throws:
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -231,7 +231,7 @@ extension MongoCollection {
      *
      * - Returns: The optional result of performing the deletion. If the `WriteConcern` is
      *            unacknowledged, `nil` is returned.
-     * - Throws:
+     *
      * - Throws:
      *   - `ServerError.writeError` if an error occurs while performing the command.
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
@@ -423,6 +423,7 @@ public struct InsertManyResult {
         self.insertedIds = insertedIds
     }
 
+    /// Internal initializer used for converting from a `BulkWriteResult` optional to an `InsertManyResult` optional.
     internal init?(from result: BulkWriteResult?) {
         guard let result = result else {
             return nil

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -12,6 +12,12 @@ extension MongoCollection {
      *
      * - Returns: The optional result of attempting to perform the insert. If the `WriteConcern`
      *            is unacknowledged, `nil` is returned.
+     *
+     * - Throws:
+     *   - `ServerError.writeError` if an error occurs while performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
      */
     @discardableResult
     public func insertOne(_ value: CollectionType, options: InsertOneOptions? = nil) throws -> InsertOneResult? {
@@ -19,9 +25,9 @@ extension MongoCollection {
         let document = try encoder.encode(value).withID()
         let opts = try encoder.encode(options)
         var error = bson_error_t()
-        guard mongoc_collection_insert_one(self._collection, document.data, opts?.data, nil, &error) else {
-            // TODO SWIFT-139: include writeErrors and writeConcernErrors from reply in the error
-            throw MongoError.commandError(message: toErrorString(error))
+        let reply = Document()
+        guard mongoc_collection_insert_one(self._collection, document.data, opts?.data, reply.data, &error) else {
+            throw getErrorFromReply(bsonError: error, from: reply)
         }
 
         guard isAcknowledged(options?.writeConcern) else {
@@ -47,50 +53,19 @@ extension MongoCollection {
      * - Returns: an `InsertManyResult`, or `nil` if the write concern is unacknowledged.
      *
      * - Throws:
-     *   - `MongoError.invalidArgument` if `values` is empty
-     *   - `MongoError.insertManyError` if any error occurs while performing the writes
+     *   - `ServerError.writeError` if an error occurs while performing the write.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     @discardableResult
     public func insertMany(_ values: [CollectionType], options: InsertManyOptions? = nil) throws -> InsertManyResult? {
         guard !values.isEmpty else {
-            throw MongoError.invalidArgument(message: "values cannot be empty")
+            throw UserError.invalidArgumentError(message: "values cannot be empty")
         }
 
-        let encoder = BSONEncoder()
-        let opts = try encoder.encode(options)
-        let documents = try values.map { try encoder.encode($0).withID() }
-        var insertedIds: [Int: BSONValue] = [:]
-
-        try documents.enumerated().forEach { index, document in
-            guard let id = try document.getValue(for: "_id") else {
-                // we called `withID()`, so this should be present.
-                fatalError("Failed to get value for _id from document")
-            }
-            insertedIds[index] = id
-        }
-
-        var docPointers = documents.map { UnsafePointer($0.data) }
-        let reply = Document()
-        var error = bson_error_t()
-
-        let success = mongoc_collection_insert_many(self._collection,
-                                                    &docPointers,
-                                                    values.count,
-                                                    opts?.data,
-                                                    reply.data,
-                                                    &error)
-        let result = try InsertManyResult(reply: reply, insertedIds: insertedIds)
-        let isAcknowledged = self.isAcknowledged(options?.writeConcern)
-
-        guard success else {
-            throw MongoError.insertManyError(code: error.code,
-                                             message: toErrorString(error),
-                                             result: (isAcknowledged ? result : nil),
-                                             writeErrors: result.writeErrors,
-                                             writeConcernError: result.writeConcernError)
-        }
-
-        return isAcknowledged ? result : nil
+        let result = try self.bulkWrite(values.map { InsertOneModel($0) }, options: BulkWriteOptions(from: options))
+        return InsertManyResult(from: result)
     }
 
     /**
@@ -103,6 +78,12 @@ extension MongoCollection {
      *
      * - Returns: The optional result of attempting to replace a document. If the `WriteConcern`
      *            is unacknowledged, `nil` is returned.
+     *
+     * - Throws:
+     *   - `ServerError.writeError` if an error occurs while performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     @discardableResult
     public func replaceOne(filter: Document,
@@ -115,15 +96,17 @@ extension MongoCollection {
         var error = bson_error_t()
         guard mongoc_collection_replace_one(
             self._collection, filter.data, replacementDoc.data, opts?.data, reply.data, &error) else {
-            // TODO SWIFT-139: include writeErrors and writeConcernError from reply in the error
-            throw MongoError.commandError(message: toErrorString(error))
+            throw getErrorFromReply(bsonError: error, from: reply)
         }
 
         guard isAcknowledged(options?.writeConcern) else {
             return nil
         }
 
-        return try BSONDecoder().decode(UpdateResult.self, from: reply)
+        return try BSONDecoder().internalDecode(
+                UpdateResult.self,
+                from: reply,
+                withError: "Couldn't understand response from the server.")
     }
 
     /**
@@ -136,6 +119,12 @@ extension MongoCollection {
      *
      * - Returns: The optional result of attempting to update a document. If the `WriteConcern` is
      *            unacknowledged, `nil` is returned.
+     *
+     * - Throws:
+     *   - `ServerError.writeError` if an error occurs while performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
     public func updateOne(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
@@ -145,15 +134,17 @@ extension MongoCollection {
         var error = bson_error_t()
         guard mongoc_collection_update_one(
             self._collection, filter.data, update.data, opts?.data, reply.data, &error) else {
-            // TODO SWIFT-139: include writeErrors and writeConcernError from reply in the error
-            throw MongoError.commandError(message: toErrorString(error))
+            throw getErrorFromReply(bsonError: error, from: reply)
         }
 
         guard isAcknowledged(options?.writeConcern) else {
             return nil
         }
 
-        return try BSONDecoder().decode(UpdateResult.self, from: reply)
+        return try BSONDecoder().internalDecode(
+                UpdateResult.self,
+                from: reply,
+                withError: "Couldn't understand response from the server.")
     }
 
     /**
@@ -166,6 +157,12 @@ extension MongoCollection {
      *
      * - Returns: The optional result of attempting to update multiple documents. If the write
      *            concern is unacknowledged, nil is returned
+     *
+     * - Throws:
+     *   - `ServerError.writeError` if an error occurs while performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
     public func updateMany(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
@@ -175,15 +172,17 @@ extension MongoCollection {
         var error = bson_error_t()
         guard mongoc_collection_update_many(
             self._collection, filter.data, update.data, opts?.data, reply.data, &error) else {
-            // TODO SWIFT-139: include writeErrors and writeConcernErrors from reply in the error
-            throw MongoError.commandError(message: toErrorString(error))
+            throw getErrorFromReply(bsonError: error, from: reply)
         }
 
         guard isAcknowledged(options?.writeConcern) else {
             return nil
         }
 
-        return try BSONDecoder().decode(UpdateResult.self, from: reply)
+        return try BSONDecoder().internalDecode(
+                UpdateResult.self,
+                from: reply,
+                withError: "Couldn't understand response from the server.")
     }
 
     /**
@@ -195,6 +194,12 @@ extension MongoCollection {
      *
      * - Returns: The optional result of performing the deletion. If the `WriteConcern` is
      *            unacknowledged, `nil` is returned.
+     *
+     * - Throws:
+     *   - `ServerError.writeError` if an error occurs while performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
     public func deleteOne(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
@@ -202,17 +207,19 @@ extension MongoCollection {
         let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        guard mongoc_collection_delete_one(
-            self._collection, filter.data, opts?.data, reply.data, &error) else {
-             // TODO SWIFT-139: include writeErrors and writeConcernErrors from reply in the error
-            throw MongoError.commandError(message: toErrorString(error))
+
+        guard mongoc_collection_delete_one(self._collection, filter.data, opts?.data, reply.data, &error) else {
+            throw getErrorFromReply(bsonError: error, from: reply)
         }
 
         guard isAcknowledged(options?.writeConcern) else {
             return nil
         }
 
-        return try BSONDecoder().decode(DeleteResult.self, from: reply)
+        return try BSONDecoder().internalDecode(
+                DeleteResult.self,
+                from: reply,
+                withError: "Couldn't understand response from the server.")
     }
 
     /**
@@ -224,6 +231,12 @@ extension MongoCollection {
      *
      * - Returns: The optional result of performing the deletion. If the `WriteConcern` is
      *            unacknowledged, `nil` is returned.
+     * - Throws:
+     * - Throws:
+     *   - `ServerError.writeError` if an error occurs while performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
     public func deleteMany(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
@@ -231,17 +244,18 @@ extension MongoCollection {
         let opts = try encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        guard mongoc_collection_delete_many(
-            self._collection, filter.data, opts?.data, reply.data, &error) else {
-            // TODO SWIFT-139: include writeErrors and writeConcernErrors from reply in the error
-            throw MongoError.commandError(message: toErrorString(error))
+        guard mongoc_collection_delete_many(self._collection, filter.data, opts?.data, reply.data, &error) else {
+            throw getErrorFromReply(bsonError: error, from: reply)
         }
 
         guard isAcknowledged(options?.writeConcern) else {
             return nil
         }
 
-        return try BSONDecoder().decode(DeleteResult.self, from: reply)
+        return try BSONDecoder().internalDecode(
+                DeleteResult.self,
+                from: reply,
+                withError: "Couldn't understand response from the server.")
     }
 
     /**
@@ -394,9 +408,6 @@ public struct InsertManyResult {
     /// Map of the index of the document in `values` to the value of its ID
     public let insertedIds: [Int: BSONValue]
 
-    fileprivate var writeErrors: [WriteError] = []
-    fileprivate var writeConcernError: WriteConcernError?
-
     /**
      * Create an `InsertManyResult` from a reply and map of inserted IDs.
      *
@@ -410,15 +421,15 @@ public struct InsertManyResult {
     fileprivate init(reply: Document, insertedIds: [Int: BSONValue]) throws {
         self.insertedCount = try reply.getValue(for: "insertedCount") as? Int ?? 0
         self.insertedIds = insertedIds
+    }
 
-        if let writeErrors = try reply.getValue(for: "writeErrors") as? [Document] {
-            self.writeErrors = try writeErrors.map { try BSONDecoder().decode(WriteError.self, from: $0) }
+    internal init?(from result: BulkWriteResult?) {
+        guard let result = result else {
+            return nil
         }
 
-        if let writeConcernErrors = try reply.getValue(for: "writeConcernErrors") as? [Document],
-            writeConcernErrors.indices.contains(0) {
-            self.writeConcernError = try BSONDecoder().decode(WriteConcernError.self, from: writeConcernErrors[0])
-        }
+        self.insertedCount = result.insertedCount
+        self.insertedIds = result.insertedIds
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -56,10 +56,13 @@ public class MongoCollection<T: Codable> {
     }
 
     /// Drops this collection from its parent database.
+    /// - Throws:
+    ///   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+    ///   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
     public func drop() throws {
         var error = bson_error_t()
         guard mongoc_collection_drop(self._collection, &error) else {
-            throw MongoError.commandError(message: toErrorString(error))
+            throw parseMongocError(error: error)
         }
     }
 }

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -62,7 +62,7 @@ public class MongoCollection<T: Codable> {
     public func drop() throws {
         var error = bson_error_t()
         guard mongoc_collection_drop(self._collection, &error) else {
-            throw parseMongocError(error: error)
+            throw parseMongocError(error)
         }
     }
 }

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -279,7 +279,7 @@ public class MongoDatabase {
      * - Returns: the newly created `MongoCollection<T>`
      *
      * - Throws:
-     *   - `ServerError.commandError` if an error occurs that prevents the command from performing the command.
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
@@ -331,7 +331,7 @@ public class MongoDatabase {
      * - Returns: a `Document` containing the server response for the command
      *
      * - Throws:
-     *   - `UserError.invalidArgument` if `requests` is empty.
+     *   - `UserError.invalidArgumentError` if `requests` is empty.
      *   - `ServerError.writeError` if any error occurs while the command was performing a write.
      *   - `ServerError.commandError` if an error occurs that prevents the command from being performed.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -199,7 +199,7 @@ public class MongoDatabase {
     public func drop() throws {
         var error = bson_error_t()
         guard mongoc_database_drop(self._database, &error) else {
-            throw parseMongocError(error: error)
+            throw parseMongocError(error)
         }
     }
 
@@ -291,7 +291,7 @@ public class MongoDatabase {
         var error = bson_error_t()
 
         guard let collection = mongoc_database_create_collection(self._database, name, opts?.data, &error) else {
-            throw parseMongocError(error: error)
+            throw parseMongocError(error)
         }
 
         guard let client = self._client else {

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -131,12 +131,6 @@ public struct BulkWriteError: Codable {
     /// The index of the request that errored.
     public let index: Int
 
-    /// The request that errored.
-    // Swift 4.0 requires a default value here because request isn't a CodingKey. Later versions do not have this
-    // problem. TODO: remove this default value and linter ignore (SWIFT-283).
-    // swiftlint:disable:next redundant_optional_initialization
-    public var request: WriteModel? = nil
-
     private enum CodingKeys: String, CodingKey {
         case code
         case message = "errmsg"
@@ -241,8 +235,7 @@ private func getBulkWriteErrorFromReply(
     var bulkWriteErrors: [BulkWriteError]?
     if let writeErrors = reply["writeErrors"] as? [Document], !writeErrors.isEmpty {
         bulkWriteErrors = try writeErrors.map {
-            var err = try decoder.decode(BulkWriteError.self, from: $0)
-            err.request = bulkWrite.requests[err.index]
+            let err = try decoder.decode(BulkWriteError.self, from: $0)
             insertedIds?[err.index] = nil
             return err
         }

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -146,7 +146,7 @@ public struct BulkWriteError: Codable {
 
 /// Internal helper function used to get an appropriate error from a libmongoc error. This should NOT be used to get
 /// `.writeError`s or `.bulkWriteError`s. Instead, construct those using `getErrorFromReply`.
-internal func parseMongocError(error: bson_error_t, errorLabels: [String]? = nil) -> MongoSwiftError {
+internal func parseMongocError(_ error: bson_error_t, errorLabels: [String]? = nil) -> MongoSwiftError {
     let domain = mongoc_error_domain_t(rawValue: error.domain)
     let code = mongoc_error_code_t(rawValue: error.code)
     let message = toErrorString(error)
@@ -180,7 +180,7 @@ internal func getErrorFromReply(
         withResult result: BulkWriteResult? = nil) -> MongoSwiftError {
     // if writeErrors or writeConcernErrors aren't present, then this is likely a commandError.
     guard reply["writeErrors"] != nil || reply["writeConcernErrors"] != nil else {
-        return parseMongocError(error: bsonError, errorLabels: reply["errorLabels"] as? [String])
+        return parseMongocError(bsonError, errorLabels: reply["errorLabels"] as? [String])
     }
 
     let fallback = RuntimeError.internalError(message: "Got error from the server but couldn't parse it. " +

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -263,7 +263,7 @@ private class BulkWriteTest: CrudTest {
                 verifyBulkWriteResult(result)
             }
             expect(expectError).to(beFalse())
-        } catch MongoError.bulkWriteError(_, _, let result, _, _) {
+        } catch ServerError.bulkWriteError(_, _, let result, _) {
             if let result = result {
                 verifyBulkWriteResult(result)
             }
@@ -499,9 +499,9 @@ private class InsertManyTest: CrudTest {
                 verifyInsertManyResult(result)
             }
             expect(expectError).to(beFalse())
-        } catch MongoError.insertManyError(_, _, let result, _, _) {
+        } catch ServerError.bulkWriteError(_, _, let result, _) {
             if let result = result {
-                verifyInsertManyResult(result)
+                verifyInsertManyResult(InsertManyResult(from: result)!)
             }
             expect(expectError).to(beTrue())
         }

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -128,7 +128,14 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
 
         let options = BulkWriteOptions(ordered: false)
 
-        expect(try self.coll.bulkWrite(requests, options: options)).to(throwError(expectedError))
+        expect(try self.coll.bulkWrite(requests, options: options)).to(throwError { err in
+            expect(err as? ServerError).to(equal(expectedError))
+
+            if case let ServerError.bulkWriteError(writeErrors, _, _, _) = err {
+                expect(writeErrors?.count).to(equal(1))
+                expect(writeErrors?[0].request as? InsertOneModel).to(equal(requests[1] as? InsertOneModel))
+            }
+        })
     }
 
     func testUpdates() throws {

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -133,7 +133,8 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
 
             if case let ServerError.bulkWriteError(writeErrors, _, _, _) = err {
                 expect(writeErrors?.count).to(equal(1))
-                expect(writeErrors?[0].request as? InsertOneModel).to(equal(requests[1] as? InsertOneModel))
+                expect((writeErrors?[0].request! as! InsertOneModel).document)
+                        .to(equal((requests[1] as! InsertOneModel).document))
             }
         })
     }

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -121,22 +121,14 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
 
         // Expect a duplicate key error (11000)
         let expectedError = ServerError.bulkWriteError(
-                writeErrors: [BulkWriteError(code: 11000, message: "", index: 1, request: nil)],
+                writeErrors: [BulkWriteError(code: 11000, message: "", index: 1)],
                 writeConcernError: nil,
                 result: expectedResult,
                 errorLabels: nil)
 
         let options = BulkWriteOptions(ordered: false)
 
-        expect(try self.coll.bulkWrite(requests, options: options)).to(throwError { err in
-            expect(err as? ServerError).to(equal(expectedError))
-
-            if case let ServerError.bulkWriteError(writeErrors, _, _, _) = err {
-                expect(writeErrors?.count).to(equal(1))
-                expect((writeErrors?[0].request! as! InsertOneModel).document)
-                        .to(equal((requests[1] as! InsertOneModel).document))
-            }
-        })
+        expect(try self.coll.bulkWrite(requests, options: options)).to(throwError(expectedError))
     }
 
     func testUpdates() throws {

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -179,7 +179,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
         let expectedResultOrdered = BulkWriteResult(insertedCount: 1, insertedIds: [0: newDoc1["_id"]!])
         let expectedErrorsOrdered = [
-            BulkWriteError(code: 11000, message: "", index: 1, request: nil)
+            BulkWriteError(code: 11000, message: "", index: 1)
         ]
 
         let expectedErrorOrdered = ServerError.bulkWriteError(
@@ -191,8 +191,8 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.insertMany([newDoc1, docId1, newDoc2, docId2])).to(throwError(expectedErrorOrdered))
 
         let expectedErrors = [
-            BulkWriteError(code: 11000, message: "", index: 1, request: nil),
-            BulkWriteError(code: 11000, message: "", index: 3, request: nil)
+            BulkWriteError(code: 11000, message: "", index: 1),
+            BulkWriteError(code: 11000, message: "", index: 3)
         ]
         let expectedResult = BulkWriteResult(insertedCount: 2, insertedIds: [0: newDoc3["_id"]!, 2: newDoc4["_id"]!])
         let expectedError = ServerError.bulkWriteError(
@@ -202,18 +202,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
                 errorLabels: nil)
 
         expect(try self.coll.insertMany([newDoc3, docId1, newDoc4, docId2], options: InsertManyOptions(ordered: false)))
-                .to(throwError { err in
-                    expect(err as? ServerError).to(equal(expectedError))
-
-                    if case let ServerError.bulkWriteError(writeErrors, _, _, _) = err {
-                        var errRequests: [Int: WriteModel] = [:]
-                        writeErrors?.forEach { errRequests[$0.index] = $0.request }
-                        expect(errRequests[0]).to(beNil())
-                        expect((errRequests[1] as? InsertOne)?.document).to(equal(docId1))
-                        expect(errRequests[2]).to(beNil())
-                        expect((errRequests[3] as? InsertOne)?.document).to(equal(docId2))
-                    }
-                })
+                .to(throwError(expectedError))
     }
 
     func testInsertManyWithEmptyValues() {

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -34,5 +34,9 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         expect(names).toNot(contain([type(of: self).testDatabase]))
 
         expect(db.name).to(equal(type(of: self).testDatabase))
+
+        // error code 59: CommandNotFound
+        expect(try db.runCommand(["asdfsadf": ObjectId()]))
+                .to(throwError(ServerError.commandError(code: 59, message: "", errorLabels: nil)))
     }
 }

--- a/Tests/MongoSwiftTests/MongoError+Equatable.swift
+++ b/Tests/MongoSwiftTests/MongoError+Equatable.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MongoSwift
+@testable import MongoSwift
 
 extension RuntimeError: Equatable {
     public static func == (lhs: RuntimeError, rhs: RuntimeError) -> Bool {
@@ -77,6 +77,12 @@ extension UserError: Equatable {
 extension WriteError: Equatable {
     public static func == (lhs: WriteError, rhs: WriteError) -> Bool {
         return lhs.code == rhs.code
+    }
+}
+
+extension MongoCollection.InsertOneModel: Equatable where T: Equatable {
+    public static func == (lhs: MongoCollection.InsertOneModel, rhs: MongoCollection.InsertOneModel) -> Bool {
+        return lhs.document == rhs.document
     }
 }
 

--- a/Tests/MongoSwiftTests/MongoError+Equatable.swift
+++ b/Tests/MongoSwiftTests/MongoError+Equatable.swift
@@ -80,12 +80,6 @@ extension WriteError: Equatable {
     }
 }
 
-extension MongoCollection.InsertOneModel: Equatable where T: Equatable {
-    public static func == (lhs: MongoCollection.InsertOneModel, rhs: MongoCollection.InsertOneModel) -> Bool {
-        return lhs.document == rhs.document
-    }
-}
-
 extension BulkWriteError: Equatable {
     public static func == (lhs: BulkWriteError, rhs: BulkWriteError) -> Bool {
         return lhs.code == rhs.code && lhs.index == rhs.index

--- a/Tests/MongoSwiftTests/MongoError+Equatable.swift
+++ b/Tests/MongoSwiftTests/MongoError+Equatable.swift
@@ -30,20 +30,35 @@ extension ServerError: Equatable {
                     && sortAndCompareOptionalArrays(lhs: lhsErrorLabels, rhs: rhsErrorLabels, cmp: { $0 < $1 })
         case let (.bulkWriteError(writeErrors: lhsWriteErrors,
                                   writeConcernError: lhsWCError,
-                                  result: _,
+                                  result: lhsResult,
                                   errorLabels: lhsErrorLabels),
                   .bulkWriteError(writeErrors: rhsWriteErrors,
                                   writeConcernError: rhsWCError,
-                                  result: _,
+                                  result: rhsResult,
                                   errorLabels: rhsErrorLabels)):
             let cmp = { (l: BulkWriteError, r: BulkWriteError) in l.index < r.index }
 
             return sortAndCompareOptionalArrays(lhs: lhsWriteErrors, rhs: rhsWriteErrors, cmp: cmp)
                     && lhsWCError == rhsWCError
                     && sortAndCompareOptionalArrays(lhs: lhsErrorLabels, rhs: rhsErrorLabels, cmp: { $0 < $1 })
+                    && lhsResult == rhsResult
         default:
             return false
         }
+    }
+}
+
+extension BulkWriteResult: Equatable {
+    public static func == (lhs: BulkWriteResult, rhs: BulkWriteResult) -> Bool {
+        let iidsEqual = lhs.insertedIds.mapValues { AnyBSONValue($0) } == rhs.insertedIds.mapValues { AnyBSONValue($0) }
+        let uidsEqual = lhs.upsertedIds.mapValues { AnyBSONValue($0) } == rhs.upsertedIds.mapValues { AnyBSONValue($0) }
+
+        return iidsEqual
+                && uidsEqual
+                && lhs.upsertedCount == rhs.upsertedCount
+                && lhs.modifiedCount == rhs.modifiedCount
+                && lhs.matchedCount == rhs.matchedCount
+                && lhs.insertedCount == rhs.insertedCount
     }
 }
 

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -279,7 +279,9 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // running command with an invalid RC level should throw
         let options3 = RunCommandOptions(readConcern: ReadConcern("blah"))
-        expect(try db.runCommand(command, options: options3)).to(throwError())
+        // error code 9: FailedToParse
+        expect(try db.runCommand(command, options: options3))
+                .to(throwError(ServerError.commandError(code: 9, message: "", errorLabels: nil)))
 
         // try various command + read concern pairs to make sure they work
         expect(try coll.find(options: FindOptions(readConcern: ReadConcern(.local)))).toNot(throwError())


### PR DESCRIPTION
[SWIFT-144](https://jira.mongodb.org/browse/SWIFT-144) / [SWIFT-300](https://jira.mongodb.org/browse/SWIFT-300)

This PR updates reading CRUD operations to throw errors from the new error hierarchy. (SWIFT-144). As part of that, `InsertMany` now both throws a `.bulkWriteError` and is implemented as a bulk write (SWIFT-300). Also, command failure events have been updated to use the new errors as well.