### PR TITLE
SWIFT-313 Move RegularExpression.nsRegularExpression logic into a new NSRegularExpression initializer

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -748,8 +748,7 @@ private let regexOptsMap: [Character: NSRegularExpression.Options] = [
     "x": .allowCommentsAndWhitespace
 ]
 
-/// An extension of `NSRegularExpression` to allow it to be initialized from a `RegularExpression` `BSONValue` and to
-/// support converting options to and from strings.
+/// An extension of `NSRegularExpression` to allow it to be initialized from a `RegularExpression` `BSONValue`.
 extension NSRegularExpression {
     /// Convert a string of options flags into an equivalent `NSRegularExpression.Options`
     internal static func optionsFromString(_ stringOptions: String) -> NSRegularExpression.Options {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -817,22 +817,20 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
         return self.init(pattern: patternString, options: optionsString)
     }
 
-    /// Creates an `NSRegularExpression` with the pattern and options of this `RegularExpression`.
-    /// Note: `NSRegularExpression` does not support the `l` locale dependence option, so it will
-    /// be omitted if set on this `RegularExpression`.
-    public var nsRegularExpression: NSRegularExpression {
-        let opts = NSRegularExpression.optionsFromString(self.options)
-        do {
-            return try NSRegularExpression(pattern: self.pattern, options: opts)
-        } catch {
-            fatalError("Failed to initialize NSRegularExpression with " +
-                "pattern '\(self.pattern)'' and options '\(self.options)'")
-        }
-    }
-
     /// Returns `true` if the two `RegularExpression`s have matching patterns and options, and `false` otherwise.
     public static func == (lhs: RegularExpression, rhs: RegularExpression) -> Bool {
         return lhs.pattern == rhs.pattern && lhs.options == rhs.options
+    }
+}
+
+/// Extension of `NSRegularExpression` allowing it to be initialized from a `RegularExpression` `BSONValue`.
+extension NSRegularExpression {
+    /// Initializes a new `NSRegularExpression` with the pattern and options of the provided `RegularExpression`.
+    /// Note: `NSRegularExpression` does not support the `l` locale dependence option, so it will
+    /// be omitted if set on the provided `RegularExpression`.
+    public convenience init(from regex: RegularExpression) throws {
+        let opts = NSRegularExpression.optionsFromString(regex.options)
+        try self.init(pattern: regex.pattern, options: opts)
     }
 }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -748,7 +748,8 @@ private let regexOptsMap: [Character: NSRegularExpression.Options] = [
     "x": .allowCommentsAndWhitespace
 ]
 
-/// An extension of `NSRegularExpression` to support converting options to and from strings.
+/// An extension of `NSRegularExpression` to allow it to be initialized from a `RegularExpression` `BSONValue` and to
+/// support converting options to and from strings.
 extension NSRegularExpression {
     /// Convert a string of options flags into an equivalent `NSRegularExpression.Options`
     internal static func optionsFromString(_ stringOptions: String) -> NSRegularExpression.Options {
@@ -766,6 +767,14 @@ extension NSRegularExpression {
         var optsString = ""
         for (char, o) in regexOptsMap { if options.contains(o) { optsString += String(char) } }
         return String(optsString.sorted())
+    }
+
+    /// Initializes a new `NSRegularExpression` with the pattern and options of the provided `RegularExpression`.
+    /// Note: `NSRegularExpression` does not support the `l` locale dependence option, so it will
+    /// be omitted if set on the provided `RegularExpression`.
+    public convenience init(from regex: RegularExpression) throws {
+        let opts = NSRegularExpression.optionsFromString(regex.options)
+        try self.init(pattern: regex.pattern, options: opts)
     }
 }
 
@@ -820,17 +829,6 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
     /// Returns `true` if the two `RegularExpression`s have matching patterns and options, and `false` otherwise.
     public static func == (lhs: RegularExpression, rhs: RegularExpression) -> Bool {
         return lhs.pattern == rhs.pattern && lhs.options == rhs.options
-    }
-}
-
-/// Extension of `NSRegularExpression` allowing it to be initialized from a `RegularExpression` `BSONValue`.
-extension NSRegularExpression {
-    /// Initializes a new `NSRegularExpression` with the pattern and options of the provided `RegularExpression`.
-    /// Note: `NSRegularExpression` does not support the `l` locale dependence option, so it will
-    /// be omitted if set on the provided `RegularExpression`.
-    public convenience init(from regex: RegularExpression) throws {
-        let opts = NSRegularExpression.optionsFromString(regex.options)
-        try self.init(pattern: regex.pattern, options: opts)
     }
 }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -140,7 +140,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
         let regex = doc["regex"] as? RegularExpression
         expect(regex).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
-        expect(regex?.nsRegularExpression).to(equal(try NSRegularExpression(
+        expect(try NSRegularExpression(from: regex!)).to(equal(try NSRegularExpression(
             pattern: "^abc",
             options: NSRegularExpression.optionsFromString("imx")
         )))
@@ -204,7 +204,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
         let regex = DocumentTests.testDoc.regex as? RegularExpression
         expect(regex).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
-        expect(regex?.nsRegularExpression).to(equal(try NSRegularExpression(
+        expect(try NSRegularExpression(from: regex!)).to(equal(try NSRegularExpression(
                 pattern: "^abc",
                 options: NSRegularExpression.optionsFromString("imx")
         )))


### PR DESCRIPTION
[SWIFT-313](https://jira.mongodb.com/browse/SWIFT-313)
