### PR TITLE
SWIFT-294, SWIFT-394 Fix memory leaks

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -48,8 +48,8 @@ public struct CommandStartedEvent: MongoEvent, InitializableFromOpaquePointer {
 
     /// Initializes a CommandStartedEvent from an OpaquePointer to a mongoc_apm_command_started_t
     fileprivate init(_ event: OpaquePointer) {
-        // swiftlint:disable:next force_unwrapping - documented as always returning a value.
-        self.command = Document(fromPointer: mongoc_apm_command_started_get_command(event)!)
+        // we have to copy because libmongoc owns the pointer.
+        self.command = Document(copying: mongoc_apm_command_started_get_command(event))
         self.databaseName = String(cString: mongoc_apm_command_started_get_database_name(event))
         self.commandName = String(cString: mongoc_apm_command_started_get_command_name(event))
         self.requestId = mongoc_apm_command_started_get_request_id(event)
@@ -89,8 +89,8 @@ public struct CommandSucceededEvent: MongoEvent, InitializableFromOpaquePointer 
     /// Initializes a CommandSucceededEvent from an OpaquePointer to a mongoc_apm_command_succeeded_t
     fileprivate init(_ event: OpaquePointer) {
         self.duration = mongoc_apm_command_succeeded_get_duration(event)
-        // swiftlint:disable:next force_unwrapping - documented as always returning a value.
-        self.reply = Document(fromPointer: mongoc_apm_command_succeeded_get_reply(event)!)
+        // we have to copy because libmongoc owns the pointer.
+        self.reply = Document(copying: mongoc_apm_command_succeeded_get_reply(event))
         self.commandName = String(cString: mongoc_apm_command_succeeded_get_command_name(event))
         self.requestId = mongoc_apm_command_succeeded_get_request_id(event)
         self.operationId = mongoc_apm_command_succeeded_get_operation_id(event)
@@ -319,8 +319,8 @@ public struct ServerHeartbeatSucceededEvent: MongoEvent, InitializableFromOpaque
     /// Initializes a ServerHeartbeatSucceededEvent from an OpaquePointer to a mongoc_apm_server_heartbeat_succeeded_t
     fileprivate init(_ event: OpaquePointer) {
         self.duration = mongoc_apm_server_heartbeat_succeeded_get_duration(event)
-        // swiftlint:disable:next force_unwrapping - documented as always returning a value.
-        self.reply = Document(fromPointer: mongoc_apm_server_heartbeat_succeeded_get_reply(event)!)
+        // we have to copy because libmongoc owns the pointer.
+        self.reply = Document(copying: mongoc_apm_server_heartbeat_succeeded_get_reply(event))
         self.connectionId = ConnectionId(mongoc_apm_server_heartbeat_succeeded_get_host(event))
     }
 }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -127,7 +127,7 @@ extension Array: BSONValue {
                 throw RuntimeError.internalError(message: "Failed to create an Array from iterator")
             }
 
-            let arrDoc = Document(fromPointer: arrayData)
+            let arrDoc = Document(stealing: arrayData)
 
             guard let arr = arrDoc.values as? Array else {
                 fatalError("Failed to cast values for document \(arrDoc) to array")
@@ -658,7 +658,7 @@ public struct CodeWithScope: BSONValue, Equatable, Codable {
             guard let scopeData = bson_new_from_data(scopePointer.pointee, Int(scopeLength)) else {
                 throw RuntimeError.internalError(message: "Failed to create a bson_t from scope data")
             }
-            let scopeDoc = Document(fromPointer: scopeData)
+            let scopeDoc = Document(stealing: scopeData)
 
             return self.init(code: code, scope: scopeDoc)
         }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -20,14 +20,18 @@ public class DocumentStorage {
         return Int(bson_count_keys(self.pointer))
     }
 
+    /// Initializes a new, empty `DocumentStorage`.
     internal init() {
         self.pointer = bson_new()
     }
 
+    /// Initializes a new `DocumentStorage` by copying over the data from the provided `bson_t`.
     internal init(copying pointer: BSONPointer) {
         self.pointer = bson_copy(pointer)
     }
 
+    /// Initializes a new `DocumentStorage` that uses the provided `bson_t` as its backing storage.
+    /// The newly created instance will handle cleaning up the pointer upon deinitialization.
     internal init(stealing pointer: MutableBSONPointer) {
         self.pointer = pointer
     }
@@ -61,8 +65,8 @@ extension Document {
     }
 
     /**
-     * Initializes a `Document` from a pointer to a `bson_t` by making a copy of the
-     * data. The caller is responsible for freeing the original `bson_t`.
+     * Initializes a `Document` from a pointer to a `bson_t` by making a copy of the data. The `bson_t`'s owner is
+     * responsible for freeing the original.
      *
      * - Parameters:
      *   - pointer: a BSONPointer
@@ -75,8 +79,8 @@ extension Document {
     }
 
     /**
-     * Initializes a `Document` from a pointer to a `bson_t`, using the `bson_t` as its
-     * underlying storage. The caller must not modify or free the `bson_t` themselves.
+     * Initializes a `Document` from a pointer to a `bson_t`, "stealing" the `bson_t` to use for underlying storage/
+     * The `bson_t` must not be modified or freed by others after it is used here/
      *
      * - Parameters:
      *   - pointer: a MutableBSONPointer

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -28,7 +28,7 @@ public class DocumentStorage {
         self.pointer = bson_copy(pointer)
     }
 
-    internal init(stealing pointer: BSONPointer) {
+    internal init(stealing pointer: MutableBSONPointer) {
         self.pointer = pointer
     }
 
@@ -83,7 +83,7 @@ extension Document {
      *
      * - Returns: a new `Document`
      */
-    internal init(stealing pointer: BSONPointer) {
+    internal init(stealing pointer: MutableBSONPointer) {
         self.storage = DocumentStorage(stealing: pointer)
         self.count = self.storage.count
     }
@@ -345,11 +345,7 @@ extension Document {
                 throw RuntimeError.internalError(message: toErrorString(error))
             }
 
-#if compiler(>=5.0)
             return bson
-#else
-            return UnsafePointer(bson)
-#endif
         })
         self.count = self.storage.count
     }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -79,7 +79,7 @@ extension Document {
      * underlying storage. The caller must not modify or free the `bson_t` themselves.
      *
      * - Parameters:
-     *   - pointer: a BSONPointer
+     *   - pointer: a MutableBSONPointer
      *
      * - Returns: a new `Document`
      */

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -63,7 +63,7 @@ extension Document {
     /**
      * Initializes a `Document` from a pointer to a `bson_t` by making a copy of the
      * data. The caller is responsible for freeing the original `bson_t`.
-     * 
+     *
      * - Parameters:
      *   - pointer: a BSONPointer
      *

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -168,6 +168,7 @@ public class MongoClient {
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
             throw parseMongocError(error)
         }
+        defer { mongoc_uri_destroy(uri) }
 
         // if retryWrites is specified, set it on the uri (libmongoc does not provide api for setting it on the client).
         if let rw = options?.retryWrites {

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -124,7 +124,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
             fatalError("mongoc_cursor_next returned true, but document is nil")
         }
 
-    // we have to copy because libmongoc owns the pointer.
+        // we have to copy because libmongoc owns the pointer.
         let doc = Document(copying: pointee)
         do {
             let outDoc = try self.decoder.decode(T.self, from: doc)

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -82,7 +82,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
         var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
         defer {
             replyPtr.deinitialize(count: 1)
-            replyPtr.deallocate() 
+            replyPtr.deallocate()
         }
 
         var error = bson_error_t()
@@ -124,7 +124,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
             fatalError("mongoc_cursor_next returned true, but document is nil")
         }
 
-        // we have to copy because libmongoc owns the pointer.
+    // we have to copy because libmongoc owns the pointer.
         let doc = Document(copying: pointee)
         do {
             let outDoc = try self.decoder.decode(T.self, from: doc)

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -70,8 +70,8 @@ public final class ReadPreference {
         guard let bson = mongoc_read_prefs_get_tags(self._readPreference) else {
             fatalError("Failed to retrieve read preference tags")
         }
-
-        let wrapped = Document(fromPointer: bson)
+        // we have to copy because libmongoc owns the pointer.
+        let wrapped = Document(copying: bson)
 
         // swiftlint:disable:next force_cast
         return wrapped.values as! [Document]

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -171,8 +171,8 @@ public struct ServerDescription {
     internal init(_ description: OpaquePointer) {
         self.connectionId = ConnectionId(mongoc_server_description_host(description))
         self.roundTripTime = mongoc_server_description_round_trip_time(description)
-        // swiftlint:disable:next force_unwrapping - documented as always returning a value.
-        let isMaster = Document(fromPointer: mongoc_server_description_ismaster(description)!)
+        // we have to copy because libmongoc owns the pointer.
+        let isMaster = Document(copying: mongoc_server_description_ismaster(description))
         self.parseIsMaster(isMaster)
 
         let serverType = String(cString: mongoc_server_description_type(description))
@@ -250,6 +250,8 @@ public struct TopologyDescription {
 
         var size = size_t()
         let serverData = mongoc_topology_description_get_servers(description, &size)
+        defer { mongoc_server_descriptions_destroy_all(serverData, size) }
+        
         let buffer = UnsafeBufferPointer(start: serverData, count: size)
         if size > 0 {
             // swiftlint:disable:next force_unwrapping - documented as always returning a value.

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -251,7 +251,7 @@ public struct TopologyDescription {
         var size = size_t()
         let serverData = mongoc_topology_description_get_servers(description, &size)
         defer { mongoc_server_descriptions_destroy_all(serverData, size) }
-        
+
         let buffer = UnsafeBufferPointer(start: serverData, count: size)
         if size > 0 {
             // swiftlint:disable:next force_unwrapping - documented as always returning a value.

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -481,7 +481,7 @@ final class DocumentTests: MongoSwiftTestCase {
     // test replacing `Overwritable` types with values of their own type
     func testOverwritable() throws {
         // make a deep copy so we start off with uniquely referenced storage
-        var doc = Document(fromPointer: DocumentTests.overwritables.data)
+        var doc = Document(copying: DocumentTests.overwritables.data)
 
         // save a reference to original bson_t so we can verify it doesn't change
         let pointer = doc.data
@@ -555,7 +555,7 @@ final class DocumentTests: MongoSwiftTestCase {
     // test replacing some of the non-Overwritable types with values of their own types
     func testNonOverwritable() throws {
         // make a deep copy so we start off with uniquely referenced storage
-        var doc = Document(fromPointer: DocumentTests.nonOverwritables.data)
+        var doc = Document(copying: DocumentTests.nonOverwritables.data)
 
         // save a reference to original bson_t so we can verify it changes
         var pointer = doc.data
@@ -578,7 +578,7 @@ final class DocumentTests: MongoSwiftTestCase {
     // test replacing both overwritable and nonoverwritable values with values of different types
     func testReplaceValueWithNewType() throws {
         // make a deep copy so we start off with uniquely referenced storage
-        var overwritableDoc = Document(fromPointer: DocumentTests.overwritables.data)
+        var overwritableDoc = Document(copying: DocumentTests.overwritables.data)
 
         // save a reference to original bson_t so we can verify it changes
         var overwritablePointer = overwritableDoc.data
@@ -613,7 +613,7 @@ final class DocumentTests: MongoSwiftTestCase {
         ]))
 
         // make a deep copy so we start off with uniquely referenced storage
-        var nonOverwritableDoc = Document(fromPointer: DocumentTests.nonOverwritables.data)
+        var nonOverwritableDoc = Document(copying: DocumentTests.nonOverwritables.data)
 
         // save a reference to original bson_t so we can verify it changes
         var nonOverwritablePointer = nonOverwritableDoc.data
@@ -631,7 +631,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
     // test setting both overwritable and nonoverwritable values to nil
     func testReplaceValueWithNil() throws {
-        var overwritableDoc = Document(fromPointer: DocumentTests.overwritables.data)
+        var overwritableDoc = Document(copying: DocumentTests.overwritables.data)
         var overwritablePointer = overwritableDoc.data
 
         ["double", "int32", "int64", "bool", "decimal", "oid", "timestamp", "datetime"].forEach {
@@ -641,7 +641,7 @@ final class DocumentTests: MongoSwiftTestCase {
             overwritablePointer = overwritableDoc.data
         }
 
-        var nonOverwritableDoc = Document(fromPointer: DocumentTests.nonOverwritables.data)
+        var nonOverwritableDoc = Document(copying: DocumentTests.nonOverwritables.data)
         var nonOverwritablePointer = nonOverwritableDoc.data
 
         ["string", "doc", "arr"].forEach {


### PR DESCRIPTION
This fixes several memory leaks in the driver. Kudos to @valeriomazzeo for pointing these out in #236.

I've done the following:
* Rename `Document(fromPointer:)` and `DocumentStorage(fromPointer:)` to `Document(copying:)` and `DocumentStorage(copying:)` to make it clearer what their behavior is 
* Add a new `DocumentStorage(stealing:)` initializer that takes over responsibility for the provided `bson_t`, and a `Document(stealing:)` initializer that calls through to it
* Update every place the `fromPointer` initializers were used to call through to the correct new methods 

I also fixed a leak of the `mongoc_uri_t` in the `MongoClient` initializer, and a leak we'd previously identified in SDAM monitoring (SWIFT-294).
