### PR TITLE
SWIFT-405 make Document.count fileprivate(set)

### DIFF
--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -54,7 +54,7 @@ public struct Document {
     internal var storage: DocumentStorage
 
     /// Returns the number of (key, value) pairs stored at the top level of this `Document`.
-    public var count: Int
+    public fileprivate(set) var count: Int
 }
 
 /// An extension of `Document` containing its private/internal functionality.


### PR DESCRIPTION
Ensures you can only update the Document count from within `Document.swift`. 