### PR TITLE
SWIFT-351 Correctly encode strings with multi-byte UTF8 characters

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -124,7 +124,7 @@ extension Array: BSONValue {
             try arr.setValue(for: String(i), to: val)
         }
 
-        guard bson_append_array(storage.pointer, key, Int32(key.count), arr.data) else {
+        guard bson_append_array(storage.pointer, key, Int32(key.utf8.count), arr.data) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -145,7 +145,7 @@ public struct BSONNull: BSONValue, Codable, Equatable {
     public init() { }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_null(storage.pointer, key, Int32(key.count)) else {
+        guard bson_append_null(storage.pointer, key, Int32(key.utf8.count)) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -242,7 +242,7 @@ public struct Binary: BSONValue, Equatable, Codable {
         let subtype = bson_subtype_t(UInt32(self.subtype))
         let length = self.data.count
         let byteArray = [UInt8](self.data)
-        guard bson_append_binary(storage.pointer, key, Int32(key.count), subtype, byteArray, UInt32(length)) else {
+        guard bson_append_binary(storage.pointer, key, Int32(key.utf8.count), subtype, byteArray, UInt32(length)) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -280,7 +280,7 @@ extension Bool: BSONValue {
     public var bsonType: BSONType { return .boolean }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_bool(storage.pointer, key, Int32(key.count), self) else {
+        guard bson_append_bool(storage.pointer, key, Int32(key.utf8.count), self) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -308,7 +308,7 @@ extension Date: BSONValue {
     public var msSinceEpoch: Int64 { return Int64((self.timeIntervalSince1970 * 1000.0).rounded()) }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_date_time(storage.pointer, key, Int32(key.count), self.msSinceEpoch) else {
+        guard bson_append_date_time(storage.pointer, key, Int32(key.utf8.count), self.msSinceEpoch) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -411,7 +411,7 @@ public struct Decimal128: BSONValue, Equatable, Codable {
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         var value = try Decimal128.toLibBSONType(self.data)
-        guard bson_append_decimal128(storage.pointer, key, Int32(key.count), &value) else {
+        guard bson_append_decimal128(storage.pointer, key, Int32(key.utf8.count), &value) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -435,7 +435,7 @@ extension Double: BSONValue {
     public var bsonType: BSONType { return .double }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_double(storage.pointer, key, Int32(key.count), self) else {
+        guard bson_append_double(storage.pointer, key, Int32(key.utf8.count), self) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -484,7 +484,7 @@ extension Int32: BSONValue {
     public var bsonType: BSONType { return .int32 }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_int32(storage.pointer, key, Int32(key.count), self) else {
+        guard bson_append_int32(storage.pointer, key, Int32(key.utf8.count), self) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -502,7 +502,7 @@ extension Int64: BSONValue {
     public var bsonType: BSONType { return .int64 }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_int64(storage.pointer, key, Int32(key.count), self) else {
+        guard bson_append_int64(storage.pointer, key, Int32(key.utf8.count), self) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -535,11 +535,11 @@ public struct CodeWithScope: BSONValue, Equatable, Codable {
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
         if let s = self.scope {
-            guard bson_append_code_with_scope(storage.pointer, key, Int32(key.count), self.code, s.data) else {
+            guard bson_append_code_with_scope(storage.pointer, key, Int32(key.utf8.count), self.code, s.data) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
         } else {
-            guard bson_append_code(storage.pointer, key, Int32(key.count), self.code) else {
+            guard bson_append_code(storage.pointer, key, Int32(key.utf8.count), self.code) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
         }
@@ -585,7 +585,7 @@ public struct MaxKey: BSONValue, Equatable, Codable {
     public var bsonType: BSONType { return .maxKey }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_maxkey(storage.pointer, key, Int32(key.count)) else {
+        guard bson_append_maxkey(storage.pointer, key, Int32(key.utf8.count)) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -610,7 +610,7 @@ public struct MinKey: BSONValue, Equatable, Codable {
     public var bsonType: BSONType { return .minKey }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_minkey(storage.pointer, key, Int32(key.count)) else {
+        guard bson_append_minkey(storage.pointer, key, Int32(key.utf8.count)) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -658,7 +658,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     /// ObjectId.
     /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/objectid.rst
     public init?(ifValid oid: String) {
-        if !bson_oid_is_valid(oid, oid.count) {
+        if !bson_oid_is_valid(oid, oid.utf8.count) {
             return nil
         } else {
             self.init(fromString: oid)
@@ -681,7 +681,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     ///   - `UserError.invalidArgumentError` if the parameter string does not correspond to a valid `ObjectId`.
     internal static func toLibBSONType(_ str: String) throws -> bson_oid_t {
         var value = bson_oid_t()
-        if !bson_oid_is_valid(str, str.count) {
+        if !bson_oid_is_valid(str, str.utf8.count) {
             throw UserError.invalidArgumentError(message: "ObjectId string is invalid")
         }
         bson_oid_init_from_string(&value, str)
@@ -692,7 +692,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         // create a new bson_oid_t with self.oid
         var oid = try ObjectId.toLibBSONType(self.oid)
         // encode the bson_oid_t to the bson_t
-        guard bson_append_oid(storage.pointer, key, Int32(key.count), &oid) else {
+        guard bson_append_oid(storage.pointer, key, Int32(key.utf8.count), &oid) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -800,7 +800,7 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_regex(storage.pointer, key, Int32(key.count), self.pattern, self.options) else {
+        guard bson_append_regex(storage.pointer, key, Int32(key.utf8.count), self.pattern, self.options) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -836,7 +836,7 @@ extension String: BSONValue {
     public var bsonType: BSONType { return .string }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_utf8(storage.pointer, key, Int32(key.count), self, Int32(self.count)) else {
+        guard bson_append_utf8(storage.pointer, key, Int32(key.utf8.count), self, Int32(self.utf8.count)) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
@@ -906,7 +906,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_timestamp(storage.pointer, key, Int32(key.count), self.timestamp, self.increment) else {
+        guard bson_append_timestamp(storage.pointer, key, Int32(key.utf8.count), self.timestamp, self.increment) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -420,7 +420,7 @@ extension Document: BSONValue {
     public var bsonType: BSONType { return .document }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        guard bson_append_document(storage.pointer, key, Int32(key.count), self.data) else {
+        guard bson_append_document(storage.pointer, key, Int32(key.utf8.count), self.data) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -68,6 +68,7 @@ extension DocumentTests {
         ("testReplaceValueNoop", testReplaceValueNoop),
         ("testDocumentDictionarySimilarity", testDocumentDictionarySimilarity),
         ("testDefaultSubscript", testDefaultSubscript),
+        ("testMultibyteCharacterStrings", testMultibyteCharacterStrings),
         ("testUUIDEncodingStrategies", testUUIDEncodingStrategies),
         ("testUUIDDecodingStrategies", testUUIDDecodingStrategies),
         ("testDateEncodingStrategies", testDateEncodingStrategies),

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -323,6 +323,27 @@ final class CodecTests: MongoSwiftTestCase {
                     lhs.int64 == rhs.int64 && lhs.dec == rhs.dec && lhs.minkey == rhs.minkey &&
                     lhs.maxkey == rhs.maxkey && lhs.regex == rhs.regex && lhs.date == rhs.date
         }
+
+        public static func factory() throws -> AllBSONTypes {
+            return AllBSONTypes(
+                    double: Double(2),
+                    string: "hi",
+                    doc: ["x": 1],
+                    arr: [1, 2],
+                    binary: try Binary(base64: "//8=", subtype: .generic),
+                    oid: ObjectId(fromString: "507f1f77bcf86cd799439011"),
+                    bool: true,
+                    date: Date(timeIntervalSinceReferenceDate: 5000),
+                    code: CodeWithScope(code: "hi", scope: ["x": 1]),
+                    int: 1,
+                    ts: Timestamp(timestamp: 1, inc: 2),
+                    int32: 5,
+                    int64: 6,
+                    dec: Decimal128("1.2E+10"),
+                    minkey: MinKey(),
+                    maxkey: MaxKey(),
+                    regex: RegularExpression(pattern: "^abc", options: "imx"))
+        }
     }
 
     /// Test decoding/encoding to all possible BSON types

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -663,6 +663,16 @@ final class DocumentTests: MongoSwiftTestCase {
             .to(bsonEqual("\(stringVal) and \(floatVal)" + stringVal))
     }
 
+    func testMultibyteStrings() throws {
+        let str = String(repeating: "🇧🇷", count: 10)
+
+        let doc: Document = ["first": str]
+        expect(doc["first"] as? String).to(equal(str))
+
+        let doc1: Document = [str: "second"]
+        expect(doc1[str] as? String).to(equal("second"))
+    }
+
     struct UUIDWrapper: Codable {
         let uuid: UUID
     }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -663,14 +663,26 @@ final class DocumentTests: MongoSwiftTestCase {
             .to(bsonEqual("\(stringVal) and \(floatVal)" + stringVal))
     }
 
-    func testMultibyteStrings() throws {
+    func testMultibyteCharacterStrings() throws {
         let str = String(repeating: "🇧🇷", count: 10)
 
-        let doc: Document = ["first": str]
+        var doc: Document = ["first": str]
         expect(doc["first"] as? String).to(equal(str))
 
         let doc1: Document = [str: "second"]
         expect(doc1[str] as? String).to(equal("second"))
+
+        let abt = try CodecTests.AllBSONTypes.factory()
+        Mirror(reflecting: abt).children.forEach { child in
+            let value = child.value as! BSONValue
+            doc[str] = value
+
+            if value is Int32 { // TODO: handle this differently (SWIFT-221)
+                expect(Int32(doc[str] as! Int)).to(bsonEqual(value))
+            } else {
+                expect(doc[str]).to(bsonEqual(value))
+            }
+        }
     }
 
     struct UUIDWrapper: Codable {


### PR DESCRIPTION
[SWIFT-351](https://jira.mongodb.com/browse/SWIFT-351)
