### PR TITLE
SWIFT-307 Audit invalid argument errors

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -201,7 +201,7 @@ public struct Binary: BSONValue, Equatable, Codable {
     /// Throws an error if the provided data is incompatible with the specified subtype.
     public init(data: Data, subtype: UInt8) throws {
         if [Subtype.uuid.rawValue, Subtype.uuidDeprecated.rawValue].contains(subtype) && data.count != 16 {
-            throw MongoError.invalidArgument(message:
+            throw UserError.invalidArgumentError(message:
                 "Binary data with UUID subtype must be 16 bytes, but data has \(data.count) bytes")
         }
         self.subtype = subtype
@@ -219,7 +219,7 @@ public struct Binary: BSONValue, Equatable, Codable {
     /// incompatible with the specified subtype.
     public init(base64: String, subtype: UInt8) throws {
         guard let dataObj = Data(base64Encoded: base64) else {
-            throw MongoError.invalidArgument(message:
+            throw UserError.invalidArgumentError(message:
                 "failed to create Data object from invalid base64 string \(base64)")
         }
         try self.init(data: dataObj, subtype: subtype)
@@ -669,7 +669,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     internal static func toLibBSONType(_ str: String) throws -> bson_oid_t {
         var value = bson_oid_t()
         if !bson_oid_is_valid(str, str.count) {
-            throw MongoError.invalidArgument(message: "ObjectId string is invalid")
+            throw UserError.invalidArgumentError(message: "ObjectId string is invalid")
         }
         bson_oid_init_from_string(&value, str)
         return value

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -184,6 +184,8 @@ public struct Binary: BSONValue, Equatable, Codable {
     }
 
     /// Initializes a `Binary` instance from a `UUID`.
+    /// - Throws:
+    ///   - `UserError.invalidArgumentError` if a `Binary` cannot be constructed from this UUID.
     public init(from uuid: UUID) throws {
         let uuidt = uuid.uuid
 
@@ -198,7 +200,8 @@ public struct Binary: BSONValue, Equatable, Codable {
     }
 
     /// Initializes a `Binary` instance from a `Data` object and a `UInt8` subtype.
-    /// Throws an error if the provided data is incompatible with the specified subtype.
+    /// - Throws:
+    ///   - `UserError.invalidArgumentError` if the provided data is incompatible with the specified subtype.
     public init(data: Data, subtype: UInt8) throws {
         if [Subtype.uuid.rawValue, Subtype.uuidDeprecated.rawValue].contains(subtype) && data.count != 16 {
             throw UserError.invalidArgumentError(message:
@@ -209,14 +212,16 @@ public struct Binary: BSONValue, Equatable, Codable {
     }
 
     /// Initializes a `Binary` instance from a `Data` object and a `Subtype`.
-    /// Throws an error if the provided data is incompatible with the specified subtype.
+    /// - Throws:
+    ///   - `UserError.invalidArgumentError` if the provided data is incompatible with the specified subtype.
     public init(data: Data, subtype: Subtype) throws {
         try self.init(data: data, subtype: subtype.rawValue)
     }
 
     /// Initializes a `Binary` instance from a base64 `String` and a `UInt8` subtype.
-    /// Throws an error if the base64 `String` is invalid or if the provided data is
-    /// incompatible with the specified subtype.
+    /// - Throws:
+    ///   - `UserError.invalidArgumentError` if the base64 `String` is invalid or if the provided data is
+    ///     incompatible with the specified subtype.
     public init(base64: String, subtype: UInt8) throws {
         guard let dataObj = Data(base64Encoded: base64) else {
             throw UserError.invalidArgumentError(message:
@@ -226,8 +231,9 @@ public struct Binary: BSONValue, Equatable, Codable {
     }
 
     /// Initializes a `Binary` instance from a base64 `String` and a `Subtype`.
-    /// Throws an error if the base64 `String` is invalid or if the provided data is
-    /// incompatible with the specified subtype.
+    /// - Throws:
+    ///   - `UserError.invalidArgumentError` if the base64 `String` is invalid or if the provided data is
+    ///     incompatible with the specified subtype.
     public init(base64: String, subtype: Subtype) throws {
         try self.init(base64: base64, subtype: subtype.rawValue)
     }
@@ -386,10 +392,12 @@ public struct Decimal128: BSONValue, Equatable, Codable {
 
     /// Returns the provided string as a `bson_decimal128_t`, or throws an error if initialization fails due an
     /// invalid string.
+    /// - Throws:
+    ///   - `UserError.invalidArgumentError` if the parameter string does not correspond to a valid `Decimal128`.
     internal static func toLibBSONType(_ str: String) throws -> bson_decimal128_t {
         var value = bson_decimal128_t()
         guard bson_decimal128_from_string(str, &value) else {
-            throw RuntimeError.internalError(message: "Invalid Decimal128 string \(str)")
+            throw UserError.invalidArgumentError(message: "Invalid Decimal128 string \(str)")
         }
         return value
     }
@@ -666,6 +674,8 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     }
 
     /// Returns the provided string as a `bson_oid_t`.
+    /// - Throws:
+    ///   - `UserError.invalidArgumentError` if the parameter string does not correspond to a valid `ObjectId`.
     internal static func toLibBSONType(_ str: String) throws -> bson_oid_t {
         var value = bson_oid_t()
         if !bson_oid_is_valid(str, str.count) {
@@ -703,6 +713,9 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 /// Extension to allow a `UUID` to be initialized from a `Binary` `BSONValue`.
 extension UUID {
     /// Initializes a `UUID` instance from a `Binary` `BSONValue`.
+    /// - Throws:
+    ///   - `UserError.logicError` if a deprecated UUID subtype is set on the `Binary`.
+    ///   - `UserError.invalidArgumentError` if a non-UUID subtype is set on the `Binary`.
     public init(from binary: Binary) throws {
         guard binary.subtype != Binary.Subtype.uuidDeprecated.rawValue else {
             throw UserError.logicError(message: "Binary subtype \(binary.subtype) is deprecated, " +

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -260,7 +260,7 @@ public class DocumentIterator: IteratorProtocol {
             return try DBPointer.asDocument(from: self)
         default:
             guard let curVal = try DocumentIterator.bsonTypeMap[currentType]?.from(iterator: self) else {
-                throw MongoError.invalidArgument(message: "Unknown BSONType for iterator's current value.")
+                throw RuntimeError.internalError(message: "Unknown BSONType for iterator's current value.")
             }
 
             return curVal

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -57,7 +57,6 @@ public class MongoCollection<T: Codable> {
     /// Drops this collection from its parent database.
     /// - Throws:
     ///   - `ServerError.commandError` if an error occurs that prevents the command from executing.
-    ///   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
     public func drop() throws {
         var error = bson_error_t()
         guard mongoc_collection_drop(self._collection, &error) else {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -194,7 +194,6 @@ public class MongoDatabase {
     /// Drops this database.
     /// - Throws:
     ///   - `ServerError.commandError` if an error occurs that prevents the command from executing.
-    ///   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
     public func drop() throws {
         var error = bson_error_t()
         guard mongoc_database_drop(self._database, &error) else {

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -106,6 +106,8 @@ public class WriteConcern: Codable {
     }
 
     /// Initializes a new `WriteConcern`.
+    /// - Throws:
+    ///   - `UserError.invalidArgumentError` if the options form an invalid combination.
     public init(journal: Bool? = nil, w: W? = nil, wtimeoutMS: Int32? = nil) throws {
         self._writeConcern = mongoc_write_concern_new()
         if let journal = journal { mongoc_write_concern_set_journal(self._writeConcern, journal) }

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -127,7 +127,7 @@ public class WriteConcern: Codable {
             let journalStr = String(describing: journal)
             let wStr = String(describing: w)
             let timeoutStr = String(describing: wtimeoutMS)
-            throw MongoError.invalidArgument(message:
+            throw UserError.invalidArgumentError(message:
                 "Invalid combination of options: journal=\(journalStr), w=\(wStr), wtimeoutMS=\(timeoutStr)")
         }
     }


### PR DESCRIPTION
[SWIFT-307](https://jira.mongodb.org/browse/SWIFT-307)

This PR updates some old `MongoError` invalid argument errors and converts any `.invalidArgumentErrors` that were thrown in the wrong places.
