### PR TITLE
SWIFT-337 Support setting of encoding/decoding strategies on client, database, and collection levels

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -113,7 +113,8 @@ public class BSONDecoder {
         self.configureWithOptions(options: options)
     }
 
-    /// Initializes `self` by copying the options of another `BSONDecoder`.
+    /// Initializes `self` by using the options of another `BSONDecoder` and the provided options, with preference
+    /// going to the provided options in the case of conflicts.
     internal init(copies other: BSONDecoder, options: CodingStrategyProvider?) {
         self.userInfo = other.userInfo
         self.dateDecodingStrategy = other.dateDecodingStrategy

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -109,12 +109,12 @@ public class BSONDecoder {
     }
 
     /// Initializes `self`.
-    public init(options: CodingStrategyOptions? = nil) {
+    public init(options: CodingStrategyProvider? = nil) {
         self.configureWithOptions(options: options)
     }
 
     /// Initializes `self` by copying the options of another `BSONDecoder`.
-    internal init(copies other: BSONDecoder, options: CodingStrategyOptions?) {
+    internal init(copies other: BSONDecoder, options: CodingStrategyProvider?) {
         self.userInfo = other.userInfo
         self.dateDecodingStrategy = other.dateDecodingStrategy
         self.uuidDecodingStrategy = other.uuidDecodingStrategy
@@ -122,7 +122,7 @@ public class BSONDecoder {
         self.configureWithOptions(options: options)
     }
 
-    internal func configureWithOptions(options: CodingStrategyOptions?) {
+    internal func configureWithOptions(options: CodingStrategyProvider?) {
         self.dateDecodingStrategy = options?.dateCodingStrategy?.rawValue.decoding ?? self.dateDecodingStrategy
         self.uuidDecodingStrategy = options?.uuidCodingStrategy?.rawValue.decoding ?? self.uuidDecodingStrategy
         self.dataDecodingStrategy = options?.dataCodingStrategy?.rawValue.decoding ?? self.dataDecodingStrategy

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -109,14 +109,23 @@ public class BSONDecoder {
     }
 
     /// Initializes `self`.
-    public init() {}
+    public init(options: CodingStrategyOptions? = nil) {
+        self.applyOptions(options: options)
+    }
 
     /// Initializes `self` by copying the options of another `BSONDecoder`.
-    public init(copies other: BSONDecoder) {
+    internal init(copies other: BSONDecoder, options: CodingStrategyOptions?) {
         self.userInfo = other.userInfo
         self.dateDecodingStrategy = other.dateDecodingStrategy
         self.uuidDecodingStrategy = other.uuidDecodingStrategy
         self.dataDecodingStrategy = other.dataDecodingStrategy
+        self.applyOptions(options: options)
+    }
+
+    internal func applyOptions(options: CodingStrategyOptions?) {
+        self.dateDecodingStrategy = options?.dateCodingStrategy?.rawValue.decoding ?? self.dateDecodingStrategy
+        self.uuidDecodingStrategy = options?.uuidCodingStrategy?.rawValue.decoding ?? self.uuidDecodingStrategy
+        self.dataDecodingStrategy = options?.dataCodingStrategy?.rawValue.decoding ?? self.dataDecodingStrategy
     }
 
     /**

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -111,6 +111,14 @@ public class BSONDecoder {
     /// Initializes `self`.
     public init() {}
 
+    /// Initializes `self` by copying the options of another `BSONDecoder`.
+    public init(copies other: BSONDecoder) {
+        self.userInfo = other.userInfo
+        self.dateDecodingStrategy = other.dateDecodingStrategy
+        self.uuidDecodingStrategy = other.uuidDecodingStrategy
+        self.dataDecodingStrategy = other.dataDecodingStrategy
+    }
+
     /**
      * Decodes a top-level value of the given type from the given BSON document.
      *

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -110,7 +110,7 @@ public class BSONDecoder {
 
     /// Initializes `self`.
     public init(options: CodingStrategyOptions? = nil) {
-        self.applyOptions(options: options)
+        self.configureWithOptions(options: options)
     }
 
     /// Initializes `self` by copying the options of another `BSONDecoder`.
@@ -119,10 +119,10 @@ public class BSONDecoder {
         self.dateDecodingStrategy = other.dateDecodingStrategy
         self.uuidDecodingStrategy = other.uuidDecodingStrategy
         self.dataDecodingStrategy = other.dataDecodingStrategy
-        self.applyOptions(options: options)
+        self.configureWithOptions(options: options)
     }
 
-    internal func applyOptions(options: CodingStrategyOptions?) {
+    internal func configureWithOptions(options: CodingStrategyOptions?) {
         self.dateDecodingStrategy = options?.dateCodingStrategy?.rawValue.decoding ?? self.dateDecodingStrategy
         self.uuidDecodingStrategy = options?.uuidCodingStrategy?.rawValue.decoding ?? self.uuidDecodingStrategy
         self.dataDecodingStrategy = options?.dataCodingStrategy?.rawValue.decoding ?? self.dataDecodingStrategy

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -1,192 +1,6 @@
 import Foundation
 import mongoc
 
-/**
- * Enum representing the various encoding/decoding strategy pairs for `Date`s.
- * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
- * interacting with the database.
- *
- * As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
- *
- * - SeeAlso: bsonspec.org
- */
-public enum DateCodingStrategy: RawRepresentable {
-    public typealias RawValue = (BSONEncoder.DateEncodingStrategy, BSONDecoder.DateDecodingStrategy)
-
-    /// Encode/decode the `Date` by deferring to its default encoding/decoding implementations.
-    case deferredToDate
-
-    /// Encode/decode the `Date` to/from a BSON datetime object (default).
-    case bsonDateTime
-
-    /// Encode/decode the `Date` to/from a 64-bit integer counting the number of milliseconds since January 1, 1970.
-    case millisecondsSince1970
-
-    /// Encode/decode the `Date` to/from a BSON double counting the number of seconds since January 1, 1970.
-    case secondsSince1970
-
-    /// Encode/decode the `Date` to/from an ISO-8601-formatted string (in RFC 339 format).
-    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-    case iso8601
-
-    /// Encode/decode the `Date` to/from a string formatted by the given formatter.
-    case formatted(DateFormatter)
-
-    /// Encode the `Date` by using the given `encodeFunc`. Decode the `Date` by using the given `decodeFunc`.
-    /// If `encodeFunc` does not encode a value, an empty document will be encoded in its place.
-    case custom(encodeFunc: (Date, Encoder) throws -> Void, decodeFunc: (Decoder) throws -> Date)
-
-    public init?(rawValue: RawValue) {
-        switch rawValue {
-        case (.deferredToDate, .deferredToDate):
-            self = .deferredToDate
-        case (.bsonDateTime, .bsonDateTime):
-            self = .bsonDateTime
-        case (.millisecondsSince1970, .millisecondsSince1970):
-            self = .millisecondsSince1970
-        case (.secondsSince1970, .secondsSince1970):
-            self = .secondsSince1970
-        case (.iso8601, .iso8601):
-            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
-            }
-            self = .iso8601
-        case let (.formatted(encodingFormatter), .formatted(decodingFormatter)):
-            guard encodingFormatter == decodingFormatter else {
-                return nil
-            }
-            self = .formatted(encodingFormatter)
-        case let (.custom(encodeFunc), .custom(decodeFunc)):
-            self = .custom(encodeFunc: encodeFunc, decodeFunc: decodeFunc)
-        default:
-            return nil
-        }
-    }
-
-    public var rawValue: RawValue {
-        switch self {
-        case .deferredToDate:
-            return (.deferredToDate, .deferredToDate)
-        case .bsonDateTime:
-            return (.bsonDateTime, .bsonDateTime)
-        case .millisecondsSince1970:
-            return (.millisecondsSince1970, .millisecondsSince1970)
-        case .secondsSince1970:
-            return (.secondsSince1970, .secondsSince1970)
-        case .iso8601:
-            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
-                fatalError("only avail on platforms")
-            }
-            return (.iso8601, .iso8601)
-        case let .formatted(formatter):
-             return (.formatted(formatter), .formatted(formatter))
-        case let .custom(encodeFunc, decodeFunc):
-            return (.custom(encodeFunc), .custom(decodeFunc))
-        }
-    }
-}
-
-/**
- * Enum representing the various encoding/decoding strategy pairs for `UUID`s.
- * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
- * interacting with the database.
- *
- * As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
- * subtype.
- *
- * - SeeAlso: bsonspec.org
- */
-public enum UUIDCodingStrategy: RawRepresentable {
-    public typealias RawValue = (BSONEncoder.UUIDEncodingStrategy, BSONDecoder.UUIDDecodingStrategy)
-
-    /// Encode/decode the `UUID` by deferring to its default encoding/decoding implementations.
-    case deferredToUUID
-
-    /// Encode/decode the `UUID` to/from a BSON binary type (default).
-    case binary
-
-    public init?(rawValue: RawValue) {
-        switch rawValue {
-        case (.deferredToUUID, .deferredToUUID):
-            self = .deferredToUUID
-        case (.binary, .binary):
-            self = .binary
-        default:
-            return nil
-        }
-    }
-
-    public var rawValue: RawValue {
-        switch self {
-        case .deferredToUUID:
-            return (.deferredToUUID, .deferredToUUID)
-        case .binary:
-            return (.binary, .binary)
-        }
-    }
-}
-
-/**
- * Enum representing the various encoding/decoding strategy pairs for `Data`s.
- * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
- * interacting with the database.
- *
- * As per the BSON specification, the default strategy is to encode `Data`s as BSON binary types with the generic
- * binary subtype.
- *
- * - SeeAlso: bsonspec.org
- */
-public enum DataCodingStrategy: RawRepresentable {
-    public typealias RawValue = (BSONEncoder.DataEncodingStrategy, BSONDecoder.DataDecodingStrategy)
-
-    /**
-     * Encode/decode the `Data` by deferring to its default encoding implementations.
-     *
-     * Note: The default encoding implementation attempts to encode the `Data` as a `[UInt8]`, but because BSON
-     * does not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int32]`.
-     * This results in a space inefficient storage of the `Data` (using 4 bytes of BSON storage per byte of data).
-     */
-    case deferredToData
-
-    /// Encode/decode the `Data` to/from a BSON binary type (default).
-    case binary
-
-    /// Encode the `Data` to/from a base64 encoded string.
-    case base64
-
-    /// Encode the `Data` by using the given `encodeFunc`. Decode the `Data` by using the given `decodeFunc`.
-    /// If `encodeFunc` does not encode a value, an empty document will be encoded in its place.
-    case custom(encodeFunc: (Data, Encoder) throws -> Void, decodeFunc: (Decoder) throws -> Data)
-
-    public init?(rawValue: RawValue) {
-        switch rawValue {
-        case (.deferredToData, .deferredToData):
-            self = .deferredToData
-        case (.binary, .binary):
-            self = .binary
-        case (.base64, .base64):
-            self = .base64
-        case let (.custom(encodeFunc), .custom(decodeFunc)):
-            self = .custom(encodeFunc: encodeFunc, decodeFunc: decodeFunc)
-        default:
-            return nil
-        }
-    }
-
-    public var rawValue: RawValue {
-        switch self {
-        case .deferredToData:
-            return (.deferredToData, .deferredToData)
-        case .binary:
-            return (.binary, .binary)
-        case .base64:
-            return (.base64, .base64)
-        case let .custom(encodeFunc, decodeFunc):
-            return (.custom(encodeFunc), .custom(decodeFunc))
-        }
-    }
-}
-
 /// `BSONEncoder` facilitates the encoding of `Encodable` values into BSON.
 public class BSONEncoder {
     /**
@@ -296,14 +110,24 @@ public class BSONEncoder {
     }
 
     /// Initializes `self`.
-    public init() {}
+    public init(options: CodingStrategyOptions? = nil) {
+        self.applyOptions(options: options)
+    }
 
     /// Initializes `self` by copying the options of another `BSONEncoder`.
-    public init(copies other: BSONEncoder) {
+    internal init(copies other: BSONEncoder, options: CodingStrategyOptions?) {
         self.userInfo = other.userInfo
         self.dateEncodingStrategy = other.dateEncodingStrategy
         self.uuidEncodingStrategy = other.uuidEncodingStrategy
         self.dataEncodingStrategy = other.dataEncodingStrategy
+
+        self.applyOptions(options: options)
+    }
+
+    internal func applyOptions(options: CodingStrategyOptions?) {
+        self.dateEncodingStrategy = options?.dateCodingStrategy?.rawValue.encoding ?? self.dateEncodingStrategy
+        self.uuidEncodingStrategy = options?.uuidCodingStrategy?.rawValue.encoding ?? self.uuidEncodingStrategy
+        self.dataEncodingStrategy = options?.dataCodingStrategy?.rawValue.encoding ?? self.dataEncodingStrategy
     }
 
     /**

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -110,12 +110,12 @@ public class BSONEncoder {
     }
 
     /// Initializes `self`.
-    public init(options: CodingStrategyOptions? = nil) {
+    public init(options: CodingStrategyProvider? = nil) {
         self.configureWithOptions(options: options)
     }
 
     /// Initializes `self` by copying the options of another `BSONEncoder`.
-    internal init(copies other: BSONEncoder, options: CodingStrategyOptions?) {
+    internal init(copies other: BSONEncoder, options: CodingStrategyProvider?) {
         self.userInfo = other.userInfo
         self.dateEncodingStrategy = other.dateEncodingStrategy
         self.uuidEncodingStrategy = other.uuidEncodingStrategy
@@ -124,7 +124,7 @@ public class BSONEncoder {
         self.configureWithOptions(options: options)
     }
 
-    internal func configureWithOptions(options: CodingStrategyOptions?) {
+    internal func configureWithOptions(options: CodingStrategyProvider?) {
         self.dateEncodingStrategy = options?.dateCodingStrategy?.rawValue.encoding ?? self.dateEncodingStrategy
         self.uuidEncodingStrategy = options?.uuidCodingStrategy?.rawValue.encoding ?? self.uuidEncodingStrategy
         self.dataEncodingStrategy = options?.dataCodingStrategy?.rawValue.encoding ?? self.dataEncodingStrategy

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -1,6 +1,184 @@
 import Foundation
 import mongoc
 
+/// Enum representing the various encoding/decoding strategy pairs for `Date`s.
+/// Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+/// interacting with the database.
+///
+/// As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
+///
+/// - SeeAlso: bsonspec.org
+public enum DateCodingStrategy: RawRepresentable {
+    public typealias RawValue = (BSONEncoder.DateEncodingStrategy, BSONDecoder.DateDecodingStrategy)
+
+    /// Encode/decode the `Date` by deferring to its default encoding/decoding implementations.
+    case deferredToDate
+
+    /// Encode/decode the `Date` to/from a BSON datetime object (default).
+    case bsonDateTime
+
+    /// Encode/decode the `Date` to/from a 64-bit integer counting the number of milliseconds since January 1, 1970.
+    case millisecondsSince1970
+
+    /// Encode/decode the `Date` to/from a BSON double counting the number of seconds since January 1, 1970.
+    case secondsSince1970
+
+    /// Encode/decode the `Date` to/from an ISO-8601-formatted string (in RFC 339 format).
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    case iso8601
+
+    /// Encode/decode the `Date` to/from a string formatted by the given formatter.
+    case formatted(DateFormatter)
+
+    /// Encode the `Date` by using the given `encodeFunc`. Decode the `Date` by using the given `decodeFunc`.
+    /// If `encodeFunc` does not encode a value, an empty document will be encoded in its place.
+    case custom(encodeFunc: (Date, Encoder) throws -> Void, decodeFunc: (Decoder) throws -> Date)
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case (.deferredToDate, .deferredToDate):
+            self = .deferredToDate
+        case (.bsonDateTime, .bsonDateTime):
+            self = .bsonDateTime
+        case (.millisecondsSince1970, .millisecondsSince1970):
+            self = .millisecondsSince1970
+        case (.secondsSince1970, .secondsSince1970):
+            self = .secondsSince1970
+        case (.iso8601, .iso8601):
+            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
+            }
+            self = .iso8601
+        case let (.formatted(encodingFormatter), .formatted(decodingFormatter)):
+            guard encodingFormatter == decodingFormatter else {
+                return nil
+            }
+            self = .formatted(encodingFormatter)
+        case let (.custom(encodeFunc), .custom(decodeFunc)):
+            self = .custom(encodeFunc: encodeFunc, decodeFunc: decodeFunc)
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+        case .deferredToDate:
+            return (.deferredToDate, .deferredToDate)
+        case .bsonDateTime:
+            return (.bsonDateTime, .bsonDateTime)
+        case .millisecondsSince1970:
+            return (.millisecondsSince1970, .millisecondsSince1970)
+        case .secondsSince1970:
+            return (.secondsSince1970, .secondsSince1970)
+        case .iso8601:
+            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
+                fatalError("only avail on platforms")
+            }
+            return (.iso8601, .iso8601)
+        case let .formatted(formatter):
+             return (.formatted(formatter), .formatted(formatter))
+        case let .custom(encodeFunc, decodeFunc):
+            return (.custom(encodeFunc), .custom(decodeFunc))
+        }
+    }
+}
+
+/// Enum representing the various encoding/decoding strategy pairs for `UUID`s.
+/// Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+/// interacting with the database.
+///
+/// As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
+/// subtype.
+///
+/// - SeeAlso: bsonspec.org
+public enum UUIDCodingStrategy: RawRepresentable {
+    public typealias RawValue = (BSONEncoder.UUIDEncodingStrategy, BSONDecoder.UUIDDecodingStrategy)
+
+    /// Encode/decode the `UUID` by deferring to its default encoding/decoding implementations.
+    case deferredToUUID
+
+    /// Encode/decode the `UUID` to/from a BSON binary type (default).
+    case binary
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case (.deferredToUUID, .deferredToUUID):
+            self = .deferredToUUID
+        case (.binary, .binary):
+            self = .binary
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+        case .deferredToUUID:
+            return (.deferredToUUID, .deferredToUUID)
+        case .binary:
+            return (.binary, .binary)
+        }
+    }
+}
+
+/// Enum representing the various encoding/decoding strategy pairs for `Data`s.
+/// Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+/// interacting with the database.
+///
+/// As per the BSON specification, the default strategy is to encode `Data`s as BSON binary types with the generic
+/// binary subtype.
+///
+/// - SeeAlso: bsonspec.org
+public enum DataCodingStrategy: RawRepresentable {
+    public typealias RawValue = (BSONEncoder.DataEncodingStrategy, BSONDecoder.DataDecodingStrategy)
+
+    /// Encode/decode the `Data` by deferring to its default encoding implementations.
+    ///
+    /// Note: The default encoding implementation attempts to encode the `Data` as a `[UInt8]`, but because BSON
+    /// does not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int32]`.
+    /// This results in a space inefficient storage of the `Data` (using 4 bytes of BSON storage per byte of data).
+    case deferredToData
+
+    /// Encode/decode the `Data` to/from a BSON binary type (default).
+    case binary
+
+    /// Encode the `Data` to/from a base64 encoded string.
+    case base64
+
+    /// Encode the `Data` by using the given `encodeFunc`. Decode the `Data` by using the given `decodeFunc`.
+    /// If `encodeFunc` does not encode a value, an empty document will be encoded in its place.
+    case custom(encodeFunc: (Data, Encoder) throws -> Void, decodeFunc: (Decoder) throws -> Data)
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case (.deferredToData, .deferredToData):
+            self = .deferredToData
+        case (.binary, .binary):
+            self = .binary
+        case (.base64, .base64):
+            self = .base64
+        case let (.custom(encodeFunc), .custom(decodeFunc)):
+            self = .custom(encodeFunc: encodeFunc, decodeFunc: decodeFunc)
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+        case .deferredToData:
+            return (.deferredToData, .deferredToData)
+        case .binary:
+            return (.binary, .binary)
+        case .base64:
+            return (.base64, .base64)
+        case let .custom(encodeFunc, decodeFunc):
+            return (.custom(encodeFunc), .custom(decodeFunc))
+        }
+    }
+}
+
 /// `BSONEncoder` facilitates the encoding of `Encodable` values into BSON.
 public class BSONEncoder {
     /// Enum representing the various strategies for encoding `Date`s.
@@ -103,6 +281,14 @@ public class BSONEncoder {
 
     /// Initializes `self`.
     public init() {}
+
+    /// Initializes `self` by copying the options of another `BSONEncoder`.
+    public init(copies other: BSONEncoder) {
+        self.userInfo = other.userInfo
+        self.dateEncodingStrategy = other.dateEncodingStrategy
+        self.uuidEncodingStrategy = other.uuidEncodingStrategy
+        self.dataEncodingStrategy = other.dataEncodingStrategy
+    }
 
     /**
      * Encodes the given top-level value and returns its BSON representation.

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -111,7 +111,7 @@ public class BSONEncoder {
 
     /// Initializes `self`.
     public init(options: CodingStrategyOptions? = nil) {
-        self.applyOptions(options: options)
+        self.configureWithOptions(options: options)
     }
 
     /// Initializes `self` by copying the options of another `BSONEncoder`.
@@ -121,10 +121,10 @@ public class BSONEncoder {
         self.uuidEncodingStrategy = other.uuidEncodingStrategy
         self.dataEncodingStrategy = other.dataEncodingStrategy
 
-        self.applyOptions(options: options)
+        self.configureWithOptions(options: options)
     }
 
-    internal func applyOptions(options: CodingStrategyOptions?) {
+    internal func configureWithOptions(options: CodingStrategyOptions?) {
         self.dateEncodingStrategy = options?.dateCodingStrategy?.rawValue.encoding ?? self.dateEncodingStrategy
         self.uuidEncodingStrategy = options?.uuidCodingStrategy?.rawValue.encoding ?? self.uuidEncodingStrategy
         self.dataEncodingStrategy = options?.dataCodingStrategy?.rawValue.encoding ?? self.dataEncodingStrategy

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -114,7 +114,8 @@ public class BSONEncoder {
         self.configureWithOptions(options: options)
     }
 
-    /// Initializes `self` by copying the options of another `BSONEncoder`.
+    /// Initializes `self` by using the options of another `BSONEncoder` and the provided options, with preference
+    /// going to the provided options in the case of conflicts.
     internal init(copies other: BSONEncoder, options: CodingStrategyProvider?) {
         self.userInfo = other.userInfo
         self.dateEncodingStrategy = other.dateEncodingStrategy

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -1,13 +1,15 @@
 import Foundation
 import mongoc
 
-/// Enum representing the various encoding/decoding strategy pairs for `Date`s.
-/// Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
-/// interacting with the database.
-///
-/// As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
-///
-/// - SeeAlso: bsonspec.org
+/**
+ * Enum representing the various encoding/decoding strategy pairs for `Date`s.
+ * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+ * interacting with the database.
+ *
+ * As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
+ *
+ * - SeeAlso: bsonspec.org
+ */
 public enum DateCodingStrategy: RawRepresentable {
     public typealias RawValue = (BSONEncoder.DateEncodingStrategy, BSONDecoder.DateDecodingStrategy)
 
@@ -84,14 +86,16 @@ public enum DateCodingStrategy: RawRepresentable {
     }
 }
 
-/// Enum representing the various encoding/decoding strategy pairs for `UUID`s.
-/// Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
-/// interacting with the database.
-///
-/// As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
-/// subtype.
-///
-/// - SeeAlso: bsonspec.org
+/**
+ * Enum representing the various encoding/decoding strategy pairs for `UUID`s.
+ * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+ * interacting with the database.
+ *
+ * As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
+ * subtype.
+ *
+ * - SeeAlso: bsonspec.org
+ */
 public enum UUIDCodingStrategy: RawRepresentable {
     public typealias RawValue = (BSONEncoder.UUIDEncodingStrategy, BSONDecoder.UUIDDecodingStrategy)
 
@@ -122,22 +126,26 @@ public enum UUIDCodingStrategy: RawRepresentable {
     }
 }
 
-/// Enum representing the various encoding/decoding strategy pairs for `Data`s.
-/// Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
-/// interacting with the database.
-///
-/// As per the BSON specification, the default strategy is to encode `Data`s as BSON binary types with the generic
-/// binary subtype.
-///
-/// - SeeAlso: bsonspec.org
+/**
+ * Enum representing the various encoding/decoding strategy pairs for `Data`s.
+ * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+ * interacting with the database.
+ *
+ * As per the BSON specification, the default strategy is to encode `Data`s as BSON binary types with the generic
+ * binary subtype.
+ *
+ * - SeeAlso: bsonspec.org
+ */
 public enum DataCodingStrategy: RawRepresentable {
     public typealias RawValue = (BSONEncoder.DataEncodingStrategy, BSONDecoder.DataDecodingStrategy)
 
-    /// Encode/decode the `Data` by deferring to its default encoding implementations.
-    ///
-    /// Note: The default encoding implementation attempts to encode the `Data` as a `[UInt8]`, but because BSON
-    /// does not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int32]`.
-    /// This results in a space inefficient storage of the `Data` (using 4 bytes of BSON storage per byte of data).
+    /**
+     * Encode/decode the `Data` by deferring to its default encoding implementations.
+     *
+     * Note: The default encoding implementation attempts to encode the `Data` as a `[UInt8]`, but because BSON
+     * does not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int32]`.
+     * This results in a space inefficient storage of the `Data` (using 4 bytes of BSON storage per byte of data).
+     */
     case deferredToData
 
     /// Encode/decode the `Data` to/from a BSON binary type (default).
@@ -181,11 +189,13 @@ public enum DataCodingStrategy: RawRepresentable {
 
 /// `BSONEncoder` facilitates the encoding of `Encodable` values into BSON.
 public class BSONEncoder {
-    /// Enum representing the various strategies for encoding `Date`s.
-    ///
-    /// As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
-    ///
-    /// - SeeAlso: bsonspec.org
+    /**
+     * Enum representing the various strategies for encoding `Date`s.
+     *
+     * As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
+     *
+     * - SeeAlso: bsonspec.org
+     */
     public enum DateEncodingStrategy {
         /// Encode the `Date` by deferring to its default encoding implementation.
         case deferredToDate
@@ -211,12 +221,14 @@ public class BSONEncoder {
         case custom((Date, Encoder) throws -> Void)
     }
 
-    /// Enum representing the various strategies for encoding `UUID`s.
-    ///
-    /// As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
-    /// subtype.
-    ///
-    /// - SeeAlso: bsonspec.org
+    /**
+     * Enum representing the various strategies for encoding `UUID`s.
+     *
+     * As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
+     * subtype.
+     *
+     * - SeeAlso: bsonspec.org
+     */
     public enum UUIDEncodingStrategy {
         /// Encode the `UUID` by deferring to its default encoding implementation.
         case deferredToUUID
@@ -225,18 +237,22 @@ public class BSONEncoder {
         case binary
     }
 
-    /// Enum representing the various strategies for encoding `Data`s.
-    ///
-    /// As per the BSON specification, the default strategy is to encode `Data`s as BSON binary types with the generic
-    /// binary subtype.
-    ///
-    /// - SeeAlso: bsonspec.org
+    /**
+     * Enum representing the various strategies for encoding `Data`s.
+     *
+     * As per the BSON specification, the default strategy is to encode `Data`s as BSON binary types with the generic
+     * binary subtype.
+     *
+     * - SeeAlso: bsonspec.org
+     */
     public enum DataEncodingStrategy {
-        /// Encode the `Data` by deferring to its default encoding implementation.
-        ///
-        /// Note: The default encoding implementation attempts to encode the `Data` as a `[UInt8]`, but because BSON
-        /// does not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int32]`.
-        /// This results in a space inefficient storage of the `Data` (using 4 bytes of BSON storage per byte of data).
+        /**
+         * Encode the `Data` by deferring to its default encoding implementation.
+         *
+         * Note: The default encoding implementation attempts to encode the `Data` as a `[UInt8]`, but because BSON
+         * does not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int32]`.
+         * This results in a space inefficient storage of the `Data` (using 4 bytes of BSON storage per byte of data).
+         */
         case deferredToData
 
         /// Encode the `Data` as a BSON binary type (default).

--- a/Sources/MongoSwift/BSON/CodingStrategies.swift
+++ b/Sources/MongoSwift/BSON/CodingStrategies.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Protocol indicating a set of options can be used to configure `BSONEncoder` and `BSONDecoder`.
-public protocol CodingStrategyOptions {
+public protocol CodingStrategyProvider {
     /// Specifies the strategy to use when converting `Date`s between their BSON representations and their
     /// representations in (non `Document`) `Codable` types.
     var dateCodingStrategy: DateCodingStrategy? { get }
@@ -16,7 +16,7 @@ public protocol CodingStrategyOptions {
 }
 
 /// Options struct used for configuring the coding strategies on `BSONEncoder` and `BSONDecoder`.
-public struct BSONCoderOptions: CodingStrategyOptions {
+public struct BSONCoderOptions: CodingStrategyProvider {
     public var dateCodingStrategy: DateCodingStrategy?
 
     public var uuidCodingStrategy: UUIDCodingStrategy?

--- a/Sources/MongoSwift/BSON/CodingStrategies.swift
+++ b/Sources/MongoSwift/BSON/CodingStrategies.swift
@@ -35,7 +35,7 @@ public struct BSONCoderOptions: CodingStrategyOptions {
 /**
  * Enum representing the various encoding/decoding strategy pairs for `Date`s.
  * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
- * interacting with the database.
+ * converting `Date`s between their BSON representations and their representations in (non `Document`) `Codable` types.
  *
  * As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
  *
@@ -120,7 +120,7 @@ public enum DateCodingStrategy: RawRepresentable {
 /**
  * Enum representing the various encoding/decoding strategy pairs for `UUID`s.
  * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
- * interacting with the database.
+ * converting `UUID`s between their BSON representations and their representations in (non `Document`) `Codable` types.
  *
  * As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
  * subtype.
@@ -160,7 +160,7 @@ public enum UUIDCodingStrategy: RawRepresentable {
 /**
  * Enum representing the various encoding/decoding strategy pairs for `Data`s.
  * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
- * interacting with the database.
+ * converting `Data`s between their BSON representations and their representations in (non `Document`) `Codable` types.
  *
  * As per the BSON specification, the default strategy is to encode `Data`s as BSON binary types with the generic
  * binary subtype.

--- a/Sources/MongoSwift/BSON/CodingStrategies.swift
+++ b/Sources/MongoSwift/BSON/CodingStrategies.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+/// Protocol indicating a set of options can be used to configure `BSONEncoder` and `BSONDecoder`.
+public protocol CodingStrategyOptions {
+    /// Specifies the strategy to use when converting `Date`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
+    var dateCodingStrategy: DateCodingStrategy? { get }
+
+    /// Specifies the strategy to use when converting `UUID`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
+    var uuidCodingStrategy: UUIDCodingStrategy? { get }
+
+    /// Specifies the strategy to use when converting `Data`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
+    var dataCodingStrategy: DataCodingStrategy? { get }
+}
+
+/// Options struct used for configuring the coding strategies on `BSONEncoder` and `BSONDecoder`.
+public struct BSONCoderOptions: CodingStrategyOptions {
+    public var dateCodingStrategy: DateCodingStrategy?
+
+    public var uuidCodingStrategy: UUIDCodingStrategy?
+
+    public var dataCodingStrategy: DataCodingStrategy?
+
+    public init(dateCodingStrategy: DateCodingStrategy? = nil,
+                uuidCodingStrategy: UUIDCodingStrategy? = nil,
+                dataCodingStrategy: DataCodingStrategy? = nil) {
+        self.dateCodingStrategy = dateCodingStrategy
+        self.uuidCodingStrategy = uuidCodingStrategy
+        self.dataCodingStrategy = dataCodingStrategy
+    }
+}
+
+/**
+ * Enum representing the various encoding/decoding strategy pairs for `Date`s.
+ * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+ * interacting with the database.
+ *
+ * As per the BSON specification, the default strategy is to encode `Date`s as BSON datetime objects.
+ *
+ * - SeeAlso: bsonspec.org
+ */
+public enum DateCodingStrategy: RawRepresentable {
+    public typealias RawValue = (encoding: BSONEncoder.DateEncodingStrategy, decoding: BSONDecoder.DateDecodingStrategy)
+
+    /// Encode/decode the `Date` by deferring to its default encoding/decoding implementations.
+    case deferredToDate
+
+    /// Encode/decode the `Date` to/from a BSON datetime object (default).
+    case bsonDateTime
+
+    /// Encode/decode the `Date` to/from a 64-bit integer counting the number of milliseconds since January 1, 1970.
+    case millisecondsSince1970
+
+    /// Encode/decode the `Date` to/from a BSON double counting the number of seconds since January 1, 1970.
+    case secondsSince1970
+
+    /// Encode/decode the `Date` to/from an ISO-8601-formatted string (in RFC 339 format).
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    case iso8601
+
+    /// Encode/decode the `Date` to/from a string formatted by the given formatter.
+    case formatted(DateFormatter)
+
+    /// Encode the `Date` by using the given `encodeFunc`. Decode the `Date` by using the given `decodeFunc`.
+    /// If `encodeFunc` does not encode a value, an empty document will be encoded in its place.
+    case custom(encodeFunc: (Date, Encoder) throws -> Void, decodeFunc: (Decoder) throws -> Date)
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case (.deferredToDate, .deferredToDate):
+            self = .deferredToDate
+        case (.bsonDateTime, .bsonDateTime):
+            self = .bsonDateTime
+        case (.millisecondsSince1970, .millisecondsSince1970):
+            self = .millisecondsSince1970
+        case (.secondsSince1970, .secondsSince1970):
+            self = .secondsSince1970
+        case (.iso8601, .iso8601):
+            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
+            }
+            self = .iso8601
+        case let (.formatted(encodingFormatter), .formatted(decodingFormatter)):
+            guard encodingFormatter == decodingFormatter else {
+                return nil
+            }
+            self = .formatted(encodingFormatter)
+        case let (.custom(encodeFunc), .custom(decodeFunc)):
+            self = .custom(encodeFunc: encodeFunc, decodeFunc: decodeFunc)
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+        case .deferredToDate:
+            return (.deferredToDate, .deferredToDate)
+        case .bsonDateTime:
+            return (.bsonDateTime, .bsonDateTime)
+        case .millisecondsSince1970:
+            return (.millisecondsSince1970, .millisecondsSince1970)
+        case .secondsSince1970:
+            return (.secondsSince1970, .secondsSince1970)
+        case .iso8601:
+            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
+            }
+            return (.iso8601, .iso8601)
+        case let .formatted(formatter):
+            return (.formatted(formatter), .formatted(formatter))
+        case let .custom(encodeFunc, decodeFunc):
+            return (.custom(encodeFunc), .custom(decodeFunc))
+        }
+    }
+}
+
+/**
+ * Enum representing the various encoding/decoding strategy pairs for `UUID`s.
+ * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+ * interacting with the database.
+ *
+ * As per the BSON specification, the default strategy is to encode `UUID`s as BSON binary types with the UUID
+ * subtype.
+ *
+ * - SeeAlso: bsonspec.org
+ */
+public enum UUIDCodingStrategy: RawRepresentable {
+    public typealias RawValue = (encoding: BSONEncoder.UUIDEncodingStrategy, decoding: BSONDecoder.UUIDDecodingStrategy)
+
+    /// Encode/decode the `UUID` by deferring to its default encoding/decoding implementations.
+    case deferredToUUID
+
+    /// Encode/decode the `UUID` to/from a BSON binary type (default).
+    case binary
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case (.deferredToUUID, .deferredToUUID):
+            self = .deferredToUUID
+        case (.binary, .binary):
+            self = .binary
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+        case .deferredToUUID:
+            return (.deferredToUUID, .deferredToUUID)
+        case .binary:
+            return (.binary, .binary)
+        }
+    }
+}
+
+/**
+ * Enum representing the various encoding/decoding strategy pairs for `Data`s.
+ * Set these on a `MongoClient`, `MongoDatabase`, or `MongoCollection` so that the strategies will be applied when
+ * interacting with the database.
+ *
+ * As per the BSON specification, the default strategy is to encode `Data`s as BSON binary types with the generic
+ * binary subtype.
+ *
+ * - SeeAlso: bsonspec.org
+ */
+public enum DataCodingStrategy: RawRepresentable {
+    public typealias RawValue = (encoding: BSONEncoder.DataEncodingStrategy, decoding: BSONDecoder.DataDecodingStrategy)
+
+    /**
+     * Encode/decode the `Data` by deferring to its default encoding implementations.
+     *
+     * Note: The default encoding implementation attempts to encode the `Data` as a `[UInt8]`, but because BSON
+     * does not support integer types besides `Int32` or `Int64`, it actually gets encoded to BSON as an `[Int32]`.
+     * This results in a space inefficient storage of the `Data` (using 4 bytes of BSON storage per byte of data).
+     */
+    case deferredToData
+
+    /// Encode/decode the `Data` to/from a BSON binary type (default).
+    case binary
+
+    /// Encode the `Data` to/from a base64 encoded string.
+    case base64
+
+    /// Encode the `Data` by using the given `encodeFunc`. Decode the `Data` by using the given `decodeFunc`.
+    /// If `encodeFunc` does not encode a value, an empty document will be encoded in its place.
+    case custom(encodeFunc: (Data, Encoder) throws -> Void, decodeFunc: (Decoder) throws -> Data)
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case (.deferredToData, .deferredToData):
+            self = .deferredToData
+        case (.binary, .binary):
+            self = .binary
+        case (.base64, .base64):
+            self = .base64
+        case let (.custom(encodeFunc), .custom(decodeFunc)):
+            self = .custom(encodeFunc: encodeFunc, decodeFunc: decodeFunc)
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+        case .deferredToData:
+            return (.deferredToData, .deferredToData)
+        case .binary:
+            return (.binary, .binary)
+        case .base64:
+            return (.base64, .base64)
+        case let .custom(encodeFunc, decodeFunc):
+            return (.custom(encodeFunc), .custom(decodeFunc))
+        }
+    }
+}

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -125,10 +125,10 @@ public class MongoClient {
     internal var monitoringEventTypes: [MongoEventType]?
 
     /// Encoder whose options are inherited by databases derived from this client.
-    internal let encoder: BSONEncoder
+    public let encoder: BSONEncoder
 
     /// Decoder whose options are inherited by databases derived from this client.
-    internal let decoder: BSONDecoder
+    public let decoder: BSONDecoder
 
     /// The read concern set on this client, or nil if one is not set.
     public var readConcern: ReadConcern? {

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -124,8 +124,10 @@ public class MongoClient {
     /// If command and/or server monitoring is enabled, indicates what event types notifications will be posted for.
     internal var monitoringEventTypes: [MongoEventType]?
 
+    /// Encoder whose options are inherited by databases derived from this client.
     internal var encoder = BSONEncoder()
 
+    /// Decoder whose options are inherited by databases derived from this client.
     internal var decoder = BSONDecoder()
 
     /// The read concern set on this client, or nil if one is not set.
@@ -147,6 +149,7 @@ public class MongoClient {
         return wc.isDefault ? nil : wc
     }
 
+    // swiftlint:disable cyclomatic_complexity
     /**
      * Create a new client connection to a MongoDB server.
      *
@@ -216,8 +219,8 @@ public class MongoClient {
             self.close()
             throw RuntimeError.internalError(message: "Could not configure error handling on client")
         }
-
     }
+    // swiftlint:enable cyclomatic_complexity
 
     /**
      * :nodoc:

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -21,19 +21,16 @@ public struct ClientOptions: CodingStrategyOptions {
     /// the server's default write concern will be used.
     public let writeConcern: WriteConcern?
 
-    /// Specifies the strategy to use when converting `Date`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
-    /// This strategy will be inherited by `MongoDatabase`s and `MongoCollection`s that derive from this client.
+    /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
+    /// databases or collections that derive from it.
     public let dateCodingStrategy: DateCodingStrategy?
 
-    /// Specifies the strategy to use when converting `UUID`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
-    /// This strategy will be inherited by `MongoDatabase`s and `MongoCollection`s that derive from this client.
+    /// Specifies the `UUIDCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
+    /// databases or collections that derive from it.
     public let uuidCodingStrategy: UUIDCodingStrategy?
 
-    /// Specifies the strategy to use when converting `Data`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
-    /// This strategy will be inherited by `MongoDatabase`s and `MongoCollection`s that derive from this client.
+    /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
+    /// databases or collections that derive from it.
     public let dataCodingStrategy: DataCodingStrategy?
 
     /// Convenience initializer allowing any/all to be omitted or optional
@@ -89,19 +86,16 @@ public struct DatabaseOptions: CodingStrategyOptions {
     /// the database will inherit the client's write concern.
     public let writeConcern: WriteConcern?
 
-    /// Specifies the strategy to use when converting `Date`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
-    /// This strategy will be inherited by `MongoDatabase`s and `MongoCollection`s that derive from this client.
+    /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this database and
+    /// any collections that derive from it.
     public let dateCodingStrategy: DateCodingStrategy?
 
-    /// Specifies the strategy to use when converting `UUID`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
-    /// This strategy will be inherited by `MongoDatabase`s and `MongoCollection`s that derive from this client.
+    /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this database and
+    /// any collections that derive from it.
     public let uuidCodingStrategy: UUIDCodingStrategy?
 
-    /// Specifies the strategy to use when converting `Data`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
-    /// This strategy will be inherited by `MongoDatabase`s and `MongoCollection`s that derive from this client.
+    /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this database and
+    /// any collections that derive from it.
     public let dataCodingStrategy: DataCodingStrategy?
 
     /// Convenience initializer allowing any/all arguments to be omitted or optional

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -2,7 +2,7 @@ import Foundation
 import mongoc
 
 /// Options to use when creating a `MongoClient`.
-public struct ClientOptions: CodingStrategyOptions {
+public struct ClientOptions: CodingStrategyProvider {
     /// Determines whether the client should retry supported write operations
     public let retryWrites: Bool?
 
@@ -73,7 +73,7 @@ public struct ListDatabasesOptions: Encodable {
 }
 
 /// Options to use when retrieving a `MongoDatabase` from a `MongoClient`.
-public struct DatabaseOptions: CodingStrategyOptions {
+public struct DatabaseOptions: CodingStrategyProvider {
     /// A read concern to set on the retrieved database. If one is not specified,
     /// the database will inherit the client's read concern.
     public let readConcern: ReadConcern?

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -119,7 +119,8 @@ extension MongoCollection {
             self.document = document
         }
 
-        /** Adds the `insertOne` operation to a bulk write.
+        /**
+         * Adds the `insertOne` operation to a bulk write.
          *
          * - Throws:
          *   - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
@@ -167,7 +168,8 @@ extension MongoCollection {
             self.options = ReplaceOneModelOptions(collation: collation, upsert: upsert)
         }
 
-        /** Adds the `replaceOne` operation to a bulk write.
+        /**
+         * Adds the `replaceOne` operation to a bulk write.
          *
          * - Throws:
          *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
@@ -220,7 +222,8 @@ extension MongoCollection {
             self.options = UpdateModelOptions(arrayFilters: arrayFilters, collation: collation, upsert: upsert)
         }
 
-        /** Adds the `updateOne` operation to a bulk write.
+        /**
+         * Adds the `updateOne` operation to a bulk write.
          *
          * - Throws:
          *   - `EncodingError` if an error occurs while encoding the options to BSON.
@@ -274,7 +277,7 @@ extension MongoCollection {
          *   - `UserError.invalidArgumentError` if the options form an invalid combination.
          */
         public func addToBulkWrite(bulk: BulkWriteOperation, index: Int) throws {
-            let opts = try BSONEncoder().encode(self.options)
+            let opts = try bulk.encoder.encode(self.options)
             var error = bson_error_t()
 
             guard mongoc_bulk_operation_update_many_with_opts(bulk.bulk,

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -47,7 +47,7 @@ extension MongoCollection {
     public func findOneAndReplace(filter: Document,
                                   replacement: CollectionType,
                                   options: FindOneAndReplaceOptions? = nil) throws -> CollectionType? {
-        let update = try BSONEncoder().encode(replacement)
+        let update = try self.encoder.encode(replacement)
         return try self.findAndModify(filter: filter, update: update, options: options)
     }
 

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -109,7 +109,7 @@ extension MongoCollection {
             return nil
         }
 
-        return try BSONDecoder().decode(CollectionType.self, from: value)
+        return try self.decoder.decode(CollectionType.self, from: value)
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -101,7 +101,7 @@ extension MongoCollection {
             return nil
         }
 
-        return try BSONDecoder().internalDecode(
+        return try self.decoder.internalDecode(
                 UpdateResult.self,
                 from: reply,
                 withError: "Couldn't understand response from the server.")
@@ -138,7 +138,7 @@ extension MongoCollection {
             return nil
         }
 
-        return try BSONDecoder().internalDecode(
+        return try self.decoder.internalDecode(
                 UpdateResult.self,
                 from: reply,
                 withError: "Couldn't understand response from the server.")
@@ -175,7 +175,7 @@ extension MongoCollection {
             return nil
         }
 
-        return try BSONDecoder().internalDecode(
+        return try self.decoder.internalDecode(
                 UpdateResult.self,
                 from: reply,
                 withError: "Couldn't understand response from the server.")
@@ -211,7 +211,7 @@ extension MongoCollection {
             return nil
         }
 
-        return try BSONDecoder().internalDecode(
+        return try self.decoder.internalDecode(
                 DeleteResult.self,
                 from: reply,
                 withError: "Couldn't understand response from the server.")
@@ -246,7 +246,7 @@ extension MongoCollection {
             return nil
         }
 
-        return try BSONDecoder().internalDecode(
+        return try self.decoder.internalDecode(
                 DeleteResult.self,
                 from: reply,
                 withError: "Couldn't understand response from the server.")

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -21,9 +21,8 @@ extension MongoCollection {
      */
     @discardableResult
     public func insertOne(_ value: CollectionType, options: InsertOneOptions? = nil) throws -> InsertOneResult? {
-        let encoder = BSONEncoder()
-        let document = try encoder.encode(value).withID()
-        let opts = try encoder.encode(options)
+        let document = try self.encoder.encode(value).withID()
+        let opts = try self.encoder.encode(options)
         var error = bson_error_t()
         let reply = Document()
         guard mongoc_collection_insert_one(self._collection, document.data, opts?.data, reply.data, &error) else {
@@ -89,9 +88,8 @@ extension MongoCollection {
     public func replaceOne(filter: Document,
                            replacement: CollectionType,
                            options: ReplaceOptions? = nil) throws -> UpdateResult? {
-        let encoder = BSONEncoder()
-        let replacementDoc = try encoder.encode(replacement)
-        let opts = try encoder.encode(options)
+        let replacementDoc = try self.encoder.encode(replacement)
+        let opts = try self.encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_collection_replace_one(
@@ -128,8 +126,7 @@ extension MongoCollection {
      */
     @discardableResult
     public func updateOne(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
-        let encoder = BSONEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try self.encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_collection_update_one(
@@ -166,8 +163,7 @@ extension MongoCollection {
      */
     @discardableResult
     public func updateMany(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
-        let encoder = BSONEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try self.encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_collection_update_many(
@@ -203,8 +199,7 @@ extension MongoCollection {
      */
     @discardableResult
     public func deleteOne(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
-        let encoder = BSONEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try self.encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
 
@@ -240,8 +235,7 @@ extension MongoCollection {
      */
     @discardableResult
     public func deleteMany(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
-        let encoder = BSONEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try self.encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_collection_delete_many(self._collection, filter.data, opts?.data, reply.data, &error) else {

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -12,14 +12,18 @@ public class MongoCollection<T: Codable> {
     /// Decoder used by this collection for BSON conversions (e.g. converting documents to `CollectionType`s).
     public let decoder: BSONDecoder
 
-    /// A `Codable` type associated with this `MongoCollection` instance.
-    /// This allows `CollectionType` values to be directly inserted into and
-    /// retrieved from the collection, by encoding/decoding them using the
-    /// `BSONEncoder` and `BSONDecoder`.
-    /// This type association only exists in the context of this particular
-    /// `MongoCollection` instance. It is the responsibility of the user to
-    /// ensure that any data already stored in the collection was encoded
-    /// from this same type.
+    /**
+     * A `Codable` type associated with this `MongoCollection` instance.
+     * This allows `CollectionType` values to be directly inserted into and retrieved from the collection, by
+     * encoding/decoding them using the `BSONEncoder` and `BSONDecoder`. The strategies to be used by the encoder and
+     * decoder for certain types can be configured by setting the coding strategies on the options used to create this
+     * collection instance. The default strategies are inherited from those set on the database this collection derived
+     * from.
+     *
+     * This type association only exists in the context of this particular `MongoCollection` instance. It is the
+     * responsibility of the user to ensure that any data already stored in the collection was encoded
+     * from this same type and according to the coding strategies set on this instance.
+     */
     public typealias CollectionType = T
 
     /// The name of this collection.

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -5,8 +5,12 @@ public class MongoCollection<T: Codable> {
     internal var _collection: OpaquePointer?
     internal var _client: MongoClient
 
-    internal let encoder: BSONEncoder
-    internal let decoder: BSONDecoder
+    /// Encoder used by this collection for BSON conversions. (e.g. converting `CollectionType`s, indexes, and options
+    /// to documents).
+    public let encoder: BSONEncoder
+
+    /// Decoder used by this collection for BSON conversions (e.g. converting documents to `CollectionType`s).
+    public let decoder: BSONDecoder
 
     /// A `Codable` type associated with this `MongoCollection` instance.
     /// This allows `CollectionType` values to be directly inserted into and

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -5,6 +5,9 @@ public class MongoCollection<T: Codable> {
     internal var _collection: OpaquePointer?
     internal var _client: MongoClient
 
+    internal let encoder: BSONEncoder
+    internal let decoder: BSONDecoder
+
     /// A `Codable` type associated with this `MongoCollection` instance.
     /// This allows `CollectionType` values to be directly inserted into and
     /// retrieved from the collection, by encoding/decoding them using the
@@ -40,9 +43,14 @@ public class MongoCollection<T: Codable> {
     }
 
     /// Initializes a new `MongoCollection` instance, not meant to be instantiated directly
-    internal init(fromCollection: OpaquePointer, withClient: MongoClient) {
+    internal init(fromCollection: OpaquePointer,
+                  withClient: MongoClient,
+                  withEncoder: BSONEncoder,
+                  withDecoder: BSONDecoder) {
         self._collection = fromCollection
         self._client = withClient
+        self.encoder = withEncoder
+        self.decoder = withDecoder
     }
 
     /// Deinitializes a `MongoCollection`, cleaning up the internal `mongoc_collection_t`

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -16,10 +16,12 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
      *   - `UserError.invalidArgumentError` if the options passed to the command that generated this cursor formed an
      *     invalid combination.
      */
-    internal init(fromCursor: OpaquePointer, withClient: MongoClient, withDecoder: BSONDecoder) throws {
-        self._cursor = fromCursor
-        self._client = withClient
-        self.decoder = withDecoder
+    internal init(fromCursor cursor: OpaquePointer,
+                  withClient client: MongoClient,
+                  withDecoder decoder: BSONDecoder) throws {
+        self._cursor = cursor
+        self._client = client
+        self.decoder = decoder
 
         if let err = self.error {
             // Need to explicitly close since deinit will not execute if we throw.

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -6,6 +6,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
     private var _client: MongoClient?
     private var swiftError: Error?
 
+    /// Decoder from the `MongoCollection` or `MongoDatabase` that created this cursor.
     private let decoder: BSONDecoder
 
     /**

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -93,6 +93,20 @@ public struct CreateCollectionOptions: Encodable {
     /// for the collection itself, retrieve the collection using `MongoDatabase.collection`.
     public let writeConcern: WriteConcern?
 
+    /// Specifies the strategy to use when coding `Date`s to/from BSON.
+    public let dateCodingStrategy: DateCodingStrategy?
+
+    /// Specifies the strategy to use when coding `UUID`s to/from BSON.
+    public let uuidCodingStrategy: UUIDCodingStrategy?
+
+    /// Specifies the strategy to use when coding `Data`s to/from BSON.
+    public let dataCodingStrategy: DataCodingStrategy?
+
+    private enum CodingKeys: String, CodingKey {
+        case capped, autoIndexId, size, max, storageEngine, validator, validationLevel, validationAction,
+             indexOptionDefaults, viewOn, collation, session, writeConcern
+    }
+
     /// Convenience initializer allowing any/all parameters to be omitted or optional
     public init(autoIndexId: Bool? = nil,
                 capped: Bool? = nil,
@@ -106,7 +120,10 @@ public struct CreateCollectionOptions: Encodable {
                 validationLevel: String? = nil,
                 validator: Document? = nil,
                 viewOn: String? = nil,
-                writeConcern: WriteConcern? = nil) {
+                writeConcern: WriteConcern? = nil,
+                dateCodingStrategy: DateCodingStrategy? = nil,
+                uuidCodingStrategy: UUIDCodingStrategy? = nil,
+                dataCodingStrategy: DataCodingStrategy? = nil) {
         self.autoIndexId = autoIndexId
         self.capped = capped
         self.collation = collation
@@ -120,6 +137,9 @@ public struct CreateCollectionOptions: Encodable {
         self.validator = validator
         self.viewOn = viewOn
         self.writeConcern = writeConcern
+        self.dateCodingStrategy = dateCodingStrategy
+        self.uuidCodingStrategy = uuidCodingStrategy
+        self.dataCodingStrategy = dataCodingStrategy
     }
 }
 
@@ -137,13 +157,28 @@ public struct CollectionOptions {
     /// the collection will inherit the database's write concern.
     public let writeConcern: WriteConcern?
 
+    /// Specifies the strategy to use when coding `Date`s to/from BSON.
+    public let dateCodingStrategy: DateCodingStrategy?
+
+    /// Specifies the strategy to use when coding `UUID`s to/from BSON.
+    public let uuidCodingStrategy: UUIDCodingStrategy?
+
+    /// Specifies the strategy to use when coding `Data`s to/from BSON.
+    public let dataCodingStrategy: DataCodingStrategy?
+
     /// Convenience initializer allowing any/all arguments to be omitted or optional
     public init(readConcern: ReadConcern? = nil,
                 readPreference: ReadPreference? = nil,
-                writeConcern: WriteConcern? = nil) {
+                writeConcern: WriteConcern? = nil,
+                dateCodingStrategy: DateCodingStrategy? = nil,
+                uuidCodingStrategy: UUIDCodingStrategy? = nil,
+                dataCodingStrategy: DataCodingStrategy? = nil) {
         self.readConcern = readConcern
         self.readPreference = readPreference
         self.writeConcern = writeConcern
+        self.dateCodingStrategy = dateCodingStrategy
+        self.uuidCodingStrategy = uuidCodingStrategy
+        self.dataCodingStrategy = dataCodingStrategy
     }
 }
 
@@ -151,6 +186,9 @@ public struct CollectionOptions {
 public class MongoDatabase {
     private var _database: OpaquePointer?
     private var _client: MongoClient
+
+    internal let encoder: BSONEncoder
+    internal let decoder: BSONDecoder
 
     /// The name of this database.
     public var name: String {
@@ -177,9 +215,14 @@ public class MongoDatabase {
     }
 
     /// Initializes a new `MongoDatabase` instance, not meant to be instantiated directly.
-    internal init(fromDatabase: OpaquePointer, withClient: MongoClient) {
+    internal init(fromDatabase: OpaquePointer,
+                  withClient: MongoClient,
+                  withEncoder: BSONEncoder,
+                  withDecoder: BSONDecoder) {
         self._database = fromDatabase
         self._client = withClient
+        self.encoder = withEncoder
+        self.decoder = withDecoder
     }
 
     /// Deinitializes a MongoDatabase, cleaning up the internal `mongoc_database_t`.
@@ -244,7 +287,30 @@ public class MongoDatabase {
             mongoc_collection_set_write_concern(collection, wc._writeConcern)
         }
 
-        return MongoCollection(fromCollection: collection, withClient: self._client)
+        let encoder = BSONEncoder(copies: self.encoder)
+        let decoder = BSONDecoder(copies: self.decoder)
+
+        if let (e, d) = options?.dateCodingStrategy?.rawValue {
+            encoder.dateEncodingStrategy = e
+            decoder.dateDecodingStrategy = d
+        }
+
+        if let (e, d) = options?.uuidCodingStrategy?.rawValue {
+            encoder.uuidEncodingStrategy = e
+            decoder.uuidDecodingStrategy = d
+        }
+
+        if let (e, d) = options?.dataCodingStrategy?.rawValue {
+            encoder.dataEncodingStrategy = e
+            decoder.dataDecodingStrategy = d
+        }
+
+        return MongoCollection(
+                fromCollection: collection,
+                withClient: self._client,
+                withEncoder: encoder,
+                withDecoder: decoder
+        )
     }
 
     /**
@@ -281,15 +347,37 @@ public class MongoDatabase {
     public func createCollection<T: Codable>(_ name: String,
                                              withType: T.Type,
                                              options: CreateCollectionOptions? = nil) throws -> MongoCollection<T> {
-        let encoder = BSONEncoder()
-        let opts = try encoder.encode(options)
+        let opts = try self.encoder.encode(options)
         var error = bson_error_t()
 
         guard let collection = mongoc_database_create_collection(self._database, name, opts?.data, &error) else {
             throw parseMongocError(error)
         }
 
-        return MongoCollection(fromCollection: collection, withClient: self._client)
+        let encoder = BSONEncoder(copies: self.encoder)
+        let decoder = BSONDecoder(copies: self.decoder)
+
+        if let (e, d) = options?.dateCodingStrategy?.rawValue {
+            encoder.dateEncodingStrategy = e
+            decoder.dateDecodingStrategy = d
+        }
+
+        if let (e, d) = options?.uuidCodingStrategy?.rawValue {
+            encoder.uuidEncodingStrategy = e
+            decoder.uuidDecodingStrategy = d
+        }
+
+        if let (e, d) = options?.dataCodingStrategy?.rawValue {
+            encoder.dataEncodingStrategy = e
+            decoder.dataDecodingStrategy = d
+        }
+
+        return MongoCollection(
+                fromCollection: collection,
+                withClient: self._client,
+                withEncoder: encoder,
+                withDecoder: decoder
+        )
     }
 
     /**
@@ -304,14 +392,12 @@ public class MongoDatabase {
      * - Throws: A `userError.invalidArgumentError` if the options passed are an invalid combination.
      */
     public func listCollections(options: ListCollectionsOptions? = nil) throws -> MongoCursor<Document> {
-        let encoder = BSONEncoder()
-        let opts = try encoder.encode(options)
-
+        let opts = try self.encoder.encode(options)
         guard let collections = mongoc_database_find_collections_with_opts(self._database, opts?.data) else {
             fatalError("Couldn't get cursor from the server")
         }
 
-        return try MongoCursor(fromCursor: collections, withClient: self._client)
+        return try MongoCursor(fromCursor: collections, withClient: self._client, withDecoder: self.decoder)
     }
 
     /**
@@ -332,7 +418,7 @@ public class MongoDatabase {
     @discardableResult
     public func runCommand(_ command: Document, options: RunCommandOptions? = nil) throws -> Document {
         let rp = options?.readPreference?._readPreference
-        let opts = try BSONEncoder().encode(options)
+        let opts = try self.encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_database_command_with_opts(self._database, command.data, rp, opts?.data, reply.data, &error) else {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -51,7 +51,7 @@ public struct ListCollectionsOptions: Encodable {
 }
 
 /// Options to use when executing a `createCollection` command on a `MongoDatabase`.
-public struct CreateCollectionOptions: Encodable, CodingStrategyOptions {
+public struct CreateCollectionOptions: Encodable, CodingStrategyProvider {
     /// Indicates whether this will be a capped collection
     public let capped: Bool?
 
@@ -150,7 +150,7 @@ public struct CreateCollectionOptions: Encodable, CodingStrategyOptions {
 }
 
 /// Options to set on a retrieved `MongoCollection`.
-public struct CollectionOptions: CodingStrategyOptions {
+public struct CollectionOptions: CodingStrategyProvider {
     /// A read concern to set on the returned collection. If one is not specified,
     /// the collection will inherit the database's read concern.
     public let readConcern: ReadConcern?
@@ -231,14 +231,14 @@ public class MongoDatabase {
     }
 
     /// Initializes a new `MongoDatabase` instance, not meant to be instantiated directly.
-    internal init(fromDatabase: OpaquePointer,
-                  withClient: MongoClient,
-                  withEncoder: BSONEncoder,
-                  withDecoder: BSONDecoder) {
-        self._database = fromDatabase
-        self._client = withClient
-        self.encoder = withEncoder
-        self.decoder = withDecoder
+    internal init(fromDatabase database: OpaquePointer,
+                  withClient client: MongoClient,
+                  withEncoder encoder: BSONEncoder,
+                  withDecoder decoder: BSONDecoder) {
+        self._database = database
+        self._client = client
+        self.encoder = encoder
+        self.decoder = decoder
     }
 
     /// Deinitializes a MongoDatabase, cleaning up the internal `mongoc_database_t`.

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -93,16 +93,19 @@ public struct CreateCollectionOptions: Encodable, CodingStrategyOptions {
     /// for the collection itself, retrieve the collection using `MongoDatabase.collection`.
     public let writeConcern: WriteConcern?
 
-    /// Specifies the strategy to use when converting `Date`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
+    /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
+    /// It is the responsibility of the user to ensure that any `Date`s already stored in this collection can be
+    /// decoded using this strategy.
     public let dateCodingStrategy: DateCodingStrategy?
 
-    /// Specifies the strategy to use when converting `UUID`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
+    /// Specifies the `UUIDCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
+    /// It is the responsibility of the user to ensure that any `UUID`s already stored in this collection can be
+    /// decoded using this strategy.
     public let uuidCodingStrategy: UUIDCodingStrategy?
 
-    /// Specifies the strategy to use when converting `Data`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
+    /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
+    /// It is the responsibility of the user to ensure that any `Data`s already stored in this collection can be
+    /// decoded using this strategy.
     public let dataCodingStrategy: DataCodingStrategy?
 
     private enum CodingKeys: String, CodingKey {
@@ -160,16 +163,19 @@ public struct CollectionOptions: CodingStrategyOptions {
     /// the collection will inherit the database's write concern.
     public let writeConcern: WriteConcern?
 
-    /// Specifies the strategy to use when converting `Date`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
+    /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
+    /// It is the responsibility of the user to ensure that any `Date`s already stored in this collection can be
+    /// decoded using this strategy.
     public let dateCodingStrategy: DateCodingStrategy?
 
-    /// Specifies the strategy to use when converting `UUID`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
+    /// Specifies the `UUIDCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
+    /// It is the responsibility of the user to ensure that any `UUID`s already stored in this collection can be
+    /// decoded using this strategy.
     public let uuidCodingStrategy: UUIDCodingStrategy?
 
-    /// Specifies the strategy to use when converting `Data`s between their BSON representations and their
-    /// representations in (non `Document`) `Codable` types.
+    /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
+    /// It is the responsibility of the user to ensure that any `Data`s already stored in this collection can be
+    /// decoded using this strategy.
     public let dataCodingStrategy: DataCodingStrategy?
 
     /// Convenience initializer allowing any/all arguments to be omitted or optional

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -51,7 +51,7 @@ public struct ListCollectionsOptions: Encodable {
 }
 
 /// Options to use when executing a `createCollection` command on a `MongoDatabase`.
-public struct CreateCollectionOptions: Encodable {
+public struct CreateCollectionOptions: Encodable, CodingStrategyOptions {
     /// Indicates whether this will be a capped collection
     public let capped: Bool?
 
@@ -93,13 +93,16 @@ public struct CreateCollectionOptions: Encodable {
     /// for the collection itself, retrieve the collection using `MongoDatabase.collection`.
     public let writeConcern: WriteConcern?
 
-    /// Specifies the strategy to use when coding `Date`s to/from BSON.
+    /// Specifies the strategy to use when converting `Date`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
     public let dateCodingStrategy: DateCodingStrategy?
 
-    /// Specifies the strategy to use when coding `UUID`s to/from BSON.
+    /// Specifies the strategy to use when converting `UUID`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
     public let uuidCodingStrategy: UUIDCodingStrategy?
 
-    /// Specifies the strategy to use when coding `Data`s to/from BSON.
+    /// Specifies the strategy to use when converting `Data`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
     public let dataCodingStrategy: DataCodingStrategy?
 
     private enum CodingKeys: String, CodingKey {
@@ -144,7 +147,7 @@ public struct CreateCollectionOptions: Encodable {
 }
 
 /// Options to set on a retrieved `MongoCollection`.
-public struct CollectionOptions {
+public struct CollectionOptions: CodingStrategyOptions {
     /// A read concern to set on the returned collection. If one is not specified,
     /// the collection will inherit the database's read concern.
     public let readConcern: ReadConcern?
@@ -157,13 +160,16 @@ public struct CollectionOptions {
     /// the collection will inherit the database's write concern.
     public let writeConcern: WriteConcern?
 
-    /// Specifies the strategy to use when coding `Date`s to/from BSON.
+    /// Specifies the strategy to use when converting `Date`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
     public let dateCodingStrategy: DateCodingStrategy?
 
-    /// Specifies the strategy to use when coding `UUID`s to/from BSON.
+    /// Specifies the strategy to use when converting `UUID`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
     public let uuidCodingStrategy: UUIDCodingStrategy?
 
-    /// Specifies the strategy to use when coding `Data`s to/from BSON.
+    /// Specifies the strategy to use when converting `Data`s between their BSON representations and their
+    /// representations in (non `Document`) `Codable` types.
     public let dataCodingStrategy: DataCodingStrategy?
 
     /// Convenience initializer allowing any/all arguments to be omitted or optional
@@ -291,23 +297,8 @@ public class MongoDatabase {
             mongoc_collection_set_write_concern(collection, wc._writeConcern)
         }
 
-        let encoder = BSONEncoder(copies: self.encoder)
-        let decoder = BSONDecoder(copies: self.decoder)
-
-        if let (e, d) = options?.dateCodingStrategy?.rawValue {
-            encoder.dateEncodingStrategy = e
-            decoder.dateDecodingStrategy = d
-        }
-
-        if let (e, d) = options?.uuidCodingStrategy?.rawValue {
-            encoder.uuidEncodingStrategy = e
-            decoder.uuidDecodingStrategy = d
-        }
-
-        if let (e, d) = options?.dataCodingStrategy?.rawValue {
-            encoder.dataEncodingStrategy = e
-            decoder.dataDecodingStrategy = d
-        }
+        let encoder = BSONEncoder(copies: self.encoder, options: options)
+        let decoder = BSONDecoder(copies: self.decoder, options: options)
 
         return MongoCollection(
                 fromCollection: collection,
@@ -358,23 +349,8 @@ public class MongoDatabase {
             throw parseMongocError(error)
         }
 
-        let encoder = BSONEncoder(copies: self.encoder)
-        let decoder = BSONDecoder(copies: self.decoder)
-
-        if let (e, d) = options?.dateCodingStrategy?.rawValue {
-            encoder.dateEncodingStrategy = e
-            decoder.dateDecodingStrategy = d
-        }
-
-        if let (e, d) = options?.uuidCodingStrategy?.rawValue {
-            encoder.uuidEncodingStrategy = e
-            decoder.uuidDecodingStrategy = d
-        }
-
-        if let (e, d) = options?.dataCodingStrategy?.rawValue {
-            encoder.dataEncodingStrategy = e
-            decoder.dataDecodingStrategy = d
-        }
+        let encoder = BSONEncoder(copies: self.encoder, options: options)
+        let decoder = BSONDecoder(copies: self.decoder, options: options)
 
         return MongoCollection(
                 fromCollection: collection,

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -187,8 +187,12 @@ public class MongoDatabase {
     private var _database: OpaquePointer?
     private var _client: MongoClient
 
-    internal let encoder: BSONEncoder
-    internal let decoder: BSONDecoder
+    /// Encoder used by this database for BSON conversions.
+    /// This encoder's options are inherited by collections derived from this database.
+    public let encoder: BSONEncoder
+
+    /// Decoder whose options are inherited by collections derived from this database.
+    public let decoder: BSONDecoder
 
     /// The name of this database.
     public var name: String {

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -110,8 +110,7 @@ public final class ReadPreference {
                 throw UserError.invalidArgumentError(message: "tagSets may not be used with primary mode")
             }
 
-            let encoder = BSONEncoder()
-            let tags = try encoder.encode(Document(tagSets))
+            let tags = try BSONEncoder().encode(Document(tagSets))
             mongoc_read_prefs_set_tags(self._readPreference, tags.data)
         }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -106,6 +106,7 @@ extension MongoClientTests {
         ("testOpaqueInitialization", testOpaqueInitialization),
         ("testFailedClientInitialization", testFailedClientInitialization),
         ("testServerVersion", testServerVersion),
+        ("testCodingStrategies", testCodingStrategies),
     ]
 }
 

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import mongoc
 @testable import MongoSwift
 import Nimble
@@ -89,5 +90,100 @@ final class MongoClientTests: MongoSwiftTestCase {
         expect(try Version("hi")).to(throwError())
         expect(try Version("3")).to(throwError())
         expect(try Version("3.x")).to(throwError())
+    }
+
+    func testCodingStrategies() throws {
+        struct Wrapper: Codable, Equatable {
+            let _id: String
+            let date: Date
+            let uuid: UUID
+            let data: Data
+        }
+
+        let date = Date(timeIntervalSince1970: 100)
+        let uuid = UUID()
+        let data = Data(base64Encoded: "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wZWQgb3ZlciB0aGUgbGF6eSBzaGVlcCBkb2cu")!
+
+        let wrapperWithId = { id in Wrapper(_id: id, date: date, uuid: uuid, data: data) }
+
+        let defaultClient = try MongoClient()
+        let defaultDb = try defaultClient.db(type(of: self).testDatabase)
+        let collDoc = try defaultDb.collection(self.getCollectionName())
+
+        // default behavior is .bsonDate, .binary, .binary
+        let collDefault = try defaultDb.collection(self.getCollectionName(), withType: Wrapper.self)
+
+        let defaultId = "default"
+        try collDefault.insertOne(wrapperWithId(defaultId))
+
+        var doc = try collDoc.find(["_id": defaultId]).nextOrError()
+        expect(doc).toNot(beNil())
+        expect(doc?["date"] as? Date).to(equal(date))
+        expect(doc?["uuid"] as? Binary).to(equal(try Binary(from: uuid)))
+        expect(doc?["data"] as? Binary).to(equal(try Binary(data: data, subtype: .generic)))
+
+        expect(try collDefault.find(["_id": defaultId]).nextOrError()).to(equal(wrapperWithId(defaultId)))
+
+        // Customize strategies on the client
+        let custom = ClientOptions(
+                dateCodingStrategy: .secondsSince1970,
+                uuidCodingStrategy: .deferredToUUID,
+                dataCodingStrategy: .base64
+        )
+        let clientCustom = try MongoClient(options: custom)
+        let collClient = try clientCustom.db(defaultDb.name).collection(collDoc.name, withType: Wrapper.self)
+
+        let collClientId = "customClient"
+        try collClient.insertOne(wrapperWithId(collClientId))
+
+        doc = try collDoc.find(["_id": collClientId] as Document).nextOrError()
+        expect(doc).toNot(beNil())
+        expect(doc?["date"] as? Double).to(beCloseTo(date.timeIntervalSince1970, within: 0.001))
+        expect(doc?["uuid"] as? String).to(equal(uuid.uuidString))
+        expect(doc?["data"] as? String).to(equal(data.base64EncodedString()))
+
+        expect(try collClient.find(["_id": collClientId]).nextOrError()).to(equal(wrapperWithId(collClientId)))
+
+        // Construct db with differing strategies from client
+        let dbOpts = DatabaseOptions(
+                dateCodingStrategy: .deferredToDate,
+                uuidCodingStrategy: .binary,
+                dataCodingStrategy: .binary
+        )
+        let dbCustom = try clientCustom.db(defaultDb.name, options: dbOpts)
+        let collDb = try dbCustom.collection(collClient.name, withType: Wrapper.self)
+
+        let customDbId = "customDb"
+        try collDb.insertOne(wrapperWithId(customDbId))
+
+        doc = try collDoc.find(["_id": customDbId] as Document).next()
+        expect(doc).toNot(beNil())
+        expect(doc?["date"] as? Double).to(beCloseTo(date.timeIntervalSinceReferenceDate, within: 0.001))
+        expect(doc?["uuid"] as? Binary).to(equal(try Binary(from: uuid)))
+        expect(doc?["data"] as? Binary).to(equal(try Binary(data: data, subtype: .generic)))
+
+        expect(try collDb.find(["_id": customDbId] as Document).nextOrError()).to(equal(wrapperWithId(customDbId)))
+
+        // Construct collection with differing strategies from database
+        let dbCollOpts = CollectionOptions(
+                dateCodingStrategy: .millisecondsSince1970,
+                uuidCodingStrategy: .deferredToUUID,
+                dataCodingStrategy: .base64
+        )
+        let collCustom = try dbCustom.collection(collClient.name, withType: Wrapper.self, options: dbCollOpts)
+
+        let customDbCollId = "customDbColl"
+        try collCustom.insertOne(wrapperWithId(customDbCollId))
+        doc = try collDoc.find(["_id": customDbCollId]).nextOrError()
+
+        expect(doc).toNot(beNil())
+        expect(doc?["date"] as? Int64).to(equal(date.msSinceEpoch))
+        expect(doc?["uuid"] as? String).to(equal(uuid.uuidString))
+        expect(doc?["data"] as? String).to(equal(data.base64EncodedString()))
+
+        expect(try collCustom.find(["_id": customDbCollId] as Document).nextOrError())
+                .to(equal(wrapperWithId(customDbCollId)))
+
+        try defaultDb.drop()
     }
 }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -107,11 +107,11 @@ final class MongoClientTests: MongoSwiftTestCase {
         let wrapperWithId = { id in Wrapper(_id: id, date: date, uuid: uuid, data: data) }
 
         let defaultClient = try MongoClient()
-        let defaultDb = try defaultClient.db(type(of: self).testDatabase)
-        let collDoc = try defaultDb.collection(self.getCollectionName())
+        let defaultDb = defaultClient.db(type(of: self).testDatabase)
+        let collDoc = defaultDb.collection(self.getCollectionName())
 
         // default behavior is .bsonDate, .binary, .binary
-        let collDefault = try defaultDb.collection(self.getCollectionName(), withType: Wrapper.self)
+        let collDefault = defaultDb.collection(self.getCollectionName(), withType: Wrapper.self)
 
         let defaultId = "default"
         try collDefault.insertOne(wrapperWithId(defaultId))
@@ -131,7 +131,7 @@ final class MongoClientTests: MongoSwiftTestCase {
                 dataCodingStrategy: .base64
         )
         let clientCustom = try MongoClient(options: custom)
-        let collClient = try clientCustom.db(defaultDb.name).collection(collDoc.name, withType: Wrapper.self)
+        let collClient = clientCustom.db(defaultDb.name).collection(collDoc.name, withType: Wrapper.self)
 
         let collClientId = "customClient"
         try collClient.insertOne(wrapperWithId(collClientId))
@@ -150,8 +150,8 @@ final class MongoClientTests: MongoSwiftTestCase {
                 uuidCodingStrategy: .binary,
                 dataCodingStrategy: .binary
         )
-        let dbCustom = try clientCustom.db(defaultDb.name, options: dbOpts)
-        let collDb = try dbCustom.collection(collClient.name, withType: Wrapper.self)
+        let dbCustom = clientCustom.db(defaultDb.name, options: dbOpts)
+        let collDb = dbCustom.collection(collClient.name, withType: Wrapper.self)
 
         let customDbId = "customDb"
         try collDb.insertOne(wrapperWithId(customDbId))
@@ -170,7 +170,7 @@ final class MongoClientTests: MongoSwiftTestCase {
                 uuidCodingStrategy: .deferredToUUID,
                 dataCodingStrategy: .base64
         )
-        let collCustom = try dbCustom.collection(collClient.name, withType: Wrapper.self, options: dbCollOpts)
+        let collCustom = dbCustom.collection(collClient.name, withType: Wrapper.self, options: dbCollOpts)
 
         let customDbCollId = "customDbColl"
         try collCustom.insertOne(wrapperWithId(customDbCollId))


### PR DESCRIPTION
[SWIFT-337](https://jira.mongodb.org/browse/SWIFT-337)

This PR allows users to set the encoding/decoding strategies at the client, database, or collection level. Collections inherit these options from databases, and databases inherit them from clients. They also can be specified when getting/creating a client, database, or collection. 

In implementing this, I defined `DateCodingStrategy`, `UUIDCodingStrategy`, and `DataCodingStrategy`, unifying the encoding/decoding pairs into single cases. This reduces some of the boilerplate for us and for users, and it also restricts users from setting incompatible pairs (e.g. encoding uses `bsonDate`, decoding uses `millisecondsSince1970`). They're defined in `BSONEncoder.swift` arbitrarily.
