### PR TITLE
SWIFT-268 Store bson_oid_t in ObjectId rather than creating one each time we need it

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -164,7 +164,7 @@ public struct ServerDescriptionChangedEvent: MongoEvent, InitializableFromOpaque
         self.connectionId = ConnectionId(mongoc_apm_server_changed_get_host(event))
         var oid = bson_oid_t()
         mongoc_apm_server_changed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(fromPointer: &oid)
+        self.topologyId = ObjectId(copying: &oid)
         self.previousDescription = ServerDescription(mongoc_apm_server_changed_get_previous_description(event))
         self.newDescription = ServerDescription(mongoc_apm_server_changed_get_new_description(event))
     }
@@ -189,7 +189,7 @@ public struct ServerOpeningEvent: MongoEvent, InitializableFromOpaquePointer {
         self.connectionId = ConnectionId(mongoc_apm_server_opening_get_host(event))
         var oid = bson_oid_t()
         mongoc_apm_server_opening_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(fromPointer: &oid)
+        self.topologyId = ObjectId(copying: &oid)
     }
 }
 
@@ -212,7 +212,7 @@ public struct ServerClosedEvent: MongoEvent, InitializableFromOpaquePointer {
         self.connectionId = ConnectionId(mongoc_apm_server_closed_get_host(event))
         var oid = bson_oid_t()
         mongoc_apm_server_closed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(fromPointer: &oid)
+        self.topologyId = ObjectId(copying: &oid)
     }
 }
 
@@ -237,7 +237,7 @@ public struct TopologyDescriptionChangedEvent: MongoEvent, InitializableFromOpaq
     fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
         mongoc_apm_topology_changed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(fromPointer: &oid)
+        self.topologyId = ObjectId(copying: &oid)
         self.previousDescription = TopologyDescription(mongoc_apm_topology_changed_get_previous_description(event))
         self.newDescription = TopologyDescription(mongoc_apm_topology_changed_get_new_description(event))
     }
@@ -258,7 +258,7 @@ public struct TopologyOpeningEvent: MongoEvent, InitializableFromOpaquePointer {
     fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
         mongoc_apm_topology_opening_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(fromPointer: &oid)
+        self.topologyId = ObjectId(copying: &oid)
     }
 }
 
@@ -277,7 +277,7 @@ public struct TopologyClosedEvent: MongoEvent, InitializableFromOpaquePointer {
     fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
         mongoc_apm_topology_closed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(fromPointer: &oid)
+        self.topologyId = ObjectId(copying: &oid)
     }
 }
 

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -163,8 +163,10 @@ public struct ServerDescriptionChangedEvent: MongoEvent, InitializableFromOpaque
     fileprivate init(_ event: OpaquePointer) {
         self.connectionId = ConnectionId(mongoc_apm_server_changed_get_host(event))
         var oid = bson_oid_t()
-        mongoc_apm_server_changed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(copying: &oid)
+        withUnsafeMutablePointer(to: &oid) { oidPtr in
+            mongoc_apm_server_changed_get_topology_id(event, oidPtr)
+        }
+        self.topologyId = ObjectId(bsonOid: oid)
         self.previousDescription = ServerDescription(mongoc_apm_server_changed_get_previous_description(event))
         self.newDescription = ServerDescription(mongoc_apm_server_changed_get_new_description(event))
     }
@@ -188,8 +190,10 @@ public struct ServerOpeningEvent: MongoEvent, InitializableFromOpaquePointer {
     fileprivate init(_ event: OpaquePointer) {
         self.connectionId = ConnectionId(mongoc_apm_server_opening_get_host(event))
         var oid = bson_oid_t()
-        mongoc_apm_server_opening_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(copying: &oid)
+        withUnsafeMutablePointer(to: &oid) { oidPtr in
+            mongoc_apm_server_opening_get_topology_id(event, oidPtr)
+        }
+        self.topologyId = ObjectId(bsonOid: oid)
     }
 }
 
@@ -211,8 +215,10 @@ public struct ServerClosedEvent: MongoEvent, InitializableFromOpaquePointer {
     fileprivate init(_ event: OpaquePointer) {
         self.connectionId = ConnectionId(mongoc_apm_server_closed_get_host(event))
         var oid = bson_oid_t()
-        mongoc_apm_server_closed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(copying: &oid)
+        withUnsafeMutablePointer(to: &oid) { oidPtr in
+            mongoc_apm_server_closed_get_topology_id(event, oidPtr)
+        }
+        self.topologyId = ObjectId(bsonOid: oid)
     }
 }
 
@@ -236,8 +242,10 @@ public struct TopologyDescriptionChangedEvent: MongoEvent, InitializableFromOpaq
     /// Initializes a TopologyDescriptionChangedEvent from an OpaquePointer to a mongoc_apm_topology_changed_t
     fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
-        mongoc_apm_topology_changed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(copying: &oid)
+        withUnsafeMutablePointer(to: &oid) { oidPtr in
+            mongoc_apm_topology_changed_get_topology_id(event, oidPtr)
+        }
+        self.topologyId = ObjectId(bsonOid: oid)
         self.previousDescription = TopologyDescription(mongoc_apm_topology_changed_get_previous_description(event))
         self.newDescription = TopologyDescription(mongoc_apm_topology_changed_get_new_description(event))
     }
@@ -257,8 +265,10 @@ public struct TopologyOpeningEvent: MongoEvent, InitializableFromOpaquePointer {
     /// Initializes a TopologyOpeningEvent from an OpaquePointer to a mongoc_apm_topology_opening_t
     fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
-        mongoc_apm_topology_opening_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(copying: &oid)
+        withUnsafeMutablePointer(to: &oid) { oidPtr in
+            mongoc_apm_topology_opening_get_topology_id(event, oidPtr)
+        }
+        self.topologyId = ObjectId(bsonOid: oid)
     }
 }
 
@@ -276,8 +286,10 @@ public struct TopologyClosedEvent: MongoEvent, InitializableFromOpaquePointer {
     /// Initializes a TopologyClosedEvent from an OpaquePointer to a mongoc_apm_topology_closed_t
     fileprivate init(_ event: OpaquePointer) {
         var oid = bson_oid_t()
-        mongoc_apm_topology_closed_get_topology_id(event, &oid)
-        self.topologyId = ObjectId(copying: &oid)
+        withUnsafeMutablePointer(to: &oid) { oidPtr in
+            mongoc_apm_topology_closed_get_topology_id(event, oidPtr)
+        }
+        self.topologyId = ObjectId(bsonOid: oid)
     }
 }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -748,6 +748,10 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         return withUnsafePointer(to: self.oid) { oidPtr in UInt32(bson_oid_get_time_t(oidPtr)) }
     }
 
+    public var description: String {
+        return self.hex
+    }
+
     internal let oid: bson_oid_t
 
     /// Initializes a new `ObjectId`.
@@ -815,10 +819,6 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
             }
             return self.init(copying: oid)
         }
-    }
-
-    public var description: String {
-        return self.hex
     }
 
     public static func == (lhs: ObjectId, rhs: ObjectId) -> Bool {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -763,9 +763,9 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
 
     /// Initializes an `ObjectId` from the provided `String`. Assumes that the given string is a valid ObjectId.
     /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/objectid.rst
-    public init(fromString oid: String) {
+    public init(from hex: String) {
         var oid_t = bson_oid_t()
-        bson_oid_init_from_string(&oid_t, oid)
+        bson_oid_init_from_string(&oid_t, hex)
         self.oid = oid_t
     }
 
@@ -776,7 +776,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         if !bson_oid_is_valid(oid, oid.utf8.count) {
             return nil
         } else {
-            self.init(fromString: oid)
+            self.init(from: oid)
         }
     }
 
@@ -791,16 +791,6 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     /// Initializes an `ObjectId` from an `UnsafePointer<bson_oid_t>` by copying the underlying `bson_oid_t`.
     internal init(copying oid_t: UnsafePointer<bson_oid_t>) {
         self.oid = oid_t.pointee
-    }
-
-    /// Returns the provided string as a `bson_oid_t`.
-    /// - Throws:
-    ///   - `UserError.invalidArgumentError` if the parameter string does not correspond to a valid `ObjectId`.
-    internal static func toLibBSONType(_ str: String) throws -> bson_oid_t {
-        guard let oid = ObjectId(ifValid: str) else {
-            throw UserError.invalidArgumentError(message: "ObjectId string is invalid")
-        }
-        return oid.oid
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -422,7 +422,7 @@ public struct DBPointer: BSONValue, Codable, Equatable {
                 throw wrongIterTypeError(iter, expected: DBPointer.self)
             }
 
-            return DBPointer(ref: String(cString: collectionP), id: ObjectId(copying: oidP))
+            return DBPointer(ref: String(cString: collectionP), id: ObjectId(bsonOid: oidP.pointee))
         }
     }
 }
@@ -772,17 +772,16 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         self.oid = oid_t
     }
 
+    internal init(bsonOid oid_t: bson_oid_t) {
+        self.oid = oid_t
+    }
+
     public init(from decoder: Decoder) throws {
         throw getDecodingError(type: ObjectId.self, decoder: decoder)
     }
 
     public func encode(to: Encoder) throws {
         throw bsonEncodingUnsupportedError(value: self, at: to.codingPath)
-    }
-
-    /// Initializes an `ObjectId` from an `UnsafePointer<bson_oid_t>` by copying the underlying `bson_oid_t`.
-    internal init(copying oid_t: UnsafePointer<bson_oid_t>) {
-        self.oid = oid_t.pointee
     }
 
     public func encode(to storage: DocumentStorage, forKey key: String) throws {
@@ -799,7 +798,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
             guard let oid = bson_iter_oid(iterPtr) else {
                 throw wrongIterTypeError(iter, expected: ObjectId.self)
             }
-            return self.init(copying: oid)
+            return self.init(bsonOid: oid.pointee)
         }
     }
 

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -761,23 +761,16 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         self.oid = oid
     }
 
-    /// Initializes an `ObjectId` from the provided `String`. Assumes that the given string is a valid ObjectId.
-    /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/objectid.rst
-    public init(from hex: String) {
-        var oid_t = bson_oid_t()
-        bson_oid_init_from_string(&oid_t, hex)
-        self.oid = oid_t
-    }
-
     /// Initializes an `ObjectId` from the provided `String`. Returns `nil` if the string is not a valid
     /// ObjectId.
     /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/objectid.rst
-    public init?(ifValid oid: String) {
-        if !bson_oid_is_valid(oid, oid.utf8.count) {
+    public init?(_ hex: String) {
+        guard bson_oid_is_valid(hex, hex.utf8.count) else {
             return nil
-        } else {
-            self.init(from: oid)
         }
+        var oid_t = bson_oid_t()
+        bson_oid_init_from_string(&oid_t, hex)
+        self.oid = oid_t
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -761,8 +761,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
         self.oid = oid
     }
 
-    /// Initializes an `ObjectId` from the provided `String`. Returns `nil` if the string is not a valid
-    /// ObjectId.
+    /// Initializes an `ObjectId` from the provided hex `String`. Returns `nil` if the string is not a valid ObjectId.
     /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/objectid.rst
     public init?(_ hex: String) {
         guard bson_oid_is_valid(hex, hex.utf8.count) else {

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -63,7 +63,7 @@ extension Decimal128: Overwritable {
 
 extension ObjectId: Overwritable {
     internal func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        var encoded = try ObjectId.toLibBSONType(self.oid)
+        var encoded = try ObjectId.toLibBSONType(self.hex)
         iter.withMutableBSONIterPointer { iterPtr in bson_iter_overwrite_oid(iterPtr, &encoded) }
     }
 }

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -63,8 +63,9 @@ extension Decimal128: Overwritable {
 
 extension ObjectId: Overwritable {
     internal func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        var encoded = try ObjectId.toLibBSONType(self.hex)
-        iter.withMutableBSONIterPointer { iterPtr in bson_iter_overwrite_oid(iterPtr, &encoded) }
+        withUnsafePointer(to: self.oid) { oidPtr in
+            iter.withMutableBSONIterPointer { iterPtr in bson_iter_overwrite_oid(iterPtr, oidPtr) }
+        }
     }
 }
 

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -140,7 +140,7 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // expect that we can pull the correct timestamp if
         // initialized from the original string
-        let objectIdFromString = ObjectId(fromString: oid)
+        let objectIdFromString = ObjectId(from: oid)
         expect(objectIdFromString.hex).to(equal(oid))
         expect(objectIdFromString.timestamp).to(equal(timestamp))
     }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -121,7 +121,7 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // initialize a new oid with the oid_t ptr
         // expect the values to be equal
-        let objectId = ObjectId(fromPointer: &oid_t)
+        let objectId = ObjectId(copying: &oid_t)
         expect(objectId.hex).to(equal(oid))
         expect(objectId.timestamp).to(equal(timestamp))
 

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -140,7 +140,7 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // expect that we can pull the correct timestamp if
         // initialized from the original string
-        let objectIdFromString = ObjectId(from: oid)
+        let objectIdFromString = ObjectId(oid)!
         expect(objectIdFromString.hex).to(equal(oid))
         expect(objectIdFromString.timestamp).to(equal(timestamp))
     }

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -121,7 +121,7 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // initialize a new oid with the oid_t ptr
         // expect the values to be equal
-        let objectId = ObjectId(copying: &oid_t)
+        let objectId = ObjectId(bsonOid: oid_t)
         expect(objectId.hex).to(equal(oid))
         expect(objectId.timestamp).to(equal(timestamp))
 

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -122,7 +122,7 @@ final class BSONValueTests: MongoSwiftTestCase {
         // initialize a new oid with the oid_t ptr
         // expect the values to be equal
         let objectId = ObjectId(fromPointer: &oid_t)
-        expect(objectId.oid).to(equal(oid))
+        expect(objectId.hex).to(equal(oid))
         expect(objectId.timestamp).to(equal(timestamp))
 
         // round trip the objectId.
@@ -135,13 +135,13 @@ final class BSONValueTests: MongoSwiftTestCase {
             return
         }
 
-        expect(_id.oid).to(equal(objectId.oid))
+        expect(_id.hex).to(equal(objectId.hex))
         expect(_id.timestamp).to(equal(objectId.timestamp))
 
         // expect that we can pull the correct timestamp if
         // initialized from the original string
         let objectIdFromString = ObjectId(fromString: oid)
-        expect(objectIdFromString.oid).to(equal(oid))
+        expect(objectIdFromString.hex).to(equal(oid))
         expect(objectIdFromString.timestamp).to(equal(timestamp))
     }
 

--- a/Tests/MongoSwiftTests/BSONValueTests.swift
+++ b/Tests/MongoSwiftTests/BSONValueTests.swift
@@ -135,12 +135,14 @@ final class BSONValueTests: MongoSwiftTestCase {
             return
         }
 
+        expect(_id).to(equal(objectId))
         expect(_id.hex).to(equal(objectId.hex))
         expect(_id.timestamp).to(equal(objectId.timestamp))
 
         // expect that we can pull the correct timestamp if
         // initialized from the original string
         let objectIdFromString = ObjectId(oid)!
+        expect(objectIdFromString).to(equal(objectId))
         expect(objectIdFromString.hex).to(equal(oid))
         expect(objectIdFromString.timestamp).to(equal(timestamp))
     }

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -296,7 +296,7 @@ final class CodecTests: MongoSwiftTestCase {
                     doc: ["x": 1],
                     arr: [1, 2],
                     binary: try Binary(base64: "//8=", subtype: .generic),
-                    oid: ObjectId(fromString: "507f1f77bcf86cd799439011"),
+                    oid: ObjectId(from: "507f1f77bcf86cd799439011"),
                     bool: true,
                     date: Date(timeIntervalSinceReferenceDate: 5000),
                     code: CodeWithScope(code: "hi", scope: ["x": 1]),
@@ -310,7 +310,7 @@ final class CodecTests: MongoSwiftTestCase {
                     regex: RegularExpression(pattern: "^abc", options: "imx"),
                     symbol: Symbol("i am a symbol"),
                     undefined: BSONUndefined(),
-                    dbpointer: DBPointer(ref: "some.namespace", id: ObjectId(fromString: "507f1f77bcf86cd799439011")),
+                    dbpointer: DBPointer(ref: "some.namespace", id: ObjectId(from: "507f1f77bcf86cd799439011")),
                     null: BSONNull())
         }
 
@@ -394,7 +394,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(Int32.self, from: "42")).to(equal(Int32(42)))
         expect(try decoder.decode(Int32.self, from: "{\"$numberInt\": \"42\"}")).to(equal(Int32(42)))
 
-        let oid = ObjectId(fromString: "507f1f77bcf86cd799439011")
+        let oid = ObjectId(from: "507f1f77bcf86cd799439011")
         expect(try decoder.decode(ObjectId.self, from: "{\"$oid\": \"507f1f77bcf86cd799439011\"}")).to(equal(oid))
 
         expect(try decoder.decode(String.self, from: "\"somestring\"")).to(equal("somestring"))

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -296,7 +296,7 @@ final class CodecTests: MongoSwiftTestCase {
                     doc: ["x": 1],
                     arr: [1, 2],
                     binary: try Binary(base64: "//8=", subtype: .generic),
-                    oid: ObjectId(from: "507f1f77bcf86cd799439011"),
+                    oid: ObjectId("507f1f77bcf86cd799439011")!,
                     bool: true,
                     date: Date(timeIntervalSinceReferenceDate: 5000),
                     code: CodeWithScope(code: "hi", scope: ["x": 1]),
@@ -310,7 +310,7 @@ final class CodecTests: MongoSwiftTestCase {
                     regex: RegularExpression(pattern: "^abc", options: "imx"),
                     symbol: Symbol("i am a symbol"),
                     undefined: BSONUndefined(),
-                    dbpointer: DBPointer(ref: "some.namespace", id: ObjectId(from: "507f1f77bcf86cd799439011")),
+                    dbpointer: DBPointer(ref: "some.namespace", id: ObjectId("507f1f77bcf86cd799439011")!),
                     null: BSONNull())
         }
 
@@ -394,7 +394,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(Int32.self, from: "42")).to(equal(Int32(42)))
         expect(try decoder.decode(Int32.self, from: "{\"$numberInt\": \"42\"}")).to(equal(Int32(42)))
 
-        let oid = ObjectId(from: "507f1f77bcf86cd799439011")
+        let oid = ObjectId("507f1f77bcf86cd799439011")!
         expect(try decoder.decode(ObjectId.self, from: "{\"$oid\": \"507f1f77bcf86cd799439011\"}")).to(equal(oid))
 
         expect(try decoder.decode(String.self, from: "\"somestring\"")).to(equal("somestring"))

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -574,7 +574,7 @@ final class CodecTests: MongoSwiftTestCase {
         let oid = ObjectId()
 
         expect(try decoder.decode(AnyBSONValue.self,
-                                  from: "{\"$oid\": \"\(oid.oid)\"}").value).to(bsonEqual(oid))
+                                  from: "{\"$oid\": \"\(oid.hex)\"}").value).to(bsonEqual(oid))
 
         let wrappedOid: Document = ["x": oid]
         expect(try encoder.encode(AnyBSONStruct(oid))).to(equal(wrappedOid))

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -74,7 +74,7 @@ final class DocumentTests: MongoSwiftTestCase {
         "timestamp": Timestamp(timestamp: 5, inc: 10),
         "nestedarray": [[1, 2], [Int32(3), Int32(4)]] as [[Int32]],
         "nesteddoc": ["a": 1, "b": 2, "c": false, "d": [3, 4]] as Document,
-        "oid": ObjectId(from: "507f1f77bcf86cd799439011"),
+        "oid": ObjectId("507f1f77bcf86cd799439011")!,
         "regex": RegularExpression(pattern: "^abc", options: "imx"),
         "array1": [1, 2],
         "array2": ["string1", "string2"],
@@ -139,7 +139,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["maxkey"]).to(bsonEqual(MaxKey()))
         expect(doc["date"]).to(bsonEqual(Date(timeIntervalSince1970: 500.004)))
         expect(doc["timestamp"]).to(bsonEqual(Timestamp(timestamp: 5, inc: 10)))
-        expect(doc["oid"]).to(bsonEqual(ObjectId(from: "507f1f77bcf86cd799439011")))
+        expect(doc["oid"]).to(bsonEqual(ObjectId("507f1f77bcf86cd799439011")!))
 
         let regex = doc["regex"] as? RegularExpression
         expect(regex).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
@@ -190,7 +190,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(DocumentTests.testDoc.maxkey).to(bsonEqual(MaxKey()))
         expect(DocumentTests.testDoc.date).to(bsonEqual(Date(timeIntervalSince1970: 500.004)))
         expect(DocumentTests.testDoc.timestamp).to(bsonEqual(Timestamp(timestamp: 5, inc: 10)))
-        expect(DocumentTests.testDoc.oid).to(bsonEqual(ObjectId(from: "507f1f77bcf86cd799439011")))
+        expect(DocumentTests.testDoc.oid).to(bsonEqual(ObjectId("507f1f77bcf86cd799439011")!))
 
         let codewscope = DocumentTests.testDoc.codewscope as? CodeWithScope
         expect(codewscope?.code).to(equal("console.log(x);"))

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -74,7 +74,7 @@ final class DocumentTests: MongoSwiftTestCase {
         "timestamp": Timestamp(timestamp: 5, inc: 10),
         "nestedarray": [[1, 2], [Int32(3), Int32(4)]] as [[Int32]],
         "nesteddoc": ["a": 1, "b": 2, "c": false, "d": [3, 4]] as Document,
-        "oid": ObjectId(fromString: "507f1f77bcf86cd799439011"),
+        "oid": ObjectId(from: "507f1f77bcf86cd799439011"),
         "regex": RegularExpression(pattern: "^abc", options: "imx"),
         "array1": [1, 2],
         "array2": ["string1", "string2"],
@@ -139,7 +139,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["maxkey"]).to(bsonEqual(MaxKey()))
         expect(doc["date"]).to(bsonEqual(Date(timeIntervalSince1970: 500.004)))
         expect(doc["timestamp"]).to(bsonEqual(Timestamp(timestamp: 5, inc: 10)))
-        expect(doc["oid"]).to(bsonEqual(ObjectId(fromString: "507f1f77bcf86cd799439011")))
+        expect(doc["oid"]).to(bsonEqual(ObjectId(from: "507f1f77bcf86cd799439011")))
 
         let regex = doc["regex"] as? RegularExpression
         expect(regex).to(equal(RegularExpression(pattern: "^abc", options: "imx")))
@@ -190,7 +190,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(DocumentTests.testDoc.maxkey).to(bsonEqual(MaxKey()))
         expect(DocumentTests.testDoc.date).to(bsonEqual(Date(timeIntervalSince1970: 500.004)))
         expect(DocumentTests.testDoc.timestamp).to(bsonEqual(Timestamp(timestamp: 5, inc: 10)))
-        expect(DocumentTests.testDoc.oid).to(bsonEqual(ObjectId(fromString: "507f1f77bcf86cd799439011")))
+        expect(DocumentTests.testDoc.oid).to(bsonEqual(ObjectId(from: "507f1f77bcf86cd799439011")))
 
         let codewscope = DocumentTests.testDoc.codewscope as? CodeWithScope
         expect(codewscope?.code).to(equal("console.log(x);"))


### PR DESCRIPTION
[SWIFT-268](https://jira.mongodb.org/browse/SWIFT-268)

As part of this update, I refactored the public `oid` property on `ObjectId` that returns the string representation to `hex`, which is more descriptive. It also aligns with Go driver's `Hex()` and Java driver's `toHexString()`. 

I also refactored `init(fromPointer:)` to `init(copying:)`, similar to the memory leak fix refactors.