### PR TITLE
SWIFT-356 / SWIFT-352 Round trip all BSONValues correctly

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -534,7 +534,7 @@ private struct _BSONKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContaine
         let entry = try getValue(forKey: key)
         return try self.decoder.with(pushedKey: key) {
             let value = try decoder.unbox(entry, as: type)
-            guard !(value is BSONNull) else {
+            guard !(value is BSONNull) || type == BSONNull.self else {
                 throw DecodingError.valueNotFound(
                     type,
                     DecodingError.Context(codingPath: self.decoder.codingPath,

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -1128,8 +1128,6 @@ public struct BSONUndefined: BSONValue, Equatable, Codable {
  * - Returns: `true` if `lhs` is equal to `rhs`, `false` otherwise.
  */
 public func bsonEquals(_ lhs: BSONValue, _ rhs: BSONValue) -> Bool {
-    validateBSONTypes(lhs, rhs)
-
     switch (lhs, rhs) {
     case let (l as Int, r as Int): return l == r
     case let (l as Int32, r as Int32): return l == r
@@ -1174,18 +1172,6 @@ public func bsonEquals(_ lhs: BSONValue?, _ rhs: BSONValue?) -> Bool {
     }
 
     return bsonEquals(left, right)
-}
-
-/// A function for catching invalid BSONTypes that should not ever arise, and triggering a fatalError when it
-/// finds such types.
-private func validateBSONTypes(_ lhs: BSONValue, _ rhs: BSONValue) {
-    let invalidTypes: [BSONType] = [.invalid]
-    guard !invalidTypes.contains(lhs.bsonType) else {
-        fatalError("\(lhs.bsonType) should not be used")
-    }
-    guard !invalidTypes.contains(rhs.bsonType) else {
-        fatalError("\(rhs.bsonType) should not be used")
-    }
 }
 
 /// Error thrown when a BSONValue type introduced by the driver (e.g. ObjectId) is encoded not using BSONEncoder

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -1075,7 +1075,7 @@ public struct Timestamp: BSONValue, Equatable, Codable {
 
 /// A struct to represent the deprecated Undefined type.
 /// Undefined instances cannot be created, but they can be read from existing documents that contain them.
-public final class BSONUndefined: BSONValue, Equatable, Codable {
+public struct BSONUndefined: BSONValue, Equatable, Codable {
     public var bsonType: BSONType { return .undefined }
 
     internal init() {}

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -407,8 +407,18 @@ public struct DBPointer: BSONValue, Codable, Equatable {
 }
 
 /// A struct to represent the BSON Decimal128 type.
-public struct Decimal128: BSONValue, Equatable, Codable {
+public struct Decimal128: BSONValue, Equatable, Codable, CustomStringConvertible {
     public var bsonType: BSONType { return .decimal128 }
+
+    public var description: String {
+        // TODO: avoid this copy via withUnsafePointer once swift 4.1 support is dropped (SWIFT-284)
+        var copy = self.decimal128
+        var str = Data(count: Int(BSON_DECIMAL128_STRING))
+        return str.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Int8>) in
+            bson_decimal128_to_string(&copy, bytes)
+            return String(cString: bytes)
+        }
+    }
 
     internal var decimal128: bson_decimal128_t
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -344,7 +344,7 @@ extension Date: BSONValue {
     }
 }
 
-/// An struct to represent the deprecated DBPointer type.
+/// A struct to represent the deprecated DBPointer type.
 /// DBPointers cannot be instantiated, but they can be read from existing documents that contain them.
 public struct DBPointer: BSONValue, Codable, Equatable {
     public var bsonType: BSONType { return .dbPointer }
@@ -361,7 +361,7 @@ public struct DBPointer: BSONValue, Codable, Equatable {
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        var oid = try ObjectId.toLibBSONType(self.id.oid)
+        var oid = try ObjectId.toLibBSONType(self.id.oid) // TODO: use the stored bson_oid_t (SWIFT-268)
         guard bson_append_dbpointer(storage.pointer, key, Int32(key.utf8.count), self.ref, &oid) else {
             throw bsonTooLargeError(value: self, forKey: key)
         }
@@ -453,7 +453,7 @@ public struct Decimal128: BSONValue, Equatable, Codable {
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        // TODO: avoid this copy via withUnsafePointer use once swift 4.1 support is dropped (SWIFT-284)
+        // TODO: avoid this copy via withUnsafePointer once swift 4.1 support is dropped (SWIFT-284)
         var copy = self.decimal128
         guard bson_append_decimal128(storage.pointer, key, Int32(key.utf8.count), &copy) else {
             throw bsonTooLargeError(value: self, forKey: key)

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -948,9 +948,9 @@ extension String: BSONValue {
         }
     }
 
-    /// Initializer that preserves null bytes embedded in C strings
-    internal init?(cStringWithEmbeddedNulls: UnsafePointer<CChar>, length: Int) {
-        let buffer = Data(bytes: cStringWithEmbeddedNulls, count: length)
+    /// Initializer that preserves null bytes embedded in C character buffers
+    internal init?(rawStringData: UnsafePointer<CChar>, length: Int) {
+        let buffer = Data(bytes: rawStringData, count: length)
         self.init(data: buffer, encoding: .utf8)
     }
 
@@ -964,7 +964,7 @@ extension String: BSONValue {
             throw RuntimeError.internalError(message: "String \(strValue) not valid UTF-8")
         }
 
-        guard let out = self.init(cStringWithEmbeddedNulls: strValue, length: Int(length)) else {
+        guard let out = self.init(rawStringData: strValue, length: Int(length)) else {
             throw RuntimeError.internalError(message: "Underlying string data could not be parsed to a Swift String")
         }
         return out
@@ -1015,7 +1015,7 @@ public struct Symbol: BSONValue, CustomStringConvertible, Codable, Equatable {
             throw wrongIterTypeError(iter, expected: Symbol.self)
         }
 
-        guard let strValue = String(cStringWithEmbeddedNulls: cStr, length: Int(length)) else {
+        guard let strValue = String(rawStringData: cStr, length: Int(length)) else {
             throw RuntimeError.internalError(message: "Cannot parse String from underlying data")
         }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -411,11 +411,11 @@ public struct Decimal128: BSONValue, Equatable, Codable, CustomStringConvertible
     public var bsonType: BSONType { return .decimal128 }
 
     public var description: String {
-        // TODO: avoid this copy via withUnsafePointer once swift 4.1 support is dropped (SWIFT-284)
-        var copy = self.decimal128
         var str = Data(count: Int(BSON_DECIMAL128_STRING))
         return str.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Int8>) in
-            bson_decimal128_to_string(&copy, bytes)
+            withUnsafePointer(to: self.decimal128) { ptr in
+                bson_decimal128_to_string(ptr, bytes)
+            }
             return String(cString: bytes)
         }
     }
@@ -450,10 +450,10 @@ public struct Decimal128: BSONValue, Equatable, Codable, CustomStringConvertible
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
-        // TODO: avoid this copy via withUnsafePointer once swift 4.1 support is dropped (SWIFT-284)
-        var copy = self.decimal128
-        guard bson_append_decimal128(storage.pointer, key, Int32(key.utf8.count), &copy) else {
-            throw bsonTooLargeError(value: self, forKey: key)
+        try withUnsafePointer(to: self.decimal128) { ptr in
+            guard bson_append_decimal128(storage.pointer, key, Int32(key.utf8.count), ptr) else {
+                throw bsonTooLargeError(value: self, forKey: key)
+            }
         }
     }
 

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -256,11 +256,11 @@ public class DocumentIterator: IteratorProtocol {
     /// - Throws:
     ///   - `RuntimeError.internalError` if the current value of this `DocumentIterator` cannot be decoded to BSON.
     internal func safeCurrentValue() throws -> BSONValue {
-        guard let curVal = try DocumentIterator.bsonTypeMap[currentType]?.from(iterator: self) else {
+        guard let bsonType = DocumentIterator.bsonTypeMap[currentType] else {
             throw RuntimeError.internalError(message: "Unknown BSONType for iterator's current value.")
         }
 
-        return curVal
+        return try bsonType.from(iterator: self)
     }
 
     // uses an iterator to copy (key, value) pairs of the provided document from range [startIndex, endIndex) into a new

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -256,18 +256,11 @@ public class DocumentIterator: IteratorProtocol {
     /// - Throws:
     ///   - `RuntimeError.internalError` if the current value of this `DocumentIterator` cannot be decoded to BSON.
     internal func safeCurrentValue() throws -> BSONValue {
-        switch self.currentType {
-        case .symbol:
-            return try Symbol.asString(from: self)
-        case .dbPointer:
-            return try DBPointer.asDocument(from: self)
-        default:
-            guard let curVal = try DocumentIterator.bsonTypeMap[currentType]?.from(iterator: self) else {
-                throw RuntimeError.internalError(message: "Unknown BSONType for iterator's current value.")
-            }
-
-            return curVal
+        guard let curVal = try DocumentIterator.bsonTypeMap[currentType]?.from(iterator: self) else {
+            throw RuntimeError.internalError(message: "Unknown BSONType for iterator's current value.")
         }
+
+        return curVal
     }
 
     // uses an iterator to copy (key, value) pairs of the provided document from range [startIndex, endIndex) into a new
@@ -340,6 +333,7 @@ public class DocumentIterator: IteratorProtocol {
         .decimal128: Decimal128.self,
         .minKey: MinKey.self,
         .maxKey: MaxKey.self,
-        .null: BSONNull.self
+        .null: BSONNull.self,
+        .undefined: BSONUndefined.self
     ]
 }

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -257,7 +257,9 @@ public class DocumentIterator: IteratorProtocol {
     ///   - `RuntimeError.internalError` if the current value of this `DocumentIterator` cannot be decoded to BSON.
     internal func safeCurrentValue() throws -> BSONValue {
         guard let bsonType = DocumentIterator.bsonTypeMap[currentType] else {
-            throw RuntimeError.internalError(message: "Unknown BSONType for iterator's current value.")
+            throw RuntimeError.internalError(
+                    message: "Unknown BSONType for iterator's current value with type: \(currentType)"
+            )
         }
 
         return try bsonType.from(iterator: self)

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -43,8 +43,9 @@ extension Double: Overwritable {
 
 extension Decimal128: Overwritable {
     internal func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        var encoded = try Decimal128.toLibBSONType(self.data)
-        bson_iter_overwrite_decimal128(&iter.iter, &encoded)
+        // TODO: avoid this copy via withUnsafePointer use once swift 4.1 support is dropped (SWIFT-284)
+        var copy = self.decimal128
+        bson_iter_overwrite_decimal128(&iter.iter, &copy)
     }
 }
 

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -43,7 +43,7 @@ extension Double: Overwritable {
 
 extension Decimal128: Overwritable {
     internal func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        // TODO: avoid this copy via withUnsafePointer use once swift 4.1 support is dropped (SWIFT-284)
+        // TODO: avoid this copy via withUnsafePointer once swift 4.1 support is dropped (SWIFT-284)
         var copy = self.decimal128
         bson_iter_overwrite_decimal128(&iter.iter, &copy)
     }

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -45,7 +45,7 @@ extension Decimal128: Overwritable {
     internal func writeToCurrentPosition(of iter: DocumentIterator) throws {
         withUnsafePointer(to: self.decimal128) { ptr in
             // bson_iter_overwrite_decimal128 takes in a (non-const) *decimal_128_t, so we need to pass in a mutable
-            // pointer. no mutation of self.decimal128 should occur, however.
+            // pointer. no mutation of self.decimal128 should occur, however. (CDRIVER-3069)
             bson_iter_overwrite_decimal128(&iter.iter, UnsafeMutablePointer<bson_decimal128_t>(mutating: ptr))
         }
     }

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -43,9 +43,11 @@ extension Double: Overwritable {
 
 extension Decimal128: Overwritable {
     internal func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        // TODO: avoid this copy via withUnsafePointer once swift 4.1 support is dropped (SWIFT-284)
-        var copy = self.decimal128
-        bson_iter_overwrite_decimal128(&iter.iter, &copy)
+        withUnsafePointer(to: self.decimal128) { ptr in
+            // bson_iter_overwrite_decimal128 takes in a (non-const) *decimal_128_t, so we need to pass in a mutable
+            // pointer. no mutation of self.decimal128 should occur, however.
+            bson_iter_overwrite_decimal128(&iter.iter, UnsafeMutablePointer<bson_decimal128_t>(mutating: ptr))
+        }
     }
 }
 

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -6,9 +6,9 @@ import XCTest
 
 final class BSONValueTests: MongoSwiftTestCase {
     func testInvalidDecimal128() throws {
-        expect(Decimal128(ifValid: "hi")).to(beNil())
-        expect(Decimal128(ifValid: "123.4.5")).to(beNil())
-        expect(Decimal128(ifValid: "10")).toNot(beNil())
+        expect(Decimal128("hi")).to(beNil())
+        expect(Decimal128("123.4.5")).to(beNil())
+        expect(Decimal128("10")).toNot(beNil())
     }
 
     func testUUIDBytes() throws {
@@ -38,7 +38,7 @@ final class BSONValueTests: MongoSwiftTestCase {
         // Double
         checkTrueAndFalse(val: 1.618, alternate: 2.718)
         // Decimal128
-        checkTrueAndFalse(val: Decimal128("1.618"), alternate: Decimal128("2.718"))
+        checkTrueAndFalse(val: Decimal128("1.618")!, alternate: Decimal128("2.718")!)
         // Bool
         checkTrueAndFalse(val: true, alternate: false)
         // String
@@ -147,24 +147,7 @@ final class BSONValueTests: MongoSwiftTestCase {
 
     /// Test AnyBSONValue Hashable conformance
     func testHashable() throws {
-        let expected = CodecTests.AllBSONTypes(
-                double: Double(2),
-                string: "hi",
-                doc: ["x": 1],
-                arr: [1, 2],
-                binary: try Binary(base64: "//8=", subtype: .generic),
-                oid: ObjectId(fromString: "507f1f77bcf86cd799439011"),
-                bool: true,
-                date: Date(timeIntervalSinceReferenceDate: 5000),
-                code: CodeWithScope(code: "hi", scope: ["x": 1]),
-                int: 1,
-                ts: Timestamp(timestamp: 1, inc: 2),
-                int32: 5,
-                int64: 6,
-                dec: Decimal128("1.2E+10"),
-                minkey: MinKey(),
-                maxkey: MaxKey(),
-                regex: RegularExpression(pattern: "^abc", options: "imx"))
+        let expected = try CodecTests.AllBSONTypes.factory()
 
         let values = Mirror(reflecting: expected).children.map { child in AnyBSONValue(child.value as! BSONValue) }
         let valuesSet = Set<AnyBSONValue>(values)

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -376,7 +376,7 @@ final class CodecTests: MongoSwiftTestCase {
                 "regex": self.regex,
                 "symbol": self.symbol,
                 "undefined": self.undefined,
-                "dbpointer": self.dbpointer,
+                "dbpointer": self.dbpointer
             ]
         }
     }

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -353,6 +353,32 @@ final class CodecTests: MongoSwiftTestCase {
                     undefined: BSONUndefined(),
                     dbpointer: DBPointer(ref: "some.namespace", id: ObjectId(fromString: "507f1f77bcf86cd799439011")))
         }
+
+        // Manually construct a document from this instance for comparision with encoder output.
+        public func toDocument() -> Document {
+            return [
+                "double": self.double,
+                "string": self.string,
+                "doc": self.doc,
+                "arr": self.arr,
+                "binary": self.binary,
+                "oid": self.oid,
+                "bool": self.bool,
+                "date": self.date,
+                "code": self.code,
+                "int": self.int,
+                "ts": self.ts,
+                "int32": self.int32,
+                "int64": self.int64,
+                "dec": self.dec,
+                "minkey": self.minkey,
+                "maxkey": self.maxkey,
+                "regex": self.regex,
+                "symbol": self.symbol,
+                "undefined": self.undefined,
+                "dbpointer": self.dbpointer,
+            ]
+        }
     }
 
     /// Test decoding/encoding to all possible BSON types
@@ -361,28 +387,7 @@ final class CodecTests: MongoSwiftTestCase {
 
         let decoder = BSONDecoder()
 
-        let doc: Document = [
-            "double": Double(2),
-            "string": "hi",
-            "doc": ["x": 1] as Document,
-            "arr": [1, 2],
-            "binary": try Binary(base64: "//8=", subtype: .generic),
-            "oid": ObjectId(fromString: "507f1f77bcf86cd799439011"),
-            "bool": true,
-            "date": Date(timeIntervalSinceReferenceDate: 5000),
-            "code": CodeWithScope(code: "hi", scope: ["x": 1]),
-            "int": 1,
-            "ts": Timestamp(timestamp: 1, inc: 2),
-            "int32": 5,
-            "int64": Int64(6),
-            "dec": Decimal128("1.2E+10")!,
-            "minkey": MinKey(),
-            "maxkey": MaxKey(),
-            "regex": RegularExpression(pattern: "^abc", options: "imx"),
-            "symbol": expected.symbol,
-            "undefined": expected.undefined,
-            "dbpointer": expected.dbpointer
-        ]
+        let doc = expected.toDocument()
 
         let res = try decoder.decode(AllBSONTypes.self, from: doc)
         expect(res).to(equal(expected))

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -319,6 +319,7 @@ final class CodecTests: MongoSwiftTestCase {
         let symbol: Symbol
         let undefined: BSONUndefined
         let dbpointer: DBPointer
+        let null: BSONNull
 
         public static func == (lhs: AllBSONTypes, rhs: AllBSONTypes) -> Bool {
             return lhs.double == rhs.double && lhs.string == rhs.string &&
@@ -327,7 +328,7 @@ final class CodecTests: MongoSwiftTestCase {
                     lhs.int == rhs.int && lhs.ts == rhs.ts && lhs.int32 == rhs.int32 &&
                     lhs.int64 == rhs.int64 && lhs.dec == rhs.dec && lhs.minkey == rhs.minkey &&
                     lhs.maxkey == rhs.maxkey && lhs.regex == rhs.regex && lhs.date == rhs.date &&
-                    lhs.symbol == rhs.symbol && lhs.dbpointer == rhs.dbpointer
+                    lhs.symbol == rhs.symbol && lhs.dbpointer == rhs.dbpointer && lhs.null == rhs.null
         }
 
         public static func factory() throws -> AllBSONTypes {
@@ -351,7 +352,8 @@ final class CodecTests: MongoSwiftTestCase {
                     regex: RegularExpression(pattern: "^abc", options: "imx"),
                     symbol: Symbol("i am a symbol"),
                     undefined: BSONUndefined(),
-                    dbpointer: DBPointer(ref: "some.namespace", id: ObjectId(fromString: "507f1f77bcf86cd799439011")))
+                    dbpointer: DBPointer(ref: "some.namespace", id: ObjectId(fromString: "507f1f77bcf86cd799439011")),
+                    null: BSONNull())
         }
 
         // Manually construct a document from this instance for comparision with encoder output.
@@ -376,7 +378,8 @@ final class CodecTests: MongoSwiftTestCase {
                 "regex": self.regex,
                 "symbol": self.symbol,
                 "undefined": self.undefined,
-                "dbpointer": self.dbpointer
+                "dbpointer": self.dbpointer,
+                "null": self.null
             ]
         }
     }
@@ -416,7 +419,8 @@ final class CodecTests: MongoSwiftTestCase {
             "regex" : { "$regularExpression" : { "pattern" : "^abc", "options" : "imx" } },
             "symbol" : { "$symbol" : "i am a symbol" },
             "undefined": { "$undefined" : true },
-            "dbpointer": { "$dbPointer" : { "$ref" : "some.namespace", "$id" : { "$oid" : "507f1f77bcf86cd799439011" } } }
+            "dbpointer": { "$dbPointer" : { "$ref" : "some.namespace", "$id" : { "$oid" : "507f1f77bcf86cd799439011" } } },
+            "null": null
         }
         """
         //swiftlint:enable line_length

--- a/Tests/MongoSwiftTests/Document+SequenceTests.swift
+++ b/Tests/MongoSwiftTests/Document+SequenceTests.swift
@@ -12,7 +12,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             "int": 25,
             "int32": Int32(5),
             "double": Double(15),
-            "decimal128": Decimal128("1.2E+10"),
+            "decimal128": Decimal128("1.2E+10")!,
             "minkey": MinKey(),
             "maxkey": MaxKey(),
             "date": Date(timeIntervalSince1970: 5000),
@@ -48,7 +48,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
 
         let decimalTup = iter.next()!
         expect(decimalTup.key).to(equal("decimal128"))
-        expect(decimalTup.value).to(bsonEqual(Decimal128("1.2E+10")))
+        expect(decimalTup.value).to(bsonEqual(Decimal128("1.2E+10")!))
 
         let minTup = iter.next()!
         expect(minTup.key).to(equal("minkey"))

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -361,9 +361,20 @@ final class DocumentTests: MongoSwiftTestCase {
                 let docFromCB = Document(fromBSON: cBData)
                 expect(docFromCB.rawBSON).to(equal(cBData))
 
-                let nativeFromDoc = docFromCB.toArray()
-                let docFromNative = Document(fromArray: nativeFromDoc)
-                expect(docFromNative.rawBSON).to(equal(cBData))
+                // test round tripping through documents
+                let testRoundTrip = {
+                    let nativeFromDoc = docFromCB.toArray()
+                    let docFromNative = Document(fromArray: nativeFromDoc)
+                    expect(docFromNative.rawBSON).to(equal(cBData))
+                }
+
+                #if swift(>=4.2.3) || !os(Linux)
+                testRoundTrip()
+                #else
+                if description != "Embedded Nulls" {
+                    testRoundTrip()
+                }
+                #endif
 
                 // native_to_canonical_extended_json( bson_to_native(cB) ) = cEJ
                 expect(docFromCB.canonicalExtendedJSON).to(cleanEqual(cEJ))

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -362,6 +362,11 @@ final class DocumentTests: MongoSwiftTestCase {
                 expect(docFromCB.rawBSON).to(equal(cBData))
 
                 // test round tripping through documents
+                // We create an array by reading every element out of the document (and therefore out of the bson_t)
+                // We then create a new document and append each element of the array to it. Once that is done, every
+                // element in the original document will have gone from bson_t -> Swift data type -> bson_t. At the end,
+                // the new bson_t should be identical to the original one. If not, our bson_t translation layer is
+                // lossy and/or buggy.
                 let testRoundTrip = {
                     let nativeFromDoc = docFromCB.toArray()
                     let docFromNative = Document(fromArray: nativeFromDoc)

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -368,10 +368,12 @@ final class DocumentTests: MongoSwiftTestCase {
                     expect(docFromNative.rawBSON).to(equal(cBData))
                 }
 
+                // Linux swift terminates all strings when encountering null bytes in Swift < 4.2.3 (SR-7455).
+                // TODO: remove this conditional compile when the minimum supported version is >= 4.2.3
                 #if swift(>=4.2.3) || !os(Linux)
                 testRoundTrip()
                 #else
-                if description != "Embedded Nulls" {
+                if description != "Embedded nulls" {
                     testRoundTrip()
                 }
                 #endif

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -27,6 +27,36 @@ extension Data {
     }
 }
 
+struct DocElem {
+    let key: String
+    let value: BSONValue
+    let type: BSONType
+}
+
+/// Extension of Document to allow conversion to and from arrays
+extension Document {
+    internal init(fromArray array: [DocElem]) {
+        self.init()
+
+        for elem in array {
+            if let subdoc = elem.value as? [DocElem], elem.type == .document {
+                self[elem.key] = Document(fromArray: subdoc)
+            } else {
+                self[elem.key] = elem.value
+            }
+        }
+    }
+
+    internal func toArray() -> [DocElem] {
+        return self.map { kvp in
+            if let subdoc = kvp.value as? Document {
+                return DocElem(key: kvp.key, value: subdoc.toArray(), type: .document)
+            }
+            return DocElem(key: kvp.key, value: kvp.value, type: kvp.value.bsonType)
+        }
+    }
+}
+
 final class DocumentTests: MongoSwiftTestCase {
     // Set up test document values
     static let testDoc: Document = [
@@ -37,7 +67,7 @@ final class DocumentTests: MongoSwiftTestCase {
         "int32": Int32(5),
         "int64": Int64(10),
         "double": Double(15),
-        "decimal128": Decimal128("1.2E+10"),
+        "decimal128": Decimal128("1.2E+10")!,
         "minkey": MinKey(),
         "maxkey": MaxKey(),
         "date": Date(timeIntervalSince1970: 500.004),
@@ -104,7 +134,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["int32"]).to(bsonEqual(5))
         expect(doc["int64"]).to(bsonEqual(Int64(10)))
         expect(doc["double"]).to(bsonEqual(15.0))
-        expect(doc["decimal128"]).to(bsonEqual(Decimal128("1.2E+10")))
+        expect(doc["decimal128"]).to(bsonEqual(Decimal128("1.2E+10")!))
         expect(doc["minkey"]).to(bsonEqual(MinKey()))
         expect(doc["maxkey"]).to(bsonEqual(MaxKey()))
         expect(doc["date"]).to(bsonEqual(Date(timeIntervalSince1970: 500.004)))
@@ -155,7 +185,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(DocumentTests.testDoc.int32).to(bsonEqual(5))
         expect(DocumentTests.testDoc.int64).to(bsonEqual(Int64(10)))
         expect(DocumentTests.testDoc.double).to(bsonEqual(15.0))
-        expect(DocumentTests.testDoc.decimal128).to(bsonEqual(Decimal128("1.2E+10")))
+        expect(DocumentTests.testDoc.decimal128).to(bsonEqual(Decimal128("1.2E+10")!))
         expect(DocumentTests.testDoc.minkey).to(bsonEqual(MinKey()))
         expect(DocumentTests.testDoc.maxkey).to(bsonEqual(MaxKey()))
         expect(DocumentTests.testDoc.date).to(bsonEqual(Date(timeIntervalSince1970: 500.004)))
@@ -328,10 +358,15 @@ final class DocumentTests: MongoSwiftTestCase {
 
                 // for cB input:
                 // native_to_bson( bson_to_native(cB) ) = cB
-                expect(Document(fromBSON: cBData).rawBSON).to(equal(cBData))
+                let docFromCB = Document(fromBSON: cBData)
+                expect(docFromCB.rawBSON).to(equal(cBData))
+
+                let nativeFromDoc = docFromCB.toArray()
+                let docFromNative = Document(fromArray: nativeFromDoc)
+                expect(docFromNative.rawBSON).to(equal(cBData))
 
                 // native_to_canonical_extended_json( bson_to_native(cB) ) = cEJ
-                expect(Document(fromBSON: cBData).canonicalExtendedJSON).to(cleanEqual(cEJ))
+                expect(docFromCB.canonicalExtendedJSON).to(cleanEqual(cEJ))
 
                 // native_to_relaxed_extended_json( bson_to_native(cB) ) = rEJ (if rEJ exists)
                 if let rEJ = validCase["relaxed_extjson"] as? String {
@@ -412,7 +447,7 @@ final class DocumentTests: MongoSwiftTestCase {
         "int32": Int32(32),
         "int64": Int64.max,
         "bool": false,
-        "decimal": Decimal128("1.2E+10"),
+        "decimal": Decimal128("1.2E+10")!,
         "oid": ObjectId(),
         "timestamp": Timestamp(timestamp: 1, inc: 2),
         "datetime": Date(msSinceEpoch: 1000)
@@ -449,7 +484,7 @@ final class DocumentTests: MongoSwiftTestCase {
         doc["double"] = 3.0
         expect(doc.data).to(equal(pointer))
 
-        doc["decimal"] = Decimal128("100")
+        doc["decimal"] = Decimal128("100")!
         expect(doc.data).to(equal(pointer))
 
         // overwrite int64 with int64
@@ -471,7 +506,7 @@ final class DocumentTests: MongoSwiftTestCase {
             "int32": 20,
             "int64": Int64.min,
             "bool": true,
-            "decimal": Decimal128("100"),
+            "decimal": Decimal128("100")!,
             "oid": newOid,
             "timestamp": Timestamp(timestamp: 5, inc: 10),
             "datetime": Date(msSinceEpoch: 2000)
@@ -492,7 +527,7 @@ final class DocumentTests: MongoSwiftTestCase {
             "int32": 20,
             "int64": bigInt,
             "bool": true,
-            "decimal": Decimal128("100"),
+            "decimal": Decimal128("100")!,
             "oid": newOid,
             "timestamp": Timestamp(timestamp: 5, inc: 10),
             "datetime": Date(msSinceEpoch: 2000)
@@ -534,7 +569,7 @@ final class DocumentTests: MongoSwiftTestCase {
         let overwritablePairs: [(String, BSONValue)] = [
             ("double", Int(10)),
             ("int32", "hi"),
-            ("int64", Decimal128("1.0")),
+            ("int64", Decimal128("1.0")!),
             ("bool", [1, 2, 3]),
             ("decimal", 100),
             ("oid", 25.5),
@@ -551,7 +586,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(overwritableDoc).to(equal([
             "double": 10,
             "int32": "hi",
-            "int64": Decimal128("1.0"),
+            "int64": Decimal128("1.0")!,
             "bool": [1, 2, 3] as [Int],
             "decimal": 100,
             "oid": 25.5,

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -7,10 +7,6 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         continueAfterFailure = false
     }
 
-    struct A: Decodable {
-        let a: ObjectId
-    }
-
     func testMongoDatabase() throws {
         let client = try MongoClient(MongoSwiftTestCase.connStr)
         let db = client.db(type(of: self).testDatabase)

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -7,6 +7,10 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         continueAfterFailure = false
     }
 
+    struct A: Decodable {
+        let a: ObjectId
+    }
+
     func testMongoDatabase() throws {
         let client = try MongoClient(MongoSwiftTestCase.connStr)
         let db = client.db(type(of: self).testDatabase)


### PR DESCRIPTION
[SWIFT-356](https://jira.mongodb.org/browse/SWIFT-356) / [SWIFT-352](https://jira.mongodb.org/browse/SWIFT-352)

This PR ensures all BSON types laid out in the bsonspec are correctly round-tripped through `Document` via the bson-corpus spec tests.

The main changes:
- introduction of `BSONUndefined` type
- exposing of `Symbol` and `DBPointer`
- `Decimal128` now stores a `bson_decimal128_t` instead of converting back and forth between strings
  - The default (and only public) constructor now is an `init?`, since we cannot avoid constructing the `bson_decimal_128_t` any longer if it's serving as the storage

