### PR TITLE
SWIFT-306 / SWIFT-309: Audit Tests for Errors / Audit Encoder/Decoder Errors

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -716,7 +716,7 @@ extension UUID {
     /// - Throws:
     ///   - `UserError.invalidArgumentError` if a non-UUID subtype is set on the `Binary`.
     public init(from binary: Binary) throws {
-        guard binary.subtype == Binary.Subtype.uuid.rawValue else {
+        guard [Binary.Subtype.uuid.rawValue, Binary.Subtype.uuidDeprecated.rawValue].contains(binary.subtype) else {
             throw UserError.invalidArgumentError(message: "Expected a UUID binary type " +
                     "(\(Binary.Subtype.uuid)), got \(binary.subtype) instead.")
         }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -714,13 +714,8 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 extension UUID {
     /// Initializes a `UUID` instance from a `Binary` `BSONValue`.
     /// - Throws:
-    ///   - `UserError.logicError` if a deprecated UUID subtype is set on the `Binary`.
     ///   - `UserError.invalidArgumentError` if a non-UUID subtype is set on the `Binary`.
     public init(from binary: Binary) throws {
-        guard binary.subtype != Binary.Subtype.uuidDeprecated.rawValue else {
-            throw UserError.logicError(message: "Binary subtype \(binary.subtype) is deprecated, " +
-                    "use \(Binary.Subtype.uuid) instead.")
-        }
         guard binary.subtype == Binary.Subtype.uuid.rawValue else {
             throw UserError.invalidArgumentError(message: "Expected a UUID binary type " +
                     "(\(Binary.Subtype.uuid)), got \(binary.subtype) instead.")

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -26,8 +26,9 @@ final class BSONValueTests: MongoSwiftTestCase {
         let sixteenBytes = Data(base64Encoded: "c//SZESzTGmQ6OfR38A11A==")!
 
         // UUIDs must have 16 bytes
-        expect(try Binary(data: twoBytes, subtype: .uuidDeprecated)).to(throwError())
-        expect(try Binary(data: twoBytes, subtype: .uuid)).to(throwError())
+        expect(try Binary(data: twoBytes, subtype: .uuidDeprecated))
+                .to(throwError(UserError.invalidArgumentError(message: "")))
+        expect(try Binary(data: twoBytes, subtype: .uuid)).to(throwError(UserError.invalidArgumentError(message: "")))
         expect(try Binary(data: sixteenBytes, subtype: .uuidDeprecated)).toNot(throwError())
         expect(try Binary(data: sixteenBytes, subtype: .uuid)).toNot(throwError())
     }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -41,7 +41,7 @@ final class MongoClientTests: MongoSwiftTestCase {
 
     func testFailedClientInitialization() {
         // check that we fail gracefully with an error if passing in an invalid URI
-        expect(try MongoClient(connectionString: "abcd")).to(throwError())
+        expect(try MongoClient(connectionString: "abcd")).to(throwError(UserError.invalidArgumentError(message: "")))
     }
 
     func testServerVersion() throws {

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -10,7 +10,8 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
             ("testUpdates", testUpdates),
             ("testDeletes", testDeletes),
             ("testMixedOrderedOperations", testMixedOrderedOperations),
-            ("testUnacknowledgedWriteConcern", testUnacknowledgedWriteConcern)
+            ("testUnacknowledgedWriteConcern", testUnacknowledgedWriteConcern),
+            ("testBulkWriteErrors", testBulkWriteErrors)
         ]
     }
 
@@ -43,11 +44,12 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
     override func tearDown() {
         do {
             try coll.drop()
+        } catch let ServerError.commandError(code, _, _) {
+            // Only ignore NamespaceNotFound errors.
+            expect(code).to(equal(26))
         } catch {
-            /* TODO: Only ignore "ns not found" error once we can differentiate
-             * MongoError.commandError by error code. */
+            fail("encountered error when tearing down: \(error)")
         }
-
         super.tearDown()
     }
 

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -198,7 +198,10 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         expect(cursor.next()).to(equal(["_id": 2, "x": 24]))
         expect(cursor.next()).to(equal(["_id": 3, "x": 34]))
         expect(cursor.next()).to(equal(["_id": 4, "x": 44]))
-        expect(cursor.next()).to(beNil())
+        expect(cursor.next()).to(beNil()) // cursor ends
+        expect(cursor.error).to(beNil())
+        expect(cursor.next()).to(beNil()) // iterate after cursor ends
+        expect(cursor.error as? UserError).to(equal(UserError.logicError(message: "")))
     }
 
     func testUnacknowledgedWriteConcern() throws {

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -44,9 +44,8 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
     override func tearDown() {
         do {
             try coll.drop()
-        } catch let ServerError.commandError(code, _, _) {
-            // Only ignore NamespaceNotFound errors.
-            expect(code).to(equal(26))
+        } catch let ServerError.commandError(code, _, _) where code == 26 {
+            // ignore ns not found errors
         } catch {
             fail("encountered error when tearing down: \(error)")
         }

--- a/Tests/MongoSwiftTests/MongoError+Equatable.swift
+++ b/Tests/MongoSwiftTests/MongoError+Equatable.swift
@@ -100,3 +100,17 @@ private func sortAndCompareOptionalArrays<T: Equatable>(lhs: [T]?, rhs: [T]?, cm
     }
     return lhsArr.sorted(by: cmp) == rhsArr.sorted(by: cmp)
 }
+
+extension DecodingError: Equatable {
+    public static func == (lhs: DecodingError, rhs: DecodingError) -> Bool {
+        switch (lhs, rhs) {
+        case (.typeMismatch, .typeMismatch),
+             (.dataCorrupted, .dataCorrupted),
+             (.keyNotFound, .keyNotFound),
+             (.valueNotFound, .valueNotFound):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/MongoSwiftTests/ReadPreferenceTests.swift
+++ b/Tests/MongoSwiftTests/ReadPreferenceTests.swift
@@ -45,8 +45,9 @@ final class ReadPreferenceTests: MongoSwiftTestCase {
         expect(rpOnlyEmptyTagSet.tagSets).to(equal([[]]))
 
         // Non-empty tag sets cannot be combined with primary mode
-        expect(try ReadPreference(.primary, tagSets: [["dc": "east"], []])).to(throwError())
-        expect(try ReadPreference(.primary, tagSets: [[]])).to(throwError())
+        expect(try ReadPreference(.primary, tagSets: [["dc": "east"], []]))
+                .to(throwError(UserError.invalidArgumentError(message: "")))
+        expect(try ReadPreference(.primary, tagSets: [[]])).to(throwError(UserError.invalidArgumentError(message: "")))
     }
 
     func testMaxStalenessSeconds() throws {
@@ -60,9 +61,12 @@ final class ReadPreferenceTests: MongoSwiftTestCase {
         expect(rpLargeMaxStaleness.maxStalenessSeconds).to(equal(2147483647))
 
         // maxStalenessSeconds cannot be less than 90
-        expect(try ReadPreference(.nearest, maxStalenessSeconds: -1)).to(throwError())
-        expect(try ReadPreference(.nearest, maxStalenessSeconds: 0)).to(throwError())
-        expect(try ReadPreference(.nearest, maxStalenessSeconds: 89)).to(throwError())
+        expect(try ReadPreference(.nearest, maxStalenessSeconds: -1))
+                .to(throwError(UserError.invalidArgumentError(message: "")))
+        expect(try ReadPreference(.nearest, maxStalenessSeconds: 0))
+                .to(throwError(UserError.invalidArgumentError(message: "")))
+        expect(try ReadPreference(.nearest, maxStalenessSeconds: 89))
+                .to(throwError(UserError.invalidArgumentError(message: "")))
     }
 
     func testInitFromPointer() {

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -73,7 +73,8 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         expect(try WriteConcern(w: .majority)).toNot(throwError())
 
         // verify that this combination is considered invalid
-        expect(try WriteConcern(journal: true, w: .number(0))).to(throwError())
+        expect(try WriteConcern(journal: true, w: .number(0)))
+                .to(throwError(UserError.invalidArgumentError(message: "")))
     }
 
     func testClientReadConcern() throws {
@@ -403,7 +404,8 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
                         }
                     }
                 } else {
-                    expect(try MongoClient(connectionString: uri)).to(throwError())
+                    expect(try MongoClient(connectionString: uri))
+                            .to(throwError(UserError.invalidArgumentError(message: "")))
                 }
             }
         }
@@ -451,7 +453,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
                             expect(try encoder.encode(wc)).to(equal(expected))
                         }
                     } else {
-                        expect(try WriteConcern(wcToUse)).to(throwError())
+                        expect(try WriteConcern(wcToUse)).to(throwError(UserError.invalidArgumentError(message: "")))
                     }
                 }
             }


### PR DESCRIPTION
[SWIFT-306](https://jira.mongodb.org/browse/SWIFT-306) / [SWIFT-309](https://jira.mongodb.org/browse/SWIFT-306)

This PR updates any tests that expect an error to explicitly match against the error they expect. As part of that, I discovered a couple of inconsistencies in how the `BSONDecoder` emits errors and have included fixes for that here.