### PR TITLE
SWIFT-373 Add CreateIndexes and DropIndexes operations

### DIFF
--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -26,8 +26,6 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
     }
 
     internal func execute() throws -> [String] {
-        let collName = String(cString: mongoc_collection_get_name(self.collection._collection))
-
         var indexData = [Document]()
         for index in self.models {
             var indexDoc = try self.collection.encoder.encode(index)
@@ -37,10 +35,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
             indexData.append(indexDoc)
         }
 
-        let command: Document = [
-            "createIndexes": collName,
-            "indexes": indexData
-        ]
+        let command: Document = ["createIndexes": self.collection.name, "indexes": indexData]
 
         let opts = try self.collection.encoder.encode(self.options)
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -1,0 +1,56 @@
+import mongoc
+
+/// Options to use when creating a new index on a `MongoCollection`.
+public struct CreateIndexOptions: Encodable {
+    /// An optional `WriteConcern` to use for the command
+    public let writeConcern: WriteConcern?
+
+    /// Initializer allowing any/all parameters to be omitted.
+    public init(writeConcern: WriteConcern? = nil) {
+        self.writeConcern = writeConcern
+    }
+}
+
+/// An operation corresponding to a "createIndexes" command.
+internal struct CreateIndexesOperation<T: Codable>: Operation {
+    private let collection: MongoCollection<T>
+    private let models: [IndexModel]
+    private let options: CreateIndexOptions?
+
+    internal init(collection: MongoCollection<T>,
+                  models: [IndexModel],
+                  options: CreateIndexOptions?) {
+        self.collection = collection
+        self.models = models
+        self.options = options
+    }
+
+    internal func execute() throws -> [String] {
+        let collName = String(cString: mongoc_collection_get_name(self.collection._collection))
+
+        var indexData = [Document]()
+        for index in self.models {
+            var indexDoc = try self.collection.encoder.encode(index)
+            if let opts = try self.collection.encoder.encode(index.options) {
+                try indexDoc.merge(opts)
+            }
+            indexData.append(indexDoc)
+        }
+
+        let command: Document = [
+            "createIndexes": collName,
+            "indexes": indexData
+        ]
+
+        let opts = try self.collection.encoder.encode(self.options)
+        var error = bson_error_t()
+        let reply = Document()
+
+        guard mongoc_collection_write_command_with_opts(
+            self.collection._collection, command.data, opts?.data, reply.data, &error) else {
+            throw getErrorFromReply(bsonError: error, from: reply)
+        }
+
+        return self.models.map { $0.options?.name ?? $0.defaultName }
+    }
+}

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -1,0 +1,41 @@
+import mongoc
+
+
+/// Options to use when dropping an index from a `MongoCollection`.
+public struct DropIndexOptions: Encodable {
+    /// An optional `WriteConcern` to use for the command
+    public let writeConcern: WriteConcern?
+
+    /// Initializer allowing any/all parameters to be omitted.
+    public init(writeConcern: WriteConcern? = nil) {
+        self.writeConcern = writeConcern
+    }
+}
+
+/// An operation corresponding to a "dropIndexes" command.
+internal struct DropIndexesOperation<T: Codable>: Operation {
+    private let collection: MongoCollection<T>
+    private let index: BSONValue
+    private let options: DropIndexOptions?
+
+    internal init(collection: MongoCollection<T>,
+                  index: BSONValue,
+                  options: DropIndexOptions?) {
+        self.collection = collection
+        self.index = index
+        self.options = options
+    }
+
+    internal func execute() throws -> Document {
+        let collName = String(cString: mongoc_collection_get_name(self.collection._collection))
+        let command: Document = ["dropIndexes": collName, "index": self.index]
+        let opts = try self.collection.encoder.encode(self.options)
+        let reply = Document()
+        var error = bson_error_t()
+        guard mongoc_collection_write_command_with_opts(
+            self.collection._collection, command.data, opts?.data, reply.data, &error) else {
+            throw getErrorFromReply(bsonError: error, from: reply)
+        }
+        return reply
+    }
+}

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -26,8 +26,7 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
     }
 
     internal func execute() throws -> Document {
-        let collName = String(cString: mongoc_collection_get_name(self.collection._collection))
-        let command: Document = ["dropIndexes": collName, "index": self.index]
+        let command: Document = ["dropIndexes": self.collection.name, "index": self.index]
         let opts = try self.collection.encoder.encode(self.options)
         let reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -1,6 +1,5 @@
 import mongoc
 
-
 /// Options to use when dropping an index from a `MongoCollection`.
 public struct DropIndexOptions: Encodable {
     /// An optional `WriteConcern` to use for the command


### PR DESCRIPTION
#248 did some refactoring so that all index creation would go through a single method, and same for dropping indexes. 
This converts those methods into operation types, `CreateIndexesOperation` and `DropIndexesOperation`. 