### PR TITLE
SWIFT-399: enable evg builds on OSX hosts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -292,9 +292,9 @@ axes:
         run_on: ubuntu1804-test
         batchtime: 10080  # 7 days
 
-      # - id: macos-1012
-      #   display_name: "macOS 10.12"
-      #   run_on: macos-1012
+      - id: macos-1014
+        display_name: "macOS 10.14"
+        run_on: macos-1014
 
   - id: topology
     display_name: Topology

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -26,9 +26,8 @@ make -j8 install
 cd "${PROJECT_DIRECTORY}"
 
 # install swiftenv
-git clone --depth 1 https://github.com/kylef/swiftenv.git "${SWIFTENV_ROOT}"
+git clone --depth 1 -b "osx-install-path" https://github.com/mbroadst/swiftenv.git "${SWIFTENV_ROOT}"
 
 # install swift
-
 eval "$(swiftenv init -)"
-swiftenv install $SWIFT_VERSION
+swiftenv install --install-local $SWIFT_VERSION

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -9,6 +9,7 @@ SWIFT_VERSION=${SWIFT_VERSION:-4.2}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 TOPOLOGY=${TOPOLOGY:-single}
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+EXTRA_FLAGS="-Xlinker -rpath -Xlinker ${INSTALL_DIR}/lib"
 
 # enable swiftenv
 export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
@@ -21,6 +22,12 @@ export PKG_CONFIG_PATH="${INSTALL_DIR}/lib/pkgconfig"
 # override where we look for libmongoc
 export LD_LIBRARY_PATH="${INSTALL_DIR}/lib"
 export DYLD_LIBRARY_PATH="${INSTALL_DIR}/lib"
+export DEVELOPER_DIR=/Applications/Xcode10.1.app
 
 swiftenv local $SWIFT_VERSION
-MONGODB_TOPOLOGY=${TOPOLOGY} MONGODB_URI=$MONGODB_URI make test
+
+# build the driver
+swift build $EXTRA_FLAGS
+
+# test the driver
+MONGODB_TOPOLOGY=${TOPOLOGY} MONGODB_URI=$MONGODB_URI swift test $EXTRA_FLAGS


### PR DESCRIPTION
This is dependent on a branch of `swiftenv` on my local github
account to work, that will hopefully be resolved shortly. Other
items of note here are that we only build on the macos-1014 hosts
due to XCode version requirements, and some tricky linker lines
to accommodate rpath linking to libmongoc.
