### PR TITLE
SWIFT-304 Convert bsonEncodeError, bsonDecodeError, typeError to new error types

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -359,7 +359,7 @@ extension _BSONDecoder {
             return Date(timeIntervalSince1970: seconds)
         case .iso8601:
             guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
-                throw MongoError.bsonDecodeError(message: "ISO8601DateFormatter is unavailable on this platform.")
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
             }
             let isoString = try self.unbox(value, as: String.self)
             guard let date = BSONDecoder.iso8601Formatter.date(from: isoString) else {

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -400,11 +400,10 @@ extension _BSONEncoder {
         case .formatted(let formatter):
             return formatter.string(from: date)
         case .iso8601:
-            if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                return BSONDecoder.iso8601Formatter.string(from: date)
-            } else {
-                throw MongoError.bsonEncodeError(message: "ISO8601DateFormatter is unavailable on this platform.")
+            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
             }
+            return BSONDecoder.iso8601Formatter.string(from: date)
         case .custom(let f):
             return try handleCustomStrategy(encodeFunc: f, forValue: date)
         }

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -19,7 +19,7 @@ extension Int: Overwritable {
             return int64.writeToCurrentPosition(of: iter)
         }
 
-        throw MongoError.bsonEncodeError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
+        throw RuntimeError.internalError(message: "`Int` value \(self) could not be encoded as `Int32` or `Int64`")
     }
 }
 

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -343,7 +343,12 @@ internal func toErrorString(_ error: bson_error_t) -> String {
     }
 }
 
-internal func bsonEncodeError(value: BSONValue, forKey: String) -> MongoError {
-    return MongoError.bsonEncodeError(message:
-        "Failed to set value for key \(forKey) to \(value) with BSON type \(value.bsonType)")
+internal func bsonTooLargeError(value: BSONValue, forKey: String) -> MongoSwiftError {
+    return RuntimeError.internalError(message:
+        "Failed to set value for key \(forKey) to \(value) with BSON type \(value.bsonType): document too large")
+}
+
+internal func wrongIterTypeError(_ iter: DocumentIterator, expected type: BSONValue.Type) -> MongoSwiftError {
+    return UserError.logicError(message: "Tried to retreive a \(type) from an iterator whose next type " +
+            "is \(iter.currentType) for key \(iter.currentKey)")
 }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -692,9 +692,7 @@ final class DocumentTests: MongoSwiftTestCase {
     }
 
     func testUUIDEncodingStrategies() throws {
-        guard let uuid = UUID(uuidString: "26cd7610-fd5a-4253-94b7-e8c4ea97b6cb") else {
-            throw MongoError.bsonEncodeError(message: "Couldn't create UUID.")
-        }
+        let uuid = UUID(uuidString: "26cd7610-fd5a-4253-94b7-e8c4ea97b6cb")!
 
         let binary = try Binary(from: uuid)
         let uuidStruct = UUIDWrapper(uuid: uuid)
@@ -714,9 +712,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
     func testUUIDDecodingStrategies() throws {
         // randomly generated uuid
-        guard let uuid = UUID(uuidString: "2c380a6c-7bc5-48cb-84a2-b26777a72276") else {
-            throw MongoError.bsonDecodeError(message: "Cant create UUID.")
-        }
+        let uuid = UUID(uuidString: "2c380a6c-7bc5-48cb-84a2-b26777a72276")!
 
         let decoder = BSONDecoder()
 


### PR DESCRIPTION
[SWIFT-304](https://jira.mongodb.org/browse/SWIFT-304)

This PR replaces `bsonEncodeError`, `bsonDecodeError`, and `typeError` with the new error types. 

The `bsonEncodeErrors` which derived from a document growing too large after being appended to were replaced with `.internalErrors`. In general, I don't like using / documenting `.internalErrors` and would prefer to reserve them for unexpected errors. I think they fit this use-case decently well, but I would not be opposed to considering the addition of one more `RuntimeError`, namely `RuntimeError.documentTooLargeError` or `RuntimeError.documentSizeError` (to account for when the document is too small as well). What do you guys think? Would this be too specific?

`bsonDecodeErrors` generally resulted from iterator methods trying to retrieve types that weren't currently on the iterator. I've replaced these with `logicErrors`, and I believe it fits nicely. I also added new error cases for this to all the `from(DocumentIterator)` methods that come with `BSONValue` conformance.
