### PR TITLE
SWIFT-297 Use synthesized Equatable where possible

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -157,10 +157,6 @@ public struct BSONNull: BSONValue, Codable, Equatable {
             throw bsonTooLargeError(value: self, forKey: key)
         }
     }
-
-    public static func == (lhs: BSONNull, rhs: BSONNull) -> Bool {
-        return true
-    }
 }
 
 /// A struct to represent the BSON Binary type.
@@ -285,10 +281,6 @@ public struct Binary: BSONValue, Equatable, Codable {
         let dataObj = Data(bytes: data, count: Int(length))
         return try self.init(data: dataObj, subtype: UInt8(subtype.rawValue))
     }
-
-    public static func == (lhs: Binary, rhs: Binary) -> Bool {
-        return lhs.data == rhs.data && lhs.subtype == rhs.subtype
-    }
 }
 
 /// An extension of `Bool` to represent the BSON Boolean type.
@@ -390,10 +382,6 @@ public struct DBPointer: BSONValue, Codable, Equatable {
         }
 
         return DBPointer(ref: String(cString: collectionP), id: ObjectId(fromPointer: oidP))
-    }
-
-    public static func == (lhs: DBPointer, rhs: DBPointer) -> Bool {
-        return lhs.ref == rhs.ref && lhs.id == rhs.id
     }
 }
 
@@ -620,10 +608,6 @@ public struct CodeWithScope: BSONValue, Equatable, Codable {
 
         return self.init(code: code, scope: scopeDoc)
     }
-
-    public static func == (lhs: CodeWithScope, rhs: CodeWithScope) -> Bool {
-        return lhs.code == rhs.code && lhs.scope == rhs.scope
-    }
 }
 
 /// A struct to represent the BSON MaxKey type.
@@ -655,8 +639,6 @@ public struct MaxKey: BSONValue, Equatable, Codable {
         }
         return MaxKey()
     }
-
-    public static func == (lhs: MaxKey, rhs: MaxKey) -> Bool { return true }
 }
 
 /// A struct to represent the BSON MinKey type.
@@ -688,8 +670,6 @@ public struct MinKey: BSONValue, Equatable, Codable {
         }
         return MinKey()
     }
-
-    public static func == (lhs: MinKey, rhs: MinKey) -> Bool { return true }
 }
 
 /// A struct to represent the BSON ObjectId type.
@@ -904,11 +884,6 @@ public struct RegularExpression: BSONValue, Equatable, Codable {
 
         return self.init(pattern: patternString, options: optionsString)
     }
-
-    /// Returns `true` if the two `RegularExpression`s have matching patterns and options, and `false` otherwise.
-    public static func == (lhs: RegularExpression, rhs: RegularExpression) -> Bool {
-        return lhs.pattern == rhs.pattern && lhs.options == rhs.options
-    }
 }
 
 /// An extension of String to represent the BSON string type.
@@ -991,10 +966,6 @@ public struct Symbol: BSONValue, CustomStringConvertible, Codable, Equatable {
 
         return Symbol(strValue)
     }
-
-    public static func == (lhs: Symbol, rhs: Symbol) -> Bool {
-        return lhs.stringValue == rhs.stringValue
-    }
 }
 
 /// A struct to represent the BSON Timestamp type.
@@ -1044,10 +1015,6 @@ public struct Timestamp: BSONValue, Equatable, Codable {
 
         return self.init(timestamp: t, inc: i)
     }
-
-    public static func == (lhs: Timestamp, rhs: Timestamp) -> Bool {
-        return lhs.timestamp == rhs.timestamp && lhs.increment == rhs.increment
-    }
 }
 
 /// A struct to represent the deprecated Undefined type.
@@ -1076,10 +1043,6 @@ public struct BSONUndefined: BSONValue, Equatable, Codable {
             throw wrongIterTypeError(iter, expected: BSONUndefined.self)
         }
         return BSONUndefined()
-    }
-
-    public static func == (lhs: BSONUndefined, rhs: BSONUndefined) -> Bool {
-        return true
     }
 }
 

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -28,11 +28,6 @@ public struct ConnectionId: Equatable {
         // swiftlint:disable:next force_unwrapping - should be valid UInt16 unless server response malformed.
         self.port = UInt16(parts[1])!
     }
-
-    /// ConnectionIds are equal if their hosts and ports match.
-    public static func == (lhs: ConnectionId, rhs: ConnectionId) -> Bool {
-        return lhs.host == rhs.host && rhs.port == lhs.port
-    }
 }
 
 /// A struct describing a mongod or mongos process.

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -36,19 +36,6 @@ public class WriteConcern: Codable {
                 try container.encode("majority")
             }
         }
-
-        public static func == (lhs: W, rhs: W) -> Bool {
-            switch (lhs, rhs) {
-            case let (.number(lNum), .number(rNum)):
-                return lNum == rNum
-            case let (.tag(lTag), .tag(rTag)):
-                return lTag == rTag
-            case (.majority, .majority):
-                return true
-            default:
-                return false
-            }
-        }
     }
 
     /// Indicates the `W` value for this `WriteConcern`.

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -32,35 +32,19 @@ final class CodecTests: MongoSwiftTestCase {
     struct BasicStruct: Codable, Equatable {
         let int: Int
         let string: String
-
-        public static func == (lhs: BasicStruct, rhs: BasicStruct) -> Bool {
-            return lhs.int == rhs.int && lhs.string == rhs.string
-        }
     }
 
     struct NestedStruct: Codable, Equatable {
         let s1: BasicStruct
         let s2: BasicStruct
-
-        public static func == (lhs: NestedStruct, rhs: NestedStruct) -> Bool {
-            return lhs.s1 == rhs.s1 && lhs.s2 == rhs.s2
-        }
     }
 
     struct NestedArray: Codable, Equatable {
         let array: [BasicStruct]
-
-        public static func == (lhs: NestedArray, rhs: NestedArray) -> Bool {
-            return lhs.array == rhs.array
-        }
     }
 
     struct NestedNestedStruct: Codable, Equatable {
         let s: NestedStruct
-
-        public static func == (lhs: NestedNestedStruct, rhs: NestedNestedStruct) -> Bool {
-            return lhs.s == rhs.s
-        }
     }
 
     /// Test encoding/decoding a variety of structs containing simple types that have 
@@ -111,10 +95,6 @@ final class CodecTests: MongoSwiftTestCase {
         let int: Int?
         let bool: Bool?
         let string: String
-
-        public static func == (lhs: OptionalsStruct, rhs: OptionalsStruct) -> Bool {
-            return lhs.int == rhs.int && lhs.bool == rhs.bool && lhs.string == rhs.string
-        }
     }
 
     /// Test encoding/decoding a struct containing optional values.
@@ -148,13 +128,6 @@ final class CodecTests: MongoSwiftTestCase {
         let float: Float?
 
         static let keys = ["int8", "int16", "uint8", "uint16", "uint32", "uint64", "uint", "float"]
-
-        public static func == (lhs: Numbers, rhs: Numbers) -> Bool {
-            return lhs.int8 == rhs.int8 && lhs.int16 == rhs.int16 &&
-                    lhs.uint8 == rhs.uint8 && lhs.uint16 == rhs.uint16 &&
-                    lhs.uint32 == rhs.uint32 && lhs.uint64 == rhs.uint64 &&
-                    lhs.uint == rhs.uint && lhs.float == rhs.float
-        }
 
         init(int8: Int8? = nil,
              int16: Int16? = nil,
@@ -265,11 +238,6 @@ final class CodecTests: MongoSwiftTestCase {
         let int32: Int32
         let int64: Int64
         let double: Double
-
-        public static func == (lhs: BSONNumbers, rhs: BSONNumbers) -> Bool {
-            return lhs.int == rhs.int && lhs.int32 == rhs.int32 &&
-                    lhs.int64 == rhs.int64 && lhs.double == rhs.double
-        }
     }
 
     /// Test that BSON number types are encoded properly, and can be decoded from any type they are stored as
@@ -320,16 +288,6 @@ final class CodecTests: MongoSwiftTestCase {
         let undefined: BSONUndefined
         let dbpointer: DBPointer
         let null: BSONNull
-
-        public static func == (lhs: AllBSONTypes, rhs: AllBSONTypes) -> Bool {
-            return lhs.double == rhs.double && lhs.string == rhs.string &&
-                    lhs.doc == rhs.doc && lhs.arr == rhs.arr && lhs.binary == rhs.binary &&
-                    lhs.oid == rhs.oid && lhs.bool == rhs.bool && lhs.code == rhs.code &&
-                    lhs.int == rhs.int && lhs.ts == rhs.ts && lhs.int32 == rhs.int32 &&
-                    lhs.int64 == rhs.int64 && lhs.dec == rhs.dec && lhs.minkey == rhs.minkey &&
-                    lhs.maxkey == rhs.maxkey && lhs.regex == rhs.regex && lhs.date == rhs.date &&
-                    lhs.symbol == rhs.symbol && lhs.dbpointer == rhs.dbpointer && lhs.null == rhs.null
-        }
 
         public static func factory() throws -> AllBSONTypes {
             return AllBSONTypes(

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -367,10 +367,6 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     struct Basic: Codable, Equatable {
         let x: Int
         let y: String
-
-        static func == (lhs: Basic, rhs: Basic) -> Bool {
-            return lhs.x == rhs.x && lhs.y == rhs.y
-        }
     }
 
     func testCodableCollection() throws {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -112,12 +112,6 @@ extension MongoClient {
             self.patch = patch ?? 0
         }
 
-        static func == (lhs: ServerVersion, rhs: ServerVersion) -> Bool {
-            return lhs.major == rhs.major &&
-                    lhs.minor == rhs.minor &&
-                    lhs.patch == rhs.patch
-        }
-
         func isLessThan(_ version: ServerVersion) -> Bool {
             if self.major == version.major {
                 if self.minor == version.minor {


### PR DESCRIPTION
Deletes our `==` functions anywhere they are just doing the default behavior (comparing all stored properties.)