### PR TITLE
SWIFT-17: add evergreen linux support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -11,7 +11,7 @@ command_type: system
 # Protect ourself against rogue test case, or curl gone wild, that runs forever
 # Good rule of thumb: the averageish length a task takes, times 5
 # That roughly accounts for variable system performance for various buildvariants
-exec_timeout_secs: 1800 # 6 minutes is the longest we'll ever run
+exec_timeout_secs: 1800 # 30 minutes is the longest we'll ever run
 
 # What to do when evergreen hits the timeout (`post:` tasks are run automatically)
 timeout:
@@ -41,7 +41,7 @@ functions:
               CURRENT_VERSION=latest
            fi
 
-           export DRIVERS_TOOLS="$(pwd)/../drivers-tools"
+           export DRIVERS_TOOLS="$(dirname $(pwd))/drivers-tools"
            export PROJECT_DIRECTORY="$(pwd)"
 
            # Python has cygwin path problems on Windows. Detect prospective mongo-orchestration home directory
@@ -96,75 +96,23 @@ functions:
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 
-  # Upload build artifacts that other tasks may depend on
-  # Note this URL needs to be totally unique, while predictable for the next task
-  # so it can automatically download the artifacts
-  # "upload build":
-  #   # Compress and upload the entire build directory
-  #   - command: archive.targz_pack
-  #     params:
-  #       # Example: mongo_c_driver_releng_9dfb7d741efbca16faa7859b9349d7a942273e43_16_11_08_19_29_52.tar.gz
-  #       target: "${build_id}.tar.gz"
-  #       source_dir: ${PROJECT_DIRECTORY}/
-  #       include:
-  #         - "./**"
-  #   - command: s3.put
-  #     params:
-  #       aws_key: ${aws_key}
-  #       aws_secret: ${aws_secret}
-  #       local_file: ${build_id}.tar.gz
-  #       # Example: /mciuploads/${UPLOAD_BUCKET}/gcc49/9dfb7d741efbca16faa7859b9349d7a942273e43/debug-compile-nosasl-nossl/mongo_c_driver_releng_9dfb7d741efbca16faa7859b9349d7a942273e43_16_11_08_19_29_52.tar.gz
-  #       remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${task_name}/${build_id}.tar.gz
-  #       bucket: mciuploads
-  #       permissions: public-read
-  #       content_type: ${content_type|application/x-gzip}
-
-  # "fetch build":
-  #   - command: shell.exec
-  #     params:
-  #       continue_on_err: true
-  #       script: "set -o xtrace && rm -rf ${PROJECT_DIRECTORY}"
-  #   - command: s3.get
-  #     params:
-  #       aws_key: ${aws_key}
-  #       aws_secret: ${aws_secret}
-  #       remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${BUILD_NAME}/${build_id}.tar.gz
-  #       bucket: mciuploads
-  #       local_file: build.tar.gz
-  #   - command: shell.exec
-  #     params:
-  #       continue_on_err: true
-  #       # EVG-1105: Use s3.get extract_to: ./
-  #       script: "set -o xtrace && cd .. && rm -rf ${PROJECT_DIRECTORY} && mkdir ${PROJECT_DIRECTORY}/ && tar xf build.tar.gz -C ${PROJECT_DIRECTORY}/"
-
-  "exec compile script" :
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          [ -f ${PROJECT_DIRECTORY}/${file} ] && BUILDTOOL="${buildtool}" sh ${PROJECT_DIRECTORY}/${file} || echo "${PROJECT_DIRECTORY}/${file} not available, skipping"
-
-  "exec script" :
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          [ -f ${PROJECT_DIRECTORY}/${file} ] && sh ${PROJECT_DIRECTORY}/${file} || echo "${PROJECT_DIRECTORY}/${file} not available, skipping"
-
   "bootstrap mongo-orchestration":
     - command: shell.exec
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          MONGODB_VERSION=${MONGODB_VERSION} \
+            TOPOLOGY=${TOPOLOGY} \
+            sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:
         file: mo-expansion.yml
+    - command: expansions.update
+      params:
+        updates:
+          - key: MONGODB_STARTED
+            value: "1"
 
   "stop mongo-orchestration":
     - command: shell.exec
@@ -180,8 +128,21 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          export ${COMPILE_ENV|}
-          AUTH=${AUTH} SSL=${SSL} MONGODB_URI="${MONGODB_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+
+          MONGODB_URI=${MONGODB_URI} \
+          TOPOLOGY=${TOPOLOGY} \
+          SWIFT_VERSION=${SWIFT_VERSION} \
+            sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+
+  "run atlas tests":
+    - command: shell.exec
+      type: test
+      params:
+        silent: true
+        working_dir: "src"
+        script: |
+          # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
+          PYTHON_BINARY=${PYTHON_BINARY} ATLAS_REPL='${atlas_repl}' ATLAS_SHRD='${atlas_shrd}' ATLAS_FREE='${atlas_free}' ATLAS_TLS11='${atlas_tls11}' ATLAS_TLS12='${atlas_tls12}'  sh ${PROJECT_DIRECTORY}/.evergreen/run-atlas-tests.sh
 
   "cleanup":
     - command: shell.exec
@@ -199,30 +160,19 @@ functions:
             perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $filename
           done
 
-  "make files executable":
-    - command: shell.exec
-      params:
-        script: |
-          ${PREPARE_SHELL}
-          for i in $(find ${DRIVERS_TOOLS}/.evergreen ${PROJECT_DIRECTORY}/.evergreen -name \*.sh); do
-            chmod +x $i
-          done
-
   "install dependencies":
     - command: shell.exec
       params:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          file="${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
-          # Don't use ${file} syntax here because evergreen treats it as an empty expansion.
-          [ -f "$file" ] && sh $file || echo "$file not available, skipping"
+
+          SWIFT_VERSION=${SWIFT_VERSION} \
+            sh ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
 
 pre:
   - func: "fetch source"
   - func: "prepare resources"
-  - func: "fix absolute paths"
-  - func: "make files executable"
   - func: "install dependencies"
 
 post:
@@ -230,121 +180,12 @@ post:
   - func: "cleanup"
 
 tasks:
-# Standard test tasks {{{
-
-    - name: "test-2.6-standalone"
-      tags: ["2.6", "standalone"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "2.6"
-            TOPOLOGY: "server"
-        - func: "run tests"
-
-    - name: "test-2.6-replica_set"
-      tags: ["2.6", "replica_set"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "2.6"
-            TOPOLOGY: "replica_set"
-        - func: "run tests"
-
-    - name: "test-2.6-sharded_cluster"
-      tags: ["2.6", "sharded_cluster"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "2.6"
-            TOPOLOGY: "sharded_cluster"
-        - func: "run tests"
-
-    - name: "test-3.0-standalone"
-      tags: ["3.0", "standalone"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.0"
-            TOPOLOGY: "server"
-        - func: "run tests"
-
-    - name: "test-3.0-replica_set"
-      tags: ["3.0", "replica_set"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.0"
-            TOPOLOGY: "replica_set"
-        - func: "run tests"
-
-    - name: "test-3.0-sharded_cluster"
-      tags: ["3.0", "sharded_cluster"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.0"
-            TOPOLOGY: "sharded_cluster"
-        - func: "run tests"
-
-    - name: "test-3.2-standalone"
-      tags: ["3.2", "standalone"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.2"
-            TOPOLOGY: "server"
-        - func: "run tests"
-
-    - name: "test-3.2-replica_set"
-      tags: ["3.2", "replica_set"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.2"
-            TOPOLOGY: "replica_set"
-        - func: "run tests"
-
-    - name: "test-3.2-sharded_cluster"
-      tags: ["3.2", "sharded_cluster"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.2"
-            TOPOLOGY: "sharded_cluster"
-        - func: "run tests"
-
-    - name: "test-3.4-standalone"
-      tags: ["3.4", "standalone"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.4"
-            TOPOLOGY: "server"
-        - func: "run tests"
-
-    - name: "test-3.4-replica_set"
-      tags: ["3.4", "replica_set"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.4"
-            TOPOLOGY: "replica_set"
-        - func: "run tests"
-
-    - name: "test-3.4-sharded_cluster"
-      tags: ["3.4", "sharded_cluster"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.4"
-            TOPOLOGY: "sharded_cluster"
-        - func: "run tests"
     - name: "test-3.6-standalone"
       tags: ["3.6", "standalone"]
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
-            VERSION: "3.6"
+            MONGODB_VERSION: "3.6"
             TOPOLOGY: "server"
         - func: "run tests"
 
@@ -353,7 +194,7 @@ tasks:
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
-            VERSION: "3.6"
+            MONGODB_VERSION: "3.6"
             TOPOLOGY: "replica_set"
         - func: "run tests"
 
@@ -362,7 +203,34 @@ tasks:
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
-            VERSION: "3.6"
+            MONGODB_VERSION: "3.6"
+            TOPOLOGY: "sharded_cluster"
+        - func: "run tests"
+
+    - name: "test-4.0-standalone"
+      tags: ["4.0", "standalone"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "4.0"
+            TOPOLOGY: "server"
+        - func: "run tests"
+
+    - name: "test-4.0-replica_set"
+      tags: ["4.0", "replica_set"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "4.0"
+            TOPOLOGY: "replica_set"
+        - func: "run tests"
+
+    - name: "test-4.0-sharded_cluster"
+      tags: ["4.0", "sharded_cluster"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "4.0"
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
 
@@ -371,7 +239,7 @@ tasks:
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
-            VERSION: "latest"
+            MONGODB_VERSION: "latest"
             TOPOLOGY: "server"
         - func: "run tests"
 
@@ -380,7 +248,7 @@ tasks:
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
-            VERSION: "latest"
+            MONGODB_VERSION: "latest"
             TOPOLOGY: "replica_set"
         - func: "run tests"
 
@@ -389,11 +257,14 @@ tasks:
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
-            VERSION: "latest"
+            MONGODB_VERSION: "latest"
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
 
-# }}}
+    - name: "atlas-connect"
+      tags: ["atlas-connect"]
+      commands:
+        - func: "run atlas tests"
 
 
 axes:
@@ -403,36 +274,27 @@ axes:
       - id: "latest"
         display_name: "latest"
         variables:
-           VERSION: "latest"
+           MONGODB_VERSION: "latest"
+      - id: "4.0"
+        display_name: "4.0"
+        variables:
+           MONGODB_VERSION: "4.0"
       - id: "3.6"
         display_name: "3.6"
         variables:
-           VERSION: "3.6"
-      - id: "3.4"
-        display_name: "3.4"
-        variables:
-           VERSION: "3.4"
-      - id: "3.2"
-        display_name: "3.2"
-        variables:
-           VERSION: "3.2"
-      - id: "3.0"
-        display_name: "3.0"
-        variables:
-           VERSION: "3.0"
-      - id: "2.6"
-        display_name: "2.6"
-        variables:
-           VERSION: "2.6"
+           MONGODB_VERSION: "3.6"
 
   - id: os-fully-featured
     display_name: OS
     values:
-      - id: macos-1012
-        display_name: "macOS 10.12"
-        run_on: macos-1012
-        variables:
-          COMPILE_ENV: DEVELOPER_DIR=/Applications/Xcode9.2.app
+      - id: ubuntu-18.04
+        display_name: "Ubuntu 18.04"
+        run_on: ubuntu1804-test
+        batchtime: 10080  # 7 days
+
+      # - id: macos-1012
+      #   display_name: "macOS 10.12"
+      #   run_on: macos-1012
 
   - id: topology
     display_name: Topology
@@ -449,67 +311,27 @@ axes:
         display_name: Sharded Cluster
         variables:
            TOPOLOGY: "sharded_cluster"
-  - id: auth
-    display_name: Authentication
+  - id: swift-version
+    display_name: "Swift"
     values:
-      - id: auth
-        display_name: Auth
+      - id: "4.2"
+        display_name: "Swift 4.2"
         variables:
-           AUTH: "auth"
-      - id: noauth
-        display_name: NoAuth
+           SWIFT_VERSION: "4.2"
+      - id: "5.0"
+        display_name: "Swift 5.0"
         variables:
-           AUTH: "noauth"
-  - id: ssl
-    display_name: SSL
-    values:
-      - id: ssl
-        display_name: SSL
-        variables:
-           SSL: "ssl"
-      - id: nossl
-        display_name: NoSSL
-        variables:
-           SSL: "nossl"
-  - id: storage-engine
-    display_name: Storage
-    values:
-      - id: mmapv1
-        display_name: MMAPv1
-        variables:
-           STORAGE_ENGINE: "mmapv1"
-      - id: wiredtiger
-        display_name: WiredTiger
-        variables:
-           STORAGE_ENGINE: "wiredtiger"
-      - id: inmemory
-        display_name: InMemory
-        variables:
-           STORAGE_ENGINE: "inmemory"
+           SWIFT_VERSION: "5.0"
+
 
 
 buildvariants:
+
 - matrix_name: "tests-all"
-#  matrix_spec: {"os-fully-featured": "*", auth: "*", ssl: "*" } // reenable when SSL support is added to the driver
-  matrix_spec: {"os-fully-featured": "*", auth: "noauth", ssl: "nossl" }
-  display_name: "${os-fully-featured} ${auth} ${ssl}"
+  matrix_spec: {"os-fully-featured": "*", "swift-version": "*"}
+  display_name: "${swift-version} ${os-fully-featured}"
   tasks:
-     - name: "test-latest-replica_set"
-     - name: "test-latest-sharded_cluster"
-     - name: "test-latest-standalone"
-     - name: "test-3.6-replica_set"
-     - name: "test-3.6-sharded_cluster"
-     - name: "test-3.6-standalone"
-     - name: "test-3.4-replica_set"
-     - name: "test-3.4-sharded_cluster"
-     - name: "test-3.4-standalone"
-     - name: "test-3.2-replica_set"
-     - name: "test-3.2-sharded_cluster"
-     - name: "test-3.2-standalone"
-     - name: "test-3.0-replica_set"
-     - name: "test-3.0-sharded_cluster"
-     - name: "test-3.0-standalone"
-     - name: "test-2.6-replica_set"
-     - name: "test-2.6-sharded_cluster"
-     - name: "test-2.6-standalone"
+     - ".latest"
+     - ".4.0"
+     - ".3.6"
 

--- a/.evergreen/find-cmake.sh
+++ b/.evergreen/find-cmake.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+find_cmake ()
+{
+  if [ ! -z "$CMAKE" ]; then
+    return 0
+  elif [ -f "/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake"
+  elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
+  elif [ -f "/opt/cmake/bin/cmake" ]; then
+    CMAKE="/opt/cmake/bin/cmake"
+  elif command -v cmake 2>/dev/null; then
+     CMAKE=cmake
+  elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     mkdir cmake-3.11.0
+     tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
+     CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
+  else
+     # Some images have no cmake yet, BUILD-4922.
+     echo "-- MAKE CMAKE --"
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     tar xzf cmake.tar.gz
+     cd cmake-3.11.0
+     ./bootstrap --prefix="${INSTALL_DIR}"
+     make -j8
+     make install
+     cd ..
+     CMAKE="${INSTALL_DIR}/bin/cmake"
+     echo "-- DONE MAKING CMAKE --"
+  fi
+}
+
+find_cmake

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -2,28 +2,25 @@
 set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
-# Supported/used environment variables:
-#       AUTH                    Set to enable authentication. Defaults to "noauth"
-#       SSL                     Set to enable SSL. Defaults to "nossl"
-#       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
-#       MARCH                   Machine Architecture. Defaults to lowercase uname -m
-
-AUTH=${AUTH:-noauth}
-SSL=${SSL:-nossl}
-MONGODB_URI=${MONGODB_URI:-}
-
+# variables
+PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
+MONGODB_URI=${MONGODB_URI:-"NO_URI_PROVIDED"}
+SWIFT_VERSION=${SWIFT_VERSION:-4.2}
+INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
+TOPOLOGY=${TOPOLOGY:-single}
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-[ -z "$MARCH" ] && MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 
-if [ "$AUTH" != "noauth" ]; then
-  export MONGOC_TEST_USER="bob"
-  export MONGOC_TEST_PASSWORD="pwd123"
-fi
+# enable swiftenv
+export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
+export PATH="${SWIFTENV_ROOT}/bin:$PATH"
+eval "$(swiftenv init -)"
 
-if [ "$SSL" != "nossl" ]; then
-   export MONGOC_TEST_SSL_PEM_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
-   export MONGOC_TEST_SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
-fi
+# switch swift version, and run tests
+export PKG_CONFIG_PATH="${INSTALL_DIR}/lib/pkgconfig"
 
-echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
-make test
+# override where we look for libmongoc
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib"
+export DYLD_LIBRARY_PATH="${INSTALL_DIR}/lib"
+
+swiftenv local $SWIFT_VERSION
+MONGODB_TOPOLOGY=${TOPOLOGY} MONGODB_URI=$MONGODB_URI make test

--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -10,6 +10,11 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
     }
 
     func testCommandMonitoring() throws {
+        guard MongoSwiftTestCase.topologyType != .sharded else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+
         let decoder = BSONDecoder()
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         client.enableMonitoring(forEvents: .commandMonitoring)

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -312,7 +312,9 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     func testDropIndexByModel() throws {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
-        expect(try self.coll.dropIndex(model)["ok"]).to(bsonEqual(1.0))
+
+        let res = try self.coll.dropIndex(model)
+        expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
@@ -324,7 +326,9 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     func testDropIndexByKeys() throws {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
-        expect(try self.coll.dropIndex(["cat": 1])["ok"]).to(bsonEqual(1.0))
+
+        let res = try self.coll.dropIndex(["cat": 1])
+        expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
@@ -336,7 +340,9 @@ final class MongoCollectionTests: MongoSwiftTestCase {
     func testDropAllIndexes() throws {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
-        expect(try self.coll.dropIndexes()["ok"]).to(bsonEqual(1.0))
+
+        let res = try self.coll.dropIndexes()
+        expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -12,7 +12,8 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         let db = client.db(type(of: self).testDatabase)
 
         let command: Document = ["create": self.getCollectionName(suffix: "1")]
-        expect(try db.runCommand(command)).to(equal(["ok": 1.0]))
+        let res = try db.runCommand(command)
+        expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
         expect(try (Array(db.listCollections()) as [Document]).count).to(equal(1))
 
         // create collection using createCollection

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -253,12 +253,12 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         // run command with a valid readConcern
         let options1 = RunCommandOptions(readConcern: ReadConcern(.local))
         let res1 = try db.runCommand(command, options: options1)
-        expect(res1["ok"]).to(bsonEqual(1.0))
+        expect((res1["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
         // run command with an empty readConcern
         let options2 = RunCommandOptions(readConcern: ReadConcern())
         let res2 = try db.runCommand(command, options: options2)
-        expect(res2["ok"]).to(bsonEqual(1.0))
+        expect((res2["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
         // running command with an invalid RC level should throw
         let options3 = RunCommandOptions(readConcern: ReadConcern("blah"))
@@ -299,12 +299,12 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         // run command with a valid writeConcern
         let options1 = RunCommandOptions(writeConcern: wc1)
         let res1 = try db.runCommand(command, options: options1)
-        expect(res1["ok"]).to(bsonEqual(1.0))
+        expect((res1["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
         // run command with an empty writeConcern
         let options2 = RunCommandOptions(writeConcern: wc2)
         let res2 = try db.runCommand(command, options: options2)
-        expect(res2["ok"]).to(bsonEqual(1.0))
+        expect((res2["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
         expect(try coll.insertOne(nextDoc(), options: InsertOneOptions(writeConcern: wc1))).toNot(throwError())
         expect(try coll.insertOne(nextDoc(), options: InsertOneOptions(writeConcern: wc3))).toNot(throwError())

--- a/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/SDAMMonitoringTests.swift
@@ -28,6 +28,11 @@ final class SDAMTests: MongoSwiftTestCase {
     // https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/tests/monitoring/standalone.json
     // swiftlint:enable line_length
     func testMonitoring() throws {
+        guard MongoSwiftTestCase.topologyType == .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+
         let client = try MongoClient(options: ClientOptions(eventMonitoring: true))
         client.enableMonitoring(forEvents: .serverMonitoring)
 


### PR DESCRIPTION
  - update evergreen config
  - install swift using swiftenv
  - add support for skipping tests by topology
  - add `find-cmake.sh` script
  - use patrick's new numeric helpers to avoid topology issues
  - ensure all tests of a commands response use `doubleValue` for `ok`
  - skip command monitoring tests on sharded topologies
  - reduce to a single mongos if multiple are provided
  - add 4.2 and 5.0 variants
  - disable macos tests until we can figure out how install without
    root permissions
