### PR TITLE
Memory leakage

### DIFF
--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -271,8 +271,10 @@ extension Document {
         guard let json = bson_as_relaxed_extended_json(self.data, nil) else {
             return ""
         }
-
-        bson_free(json)
+        
+        defer {
+            bson_free(json)
+        }
 
         return String(cString: json)
     }
@@ -283,8 +285,10 @@ extension Document {
         guard let json = bson_as_canonical_extended_json(self.data, nil) else {
             return ""
         }
-
-        bson_free(json)
+        
+        defer {
+            bson_free(json)
+        }
 
         return String(cString: json)
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -272,6 +272,8 @@ extension Document {
             return ""
         }
 
+        bson_free(json)
+
         return String(cString: json)
     }
 
@@ -281,6 +283,8 @@ extension Document {
         guard let json = bson_as_canonical_extended_json(self.data, nil) else {
             return ""
         }
+
+        bson_free(json)
 
         return String(cString: json)
     }


### PR DESCRIPTION
The two following functions don't release memory, added bson_free(json) to them and everything works fine!

BSON.Document.extendedJSON
BSON.Document.canonicalExtendedJSON