### PR TITLE
use internal `_bson_get_len` from swift C bson bindings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
-          "version": "7.3.1"
+          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
+          "version": "7.3.4"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mongodb/swift-bson",
         "state": {
           "branch": null,
-          "revision": "87b458f55ba66f20305341d9d138e47dbcc92da7",
-          "version": "2.0.0"
+          "revision": "40f770ed265bb9958edbcd0c809a3c2afe75a3ba",
+          "version": "2.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ let package = Package(
         .library(name: "MongoSwift", targets: ["MongoSwift"])
     ],
     dependencies: [
-        .package(url: "https://github.com/mongodb/swift-bson", from: "2.0.0"),
-        .package(url: "https://github.com/mongodb/swift-mongoc", from: "2.0.0"),
+        .package(url: "https://github.com/mongodb/swift-bson", .upToNextMajor(from: "2.0.0")),
+        .package(url: "https://github.com/mongodb/swift-mongoc", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/Quick/Nimble.git", from: "7.3.0")
     ],
     targets: [

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -283,7 +283,11 @@ extension Document {
     public var rawBSON: Data {
         // swiftlint:disable:next force_unwrapping - documented as always returning a value.
         let data = bson_get_data(self.data)!
+#if compiler(>=5.0)
+        let length = _bson_get_len(self.data)
+#else
         let length = self.data.pointee.len
+#endif
         return Data(bytes: data, count: Int(length))
     }
 


### PR DESCRIPTION
This method is introduced to overcome limitations around field
access when `bson_t` is treated as an `OpaquePointer`.
