### PR TITLE
SWIFT-373: Introduce Operation protocol, CountOperation, and DistinctOperation 

### DIFF
--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -1,0 +1,75 @@
+import mongoc
+
+/// An operation corresponding to a "count" command on a collection.
+internal struct CountOperation<T: Codable>: Operation {
+    private let collection: MongoCollection<T>
+    private let filter: Document
+    private let options: CountOptions?
+
+    internal init(collection: MongoCollection<T>,
+                  filter: Document,
+                  options: CountOptions? = nil) {
+        self.collection = collection
+        self.filter = filter
+        self.options = options
+    }
+
+    internal func execute() throws -> Int {
+        let opts = try collection.encoder.encode(self.options)
+        let rp = self.options?.readPreference?._readPreference
+        var error = bson_error_t()
+        // because we already encode skip and limit in the options,
+        // pass in 0s so we don't get duplicate parameter errors.
+        let count = mongoc_collection_count_with_opts(
+            self.collection._collection, MONGOC_QUERY_NONE, self.filter.data, 0, 0, opts?.data, rp, &error)
+
+        if count == -1 { throw parseMongocError(error) }
+
+        return Int(count)
+    }
+}
+
+/// Options to use when executing a `count` command on a `MongoCollection`.
+public struct CountOptions: Encodable {
+    /// Specifies a collation.
+    public let collation: Document?
+
+    /// A hint for the index to use.
+    public let hint: Hint?
+
+    /// The maximum number of documents to count.
+    public let limit: Int64?
+
+    /// The maximum amount of time to allow the query to run.
+    public let maxTimeMS: Int64?
+
+    /// The number of documents to skip before counting.
+    public let skip: Int64?
+
+    /// A ReadConcern to use for this operation.
+    public let readConcern: ReadConcern?
+
+    /// A ReadPreference to use for this operation.
+    public let readPreference: ReadPreference?
+
+    /// Convenience initializer allowing any/all parameters to be optional
+    public init(collation: Document? = nil,
+                hint: Hint? = nil,
+                limit: Int64? = nil,
+                maxTimeMS: Int64? = nil,
+                readConcern: ReadConcern? = nil,
+                readPreference: ReadPreference? = nil,
+                skip: Int64? = nil) {
+        self.collation = collation
+        self.hint = hint
+        self.limit = limit
+        self.maxTimeMS = maxTimeMS
+        self.readConcern = readConcern
+        self.readPreference = readPreference
+        self.skip = skip
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case collation, hint, limit, maxTimeMS, readConcern, skip
+    }
+}

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -8,7 +8,7 @@ internal struct CountOperation<T: Codable>: Operation {
 
     internal init(collection: MongoCollection<T>,
                   filter: Document,
-                  options: CountOptions? = nil) {
+                  options: CountOptions?) {
         self.collection = collection
         self.filter = filter
         self.options = options

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -1,0 +1,74 @@
+import mongoc
+
+/// An operation corresponding to a "distinct" command on a collection.
+internal struct DistinctOperation<T: Codable> {
+    private let collection: MongoCollection<T>
+    private let fieldName: String
+    private let filter: Document
+    private let options: DistinctOptions?
+
+    internal init(collection: MongoCollection<T>,
+                  fieldName: String,
+                  filter: Document,
+                  options: DistinctOptions? = nil) {
+        self.collection = collection
+        self.fieldName = fieldName
+        self.filter = filter
+        self.options = options
+    }
+
+    internal func execute() throws -> [BSONValue] {
+        let collName = String(cString: mongoc_collection_get_name(self.collection._collection))
+        let command: Document = [
+            "distinct": collName,
+            "key": self.fieldName,
+            "query": self.filter
+        ]
+
+        let opts = try collection.encoder.encode(self.options)
+        let rp = self.options?.readPreference?._readPreference
+        let reply = Document()
+        var error = bson_error_t()
+        guard mongoc_collection_read_command_with_opts(
+            self.collection._collection, command.data, rp, opts?.data, reply.data, &error) else {
+            throw parseMongocError(error, errorLabels: reply["errorLabels"] as? [String])
+        }
+
+        guard let values = try reply.getValue(for: "values") as? [BSONValue] else {
+            throw RuntimeError.internalError(message:
+                "expected server reply \(reply) to contain an array of distinct values")
+        }
+
+        return values
+    }
+}
+
+/// Options to use when executing a `distinct` command on a `MongoCollection`.
+public struct DistinctOptions: Encodable {
+    /// Specifies a collation.
+    public let collation: Document?
+
+    /// The maximum amount of time to allow the query to run.
+    public let maxTimeMS: Int64?
+
+    /// A ReadConcern to use for this operation.
+    public let readConcern: ReadConcern?
+
+    /// A ReadPreference to use for this operation.
+    public let readPreference: ReadPreference?
+
+    /// Convenience initializer allowing any/all parameters to be optional
+    public init(collation: Document? = nil,
+                maxTimeMS: Int64? = nil,
+                readConcern: ReadConcern? = nil,
+                readPreference: ReadPreference? = nil) {
+        self.collation = collation
+        self.maxTimeMS = maxTimeMS
+        self.readConcern = readConcern
+        self.readPreference = readPreference
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case collation, maxTimeMS, readConcern
+    }
+}

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -1,5 +1,35 @@
 import mongoc
 
+/// Options to use when executing a `distinct` command on a `MongoCollection`.
+public struct DistinctOptions: Encodable {
+    /// Specifies a collation.
+    public let collation: Document?
+
+    /// The maximum amount of time to allow the query to run.
+    public let maxTimeMS: Int64?
+
+    /// A ReadConcern to use for this operation.
+    public let readConcern: ReadConcern?
+
+    /// A ReadPreference to use for this operation.
+    public let readPreference: ReadPreference?
+
+    /// Convenience initializer allowing any/all parameters to be optional
+    public init(collation: Document? = nil,
+                maxTimeMS: Int64? = nil,
+                readConcern: ReadConcern? = nil,
+                readPreference: ReadPreference? = nil) {
+        self.collation = collation
+        self.maxTimeMS = maxTimeMS
+        self.readConcern = readConcern
+        self.readPreference = readPreference
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case collation, maxTimeMS, readConcern
+    }
+}
+
 /// An operation corresponding to a "distinct" command on a collection.
 internal struct DistinctOperation<T: Codable> {
     private let collection: MongoCollection<T>
@@ -40,35 +70,5 @@ internal struct DistinctOperation<T: Codable> {
         }
 
         return values
-    }
-}
-
-/// Options to use when executing a `distinct` command on a `MongoCollection`.
-public struct DistinctOptions: Encodable {
-    /// Specifies a collation.
-    public let collation: Document?
-
-    /// The maximum amount of time to allow the query to run.
-    public let maxTimeMS: Int64?
-
-    /// A ReadConcern to use for this operation.
-    public let readConcern: ReadConcern?
-
-    /// A ReadPreference to use for this operation.
-    public let readPreference: ReadPreference?
-
-    /// Convenience initializer allowing any/all parameters to be optional
-    public init(collation: Document? = nil,
-                maxTimeMS: Int64? = nil,
-                readConcern: ReadConcern? = nil,
-                readPreference: ReadPreference? = nil) {
-        self.collation = collation
-        self.maxTimeMS = maxTimeMS
-        self.readConcern = readConcern
-        self.readPreference = readPreference
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case collation, maxTimeMS, readConcern
     }
 }

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -10,7 +10,7 @@ internal struct DistinctOperation<T: Codable> {
     internal init(collection: MongoCollection<T>,
                   fieldName: String,
                   filter: Document,
-                  options: DistinctOptions? = nil) {
+                  options: DistinctOptions?) {
         self.collection = collection
         self.fieldName = fieldName
         self.filter = filter

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -1,5 +1,5 @@
-/// A protocol for operation types to conform to. An operation corresponds to any single operation a user can perform
-/// with the driver's API that requires I/O.
+/// A protocol for operation types to conform to. An `Operation` instance corresponds to any single operation a user
+/// can perform with the driver's API that requires I/O.
 internal protocol Operation {
     /// The result type this operation returns.
     associatedtype OperationResult

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -1,0 +1,8 @@
+/// A protocol for operation types to conform to. An operation corresponds to any single operation a user can perform
+/// with the driver's API that requires I/O.
+internal protocol Operation {
+    /// The result type this operation returns.
+    associatedtype OperationResult
+    /// Executes this operation and returns its corresponding result type.
+    func execute() throws -> OperationResult
+}


### PR DESCRIPTION
Part 1 of many. This introduces the `Operation` protocol and migrates the non-cursor `MongoCollection` "read" methods to use it.