### PR TITLE
Fixed warnings

### DIFF
--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -5,21 +5,23 @@ import Foundation
 public struct AnyBSONValue: Codable, Equatable, Hashable {
     // TODO: conform all `BSONValue` types to `Hashable` (SWIFT-320).
     // swiftlint:disable:next legacy_hashing
-    public var hashValue: Int {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.value.bsonType)
         // A few types need to be handled specifically because their string representations aren't sufficient or
         // performant.
         if let date = self.value as? Date {
             // `Date`'s string conversion omits milliseconds and smaller time units, and using a string formatter is
             // expensive. Instead, we just include the time interval itself.
-            return "\(self.value.bsonType)-\(date.timeIntervalSince1970)".hashValue
+            hasher.combine(date.timeIntervalSince1970)
         } else if let binary = self.value as? Binary {
             // `Binary`'s string representation omits the data itself, so we include its hashValue.
-            return "\(self.value.bsonType)-\(binary.data.hashValue)-\(binary.subtype)".hashValue
+            hasher.combine(binary.data)
+            hasher.combine(binary.subtype)
         } else if let arr = self.value as? [BSONValue] {
             // To factor in every item in the array, we include the arrays extended JSON representation.
-            return "\(self.value.bsonType)-\((["value": arr] as Document).extendedJSON)".hashValue
+            hasher.combine((["value": arr] as Document).extendedJSON)
         }
-        return "\(self.value.bsonType)-\(self.value)".hashValue
+        hasher.combine("\(self.value)")
     }
 
     /// The `BSONValue` wrapped by this struct.

--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -4,7 +4,6 @@ import Foundation
 /// decoding `BSONValue`s of unknown type.
 public struct AnyBSONValue: Codable, Equatable, Hashable {
     // TODO: conform all `BSONValue` types to `Hashable` (SWIFT-320).
-    // swiftlint:disable:next legacy_hashing
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.value.bsonType)
         // A few types need to be handled specifically because their string representations aren't sufficient or

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -842,15 +842,15 @@ internal struct _BSONKey: CodingKey {
     internal static let `super` = _BSONKey(stringValue: "super")!
 }
 
-internal extension DecodingError {
-    internal static func _typeMismatch(at path: [CodingKey],
+extension DecodingError {
+    static func _typeMismatch(at path: [CodingKey],
                                        expectation: Any.Type,
                                        reality: BSONValue) -> DecodingError {
         let description = "Expected to decode \(expectation) but found \(type(of: reality)) instead."
         return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
     }
 
-    internal static func _numberMismatch(at path: [CodingKey],
+    static func _numberMismatch(at path: [CodingKey],
                                          expectation: Any.Type,
                                          reality: BSONValue) -> DecodingError {
         let description = "Expected to find a value that can be represented as a \(expectation), " +

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -843,14 +843,14 @@ internal struct _BSONKey: CodingKey {
 }
 
 extension DecodingError {
-    static func _typeMismatch(at path: [CodingKey],
+    internal static func _typeMismatch(at path: [CodingKey],
                                        expectation: Any.Type,
                                        reality: BSONValue) -> DecodingError {
         let description = "Expected to decode \(expectation) but found \(type(of: reality)) instead."
         return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
     }
 
-    static func _numberMismatch(at path: [CodingKey],
+    internal static func _numberMismatch(at path: [CodingKey],
                                          expectation: Any.Type,
                                          reality: BSONValue) -> DecodingError {
         let description = "Expected to find a value that can be represented as a \(expectation), " +


### PR DESCRIPTION
- Fixed redundant `internal` declaration that were triggering warnings on Xcode 10.2
- Updated `AnyBSONValue` conformance to `Hashable`