### PR TITLE
SWIFT-310 Remove old errors

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -113,8 +113,8 @@ public struct CommandFailedEvent: MongoEvent, InitializableFromOpaquePointer {
     /// The command name.
     public let commandName: String
 
-    /// The failure, represented as a MongoSwiftError.
-    public let failure: MongoSwiftError
+    /// The failure, represented as a MongoError.
+    public let failure: MongoError
 
     /// The client generated request id.
     public let requestId: Int64
@@ -337,7 +337,7 @@ public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePoi
     public let duration: Int64
 
     /// The failure.
-    public let failure: MongoSwiftError
+    public let failure: MongoError
 
     /// The connection ID (host/port pair) of the server.
     public let connectionId: ConnectionId

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -189,8 +189,9 @@ extension Document {
      *      - key: The key under which the value you are looking up is stored
      *      - `T`: Any type conforming to the `BSONValue` protocol
      *  - Returns: The value stored under key, as type `T`
-     *  - Throws: A `MongoError.typeError` if the value cannot be cast to type `T` or is not in the `Document`, or a
-     *            `MongoError.bsonDecodeError` if there is an issue decoding the `BSONValue`.
+     *  - Throws:
+     *    - `RuntimeError.internalError` if the value cannot be cast to type `T` or is not in the `Document`, or an
+     *      unexpected error occurs while decoding the `BSONValue`.
      *
      */
     internal func get<T: BSONValue>(_ key: String) throws -> T {

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -18,7 +18,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
             // Errors in creation of the cursor are limited to invalid argument errors, but some errors are reported
             // by libmongoc as invalid cursor errors. These would be parsed to .logicErrors, so we need to rethrow them
             // as the correct case.
-            if let mongoSwiftErr = err as? MongoSwiftError {
+            if let mongoSwiftErr = err as? MongoError {
                 throw UserError.invalidArgumentError(message: mongoSwiftErr.errorDescription ?? "")
             }
 

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -278,60 +278,6 @@ private func getBulkWriteErrorFromReply(
     )
 }
 
-/// The possible errors that can occur when using this package.
-public enum MongoError {
-    /// Thrown when an invalid connection string is provided when initializing a `MongoClient`.
-    case invalidUri(message: String)
-    /// Thrown when a `MongoClient` is invalid.
-    case invalidClient()
-    /// Thrown when the server sends an invalid response.
-    case invalidResponse()
-    /// Thrown when a `MongoCursor` is invalid.
-    case invalidCursor(message: String)
-    /// Thrown when a `MongoCollection` is invalid.
-    case invalidCollection(message: String)
-    /// Thrown when there is an error executing a command.
-    case commandError(message: String)
-    /// Thrown when there is an error parsing raw BSON `Data`.
-    case bsonParseError(domain: UInt32, code: UInt32, message: String)
-    /// Thrown when there is an error encoding a `BSONValue` to a `Document`.
-    case bsonEncodeError(message: String)
-    /// Thrown when there is an error decoding a `BSONValue` from a `Document`.
-    case bsonDecodeError(message: String)
-    /// Thrown when the value stored under a key in a `Document` does not match the expected type.
-    case typeError(message: String)
-    /// Thrown when there is an error involving a `ReadConcern`.
-    case readConcernError(message: String)
-    /// Thrown when there is an error involving a `ReadPreference`.
-    case readPreferenceError(message: String)
-    /// Thrown when a user-provided argument is invalid.
-    case invalidArgument(message: String)
-    /// Thrown when there is an error executing a multi-document insert operation.
-    case insertManyError(code: UInt32, message: String, result: InsertManyResult?, writeErrors: [WriteError],
-        writeConcernError: WriteConcernError?)
-    /// Thrown when there is an error executing a bulk write operation.
-    case bulkWriteError(code: UInt32, message: String, result: BulkWriteResult?, writeErrors: [BulkWriteError],
-        writeConcernError: WriteConcernError?)
-}
-
-/// An extension of `MongoError` to support printing out descriptive error messages.
-extension MongoError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case let .invalidUri(message), let .invalidCursor(message),
-            let .invalidCollection(message), let .commandError(message),
-            let .bsonParseError(_, _, message), let .bsonEncodeError(message),
-            let .typeError(message), let .readConcernError(message),
-            let .readPreferenceError(message), let .invalidArgument(message):
-            return message
-        case let .bulkWriteError(code, message, _, _, _):
-            return "\(message) (error code \(code))"
-        default:
-            return nil
-        }
-    }
-}
-
 internal func toErrorString(_ error: bson_error_t) -> String {
     var e = error
     return withUnsafeBytes(of: &e.message) { rawPtr -> String in

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -65,7 +65,7 @@ public struct ServerDescription {
     public let connectionId: ConnectionId
 
     /// The last error related to this server.
-    public let error: MongoSwiftError? = nil // currently we will never set this
+    public let error: MongoError? = nil // currently we will never set this
 
     /// The duration of the server's last ismaster call.
     public var roundTripTime: Int64?
@@ -222,7 +222,7 @@ public struct TopologyDescription {
     public let stale: Bool = false // currently, this will never be set
 
     /// Exists if any server's wire protocol version range is incompatible with the client's.
-    public let compatibilityError: MongoSwiftError? = nil // currently, this will never be set
+    public let compatibilityError: MongoError? = nil // currently, this will never be set
 
     /// The logicalSessionTimeoutMinutes value for this topology. This value is the minimum
     /// of the `logicalSessionTimeoutMinutes` values across all the servers in `servers`,

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -65,7 +65,7 @@ public struct ServerDescription {
     public let connectionId: ConnectionId
 
     /// The last error related to this server.
-    public let error: MongoError? = nil // currently we will never set this
+    public let error: MongoSwiftError? = nil // currently we will never set this
 
     /// The duration of the server's last ismaster call.
     public var roundTripTime: Int64?
@@ -222,7 +222,7 @@ public struct TopologyDescription {
     public let stale: Bool = false // currently, this will never be set
 
     /// Exists if any server's wire protocol version range is incompatible with the client's.
-    public let compatibilityError: MongoError? = nil // currently, this will never be set
+    public let compatibilityError: MongoSwiftError? = nil // currently, this will never be set
 
     /// The logicalSessionTimeoutMinutes value for this topology. This value is the minimum
     /// of the `logicalSessionTimeoutMinutes` values across all the servers in `servers`,


### PR DESCRIPTION
[SWIFT-310](https://jira.mongodb.org/browse/SWIFT-310)

This pr removes the old errors and any references to them, and refactors the new `MongoSwiftError` protocol to be `MongoError`. 