### PR TITLE
Adds osx support for Podspec

### DIFF
--- a/MongoSwift.podspec
+++ b/MongoSwift.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
     :tag => 'v0.1.0'
   }
 
+  spec.osx.deployment_target = "10.12"
   spec.ios.deployment_target = "11.0"
   spec.tvos.deployment_target = "10.2"
   spec.watchos.deployment_target = "4.3"


### PR DESCRIPTION
This commit introduces a simple change that would make `mongo-swift-driver` installable through `cocoapods` for macOS desktop applications in Xcode.

Since this change is outside of the testing domain of the codebase, you can simply test it with the following steps:

- Create a new macOS project using xcode
- Initialize `cocopods` for the project
- Add `pod 'MongoSwift', :git => 'https://github.com/alicin/mongo-swift-driver.git'` to your Podfile.
- run `pod install`
- Profit!

<!--
Thanks for contributing!
-->

Some things to make sure you have:
- [ ] Read `CONTRIBUTING.md`!
- [ ] Ran `swiftlint` and ensured that your additions/deletions are not causing
any new warnings or errors.
- [ ] Added new tests that correctly verify the correctness of any new/added
functionality.
- [ ] Ran `make test` and ensured that the driver still passes all of its
pre-existing tests.
- [ ] _Not_ included any changes to the generated documentation (we update
the documentation as part of a separate commit).

<!--
Thanks again!
-->
