### PR TITLE
Enable trailing whitespace rule in comments

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,7 +51,6 @@ excluded:
   - Sources/libbson
   - Sources/libmongoc
   - Package.swift
-  - Package@swift-4.2.swift
   - Examples/*/Package.swift
 
 trailing_whitespace:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,3 +53,6 @@ excluded:
   - Package.swift
   - Package@swift-4.2.swift
   - Examples/*/Package.swift
+
+trailing_whitespace:
+  ignores_comments: false

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A struct wrapping a `BSONValue` type that allows for encoding/
-/// decoding `BSONValue`s of unknown type.  
+/// decoding `BSONValue`s of unknown type.
 public struct AnyBSONValue: Codable, Equatable, Hashable {
     // TODO: conform all `BSONValue` types to `Hashable` (SWIFT-320).
     // swiftlint:disable:next legacy_hashing
@@ -45,7 +45,7 @@ public struct AnyBSONValue: Codable, Equatable, Hashable {
         }
 
         // in this case, we need to wrap each value in an
-        // `AnyBSONValue`, before we encode, because `[BSONValue]` 
+        // `AnyBSONValue`, before we encode, because `[BSONValue]`
         // is not considered `Encodable`
         if let arr = self.value as? [BSONValue] {
             let mapped = arr.map { AnyBSONValue($0) }

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -305,7 +305,7 @@ internal struct _BSONDecodingStorage {
         self.containers.append(container)
     }
 
-    /// Pops the top container from the stack. 
+    /// Pops the top container from the stack.
     fileprivate mutating func popContainer() {
         guard !self.containers.isEmpty else {
             fatalError("Empty container stack.")
@@ -657,7 +657,7 @@ private struct _BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     // swiftlint:disable:previous force_unwrapping - `.count` always returns a value and is only an `Int?`
     // because it's required of the UnkeyedDecodingContainer protocol.
 
-    /// A private helper function to check if we're at the end of the container, and if so throw an error. 
+    /// A private helper function to check if we're at the end of the container, and if so throw an error.
     private func checkAtEnd() throws {
         guard !self.isAtEnd else {
             throw DecodingError.valueNotFound(

--- a/Sources/MongoSwift/BSON/CodableNumber.swift
+++ b/Sources/MongoSwift/BSON/CodableNumber.swift
@@ -13,7 +13,7 @@ internal protocol CodableNumber {
     init?(exactly source: Double)
 
     /// Converts this number to a `BSONValue`. Returns `nil` if it cannot
-    /// be represented exactly. 
+    /// be represented exactly.
     var bsonValue: BSONValue? { get }
 }
 
@@ -129,7 +129,7 @@ extension UInt: CodableNumber {
         }
         // we could consider trying a Decimal128 here. However,
         // it's not clear how we could support decoding something
-        // stored as Decimal128 back to a UInt without access 
+        // stored as Decimal128 back to a UInt without access
         // to libbson internals.
         return nil
     }

--- a/Sources/MongoSwift/BSON/Document+Codable.swift
+++ b/Sources/MongoSwift/BSON/Document+Codable.swift
@@ -27,10 +27,10 @@ extension Document: Codable {
 
     /// This method will work with any `Decoder`, but for non-BSON
     /// decoders, we do not support decoding `Date`s, because of limitations
-    /// of decoding to `AnyBSONValue`s. See `AnyBSONValue.init(from:)` for 
+    /// of decoding to `AnyBSONValue`s. See `AnyBSONValue.init(from:)` for
     /// more information.
     public init(from decoder: Decoder) throws {
-        // if it's a `BSONDecoder` we should just short-circuit and 
+        // if it's a `BSONDecoder` we should just short-circuit and
         // return the container `Document`
         if let bsonDecoder = decoder as? _BSONDecoder {
             let topContainer = bsonDecoder.storage.topContainer

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -10,12 +10,12 @@ public final class ReadPreference {
     public enum Mode: String {
         /// Default mode. All operations read from the current replica set primary.
         case primary
-        /// In most situations, operations read from the primary but if it is 
+        /// In most situations, operations read from the primary but if it is
         /// unavailable, operations read from secondary members.
         case primaryPreferred
         /// All operations read from the secondary members of the replica set.
         case secondary
-        /// In most situations, operations read from secondary members but if no 
+        /// In most situations, operations read from secondary members but if no
         /// secondary members are available, operations read from the primary.
         case secondaryPreferred
         /// Operations read from member of the replica set with the least network

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -47,7 +47,7 @@ final class CodecTests: MongoSwiftTestCase {
         let s: NestedStruct
     }
 
-    /// Test encoding/decoding a variety of structs containing simple types that have 
+    /// Test encoding/decoding a variety of structs containing simple types that have
     /// built in Codable support (strings, arrays, ints, and structs composed of them.)
     func testStructs() throws {
         let encoder = BSONEncoder()
@@ -63,7 +63,7 @@ final class CodecTests: MongoSwiftTestCase {
 
         expect(try encoder.encode(TestClass())).to(equal(expected))
 
-        // a basic struct 
+        // a basic struct
         let basic1 = BasicStruct(int: 1, string: "hello")
         let basic1Doc: Document = ["int": 1, "string": "hello"]
         expect(try encoder.encode(basic1)).to(equal(basic1Doc))
@@ -444,7 +444,7 @@ final class CodecTests: MongoSwiftTestCase {
     func testDocumentIsCodable() throws {
 #if os(macOS) // presently skipped on linux due to nondeterministic key ordering
         // note: instead of doing this, one can and should just initialize a Document with the `init(fromJSON:)`
-        // constructor, and conver to JSON using the .extendedJSON property. this test is just to demonstrate 
+        // constructor, and conver to JSON using the .extendedJSON property. this test is just to demonstrate
         // that a Document can theoretically work with any encoder/decoder.
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -39,7 +39,7 @@ final class CrudTests: MongoSwiftTestCase {
 
                 // for each test case:
                 // 1) create a unique collection to use
-                // 2) insert the data specified by this test file 
+                // 2) insert the data specified by this test file
                 // 3) execute the test according to the type's execute method
                 // 4) verify that expected data is present
                 // 5) drop the collection to clean up
@@ -82,7 +82,7 @@ final class CrudTests: MongoSwiftTestCase {
     }
 }
 
-/// A container for the data from a single .json file. 
+/// A container for the data from a single .json file.
 private struct CrudTestFile: Decodable {
     let data: [Document]
     let testDocs: [Document]
@@ -95,7 +95,7 @@ private struct CrudTestFile: Decodable {
     }
 }
 
-/// Initializes a new `CrudTest` of the appropriate subclass from a `Document` 
+/// Initializes a new `CrudTest` of the appropriate subclass from a `Document`
 private func makeCrudTest(_ doc: Document) throws -> CrudTest {
     let operation: Document = try doc.get("operation")
     let opName: String = try operation.get("name")
@@ -105,7 +105,7 @@ private func makeCrudTest(_ doc: Document) throws -> CrudTest {
     return try type.init(doc)
 }
 
-// Maps operation names to the appropriate test class to use for them. 
+// Maps operation names to the appropriate test class to use for them.
 private var testTypeMap: [String: CrudTest.Type] = [
     "aggregate": AggregateTest.self,
     "bulkWrite": BulkWriteTest.self,
@@ -125,7 +125,7 @@ private var testTypeMap: [String: CrudTest.Type] = [
 ]
 
 /// An abstract class to represent a single test within a CrudTestFile. Subclasses must
-/// implement the `execute` method themselves. 
+/// implement the `execute` method themselves.
 private class CrudTest {
     let description: String
     let operationName: String
@@ -164,7 +164,7 @@ private class CrudTest {
     }
     var upsert: Bool? { return self.args["upsert"] as? Bool }
 
-    /// Initializes a new `CrudTest` from a `Document`. 
+    /// Initializes a new `CrudTest` from a `Document`.
     required init(_ test: Document) throws {
         self.description = try test.get("description")
         let operation: Document = try test.get("operation")
@@ -176,11 +176,11 @@ private class CrudTest {
         self.collection = outcome["collection"] as? Document
     }
 
-    // Subclasses should implement `execute` according to the particular operation(s) they are for. 
+    // Subclasses should implement `execute` according to the particular operation(s) they are for.
     func execute(usingCollection coll: MongoCollection<Document>) throws { XCTFail("Unimplemented") }
 
     // If the test has a `collection` field in its `outcome`, verify that the expected
-    // data is present. If there is no `collection` field, do nothing. 
+    // data is present. If there is no `collection` field, do nothing.
     func verifyData(testCollection coll: MongoCollection<Document>, db: MongoDatabase) throws {
         // only  some tests have data to verify
         guard let collection = self.collection else {
@@ -194,9 +194,9 @@ private class CrudTest {
         expect(Array(try collToCheck.find([:]))).to(equal(try collection.get("data")))
     }
 
-    // Given an `UpdateResult`, verify that it matches the expected results in this `CrudTest`. 
-    // Meant for use by subclasses whose operations return `UpdateResult`s, such as `UpdateTest` 
-    // and `ReplaceOneTest`. 
+    // Given an `UpdateResult`, verify that it matches the expected results in this `CrudTest`.
+    // Meant for use by subclasses whose operations return `UpdateResult`s, such as `UpdateTest`
+    // and `ReplaceOneTest`.
     func verifyUpdateResult(_ result: UpdateResult?) throws {
         let expected = try BSONDecoder().decode(UpdateResult.self, from: self.result as! Document)
         expect(result?.matchedCount).to(equal(expected.matchedCount))
@@ -211,7 +211,7 @@ private class CrudTest {
     }
 
     /// Given the response to a findAndModify command, verify that it matches the expected
-    /// results for this `CrudTest`. Meant for use by findAndModify subclasses, i.e. findOneAndX. 
+    /// results for this `CrudTest`. Meant for use by findAndModify subclasses, i.e. findOneAndX.
     func verifyFindAndModifyResult(_ result: Document?) {
         guard self.result != nil else {
             return
@@ -232,13 +232,13 @@ private class AggregateTest: CrudTest {
         let options = AggregateOptions(batchSize: self.batchSize, collation: self.collation)
         let cursor = try coll.aggregate(pipeline, options: options)
         if self.collection != nil {
-            // this is $out case - we need to iterate the cursor once in 
+            // this is $out case - we need to iterate the cursor once in
             // order to make the aggregation happen. there is nothing in
             // the cursor to verify, but verifyData() will check that the
             // $out collection has the new data.
             expect(cursor.next()).to(beNil())
         } else {
-            // if not $out, verify that the cursor contains the expected documents. 
+            // if not $out, verify that the cursor contains the expected documents.
             expect(Array(cursor)).to(equal(self.result as? [Document]))
         }
     }

--- a/Tests/MongoSwiftTests/Document+SequenceTests.swift
+++ b/Tests/MongoSwiftTests/Document+SequenceTests.swift
@@ -77,7 +77,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             expect(k).to(equal(expectedKeys.removeFirst()))
             // we can't compare `BSONValue`s for equality, nor can we cast v
             // to a dynamically determined equatable type, so just verify
-            // it's a `BSONValue` anyway 
+            // it's a `BSONValue` anyway
             expect(v).to(beAKindOf(BSONValue.self))
         }
     }

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -97,7 +97,7 @@ final class DocumentTests: MongoSwiftTestCase {
             return
         }
 
-        // splitting this out is necessary because the swift 4.0 compiler 
+        // splitting this out is necessary because the swift 4.0 compiler
         // can't handle all the keys being declared together
 
         let binaryData: Document = [
@@ -530,7 +530,7 @@ final class DocumentTests: MongoSwiftTestCase {
             "datetime": Date(msSinceEpoch: 2000)
         ]))
 
-        // return early as we will to use an Int requiring > 32 bits after this 
+        // return early as we will to use an Int requiring > 32 bits after this
         if MongoSwiftTestCase.is32Bit {
             return
         }
@@ -636,7 +636,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
         ["double", "int32", "int64", "bool", "decimal", "oid", "timestamp", "datetime"].forEach {
             overwritableDoc[$0] = BSONNull()
-            // the storage should change every time 
+            // the storage should change every time
             expect(overwritableDoc.data).toNot(equal(overwritablePointer))
             overwritablePointer = overwritableDoc.data
         }
@@ -646,7 +646,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
         ["string", "doc", "arr"].forEach {
             nonOverwritableDoc[$0] = BSONNull()
-            // the storage should change every time 
+            // the storage should change every time
             expect(nonOverwritableDoc.data).toNot(equal(nonOverwritablePointer))
             nonOverwritablePointer = nonOverwritableDoc.data
         }

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -346,7 +346,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
     func testListIndexes() throws {
         let indexes = try coll.listIndexes()
-        // New collection, so expect just the _id_ index to exist. 
+        // New collection, so expect just the _id_ index to exist.
         expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
         expect(indexes.next()).to(beNil())
     }

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -71,7 +71,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             // expect the readConcern property to exist with a nil level
             expect(client.readConcern).to(beNil())
 
-            // expect that a DB created from this client inherits its unset RC 
+            // expect that a DB created from this client inherits its unset RC
             let db1 = client.db(type(of: self).testDatabase)
             expect(db1.readConcern).to(beNil())
 
@@ -86,7 +86,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
             // although local is default, if it is explicitly provided it should be set
             expect(client.readConcern?.level).to(equal("local"))
 
-            // expect that a DB created from this client inherits its local RC 
+            // expect that a DB created from this client inherits its local RC
             let db1 = client.db(type(of: self).testDatabase)
             expect(db1.readConcern?.level).to(equal("local"))
 
@@ -245,7 +245,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     }
 
     func testOperationReadConcerns() throws {
-        // setup a collection 
+        // setup a collection
         let client = try MongoClient()
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -7,7 +7,7 @@ import XCTest
 class MongoSwiftTestCase: XCTestCase {
     /* Ensure libmongoc is initialized. This will be called multiple times, but that's ok
      * as repeated calls have no effect. There is no way to call final cleanup code just
-     * once at the very end, either explicitly or with a deinit. This may appear as a 
+     * once at the very end, either explicitly or with a deinit. This may appear as a
      * memory leak. */
     override class func setUp() {
         MongoSwift.initialize()
@@ -71,7 +71,7 @@ extension MongoClient {
         return try ServerVersion(versionString)
     }
 
-    /// A struct representing a server version. 
+    /// A struct representing a server version.
     internal struct ServerVersion: Equatable {
         let major: Int
         let minor: Int
@@ -93,8 +93,8 @@ extension MongoClient {
 
             var patch = 0
             if versionComponents.count == 3 {
-                // in case there is text at the end, for ex "3.6.0-rc1", stop first time 
-                /// we encounter a non-numeric character. 
+                // in case there is text at the end, for ex "3.6.0-rc1", stop first time
+                /// we encounter a non-numeric character.
                 let numbersOnly = versionComponents[2].prefix { "0123456789".contains($0) }
                 guard let patchValue = Int(numbersOnly) else {
                     throw TestError(message: "Error parsing patch version from \(str)")
@@ -199,7 +199,7 @@ internal func cleanEqual(_ expectedValue: String?) -> Predicate<String> {
 }
 
 // Adds a custom "sortedEqual" predicate that compares two `Document`s and returns true if they
-// have the same key/value pairs in them 
+// have the same key/value pairs in them
 internal func sortedEqual(_ expectedValue: Document?) -> Predicate<Document> {
     return Predicate.define("sortedEqual <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()


### PR DESCRIPTION
So apparently you have to tell SwiftLint that you want this rule on for comments....