### PR TITLE
Add pipeline option to createCollection and test all createCollection options

### DIFF
--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -64,7 +64,7 @@ public struct CreateCollectionOptions: Encodable, CodingStrategyProvider {
     /// Maximum number of documents allowed in the collection (if capped).
     public let max: Int64?
 
-    /// Determine which storage engine to use.
+    /// Specifies storage engine configuration for this collection.
     public let storageEngine: Document?
 
     /// What validator should be used for the collection.
@@ -77,17 +77,18 @@ public struct CreateCollectionOptions: Encodable, CodingStrategyProvider {
     /// to be inserted.
     public let validationAction: String?
 
-    /// Allows users to specify a default configuration for indexes when creating a collection.
+    /// Specify a default configuration for indexes created on this collection.
     public let indexOptionDefaults: Document?
 
     /// The name of the source collection or view from which to create the view.
     public let viewOn: String?
 
+    /// An array consisting of aggregation pipeline stages. When used with `viewOn`, will create the view by applying
+    /// this pipeline to the source collection or view.
+    public let pipeline: [Document]?
+
     /// Specifies the default collation for the collection.
     public let collation: Document?
-
-    /// A session to associate with this operation.
-    public let session: ClientSession?
 
     /// A write concern to use when executing this command. To set a read or write concern for the collection itself,
     /// retrieve the collection using `MongoDatabase.collection`.
@@ -110,7 +111,7 @@ public struct CreateCollectionOptions: Encodable, CodingStrategyProvider {
 
     private enum CodingKeys: String, CodingKey {
         case capped, autoIndexId, size, max, storageEngine, validator, validationLevel, validationAction,
-             indexOptionDefaults, viewOn, collation, session, writeConcern
+             indexOptionDefaults, viewOn, pipeline, collation, writeConcern
     }
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
@@ -119,7 +120,7 @@ public struct CreateCollectionOptions: Encodable, CodingStrategyProvider {
                 collation: Document? = nil,
                 indexOptionDefaults: Document? = nil,
                 max: Int64? = nil,
-                session: ClientSession? = nil,
+                pipeline: [Document]? = nil,
                 size: Int64? = nil,
                 storageEngine: Document? = nil,
                 validationAction: String? = nil,
@@ -135,7 +136,7 @@ public struct CreateCollectionOptions: Encodable, CodingStrategyProvider {
         self.collation = collation
         self.indexOptionDefaults = indexOptionDefaults
         self.max = max
-        self.session = session
+        self.pipeline = pipeline
         self.size = size
         self.storageEngine = storageEngine
         self.validationAction = validationAction

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -51,7 +51,7 @@ public struct ListCollectionsOptions: Encodable {
 }
 
 /// Options to use when executing a `createCollection` command on a `MongoDatabase`.
-public struct CreateCollectionOptions: Encodable, CodingStrategyProvider {
+public struct CreateCollectionOptions: Codable, CodingStrategyProvider {
     /// Indicates whether this will be a capped collection.
     public let capped: Bool?
 
@@ -94,20 +94,24 @@ public struct CreateCollectionOptions: Encodable, CodingStrategyProvider {
     /// retrieve the collection using `MongoDatabase.collection`.
     public let writeConcern: WriteConcern?
 
+    // swiftlint:disable redundant_optional_initialization
+    // to get synthesized decodable conformance for the struct, these strategies need default values.
+
     /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
     /// It is the responsibility of the user to ensure that any `Date`s already stored in this collection can be
     /// decoded using this strategy.
-    public let dateCodingStrategy: DateCodingStrategy?
+    public var dateCodingStrategy: DateCodingStrategy? = nil
 
     /// Specifies the `UUIDCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
     /// It is the responsibility of the user to ensure that any `UUID`s already stored in this collection can be
     /// decoded using this strategy.
-    public let uuidCodingStrategy: UUIDCodingStrategy?
+    public var uuidCodingStrategy: UUIDCodingStrategy? = nil
 
     /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
     /// It is the responsibility of the user to ensure that any `Data`s already stored in this collection can be
     /// decoded using this strategy.
-    public let dataCodingStrategy: DataCodingStrategy?
+    public var dataCodingStrategy: DataCodingStrategy? = nil
+    // swiftlint:enable redundant_optional_initialization
 
     private enum CodingKeys: String, CodingKey {
         case capped, autoIndexId, size, max, storageEngine, validator, validationLevel, validationAction,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -170,6 +170,7 @@ extension MongoCollection_BulkWriteTests {
 extension MongoDatabaseTests {
     static var allTests = [
         ("testMongoDatabase", testMongoDatabase),
+        ("testCreateCollection", testCreateCollection),
     ]
 }
 

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -40,12 +40,15 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
 
+        let indexOpts: Document =
+            ["storageEngine": ["wiredTiger": ["configString": "access_pattern_hint=random"] as Document] as Document]
+
         // test non-view options
         let options = CreateCollectionOptions(
             autoIndexId: true,
             capped: true,
             collation: ["locale": "fr"],
-            indexOptionDefaults: ["storageEngine": ["wiredTiger": ["configString": "access_pattern_hint=random"] as Document] as Document],
+            indexOptionDefaults: indexOpts,
             max: 1000,
             size: 10000,
             storageEngine: ["wiredTiger": ["configString": "access_pattern_hint=random"] as Document],

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -42,9 +42,6 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
 
         let indexOpts: Document =
             ["storageEngine": ["wiredTiger": ["configString": "access_pattern_hint=random"] as Document] as Document]
-        let doc1: Document = ["_id": 1, "a": "aaa", "b": "bbb"]
-        let doc2: Document = ["_id": 2, "a": "abc", "b": "def"]
-        let doc3: Document = ["_id": 3, "a": "ghi", "b": "jkl"]
 
         // test non-view options
         let options = CreateCollectionOptions(
@@ -52,26 +49,15 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
             capped: true,
             collation: ["locale": "fr"],
             indexOptionDefaults: indexOpts,
-            max: 2,
-            size: doc1.rawBSON.count + doc2.rawBSON.count,
+            max: 1000,
+            size: 10000,
             storageEngine: ["wiredTiger": ["configString": "access_pattern_hint=random"] as Document],
-            validationAction: "error",
+            validationAction: "warn",
             validationLevel: "moderate",
-            validator: ["a": ["$type": "string"] as Document],
+            validator: ["phone": ["$type": "string"] as Document],
             writeConcern: try WriteConcern(w: .majority)
         )
-
-        let collection = try db.createCollection("foo", options: options)
-        try collection.insertOne(doc1)
-
-        // should error with a as integer due to validator
-        expect(try collection.insertOne(["a": 1])).to(throwError())
-
-        try collection.insertOne(doc2)
-
-        // should overwrite first doc as we've reached max size
-        try collection.insertOne(doc3)
-        expect(try coll.count()).to(equal(2))
+        expect(try db.createCollection("foo", options: options)).toNot(throwError())
 
         // test view options
         let viewOptions = CreateCollectionOptions(
@@ -79,10 +65,6 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
             viewOn: "foo"
         )
 
-        let view = try db.createCollection("fooView", options: viewOptions)
-        let docs = Array(try view.find(options: FindOptions(sort: ["_id": 1])))
-        expect(docs).to(haveCount(2))
-        expect(docs[0]).to(equal(["_id": 1, "a": "aaa"]))
-        expect(docs[1]).to(equal(["_id": 2, "a": "abc"]))
+        expect(try db.createCollection("fooView", options: viewOptions)).toNot(throwError())
     }
 }


### PR DESCRIPTION
When refactoring the database methods to be operations, I decided to check if we had all of the correct options available for `createCollection`. turns out we were missing `pipeline`.

I've added it and also a test that exercises all the possible createCollection options to make sure the server accepts them. 
