### PR TITLE
Various error migrations

### DIFF
--- a/Examples/Kitura/Sources/KituraExample/main.swift
+++ b/Examples/Kitura/Sources/KituraExample/main.swift
@@ -7,7 +7,7 @@ private struct Kitten: Codable {
 }
 
 private let client = try MongoClient()
-private let collection = try client.db("home").collection("kittens", withType: Kitten.self)
+private let collection = client.db("home").collection("kittens", withType: Kitten.self)
 
 private let router: Router = {
     let router = Router()

--- a/Examples/Vapor/Sources/VaporExample/main.swift
+++ b/Examples/Vapor/Sources/VaporExample/main.swift
@@ -9,7 +9,7 @@ private struct Kitten: Content {
 private let app = try Application()
 private let router = try app.make(Router.self)
 private let client = try MongoClient()
-private let collection = try client.db("home").collection("kittens", withType: Kitten.self)
+private let collection = client.db("home").collection("kittens", withType: Kitten.self)
 
 router.get("kittens") { _ -> [Kitten] in
     let docs = try collection.find()

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -134,7 +134,7 @@ public class MongoClient {
 
         self._client = mongoc_client_new_from_uri(uri)
         guard self._client != nil else {
-            throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support.")
+            throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support")
         }
 
         // if a readConcern is provided, set it on the client

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -318,14 +318,14 @@ extension MongoCollection {
      * Retrieves a list of the indexes currently on this collection.
      *
      * - Returns: A `MongoCursor` over the index names.
+     *
+     * - Throws: A `userError.invalidArgumentError` if the options passed are an invalid combination.
      */
     public func listIndexes() throws -> MongoCursor<Document> {
         guard let cursor = mongoc_collection_find_indexes_with_opts(self._collection, nil) else {
-            throw MongoError.invalidResponse()
+            fatalError("Couldn't get cursor from the server")
         }
-        guard let client = self._client else {
-            throw MongoError.invalidClient()
-        }
-        return MongoCursor(fromCursor: cursor, withClient: client)
+
+        return try MongoCursor(fromCursor: cursor, withClient: self._client)
     }
 }

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -3,7 +3,7 @@ import mongoc
 /// A MongoDB collection.
 public class MongoCollection<T: Codable> {
     internal var _collection: OpaquePointer?
-    internal var _client: MongoClient?
+    internal var _client: MongoClient
 
     /// A `Codable` type associated with this `MongoCollection` instance.
     /// This allows `CollectionType` values to be directly inserted into and
@@ -47,7 +47,6 @@ public class MongoCollection<T: Codable> {
 
     /// Deinitializes a `MongoCollection`, cleaning up the internal `mongoc_collection_t`
     deinit {
-        self._client = nil
         guard let collection = self._collection else {
             return
         }

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -13,7 +13,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
 
         if let err = self.error {
             // Need to explicitly close since deinit will not execute if we throw.
-            close()
+            self.close()
 
             // Errors in creation of the cursor are limited to invalid argument errors, but some errors are reported
             // by libmongoc as invalid cursor errors. These would be parsed to .logicErrors, so we need to rethrow them
@@ -28,7 +28,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
 
     /// Deinitializes a `MongoCursor`, cleaning up the internal `mongoc_cursor_t`.
     deinit {
-        close()
+        self.close()
     }
 
     /// Closes the cursor.

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -4,12 +4,26 @@ import mongoc
 public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
     private var _cursor: OpaquePointer?
     private var _client: MongoClient?
-    private var decodeError: Error?
+    private var swiftError: Error?
 
     /// Initializes a new `MongoCursor` instance, not meant to be instantiated directly.
-    internal init(fromCursor: OpaquePointer, withClient: MongoClient) {
+    internal init(fromCursor: OpaquePointer, withClient: MongoClient) throws {
         self._cursor = fromCursor
         self._client = withClient
+
+        if let err = self.error {
+            // Need to explicitly close since deinit will not execute if we throw.
+            close()
+
+            // Errors in creation of the cursor are limited to invalid argument errors, but some errors are reported
+            // by libmongoc as invalid cursor errors. These would be parsed to .logicErrors, so we need to rethrow them
+            // as the correct case.
+            if let mongoSwiftErr = err as? MongoSwiftError {
+                throw UserError.invalidArgumentError(message: mongoSwiftErr.errorDescription ?? "")
+            }
+
+            throw err
+        }
     }
 
     /// Deinitializes a `MongoCursor`, cleaning up the internal `mongoc_cursor_t`.
@@ -44,19 +58,38 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
     /// The error that occurred while iterating this cursor, if one exists. This should be used to check for errors
     /// after `next()` returns `nil`.
     public var error: Error? {
-        if let err = self.decodeError {
+        if let err = self.swiftError {
             return err
         }
+
+        var replyPtr = UnsafeMutablePointer<UnsafePointer<bson_t>?>.allocate(capacity: 1)
+        defer { replyPtr.deallocate() }
+
         var error = bson_error_t()
-        if mongoc_cursor_error(self._cursor, &error) {
-            return MongoError.invalidCursor(message: toErrorString(error))
+        guard mongoc_cursor_error_document(self._cursor, &error, replyPtr) else {
+            return nil
         }
-        return nil
+
+        // If a reply is present, it implies the error occurred on the server. This *should* always be a commandError,
+        // but we will still parse the mongoc error to cover all cases.
+        if let docPtr = replyPtr.pointee {
+            let reply = Document(fromPointer: docPtr)
+            return parseMongocError(error: error, errorLabels: reply["errorLabels"] as? [String])
+        }
+
+        // Otherwise, the only feasible error is that the user tried to advance a dead cursor, which is a logic error.
+        // We will still parse the mongoc error to cover all cases.
+        return parseMongocError(error: error)
     }
 
     /// Returns the next `Document` in this cursor, or nil. Once this function returns `nil`, the caller should use
     /// the `.error` property to check for errors.
     public func next() -> T? {
+        guard self._cursor != nil else {
+            self.swiftError = UserError.logicError(message: "Tried to iterate a closed cursor.")
+            return nil
+        }
+
         let out = UnsafeMutablePointer<UnsafePointer<bson_t>?>.allocate(capacity: 1)
         defer {
             out.deinitialize(count: 1)
@@ -69,9 +102,11 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
         let doc = Document(fromPointer: out.pointee!)
 
         do {
-            return try BSONDecoder().decode(T.self, from: doc)
+            let outDoc = try BSONDecoder().decode(T.self, from: doc)
+            self.swiftError = nil
+            return outDoc
         } catch {
-            self.decodeError = error
+            self.swiftError = error
             return nil
         }
     }

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -162,6 +162,8 @@ internal func parseMongocError(error: bson_error_t, errorLabels: [String]? = nil
          (MONGOC_ERROR_SERVER_SELECTION, MONGOC_ERROR_SERVER_SELECTION_FAILURE),
          (MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION):
         return RuntimeError.connectionError(message: message, errorLabels: errorLabels)
+    case (MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR):
+        return UserError.logicError(message: message)
     default:
         assert(errorLabels == nil, "errorLabels set on error, but were not thrown as a MongoSwiftError. " +
                 "Labels: \(errorLabels ?? [])")

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -99,15 +99,15 @@ public final class ReadPreference {
      * - Returns: a new `ReadPreference`
      *
      * - Throws:
-     *   - A `MongoError.readPreferenceError` if `mode` is `.primary` and `tagSets` is non-empty
-     *   - A `MongoError.readPreferenceError` if `maxStalenessSeconds` non-nil and < 90
+     *   - A `UserError.invalidArgumentError` if `mode` is `.primary` and `tagSets` is non-empty
+     *   - A `UserError.invalidArgumentError` if `maxStalenessSeconds` non-nil and < 90
      */
     public init(_ mode: Mode, tagSets: [Document]? = nil, maxStalenessSeconds: Int64? = nil) throws {
         self._readPreference = mongoc_read_prefs_new(mode.readMode)
 
         if let tagSets = tagSets {
             guard mode != .primary || tagSets.isEmpty else {
-                throw MongoError.readPreferenceError(message: "tagSets may not be used with primary mode")
+                throw UserError.invalidArgumentError(message: "tagSets may not be used with primary mode")
             }
 
             let encoder = BSONEncoder()
@@ -117,7 +117,7 @@ public final class ReadPreference {
 
         if let maxStalenessSeconds = maxStalenessSeconds {
             guard maxStalenessSeconds >= MONGOC_SMALLEST_MAX_STALENESS_SECONDS else {
-                throw MongoError.readPreferenceError(message: "Expected maxStalenessSeconds to be >= " +
+                throw UserError.invalidArgumentError(message: "Expected maxStalenessSeconds to be >= " +
                     " \(MONGOC_SMALLEST_MAX_STALENESS_SECONDS), \(maxStalenessSeconds) given")
             }
 

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -47,7 +47,7 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
                 print("Test case: \(test.description)")
 
                 // 1. Setup the specified DB and collection with provided data
-                let db = try client.db(testFile.databaseName)
+                let db = client.db(testFile.databaseName)
                 try db.drop() // In case last test run failed, drop to clear out DB
                 let collection = try db.createCollection(testFile.collectionName)
                 try collection.insertMany(testFile.data)
@@ -83,7 +83,7 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
 
     func testAlternateNotificationCenters() throws {
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
-        let db = try client.db(type(of: self).testDatabase)
+        let db = client.db(type(of: self).testDatabase)
         let collection = try db.createCollection(self.getCollectionName())
         let customCenter = NotificationCenter()
         client.enableMonitoring(forEvents: .commandMonitoring, usingCenter: customCenter)

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -31,7 +31,7 @@ final class CrudTests: MongoSwiftTestCase {
     // Run tests for .json files at the provided path
     func doTests(forPath: String) throws {
         let client = try MongoClient()
-        let db = try client.db(type(of: self).testDatabase)
+        let db = client.db(type(of: self).testDatabase)
         for (filename, file) in try parseFiles(atPath: forPath) {
             if try !client.serverVersionIsInRange(file.minServerVersion, file.maxServerVersion) {
                 print("Skipping tests from file \(filename) for server version \(try client.serverVersion())")
@@ -50,7 +50,7 @@ final class CrudTests: MongoSwiftTestCase {
                 // 3) execute the test according to the type's execute method
                 // 4) verify that expected data is present
                 // 5) drop the collection to clean up
-                let collection = try db.collection(self.getCollectionName(suffix: "\(filename)_\(i)"))
+                let collection = db.collection(self.getCollectionName(suffix: "\(filename)_\(i)"))
                 try collection.insertMany(file.data)
                 try test.execute(usingCollection: collection)
                 try test.verifyData(testCollection: collection, db: db)
@@ -196,7 +196,7 @@ private class CrudTest {
         // if a name is not specified, check the current collection
         var collToCheck = coll
         if let name = collection["name"] as? String {
-            collToCheck = try db.collection(name)
+            collToCheck = db.collection(name)
         }
         expect(Array(try collToCheck.find([:]))).to(equal(try collection.get("data")))
     }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -26,7 +26,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         }
 
         guard let client_t = mongoc_client_new_from_uri(uri) else {
-            throw RuntimeError.internalError(message: "creating client from uri failed")
+            throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support.")
         }
 
         let client = MongoClient(fromPointer: client_t)

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -22,16 +22,16 @@ final class MongoClientTests: MongoSwiftTestCase {
         let connectionString = MongoSwiftTestCase.connStr
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
-            throw MongoError.invalidUri(message: toErrorString(error))
+            throw parseMongocError(error: error)
         }
 
         guard let client_t = mongoc_client_new_from_uri(uri) else {
-            throw MongoError.invalidClient()
+            throw RuntimeError.internalError(message: "creating client from uri failed")
         }
 
         let client = MongoClient(fromPointer: client_t)
-        let db = try client.db(type(of: self).testDatabase)
-        let coll = try db.collection(self.getCollectionName())
+        let db = client.db(type(of: self).testDatabase)
+        let coll = db.collection(self.getCollectionName())
         let insertResult = try coll.insertOne([ "test": 42 ])
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])
         let docs = Array(findResult)

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -36,11 +36,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
             return XCTFail("Client is not initialized")
         }
 
-        do {
-            coll = try client.db(type(of: self).testDatabase).collection(self.getCollectionName())
-        } catch {
-            return XCTFail("Setup failed: \(error)")
-        }
+        coll = client.db(type(of: self).testDatabase).collection(self.getCollectionName())
     }
 
     /// Teardown a single test - run after each testX function

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -369,7 +369,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
     func testCodableCollection() throws {
         let client = try MongoClient()
-        let db = try client.db(type(of: self).testDatabase)
+        let db = client.db(type(of: self).testDatabase)
         let coll1 = try db.createCollection(self.getCollectionName(suffix: "codable"), withType: Basic.self)
         defer { try? coll1.drop() }
 

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -15,11 +15,11 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
 
     func testMongoDatabase() throws {
         let client = try MongoClient(connectionString: MongoSwiftTestCase.connStr)
-        let db = try client.db(type(of: self).testDatabase)
+        let db = client.db(type(of: self).testDatabase)
 
         let command: Document = ["create": self.getCollectionName(suffix: "1")]
         expect(try db.runCommand(command)).to(equal(["ok": 1.0]))
-        expect(try db.collection(command["create"] as! String)).toNot(throwError())
+        expect(try (Array(db.listCollections()) as [Document]).count).to(equal(1))
 
         // create collection using createCollection
         expect(try db.createCollection(self.getCollectionName(suffix: "2"))).toNot(throwError())

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -86,11 +86,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern).to(beNil())
 
             // expect that a DB created from this client inherits its unset RC 
-            let db1 = try client.db(type(of: self).testDatabase)
+            let db1 = client.db(type(of: self).testDatabase)
             expect(db1.readConcern).to(beNil())
 
             // expect that a DB created from this client can override the client's unset RC
-            let db2 = try client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
+            let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
             expect(db2.readConcern?.level).to(equal("majority"))
         }
 
@@ -101,11 +101,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern?.level).to(equal("local"))
 
             // expect that a DB created from this client inherits its local RC 
-            let db1 = try client.db(type(of: self).testDatabase)
+            let db1 = client.db(type(of: self).testDatabase)
             expect(db1.readConcern?.level).to(equal("local"))
 
             // expect that a DB created from this client can override the client's local RC
-            let db2 = try client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
+            let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
             expect(db2.readConcern?.level).to(equal("majority"))
         }
 
@@ -115,7 +115,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client.readConcern?.level).to(equal("majority"))
 
             // expect that a DB created from this client can override the client's majority RC with an unset one
-            let db = try client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: ReadConcern()))
+            let db = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: ReadConcern()))
             expect(db.readConcern).to(beNil())
         }
     }
@@ -132,11 +132,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client1.writeConcern).to(beNil())
 
             // expect that a DB created from this client inherits its default WC
-            let db1 = try client1.db(type(of: self).testDatabase)
+            let db1 = client1.db(type(of: self).testDatabase)
             expect(db1.writeConcern).to(beNil())
 
             // expect that a DB created from this client can override the client's default WC
-            let db2 = try client1.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc2))
+            let db2 = client1.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc2))
             expect(db2.writeConcern?.w).to(equal(w2))
         }
 
@@ -147,11 +147,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client2.writeConcern?.w).to(equal(w1))
 
             // expect that a DB created from this client inherits its WC
-            let db3 = try client2.db(type(of: self).testDatabase)
+            let db3 = client2.db(type(of: self).testDatabase)
             expect(db3.writeConcern?.w).to(equal(w1))
 
             // expect that a DB created from this client can override the client's WC
-            let db4 = try client2.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc2))
+            let db4 = client2.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc2))
             expect(db4.writeConcern?.w).to(equal(w2))
         }
 
@@ -161,7 +161,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             expect(client3.writeConcern?.w).to(equal(w2))
 
             // expect that a DB created from this client can override the client's WC with an unset one
-            let db5 = try client3.db(
+            let db5 = client3.db(
                     type(of: self).testDatabase,
                     options: DatabaseOptions(writeConcern: WriteConcern()))
             expect(db5.writeConcern).to(beNil())
@@ -171,7 +171,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testDatabaseReadConcern() throws {
         let client = try MongoClient()
 
-        let db1 = try client.db(type(of: self).testDatabase)
+        let db1 = client.db(type(of: self).testDatabase)
         defer { try? db1.drop() }
 
         let coll1Name = self.getCollectionName(suffix: "1")
@@ -180,11 +180,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         expect(coll1.readConcern).to(beNil())
 
         // expect that a collection retrieved from a DB with unset RC also has unset RC
-        coll1 = try db1.collection(coll1Name)
+        coll1 = db1.collection(coll1Name)
         expect(coll1.readConcern).to(beNil())
 
         // expect that a collection retrieved from a DB with unset RC can override the DB's RC
-        var coll2 = try db1.collection(
+        var coll2 = db1.collection(
                 self.getCollectionName(suffix: "2"),
                 options: CollectionOptions(readConcern: ReadConcern(.local))
         )
@@ -192,7 +192,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         try db1.drop()
 
-        let db2 = try client.db(
+        let db2 = client.db(
                 type(of: self).testDatabase,
                 options: DatabaseOptions(readConcern: ReadConcern(.local)))
         defer { try? db2.drop() }
@@ -203,11 +203,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         expect(coll3.readConcern?.level).to(equal("local"))
 
         // expect that a collection retrieved from a DB with local RC also has local RC
-        coll3 = try db2.collection(coll3Name)
+        coll3 = db2.collection(coll3Name)
         expect(coll3.readConcern?.level).to(equal("local"))
 
         // expect that a collection retrieved from a DB with local RC can override the DB's RC
-        let coll4 = try db2.collection(
+        let coll4 = db2.collection(
                 self.getCollectionName(suffix: "4"),
                 options: CollectionOptions(readConcern: ReadConcern(.majority))
         )
@@ -217,7 +217,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testDatabaseWriteConcern() throws {
         let client = try MongoClient()
 
-        let db1 = try client.db(type(of: self).testDatabase)
+        let db1 = client.db(type(of: self).testDatabase)
         defer { try? db1.drop() }
 
         // expect that a collection created from a DB with default WC also has default WC
@@ -225,14 +225,14 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         expect(coll1.writeConcern).to(beNil())
 
         // expect that a collection retrieved from a DB with default WC also has default WC
-        coll1 = try db1.collection(coll1.name)
+        coll1 = db1.collection(coll1.name)
         expect(coll1.writeConcern).to(beNil())
 
         let wc1 = try WriteConcern(w: .number(1))
         let wc2 = try WriteConcern(w: .number(2))
 
         // expect that a collection retrieved from a DB with default WC can override the DB's WC
-        var coll2 = try db1.collection(
+        var coll2 = db1.collection(
                 self.getCollectionName(suffix: "2"),
                 options: CollectionOptions(writeConcern: wc1)
         )
@@ -240,7 +240,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         try db1.drop()
 
-        let db2 = try client.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc1))
+        let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc1))
         defer { try? db2.drop() }
 
         // expect that a collection created from a DB with w:1 also has w:1
@@ -248,11 +248,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         expect(coll3.writeConcern?.w).to(equal(wc1.w))
 
         // expect that a collection retrieved from a DB with w:1 also has w:1
-        coll3 = try db2.collection(coll3.name)
+        coll3 = db2.collection(coll3.name)
         expect(coll3.writeConcern?.w).to(equal(wc1.w))
 
         // expect that a collection retrieved from a DB with w:1 can override the DB's WC
-        let coll4 = try db2.collection(
+        let coll4 = db2.collection(
                 self.getCollectionName(suffix: "4"),
                 options: CollectionOptions(writeConcern: wc2))
         expect(coll4.writeConcern?.w).to(equal(wc2.w))
@@ -261,7 +261,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testOperationReadConcerns() throws {
         // setup a collection 
         let client = try MongoClient()
-        let db = try client.db(type(of: self).testDatabase)
+        let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
         let coll = try db.createCollection(self.getCollectionName())
 
@@ -295,7 +295,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
     func testOperationWriteConcerns() throws {
         let client = try MongoClient()
-        let db = try client.db(type(of: self).testDatabase)
+        let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
 
         var counter = 0

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -54,7 +54,7 @@ final class SDAMTests: MongoSwiftTestCase {
             receivedEvents.append(event)
         }
         // do some basic operations
-        let db = try client.db(type(of: self).testDatabase)
+        let db = client.db(type(of: self).testDatabase)
         _ = try db.createCollection(self.getCollectionName())
         try db.drop()
 


### PR DESCRIPTION
[SWIFT-301](https://jira.mongodb.org/browse/SWIFT-301) / [SWIFT-302 ](https://jira.mongodb.org/browse/SWIFT-302)/ [SWIFT-303](https://jira.mongodb.org/browse/SWIFT-303) / [SWIFT-305](https://jira.mongodb.org/browse/SWIFT-305)

In this PR:

- `.invalidCollection`, `.invalidClient`, `.invalidUri`, and `.invalidResponse` updated to `.internalErrors` or `.fatalErrors` as necessary (SWIFT-301).
    - Most notable change: `MongoDatabase.collection`, `MongoClient.database` no longer throw. They simply `fatalError` when something goes wrong (which it should never).
- `.invalidCursor` converted to new errors as necessary (SWIFT-302)
    - The most notable change here involves making the initializer of `Cursor` throw. This way users will be notified of `.invalidArgumentErrors` when creating the cursor (through a command) instead of checking the error after creation.
    - Errors at creation are `.invalidArgumentError`, server errors are `.commandError`, and iterating a dead cursor yields a `.logicError`.
- `.bsonParseError` changed to `.invalidArgumentError` or `.internalError` (SWIFT-303)
- `.readPreferenceError` changed to `.invalidArgumentError` (SWIFT-305)