### PR TITLE
move SwiftLint disable justification comments into different lines

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// `BSONDecoder` facilitates the decoding of BSON into semantic `Decodable` types.
 public class BSONDecoder {
-    // swiftlint:disable explicit_acl - seems to be a Swiftlint bug.
+    // swiftlint:disable explicit_acl
+    // some kind of swiftlint bug here.
     @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     internal static var iso8601Formatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
@@ -296,8 +297,8 @@ internal struct _BSONDecodingStorage {
         guard !self.containers.isEmpty else {
             fatalError("Empty container stack.")
         }
-        // swiftlint:disable:next force_unwrapping - guaranteed safe because of precondition.
-        return self.containers.last!
+        // swiftlint:disable:next force_unwrapping
+        return self.containers.last! // guaranteed safe because of precondition.
     }
 
     /// Adds a new container to the stack.
@@ -654,8 +655,9 @@ private struct _BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
     /// A Boolean value indicating whether there are no more elements left to be decoded in the container.
     public var isAtEnd: Bool { return self.currentIndex >= self.count! }
-    // swiftlint:disable:previous force_unwrapping - `.count` always returns a value and is only an `Int?`
-    // because it's required of the UnkeyedDecodingContainer protocol.
+    // swiftlint:disable:previous force_unwrapping
+    // `.count` always returns a value and is only an `Int?` because it's required of the
+    // UnkeyedDecodingContainer protocol.
 
     /// A private helper function to check if we're at the end of the container, and if so throw an error.
     private func checkAtEnd() throws {
@@ -838,8 +840,8 @@ internal struct _BSONKey: CodingKey {
         self.intValue = index
     }
 
-    // swiftlint:disable:next force_unwrapping - this initializer never actually returns nil.
-    internal static let `super` = _BSONKey(stringValue: "super")!
+    // swiftlint:disable:next force_unwrapping
+    internal static let `super` = _BSONKey(stringValue: "super")! // this initializer never actually returns nil.
 }
 
 extension DecodingError {

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -313,8 +313,8 @@ internal struct _BSONEncodingStorage {
         guard !self.containers.isEmpty else {
             fatalError("Empty container stack.")
         }
-        // swiftlint:disable:next force_unwrapping - guaranteed safe because of precondition.
-        return self.containers.popLast()!
+        // swiftlint:disable:next force_unwrapping
+        return self.containers.popLast()! // guaranteed safe because of precondition.
     }
 }
 

--- a/Sources/MongoSwift/BSON/Document+Codable.swift
+++ b/Sources/MongoSwift/BSON/Document+Codable.swift
@@ -14,8 +14,8 @@ extension Document: Codable {
         // and then wrap the values in `AnyBSONValue`s and encode them
         var container = encoder.container(keyedBy: _BSONKey.self)
         for (k, v) in self {
-            // swiftlint:disable:next force_unwrapping - the initializer never actually returns nil.
-            let key = _BSONKey(stringValue: k)!
+            // swiftlint:disable:next force_unwrapping
+            let key = _BSONKey(stringValue: k)! // the initializer never actually returns nil.
             if v is BSONNull {
                 try container.encodeNil(forKey: key)
             } else {

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -159,7 +159,8 @@ extension Document {
             // if the new type is the same and it's a fixed length type, we can overwrite
             if let ov = newValue as? Overwritable, ov.bsonType == existingType {
                 self.copyStorageIfRequired()
-                // swiftlint:disable:next force_unwrapping - key is guaranteed present so initialization will succeed.
+                // key is guaranteed present so initialization will succeed.
+                // swiftlint:disable:next force_unwrapping
                 try DocumentIterator(forDocument: self, advancedTo: key)!.overwriteCurrentValue(with: ov)
 
             // otherwise, we just create a new document and replace this key
@@ -312,8 +313,8 @@ extension Document {
 
     /// Returns a copy of the raw BSON data for this `Document`, represented as `Data`.
     public var rawBSON: Data {
-        // swiftlint:disable:next force_unwrapping - documented as always returning a value.
-        let data = bson_get_data(self.data)!
+        // swiftlint:disable:next force_unwrapping
+        let data = bson_get_data(self.data)! // documented as always returning a value.
 
         /// BSON encodes the length in the first four bytes, so we can read it in from the
         /// raw data without needing to access the `len` field of the `bson_t`.

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -325,7 +325,8 @@ public class BulkWriteOperation {
 
     /// Initializes the object from a `mongoc_collection_t` and `bson_t`.
     fileprivate init(collection: OpaquePointer?, opts: Document?, withEncoder: BSONEncoder) {
-        // swiftlint:disable:next force_unwrapping - documented as always returning a value.
+        // documented as always returning a value.
+        // swiftlint:disable:next force_unwrapping
         self.bulk = mongoc_collection_create_bulk_operation_with_opts(collection, opts?.data)!
         self.opts = opts
         self.encoder = withEncoder

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -25,8 +25,8 @@ public struct ConnectionId: Equatable {
     internal init(_ hostAndPort: String = "localhost:27017") {
         let parts = hostAndPort.split(separator: ":")
         self.host = String(parts[0])
-        // swiftlint:disable:next force_unwrapping - should be valid UInt16 unless server response malformed.
-        self.port = UInt16(parts[1])!
+        // swiftlint:disable:next force_unwrapping
+        self.port = UInt16(parts[1])! // should be valid UInt16 unless server response malformed.
     }
 }
 
@@ -176,8 +176,8 @@ public struct ServerDescription {
         self.parseIsMaster(isMaster)
 
         let serverType = String(cString: mongoc_server_description_type(description))
-        // swiftlint:disable:next force_unwrapping - libmongoc will always give us a valid raw value.
-        self.type = ServerType(rawValue: serverType)!
+        // swiftlint:disable:next force_unwrapping
+        self.type = ServerType(rawValue: serverType)! // libmongoc will always give us a valid raw value.
     }
 }
 
@@ -245,8 +245,8 @@ public struct TopologyDescription {
     /// to a `mongoc_server_description_t`
     internal init(_ description: OpaquePointer) {
         let topologyType = String(cString: mongoc_topology_description_type(description))
-        // swiftlint:disable:next force_unwrapping - libmongoc will only give us back valid raw values.
-        self.type = TopologyType(rawValue: topologyType)!
+        // swiftlint:disable:next force_unwrapping
+        self.type = TopologyType(rawValue: topologyType)! // libmongoc will only give us back valid raw values.
 
         var size = size_t()
         let serverData = mongoc_topology_description_get_servers(description, &size)
@@ -254,8 +254,8 @@ public struct TopologyDescription {
 
         let buffer = UnsafeBufferPointer(start: serverData, count: size)
         if size > 0 {
-            // swiftlint:disable:next force_unwrapping - documented as always returning a value.
-            self.servers = Array(buffer).map { ServerDescription($0!) }
+            // swiftlint:disable:next force_unwrapping
+            self.servers = Array(buffer).map { ServerDescription($0!) } // documented as always returning a value.
         }
     }
 }


### PR DESCRIPTION
fixes what we were talking about earlier with the justifications needing to be in separate lines.