### PR TITLE
SWIFT-340 Add missing documentation

### DIFF
--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -30,13 +30,11 @@ extension Document: Sequence {
     }
 
     /**
-     * Returns a new document containing the keys of this document with the values transformed by
-     * the given closure.
+     * Returns a new document containing the keys of this document with the values transformed by the given closure.
      *
      * - Parameters:
-     *   - transform: A closure that transforms a `BSONValue`. `transform` accepts each value of the
-     *                document as its parameter and returns a transformed `BSONValue` of the same or
-     *                of a different type.
+     *   - transform: A closure that transforms a `BSONValue`. `transform` accepts each value of the document as its
+     *                parameter and returns a transformed `BSONValue` of the same or of a different type.
      *
      * - Returns: A document containing the keys and transformed values of this document.
      *
@@ -50,6 +48,14 @@ extension Document: Sequence {
         return output
     }
 
+    /**
+     * Returns a document containing all but the given number of initial key-value pairs.
+     *
+     * - Parameters:
+     *   - k: The number of key-value pairs to drop from the beginning of the document. k must be > 0.
+     *
+     * - Returns: A document starting after the specified number of key-value pairs.
+     */
     public func dropFirst(_ n: Int) -> Document {
         switch n {
         case ..<0:
@@ -64,6 +70,14 @@ extension Document: Sequence {
         }
     }
 
+    /**
+     * Returns a document containing all but the given number of final key-value pairs.
+     *
+     * - Parameters:
+     *   - k: The number of key-value pairs to drop from the end of the document. Must be greater than or equal to zero.
+     *
+     * - Returns: A document leaving off the specified number of final key-value pairs.
+     */
     public func dropLast(_ n: Int) -> Document {
         switch n {
         case ..<0:
@@ -78,6 +92,17 @@ extension Document: Sequence {
         }
     }
 
+    /**
+     * Returns a document by skipping the initial, consecutive key-value pairs that satisfy the given predicate.
+     *
+     * - Parameters:
+     *   - predicate: A closure that takes a key-value pair as its argument and returns a boolean indicating whether
+     *                the key-value pair should be included in the result.
+     *
+     * - Returns: A document starting after the initial, consecutive key-value pairs that satisfy `predicate`.
+     *
+     * - Throws: An error if `predicate` throws an error.
+     */
     public func drop(while predicate: (KeyValuePair) throws -> Bool) rethrows -> Document {
         // tracks whether we are still in a "dropping" state. once we encounter
         // an element that doesn't satisfy the predicate, we stop dropping.
@@ -97,6 +122,14 @@ extension Document: Sequence {
         }
     }
 
+    /**
+     * Returns a document, up to the specified maximum length, containing the initial key-value pairs of the document.
+     *
+     * - Parameters:
+     *   - maxLength: The maximum length for the returned document. Must be greater than or equal to zero.
+     *
+     * - Returns: A document starting at the beginning of this document with at most `maxLength` key-value pairs.
+     */
     public func prefix(_ maxLength: Int) -> Document {
         switch maxLength {
         case ..<0:
@@ -109,6 +142,17 @@ extension Document: Sequence {
         }
     }
 
+    /**
+     * Returns a document containing the initial, consecutive key-value pairs that satisfy the given predicate.
+     *
+     * - Parameters:
+     *   - predicate: A closure that takes a key-value pair as its argument and returns a boolean indicating whether
+     *                the key-value pair should be included in the result.
+     *
+     * - Returns: A document containing the initial, consecutive key-value pairs that satisfy `predicate`.
+     *
+     * - Throws: An error if `predicate` throws an error.
+     */
     public func prefix(while predicate: (KeyValuePair) throws -> Bool) rethrows -> Document {
         var output = Document()
         for elt in self {
@@ -118,6 +162,14 @@ extension Document: Sequence {
         return output
     }
 
+    /**
+     * Returns a document, up to the specified maximum length, containing the final key-value pairs of the document.
+     *
+     * - Parameters:
+     *   - maxLength: The maximum length for the returned document. Must be greater than or equal to zero.
+     *
+     * - Returns: A document ending at the end of this document with at most `maxLength` key-value pairs.
+     */
     public func suffix(_ maxLength: Int) -> Document {
         switch maxLength {
         case ..<0:
@@ -131,6 +183,26 @@ extension Document: Sequence {
         }
     }
 
+    /**
+     * Returns the longest possible subsequences of the document, in order, that don’t contain key-value pairs
+     * satisfying the given predicate. Key-value pairs that are used to split the document are not returned as part of
+     * any subsequence.
+     *
+     * - Parameters:
+     *   - maxSplits: The maximum number of times to split the document, or one less than the number of subsequences to
+     *                return. If `maxSplits` + 1 subsequences are returned, the last one is a suffix of the original 
+     *                document containing the remaining key-value pairs. `maxSplits` must be greater than or equal to
+     *                zero. The default value is `Int.max`.
+     *   - omittingEmptySubsequences: If false, an empty document is returned in the result for each pair of 
+     *                                consecutive key-value pairs satisfying the `isSeparator` predicate and for each
+     *                                key-value pair at the start or end of the document satisfying the `isSeparator` 
+     *                                predicate. If true, only nonempty documents are returned. The default value is
+     *                                true.
+     *   - isSeparator: A closure that returns true if its argument should be used to split the document and otherwise
+     *                  returns false.
+     *
+     * - Returns: An array of documents, split from this document's key-value pairs.
+     */ 
     public func split(maxSplits: Int = Int.max,
                       omittingEmptySubsequences: Bool = true,
                       whereSeparator isSeparator: (KeyValuePair) throws -> Bool) rethrows -> [Document] {
@@ -158,13 +230,13 @@ extension Document {
     // this variant is called by default, but the other is still accessible by explicitly stating
     // return type: `let newDocPairs: [Document.KeyValuePair] = newDoc.filter { ... }`
     /**
-     * Returns a new document containing the key-value pairs of the dictionary that satisfy the given predicate.
+     * Returns a new document containing the elements of the document that satisfy the given predicate.
      *
      * - Parameters:
      *   - isIncluded: A closure that takes a key-value pair as its argument and returns a `Bool` indicating whether
      *                 the pair should be included in the returned document.
      *
-     * - Returns: A document of the key-value pairs that `isIncluded` allows.
+     * - Returns: A document containing the key-value pairs that `isIncluded` allows.
      *
      * - Throws: An error if `isIncluded` throws an error.
      */

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -20,6 +20,7 @@ public class DocumentStorage {
         self.pointer = bson_copy(pointer)
     }
 
+    /// Deinitializes a `DocumentStorage`, cleaning up its internal state.
     deinit {
         guard let pointer = self.pointer else {
             return

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -20,7 +20,7 @@ public class DocumentStorage {
         self.pointer = bson_copy(pointer)
     }
 
-    /// Deinitializes a `DocumentStorage`, cleaning up its internal state.
+    /// Cleans up internal state.
     deinit {
         guard let pointer = self.pointer else {
             return

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -10,7 +10,7 @@ public class ClientSession: Encodable {
     internal init() {
     }
 
-    /// Clean up the internal mongoc_session_t.
+    /// Cleans up internal state.
     deinit {
     }
 

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -179,9 +179,7 @@ public class MongoClient {
         mongoc_client_set_error_api(self._client, MONGOC_ERROR_API_VERSION_2)
     }
 
-    /**
-     * Cleans up the internal `mongoc_client_t`.
-     */
+    /// Cleans up internal state.
     deinit {
         close()
     }

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -352,7 +352,7 @@ public class BulkWriteOperation {
         return self.isAcknowledged ? result : nil
     }
 
-    /// Deinitializes a `BulkWriteOperation`, cleaning up internal state.
+    /// Cleans up internal state.
     deinit {
         guard let bulk = self.bulk else {
             return

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -352,6 +352,7 @@ public class BulkWriteOperation {
         return self.isAcknowledged ? result : nil
     }
 
+    /// Deinitializes a `BulkWriteOperation`, cleaning up internal state.
     deinit {
         guard let bulk = self.bulk else {
             return

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -383,6 +383,7 @@ private class FindAndModifyOptions {
         }
     }
 
+    /// Cleans up internal state.
     deinit {
         guard let options = self._options else {
             return

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -45,7 +45,7 @@ public class MongoCollection<T: Codable> {
         self._client = withClient
     }
 
-    /// Deinitializes a `MongoCollection`, cleaning up the internal `mongoc_collection_t`
+    /// Cleans up internal state.
     deinit {
         guard let collection = self._collection else {
             return

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -32,7 +32,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
         }
     }
 
-    /// Deinitializes a `MongoCursor`, cleaning up the internal `mongoc_cursor_t`.
+    /// Cleans up internal state.
     deinit {
         self.close()
     }

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -182,7 +182,7 @@ public class MongoDatabase {
         self._client = withClient
     }
 
-    /// Deinitializes a MongoDatabase, cleaning up the internal `mongoc_database_t`.
+    /// Cleans up internal state.
     deinit {
         guard let database = self._database else {
             return

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -86,7 +86,7 @@ public class ReadConcern: Codable {
         try container.encodeIfPresent(self.level, forKey: .level)
     }
 
-    /// Cleans up the internal `mongoc_read_concern_t`.
+    /// Cleans up internal state.
     deinit {
         guard let readConcern = self._readConcern else {
             return

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -8,10 +8,18 @@ import mongoc
 public final class ReadPreference {
     /// An enumeration of possible ReadPreference modes.
     public enum Mode: String {
+        /// Default mode. All operations read from the current replica set primary.
         case primary
+        /// In most situations, operations read from the primary but if it is 
+        /// unavailable, operations read from secondary members.
         case primaryPreferred
+        /// All operations read from the secondary members of the replica set.
         case secondary
+        /// In most situations, operations read from secondary members but if no 
+        /// secondary members are available, operations read from the primary.
         case secondaryPreferred
+        /// Operations read from member of the replica set with the least network
+        /// latency, irrespective of the member’s type.
         case nearest
 
         internal var readMode: mongoc_read_mode_t {

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -144,7 +144,7 @@ public final class ReadPreference {
         self._readPreference = mongoc_read_prefs_copy(readPreference)
     }
 
-    /// Cleans up the internal `mongoc_read_prefs_t`.
+    /// Cleans up internal state.
     deinit {
         guard let readPreference = self._readPreference else {
             return

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -159,7 +159,7 @@ public class WriteConcern: Codable {
         try container.encodeIfPresent(self.journal, forKey: .j)
     }
 
-    /// /// Cleans up the internal `mongoc_write_concern_t`.
+    /// Cleans up internal state.
     deinit {
         guard let writeConcern = self._writeConcern else {
             return

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -159,6 +159,7 @@ public class WriteConcern: Codable {
         try container.encodeIfPresent(self.journal, forKey: .j)
     }
 
+    /// /// Cleans up the internal `mongoc_write_concern_t`.
     deinit {
         guard let writeConcern = self._writeConcern else {
             return


### PR DESCRIPTION
This brings us to 100% documentation on jazzy.

The ReadPreference mode docs were missing (which is what this ticket was initially about), but it appears jazzy now also cares about having documentation for protocol methods (e.g. all the `Sequence` protocol methods I've added docstrings for here), as well as for `deinit`s. I standardized the docstring for all of the `deinit`s - a lot of them mentioned libmongoc/libbson internals which we should avoid talking about in documentation. 