### PR TITLE
Swift-28 Implement Sessions

### DIFF
--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -54,7 +54,7 @@ public struct Document {
     internal var storage: DocumentStorage
 
     /// Returns the number of (key, value) pairs stored at the top level of this `Document`.
-    public fileprivate(set) var count: Int
+    public internal(set) var count: Int
 }
 
 /// An extension of `Document` containing its private/internal functionality.
@@ -252,7 +252,7 @@ extension Document {
      * Therefore, this function should be called just before we are about to modify a document - either by
      * setting a value or merging in another doc.
      */
-    private mutating func copyStorageIfRequired() {
+    internal mutating func copyStorageIfRequired() {
         if !isKnownUniquelyReferenced(&self.storage) {
             self.storage = DocumentStorage(copying: self.data)
         }

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -1,35 +1,121 @@
+import Foundation
+import mongoc
+
+#if compiler(>=5.0)
+internal typealias ClientSessionPointer = OpaquePointer
+internal typealias MutableClientSessionPointer = OpaquePointer
+#else
+internal typealias ClientSessionPointer = UnsafePointer<mongoc_client_session_t>
+internal typealias MutableClientSessionPointer = UnsafeMutablePointer<mongoc_client_session_t>
+#endif
+
 /// Options to use when creating a ClientSession.
-internal struct SessionOptions: Encodable {
-    /// Specifies whether read operations should be causally ordered within the session.
-    private let causalConsistency: Bool?
+public struct ClientSessionOptions {}
+
+/// Private wrapper of a mongoc_session_opt_t.
+private class SessionOptWrapper {
+    /// Opaque pointer to a `mongoc_session_opt_t`
+    fileprivate var _opts: OpaquePointer?
+
+    fileprivate init(from options: ClientSessionOptions?) {
+        guard options != nil else {
+            return
+        }
+        self._opts = mongoc_session_opts_new()
+    }
+
+    deinit {
+        guard let opts = self._opts else {
+            return
+        }
+        mongoc_session_opts_destroy(opts)
+    }
 }
 
-/// :nodoc: A session for ordering sequential operations.
-public class ClientSession: Encodable {
+/// A MongoDB client session.
+public final class ClientSession {
+    /// Error thrown when an inactive session is used.
+    internal static var SessionInactiveError: Error = UserError.logicError(message: "Tried to use an inactive session")
+
+    /// Pointer to the underlying `mongoc_client_session_t`.
+    internal fileprivate(set) var _session: ClientSessionPointer?
+
+    /// Returns whether this session has been ended or not.
+    internal var active: Bool { return self._session != nil }
+
+    /// The client used to start this session.
+    public let client: MongoClient
+
+    /// The session ID of this session.
+    public let id: Document
+
+    /// The most recent cluster time seen by this session.
+    /// If no operations have been executed using this session and `advanceClusterTime` has not been called, this will
+    /// be `nil`.
+    public var clusterTime: Document? {
+        guard let time = mongoc_client_session_get_cluster_time(self._session) else {
+            return nil
+        }
+        return Document(copying: time)
+    }
+
+    /// The options used to start this session.
+    public let options: ClientSessionOptions?
+
     /// Initializes a new client session.
-    internal init() {
+    internal init(client: MongoClient, options: ClientSessionOptions? = nil) throws {
+        self.options = options
+        self.client = client
+
+        let opts = SessionOptWrapper(from: options)
+        var error = bson_error_t()
+        guard let session = mongoc_client_start_session(client._client, opts._opts, &error) else {
+            throw parseMongocError(error)
+        }
+        // swiftlint:disable:next force_unwrapping
+        self.id = Document(copying: mongoc_client_session_get_lsid(session)!) // always returns a value
+        self._session = session
+    }
+
+    /// Destroy the underlying `mongoc_client_session_t` and set this session to inactive.
+    /// Does nothing if this session is already inactive.
+    internal func end() {
+        guard self.active else {
+            return
+        }
+        mongoc_client_session_destroy(self._session)
+        self._session = nil
     }
 
     /// Cleans up internal state.
     deinit {
+        self.end()
     }
 
-    /// Finish the session.
-    private func endSession() {
+    /**
+     * Advances the clusterTime for this session to the given time, if it is greater than the current clusterTime.
+     * If the provided clusterTime is less than the current clusterTime, this method has no effect.
+     *
+     * - Parameters:
+     *   - clusterTime: The session's new cluster time, as a `Document` like `["cluster time": Timestamp(...)]`
+     */
+    public func advanceClusterTime(to clusterTime: Document) {
+        mongoc_client_session_advance_cluster_time(self._session, clusterTime.storage.pointer)
     }
 
-    /// The server session id for this session.
-    private var sessionId: Document {
-        return Document()
-    }
+    /// Appends this provided session to an options document for libmongoc interoperability.
+    /// - Throws:
+    ///   - `UserError.logicError` if this session is inactive
+    internal func append(to doc: inout Document) throws {
+        guard self.active else {
+            throw ClientSession.SessionInactiveError
+        }
 
-    /// The cluster time returned by the last operation executed in this session.
-    private var clusterTime: Int64 {
-        return Int64()
-    }
-
-    /// The operation time returned by the last operation executed in this session.
-    private var operationTime: Int64 {
-        return Int64()
+        doc.copyStorageIfRequired()
+        var error = bson_error_t()
+        guard mongoc_client_session_append(self._session, doc.storage.pointer, &error) else {
+            throw parseMongocError(error)
+        }
+        doc.count = Int(bson_count_keys(doc.storage.pointer))
     }
 }

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -1,13 +1,7 @@
 import Foundation
 import mongoc
 
-#if compiler(>=5.0)
-internal typealias ClientSessionPointer = OpaquePointer
 internal typealias MutableClientSessionPointer = OpaquePointer
-#else
-internal typealias ClientSessionPointer = UnsafePointer<mongoc_client_session_t>
-internal typealias MutableClientSessionPointer = UnsafeMutablePointer<mongoc_client_session_t>
-#endif
 
 /// Options to use when creating a ClientSession.
 public struct ClientSessionOptions {}
@@ -38,7 +32,7 @@ public final class ClientSession {
     internal static var SessionInactiveError: Error = UserError.logicError(message: "Tried to use an inactive session")
 
     /// Pointer to the underlying `mongoc_client_session_t`.
-    internal fileprivate(set) var _session: ClientSessionPointer?
+    internal fileprivate(set) var _session: MutableClientSessionPointer?
 
     /// Returns whether this session has been ended or not.
     internal var active: Bool { return self._session != nil }

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -29,7 +29,7 @@ private class SessionOptWrapper {
 /// A MongoDB client session.
 public final class ClientSession {
     /// Error thrown when an inactive session is used.
-    internal static var SessionInactiveError: Error = UserError.logicError(message: "Tried to use an inactive session")
+    internal static var SessionInactiveError = UserError.logicError(message: "Tried to use an inactive session")
 
     /// Pointer to the underlying `mongoc_client_session_t`.
     internal fileprivate(set) var _session: MutableClientSessionPointer?

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -1,8 +1,6 @@
 import Foundation
 import mongoc
 
-internal typealias MutableClientSessionPointer = OpaquePointer
-
 /// Options to use when creating a ClientSession.
 public struct ClientSessionOptions {}
 
@@ -17,12 +15,13 @@ private func withSessionOpts<T>(wrapping options: ClientSessionOptions?,
 }
 
 /// A MongoDB client session.
+/// This class represents a logical session used for ordering sequential operations.
 public final class ClientSession {
     /// Error thrown when an inactive session is used.
     internal static var SessionInactiveError = UserError.logicError(message: "Tried to use an inactive session")
 
     /// Pointer to the underlying `mongoc_client_session_t`.
-    internal fileprivate(set) var _session: MutableClientSessionPointer?
+    internal fileprivate(set) var _session: OpaquePointer?
 
     /// Returns whether this session has been ended or not.
     internal var active: Bool { return self._session != nil }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -283,7 +283,7 @@ public class MongoClient {
      */
     public func listDatabases(options: ListDatabasesOptions? = nil,
                               session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session)
         guard let cursor = mongoc_client_find_databases_with_opts(self._client, opts?.data) else {
             fatalError("Couldn't get cursor from the server")
         }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -283,7 +283,7 @@ public class MongoClient {
      */
     public func listDatabases(options: ListDatabasesOptions? = nil,
                               session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        let opts = try combine(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
         guard let cursor = mongoc_client_find_databases_with_opts(self._client, opts?.data) else {
             fatalError("Couldn't get cursor from the server")
         }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -283,9 +283,8 @@ public class MongoClient {
      */
     public func listDatabases(options: ListDatabasesOptions? = nil,
                               session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        var opts = try self.encoder.encode(options) ?? Document()
-        try session?.append(to: &opts)
-        guard let cursor = mongoc_client_find_databases_with_opts(self._client, opts.data) else {
+        let opts = try combine(options: options, session: session, using: self.encoder)
+        guard let cursor = mongoc_client_find_databases_with_opts(self._client, opts?.data) else {
             fatalError("Couldn't get cursor from the server")
         }
         return try MongoCursor(from: cursor, client: self, decoder: self.decoder, session: session)

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -26,7 +26,7 @@ extension MongoCollection {
             throw UserError.invalidArgumentError(message: "requests cannot be empty")
         }
 
-        let opts = try combine(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
         let bulk = BulkWriteOperation(collection: self._collection, opts: opts, withEncoder: self.encoder)
 
         try requests.enumerated().forEach { index, model in

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -26,8 +26,7 @@ extension MongoCollection {
             throw UserError.invalidArgumentError(message: "requests cannot be empty")
         }
 
-        var opts = try self.encoder.encode(options) ?? Document()
-        try session?.append(to: &opts)
+        let opts = try combine(options: options, session: session, using: self.encoder)
         let bulk = BulkWriteOperation(collection: self._collection, opts: opts, withEncoder: self.encoder)
 
         try requests.enumerated().forEach { index, model in

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -26,7 +26,7 @@ extension MongoCollection {
             throw UserError.invalidArgumentError(message: "requests cannot be empty")
         }
 
-        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session)
         let bulk = BulkWriteOperation(collection: self._collection, opts: opts, withEncoder: self.encoder)
 
         try requests.enumerated().forEach { index, model in

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -13,17 +13,21 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `UserError.invalidArgumentError` if `requests` is empty.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `ServerError.bulkWriteError` if any error occurs while performing the writes.
      *   - `ServerError.commandError` if an error occurs that prevents the operation from being performed.
      *   - `EncodingError` if an error occurs while encoding the `CollectionType` or the options to BSON.
      */
     @discardableResult
-    public func bulkWrite(_ requests: [WriteModel], options: BulkWriteOptions? = nil) throws -> BulkWriteResult? {
+    public func bulkWrite(_ requests: [WriteModel],
+                          options: BulkWriteOptions? = nil,
+                          session: ClientSession? = nil) throws -> BulkWriteResult? {
         guard !requests.isEmpty else {
             throw UserError.invalidArgumentError(message: "requests cannot be empty")
         }
 
-        let opts = try self.encoder.encode(options)
+        var opts = try self.encoder.encode(options) ?? Document()
+        try session?.append(to: &opts)
         let bulk = BulkWriteOperation(collection: self._collection, opts: opts, withEncoder: self.encoder)
 
         try requests.enumerated().forEach { index, model in

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -331,7 +331,7 @@ extension MongoCollection {
      */
     public func listIndexes(session: ClientSession? = nil) throws -> MongoCursor<Document> {
         // need this cast to infer a generic type
-        let opts = try combine(options: nil as DropIndexOptions?, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: nil as DropIndexOptions?, session: session, using: self.encoder)
 
         guard let cursor = mongoc_collection_find_indexes_with_opts(self._collection, opts?.data) else {
             fatalError("Couldn't get cursor from the server")

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -330,12 +330,8 @@ extension MongoCollection {
      * - Throws: `UserError.logicError` if the provided session is inactive.
      */
     public func listIndexes(session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        var opts: Document?
-        if let session = session {
-            var sessionOpts = Document()
-            try session.append(to: &sessionOpts)
-            opts = sessionOpts
-        }
+        // need this cast to infer a generic type
+        let opts = try combine(options: nil as DropIndexOptions?, session: session, using: self.encoder)
 
         guard let cursor = mongoc_collection_find_indexes_with_opts(self._collection, opts?.data) else {
             fatalError("Couldn't get cursor from the server")

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -330,8 +330,7 @@ extension MongoCollection {
      * - Throws: `UserError.logicError` if the provided session is inactive.
      */
     public func listIndexes(session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        // need this cast to infer a generic type
-        let opts = try encodeOptions(options: nil as DropIndexOptions?, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: Document(), session: session)
 
         guard let cursor = mongoc_collection_find_indexes_with_opts(self._collection, opts?.data) else {
             fatalError("Couldn't get cursor from the server")

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -19,7 +19,7 @@ extension MongoCollection {
     public func find(_ filter: Document = [:],
                      options: FindOptions? = nil,
                      session: ClientSession? = nil) throws -> MongoCursor<CollectionType> {
-        let opts = try combine(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
         let rp = options?.readPreference?._readPreference
 
         guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts?.data, rp) else {
@@ -45,7 +45,7 @@ extension MongoCollection {
     public func aggregate(_ pipeline: [Document],
                           options: AggregateOptions? = nil,
                           session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        let opts = try combine(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
         let rp = options?.readPreference?._readPreference
         let pipeline: Document = ["pipeline": pipeline]
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -19,11 +19,10 @@ extension MongoCollection {
     public func find(_ filter: Document = [:],
                      options: FindOptions? = nil,
                      session: ClientSession? = nil) throws -> MongoCursor<CollectionType> {
-        var opts = try self.encoder.encode(options) ?? Document()
-        try session?.append(to: &opts)
+        let opts = try combine(options: options, session: session, using: self.encoder)
         let rp = options?.readPreference?._readPreference
 
-        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts.data, rp) else {
+        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts?.data, rp) else {
             fatalError("Couldn't get cursor from the server")
         }
         return try MongoCursor(from: cursor, client: self._client, decoder: self.decoder, session: session)
@@ -46,13 +45,12 @@ extension MongoCollection {
     public func aggregate(_ pipeline: [Document],
                           options: AggregateOptions? = nil,
                           session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        var opts = try self.encoder.encode(options) ?? Document()
-        try session?.append(to: &opts)
+        let opts = try combine(options: options, session: session, using: self.encoder)
         let rp = options?.readPreference?._readPreference
         let pipeline: Document = ["pipeline": pipeline]
 
         guard let cursor = mongoc_collection_aggregate(
-            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts.data, rp) else {
+            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts?.data, rp) else {
             fatalError("Couldn't get cursor from the server")
         }
         return try MongoCursor(from: cursor, client: self._client, decoder: self.decoder, session: session)

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -73,8 +73,10 @@ extension MongoCollection {
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
-    public func count(_ filter: Document = [:], options: CountOptions? = nil) throws -> Int {
-        let operation = CountOperation(collection: self, filter: filter, options: options)
+    public func count(_ filter: Document = [:],
+                      options: CountOptions? = nil,
+                      session: ClientSession? = nil) throws -> Int {
+        let operation = CountOperation(collection: self, filter: filter, options: options, session: session)
         return try operation.execute()
     }
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -13,16 +13,20 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `UserError.invalidArgumentError` if the options passed are an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
-    public func find(_ filter: Document = [:], options: FindOptions? = nil) throws -> MongoCursor<CollectionType> {
-        let opts = try self.encoder.encode(options)
+    public func find(_ filter: Document = [:],
+                     options: FindOptions? = nil,
+                     session: ClientSession? = nil) throws -> MongoCursor<CollectionType> {
+        var opts = try self.encoder.encode(options) ?? Document()
+        try session?.append(to: &opts)
         let rp = options?.readPreference?._readPreference
 
-        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts?.data, rp) else {
+        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts.data, rp) else {
             fatalError("Couldn't get cursor from the server")
         }
-        return try MongoCursor(fromCursor: cursor, withClient: self._client, withDecoder: self.decoder)
+        return try MongoCursor(from: cursor, client: self._client, decoder: self.decoder, session: session)
     }
 
     /**
@@ -36,18 +40,22 @@ extension MongoCollection {
      *
      * - Throws:
      *   - `UserError.invalidArgumentError` if the options passed are an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
-    public func aggregate(_ pipeline: [Document], options: AggregateOptions? = nil) throws -> MongoCursor<Document> {
-        let opts = try self.encoder.encode(options)
+    public func aggregate(_ pipeline: [Document],
+                          options: AggregateOptions? = nil,
+                          session: ClientSession? = nil) throws -> MongoCursor<Document> {
+        var opts = try self.encoder.encode(options) ?? Document()
+        try session?.append(to: &opts)
         let rp = options?.readPreference?._readPreference
         let pipeline: Document = ["pipeline": pipeline]
 
         guard let cursor = mongoc_collection_aggregate(
-            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts?.data, rp) else {
+            self._collection, MONGOC_QUERY_NONE, pipeline.data, opts.data, rp) else {
             fatalError("Couldn't get cursor from the server")
         }
-        return try MongoCursor(fromCursor: cursor, withClient: self._client, withDecoder: self.decoder)
+        return try MongoCursor(from: cursor, client: self._client, decoder: self.decoder, session: session)
     }
 
     // TODO SWIFT-133: mark this method deprecated https://jira.mongodb.org/browse/SWIFT-133
@@ -79,7 +87,9 @@ extension MongoCollection {
      *
      * - Returns: The count of the documents that matched the filter
      */
-    private func countDocuments(_ filter: Document = [:], options: CountDocumentsOptions? = nil) throws -> Int {
+    private func countDocuments(_ filter: Document = [:],
+                                options: CountDocumentsOptions? = nil,
+                                session: ClientSession? = nil) throws -> Int {
         // TODO SWIFT-133: implement this https://jira.mongodb.org/browse/SWIFT-133
         throw UserError.logicError(message: "Unimplemented command")
     }
@@ -92,7 +102,8 @@ extension MongoCollection {
      *
      * - Returns: an estimate of the count of documents in this collection
      */
-    private func estimatedDocumentCount(options: EstimatedDocumentCountOptions? = nil) throws -> Int {
+    private func estimatedDocumentCount(options: EstimatedDocumentCountOptions? = nil,
+                                        session: ClientSession? = nil) throws -> Int {
         // TODO SWIFT-133: implement this https://jira.mongodb.org/browse/SWIFT-133
         throw UserError.logicError(message: "Unimplemented command")
     }
@@ -110,12 +121,18 @@ extension MongoCollection {
      * - Throws:
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func distinct(fieldName: String,
                          filter: Document = [:],
-                         options: DistinctOptions? = nil) throws -> [BSONValue] {
-        let operation = DistinctOperation(collection: self, fieldName: fieldName, filter: filter, options: options)
+                         options: DistinctOptions? = nil,
+                         session: ClientSession? = nil) throws -> [BSONValue] {
+        let operation = DistinctOperation(collection: self,
+                                          fieldName: fieldName,
+                                          filter: filter,
+                                          options: options,
+                                          session: session)
         return try operation.execute()
     }
 }

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -19,7 +19,7 @@ extension MongoCollection {
     public func find(_ filter: Document = [:],
                      options: FindOptions? = nil,
                      session: ClientSession? = nil) throws -> MongoCursor<CollectionType> {
-        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session)
         let rp = options?.readPreference?._readPreference
 
         guard let cursor = mongoc_collection_find_with_opts(self._collection, filter.data, opts?.data, rp) else {
@@ -45,7 +45,7 @@ extension MongoCollection {
     public func aggregate(_ pipeline: [Document],
                           options: AggregateOptions? = nil,
                           session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session)
         let rp = options?.readPreference?._readPreference
         let pipeline: Document = ["pipeline": pipeline]
 

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -17,13 +17,16 @@ extension MongoCollection {
      *   - `ServerError.writeError` if an error occurs while performing the command.
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
      */
     @discardableResult
-    public func insertOne(_ value: CollectionType, options: InsertOneOptions? = nil) throws -> InsertOneResult? {
+    public func insertOne(_ value: CollectionType,
+                          options: InsertOneOptions? = nil,
+                          session: ClientSession? = nil) throws -> InsertOneResult? {
         return try convertingBulkWriteErrors {
             let model = InsertOneModel(value)
-            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions())
+            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions(), session: session)
             return try InsertOneResult(from: result)
         }
     }
@@ -42,12 +45,15 @@ extension MongoCollection {
      *   - `ServerError.bulkWriteError` if an error occurs while performing any of the writes.
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     @discardableResult
-    public func insertMany(_ values: [CollectionType], options: InsertManyOptions? = nil) throws -> InsertManyResult? {
+    public func insertMany(_ values: [CollectionType],
+                           options: InsertManyOptions? = nil,
+                           session: ClientSession? = nil) throws -> InsertManyResult? {
         let models = values.map { InsertOneModel($0) }
-        let result = try self.bulkWrite(models, options: options)
+        let result = try self.bulkWrite(models, options: options, session: session)
         return InsertManyResult(from: result)
     }
 
@@ -66,18 +72,20 @@ extension MongoCollection {
      *   - `ServerError.writeError` if an error occurs while performing the command.
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     @discardableResult
     public func replaceOne(filter: Document,
                            replacement: CollectionType,
-                           options: ReplaceOptions? = nil) throws -> UpdateResult? {
+                           options: ReplaceOptions? = nil,
+                           session: ClientSession? = nil) throws -> UpdateResult? {
         return try convertingBulkWriteErrors {
             let model = ReplaceOneModel(filter: filter,
                                         replacement: replacement,
                                         collation: options?.collation,
                                         upsert: options?.upsert)
-            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions())
+            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions(), session: session)
             return try UpdateResult(from: result)
         }
     }
@@ -97,17 +105,21 @@ extension MongoCollection {
      *   - `ServerError.writeError` if an error occurs while performing the command.
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
-    public func updateOne(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
+    public func updateOne(filter: Document,
+                          update: Document,
+                          options: UpdateOptions? = nil,
+                          session: ClientSession? = nil) throws -> UpdateResult? {
         return try convertingBulkWriteErrors {
             let model = UpdateOneModel(filter: filter,
                                        update: update,
                                        arrayFilters: options?.arrayFilters,
                                        collation: options?.collation,
                                        upsert: options?.upsert)
-            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions())
+            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions(), session: session)
             return try UpdateResult(from: result)
         }
     }
@@ -127,17 +139,21 @@ extension MongoCollection {
      *   - `ServerError.writeError` if an error occurs while performing the command.
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
-    public func updateMany(filter: Document, update: Document, options: UpdateOptions? = nil) throws -> UpdateResult? {
+    public func updateMany(filter: Document,
+                           update: Document,
+                           options: UpdateOptions? = nil,
+                           session: ClientSession? = nil) throws -> UpdateResult? {
         return try convertingBulkWriteErrors {
             let model = UpdateManyModel(filter: filter,
                                         update: update,
                                         arrayFilters: options?.arrayFilters,
                                         collation: options?.collation,
                                         upsert: options?.upsert)
-            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions())
+            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions(), session: session)
             return try UpdateResult(from: result)
         }
     }
@@ -156,13 +172,16 @@ extension MongoCollection {
      *   - `ServerError.writeError` if an error occurs while performing the command.
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
-    public func deleteOne(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
+    public func deleteOne(_ filter: Document,
+                          options: DeleteOptions? = nil,
+                          session: ClientSession? = nil) throws -> DeleteResult? {
         return try convertingBulkWriteErrors {
             let model = DeleteOneModel(filter, collation: options?.collation)
-            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions())
+            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions(), session: session)
             return try DeleteResult(from: result)
         }
     }
@@ -181,13 +200,16 @@ extension MongoCollection {
      *   - `ServerError.writeError` if an error occurs while performing the command.
      *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
      *   - `UserError.invalidArgumentError` if the options passed in form an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
-    public func deleteMany(_ filter: Document, options: DeleteOptions? = nil) throws -> DeleteResult? {
+    public func deleteMany(_ filter: Document,
+                           options: DeleteOptions? = nil,
+                           session: ClientSession? = nil) throws -> DeleteResult? {
         return try convertingBulkWriteErrors {
             let model = DeleteManyModel(filter, collation: options?.collation)
-            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions())
+            let result = try self.bulkWrite([model], options: options?.asBulkWriteOptions(), session: session)
             return try DeleteResult(from: result)
         }
     }

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -1,8 +1,10 @@
 import mongoc
 
+internal typealias MutableCursorPointer = OpaquePointer
+
 /// A MongoDB cursor.
 public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
-    private var _cursor: OpaquePointer?
+    private var _cursor: MutableCursorPointer?
     private var _client: MongoClient?
     private var _session: ClientSession?
 
@@ -18,7 +20,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
      *   - `UserError.invalidArgumentError` if the options passed to the command that generated this cursor formed an
      *     invalid combination.
      */
-    internal init(from cursor: OpaquePointer,
+    internal init(from cursor: MutableCursorPointer,
                   client: MongoClient,
                   decoder: BSONDecoder,
                   session: ClientSession?) throws {

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -1,10 +1,8 @@
 import mongoc
 
-internal typealias MutableCursorPointer = OpaquePointer
-
 /// A MongoDB cursor.
 public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
-    private var _cursor: MutableCursorPointer?
+    private var _cursor: OpaquePointer?
     private var _client: MongoClient?
     private var _session: ClientSession?
 
@@ -20,7 +18,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
      *   - `UserError.invalidArgumentError` if the options passed to the command that generated this cursor formed an
      *     invalid combination.
      */
-    internal init(from cursor: MutableCursorPointer,
+    internal init(from cursor: OpaquePointer,
                   client: MongoClient,
                   decoder: BSONDecoder,
                   session: ClientSession?) throws {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -352,7 +352,7 @@ public class MongoDatabase {
                                              withType: T.Type,
                                              options: CreateCollectionOptions? = nil,
                                              session: ClientSession? = nil) throws -> MongoCollection<T> {
-        let opts = try combine(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
         var error = bson_error_t()
 
         guard let collection = mongoc_database_create_collection(self._database, name, opts?.data, &error) else {
@@ -385,7 +385,7 @@ public class MongoDatabase {
      */
     public func listCollections(options: ListCollectionsOptions? = nil,
                                 session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        let opts = try combine(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
 
         guard let collections = mongoc_database_find_collections_with_opts(self._database, opts?.data) else {
             fatalError("Couldn't get cursor from the server")
@@ -415,7 +415,7 @@ public class MongoDatabase {
                            options: RunCommandOptions? = nil,
                            session: ClientSession? = nil) throws -> Document {
         let rp = options?.readPreference ?? self.readPreference
-        let opts = try combine(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_database_command_with_opts(

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -352,11 +352,10 @@ public class MongoDatabase {
                                              withType: T.Type,
                                              options: CreateCollectionOptions? = nil,
                                              session: ClientSession? = nil) throws -> MongoCollection<T> {
-        var opts = try self.encoder.encode(options) ?? Document()
-        try session?.append(to: &opts)
+        let opts = try combine(options: options, session: session, using: self.encoder)
         var error = bson_error_t()
 
-        guard let collection = mongoc_database_create_collection(self._database, name, opts.data, &error) else {
+        guard let collection = mongoc_database_create_collection(self._database, name, opts?.data, &error) else {
             throw parseMongocError(error)
         }
 
@@ -386,10 +385,9 @@ public class MongoDatabase {
      */
     public func listCollections(options: ListCollectionsOptions? = nil,
                                 session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        var opts = try self.encoder.encode(options) ?? Document()
-        try session?.append(to: &opts)
+        let opts = try combine(options: options, session: session, using: self.encoder)
 
-        guard let collections = mongoc_database_find_collections_with_opts(self._database, opts.data) else {
+        guard let collections = mongoc_database_find_collections_with_opts(self._database, opts?.data) else {
             fatalError("Couldn't get cursor from the server")
         }
 
@@ -417,12 +415,11 @@ public class MongoDatabase {
                            options: RunCommandOptions? = nil,
                            session: ClientSession? = nil) throws -> Document {
         let rp = options?.readPreference ?? self.readPreference
-        var opts = try self.encoder.encode(options) ?? Document()
-        try session?.append(to: &opts)
+        let opts = try combine(options: options, session: session, using: self.encoder)
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_database_command_with_opts(
-            self._database, command.data, rp?._readPreference, opts.data, reply.data, &error) else {
+            self._database, command.data, rp?._readPreference, opts?.data, reply.data, &error) else {
             throw getErrorFromReply(bsonError: error, from: reply)
         }
         return reply

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -352,7 +352,7 @@ public class MongoDatabase {
                                              withType: T.Type,
                                              options: CreateCollectionOptions? = nil,
                                              session: ClientSession? = nil) throws -> MongoCollection<T> {
-        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session)
         var error = bson_error_t()
 
         guard let collection = mongoc_database_create_collection(self._database, name, opts?.data, &error) else {
@@ -385,7 +385,7 @@ public class MongoDatabase {
      */
     public func listCollections(options: ListCollectionsOptions? = nil,
                                 session: ClientSession? = nil) throws -> MongoCursor<Document> {
-        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session)
 
         guard let collections = mongoc_database_find_collections_with_opts(self._database, opts?.data) else {
             fatalError("Couldn't get cursor from the server")
@@ -415,7 +415,7 @@ public class MongoDatabase {
                            options: RunCommandOptions? = nil,
                            session: ClientSession? = nil) throws -> Document {
         let rp = options?.readPreference ?? self.readPreference
-        let opts = try encodeOptions(options: options, session: session, using: self.encoder)
+        let opts = try encodeOptions(options: options, session: session)
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_database_command_with_opts(

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -2,9 +2,6 @@ import mongoc
 
 /// Options to use when running a command against a `MongoDatabase`.
 public struct RunCommandOptions: Encodable {
-    /// A session to associate with this operation.
-    public let session: ClientSession?
-
     /// An optional `ReadConcern` to use for this operation.
     public let readConcern: ReadConcern?
 
@@ -17,16 +14,13 @@ public struct RunCommandOptions: Encodable {
     /// Convenience initializer allowing session to be omitted or optional.
     public init(readConcern: ReadConcern? = nil,
                 readPreference: ReadPreference? = nil,
-                session: ClientSession? = nil,
                 writeConcern: WriteConcern? = nil) {
         self.readConcern = readConcern
         self.readPreference = readPreference
-        self.session = session
         self.writeConcern = writeConcern
     }
 
     private enum CodingKeys: String, CodingKey {
-        // TODO: Encode ClientSession as "sessionId" (see: SWIFT-28)
         case readConcern, writeConcern
     }
 }

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -63,14 +63,13 @@ internal struct CountOperation<T: Codable>: Operation {
     }
 
     internal func execute() throws -> Int {
-        var opts = try collection.encoder.encode(self.options) ?? Document()
-        try session?.append(to: &opts)
+        let opts = try combine(options: options, session: session, using: self.collection.encoder)
         let rp = self.options?.readPreference?._readPreference
         var error = bson_error_t()
         // because we already encode skip and limit in the options,
         // pass in 0s so we don't get duplicate parameter errors.
         let count = mongoc_collection_count_with_opts(
-            self.collection._collection, MONGOC_QUERY_NONE, self.filter.data, 0, 0, opts.data, rp, &error)
+            self.collection._collection, MONGOC_QUERY_NONE, self.filter.data, 0, 0, opts?.data, rp, &error)
 
         if count == -1 { throw parseMongocError(error) }
 

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -63,7 +63,7 @@ internal struct CountOperation<T: Codable>: Operation {
     }
 
     internal func execute() throws -> Int {
-        let opts = try encodeOptions(options: options, session: session, using: self.collection.encoder)
+        let opts = try encodeOptions(options: options, session: session)
         let rp = self.options?.readPreference?._readPreference
         var error = bson_error_t()
         // because we already encode skip and limit in the options,

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -63,7 +63,7 @@ internal struct CountOperation<T: Codable>: Operation {
     }
 
     internal func execute() throws -> Int {
-        let opts = try combine(options: options, session: session, using: self.collection.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.collection.encoder)
         let rp = self.options?.readPreference?._readPreference
         var error = bson_error_t()
         // because we already encode skip and limit in the options,

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -40,7 +40,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
 
         let command: Document = ["createIndexes": self.collection.name, "indexes": indexData]
 
-        let opts = try encodeOptions(options: options, session: session, using: self.collection.encoder)
+        let opts = try encodeOptions(options: options, session: session)
 
         var error = bson_error_t()
         let reply = Document()

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -40,7 +40,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
 
         let command: Document = ["createIndexes": self.collection.name, "indexes": indexData]
 
-        let opts = try combine(options: options, session: session, using: self.collection.encoder)
+        let opts = try encodeOptions(options: options, session: session, using: self.collection.encoder)
 
         var error = bson_error_t()
         let reply = Document()

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -40,14 +40,13 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
 
         let command: Document = ["createIndexes": self.collection.name, "indexes": indexData]
 
-        var opts = try self.collection.encoder.encode(self.options) ?? Document()
-        try self.session?.append(to: &opts)
+        let opts = try combine(options: options, session: session, using: self.collection.encoder)
 
         var error = bson_error_t()
         let reply = Document()
 
         guard mongoc_collection_write_command_with_opts(
-            self.collection._collection, command.data, opts.data, reply.data, &error) else {
+            self.collection._collection, command.data, opts?.data, reply.data, &error) else {
             throw getErrorFromReply(bsonError: error, from: reply)
         }
 

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -58,7 +58,7 @@ internal struct DistinctOperation<T: Codable> {
             "query": self.filter
         ]
 
-        let opts = try encodeOptions(options: self.options, session: self.session, using: self.collection.encoder)
+        let opts = try encodeOptions(options: self.options, session: self.session)
         let rp = self.options?.readPreference?._readPreference
         let reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -58,13 +58,12 @@ internal struct DistinctOperation<T: Codable> {
             "query": self.filter
         ]
 
-        var opts = try collection.encoder.encode(self.options) ?? Document()
-        try session?.append(to: &opts)
+        let opts = try combine(options: self.options, session: self.session, using: self.collection.encoder)
         let rp = self.options?.readPreference?._readPreference
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_collection_read_command_with_opts(
-            self.collection._collection, command.data, rp, opts.data, reply.data, &error) else {
+            self.collection._collection, command.data, rp, opts?.data, reply.data, &error) else {
             throw parseMongocError(error, errorLabels: reply["errorLabels"] as? [String])
         }
 

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -58,7 +58,7 @@ internal struct DistinctOperation<T: Codable> {
             "query": self.filter
         ]
 
-        let opts = try combine(options: self.options, session: self.session, using: self.collection.encoder)
+        let opts = try encodeOptions(options: self.options, session: self.session, using: self.collection.encoder)
         let rp = self.options?.readPreference?._readPreference
         let reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -14,24 +14,29 @@ public struct DropIndexOptions: Encodable {
 /// An operation corresponding to a "dropIndexes" command.
 internal struct DropIndexesOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
+    private let session: ClientSession?
     private let index: BSONValue
     private let options: DropIndexOptions?
 
     internal init(collection: MongoCollection<T>,
                   index: BSONValue,
-                  options: DropIndexOptions?) {
+                  options: DropIndexOptions?,
+                  session: ClientSession?) {
         self.collection = collection
         self.index = index
         self.options = options
+        self.session = session
     }
 
     internal func execute() throws -> Document {
         let command: Document = ["dropIndexes": self.collection.name, "index": self.index]
-        let opts = try self.collection.encoder.encode(self.options)
+        var opts = try self.collection.encoder.encode(self.options) ?? Document()
+        try self.session?.append(to: &opts)
+
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_collection_write_command_with_opts(
-            self.collection._collection, command.data, opts?.data, reply.data, &error) else {
+            self.collection._collection, command.data, opts.data, reply.data, &error) else {
             throw getErrorFromReply(bsonError: error, from: reply)
         }
         return reply

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -30,7 +30,7 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
 
     internal func execute() throws -> Document {
         let command: Document = ["dropIndexes": self.collection.name, "index": self.index]
-        let opts = try encodeOptions(options: self.options, session: self.session, using: self.collection.encoder)
+        let opts = try encodeOptions(options: self.options, session: self.session)
 
         let reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -30,7 +30,7 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
 
     internal func execute() throws -> Document {
         let command: Document = ["dropIndexes": self.collection.name, "index": self.index]
-        let opts = try combine(options: self.options, session: self.session, using: self.collection.encoder)
+        let opts = try encodeOptions(options: self.options, session: self.session, using: self.collection.encoder)
 
         let reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -30,13 +30,12 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
 
     internal func execute() throws -> Document {
         let command: Document = ["dropIndexes": self.collection.name, "index": self.index]
-        var opts = try self.collection.encoder.encode(self.options) ?? Document()
-        try self.session?.append(to: &opts)
+        let opts = try combine(options: self.options, session: self.session, using: self.collection.encoder)
 
         let reply = Document()
         var error = bson_error_t()
         guard mongoc_collection_write_command_with_opts(
-            self.collection._collection, command.data, opts.data, reply.data, &error) else {
+            self.collection._collection, command.data, opts?.data, reply.data, &error) else {
             throw getErrorFromReply(bsonError: error, from: reply)
         }
         return reply

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -8,14 +8,12 @@ internal protocol Operation {
 }
 
 /// Internal function for generating an options `Document` for passing to libmongoc.
-internal func encodeOptions<T: Encodable>(options: T?,
-                                          session: ClientSession?,
-                                          using encoder: BSONEncoder) throws -> Document? {
+internal func encodeOptions<T: Encodable>(options: T?, session: ClientSession?) throws -> Document? {
     guard options != nil || session != nil else {
         return nil
     }
 
-    var doc = try encoder.encode(options) ?? Document()
+    var doc = try BSONEncoder().encode(options) ?? Document()
     try session?.append(to: &doc)
     return doc
 }

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -6,3 +6,14 @@ internal protocol Operation {
     /// Executes this operation and returns its corresponding result type.
     func execute() throws -> OperationResult
 }
+
+/// Internal function for generating an options `Document` for passing to libmongoc.
+internal func combine<T: Encodable>(options: T?, session: ClientSession?, using encoder: BSONEncoder) throws -> Document? {
+    guard options != nil || session != nil else {
+        return nil
+    }
+
+    var doc = try encoder.encode(options) ?? Document()
+    try session?.append(to: &doc)
+    return doc
+}

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -8,7 +8,9 @@ internal protocol Operation {
 }
 
 /// Internal function for generating an options `Document` for passing to libmongoc.
-internal func combine<T: Encodable>(options: T?, session: ClientSession?, using encoder: BSONEncoder) throws -> Document? {
+internal func encodeOptions<T: Encodable>(options: T?,
+                                          session: ClientSession?,
+                                          using encoder: BSONEncoder) throws -> Document? {
     guard options != nil || session != nil else {
         return nil
     }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -18,6 +18,17 @@ extension BSONValueTests {
     ]
 }
 
+extension ClientSessionTests {
+    static var allTests = [
+        ("testSessionCleanup", testSessionCleanup),
+        ("testSessionArguments", testSessionArguments),
+        ("testSessionClientValidation", testSessionClientValidation),
+        ("testInactiveSession", testInactiveSession),
+        ("testSessionCursor", testSessionCursor),
+        ("testClusterTime", testClusterTime),
+    ]
+}
+
 extension CodecTests {
     static var allTests = [
         ("testEncodeListDatabasesOptions", testEncodeListDatabasesOptions),
@@ -207,6 +218,7 @@ extension SDAMTests {
 
 XCTMain([
     testCase(BSONValueTests.allTests),
+    testCase(ClientSessionTests.allTests),
     testCase(CodecTests.allTests),
     testCase(CommandMonitoringTests.allTests),
     testCase(CrudTests.allTests),

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -144,7 +144,8 @@ final class ClientSessionTests: MongoSwiftTestCase {
             },
             SessionsArgTest(name: "dropIndex2") { try collection.dropIndex("x_7", session: $0) },
             SessionsArgTest(name: "dropIndexes") { try collection.dropIndexes(session: $0) },
-            SessionsArgTest(name: "listIndexes") { _ = try collection.listIndexes(session: $0).next() }
+            SessionsArgTest(name: "listIndexes") { _ = try collection.listIndexes(session: $0).next() },
+            SessionsArgTest(name: "count") { _ = try collection.count(session: $0) }
         ]
         try collectionCases.forEach { try $0.execute(session: session) }
 

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -66,6 +66,8 @@ final class ClientSessionTests: MongoSwiftTestCase {
         let name: String
         let body: (ClientSession?) throws -> Void
 
+        // Executes the body twice, once with the supplied session and once without, verifying that a correct lsid is
+        // seen both times.
         func execute(session: ClientSession) throws {
             let center = NotificationCenter.default
 

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -1,0 +1,293 @@
+import Foundation
+@testable import MongoSwift
+import Nimble
+import XCTest
+
+final class ClientSessionTests: MongoSwiftTestCase {
+    override func tearDown() {
+        do {
+            let client = try MongoClient(MongoSwiftTestCase.connStr)
+            try client.db(type(of: self).testDatabase).drop()
+        } catch {
+            fail("encountered error when tearing down: \(error)")
+        }
+        super.tearDown()
+    }
+
+    /// Test that sessions are properly returned to the pool when ended.
+    func testSessionCleanup() throws {
+        let client = try MongoClient(MongoSwiftTestCase.connStr)
+
+        var sessionA: ClientSession? = try client.startSession()
+        expect(sessionA!.active).to(beTrue())
+
+        var sessionB: ClientSession? = try client.startSession()
+        expect(sessionB!.active).to(beTrue())
+
+        let idA = sessionA!.id
+        let idB = sessionB!.id
+
+        // test via deinit
+        sessionA = nil
+        sessionB = nil
+
+        let sessionC: ClientSession = try client.startSession()
+        expect(sessionC.active).to(beTrue())
+        expect(sessionC.id).to(bsonEqual(idB))
+
+        let sessionD: ClientSession = try client.startSession()
+        expect(sessionD.active).to(beTrue())
+        expect(sessionD.id).to(bsonEqual(idA))
+
+        // test via explicitly ending
+        sessionC.end()
+        expect(sessionC.active).to(beFalse())
+        sessionD.end()
+        expect(sessionD.active).to(beFalse())
+
+        // test via withSession
+        try client.withSession { session in
+            expect(session.id).to(bsonEqual(idA))
+        }
+
+        try client.withSession { session in
+            expect(session.id).to(bsonEqual(idA))
+        }
+
+        try client.withSession { session in
+            expect(session.id).to(bsonEqual(idA))
+            try client.withSession { nestedSession in
+                expect(nestedSession.id).to(bsonEqual(idB))
+            }
+        }
+    }
+
+    struct SessionsArgTest {
+        let name: String
+        let body: (ClientSession?) throws -> Void
+
+        func execute(session: ClientSession) throws {
+            let center = NotificationCenter.default
+
+            var seenExplicit = false
+            var seenImplicit = false
+            let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                    return
+                }
+                expect(event.command["lsid"]).toNot(beNil(), description: self.name)
+                if !seenExplicit {
+                    expect(event.command["lsid"]).to(bsonEqual(session.id), description: self.name)
+                    seenExplicit = true
+                } else {
+                    expect(seenImplicit).to(beFalse())
+                    expect(event.command["lsid"]).toNot(bsonEqual(session.id), description: self.name)
+                    seenImplicit = true
+                }
+            }
+            // We don't care if they succeed (e.g. a drop index may fail if index doesn't exist)
+            try? self.body(session)
+            try? self.body(nil)
+
+            expect(seenImplicit).to(beTrue(), description: self.name)
+            expect(seenExplicit).to(beTrue(), description: self.name)
+
+            center.removeObserver(observer)
+        }
+    }
+
+    /// Test that every function that takes a session parameter passes the sends implicit and explicit lsids to server.
+    func testSessionArguments() throws {
+        let client1 = try MongoClient(MongoSwiftTestCase.connStr, options: ClientOptions(eventMonitoring: true))
+        client1.enableMonitoring(forEvents: .commandMonitoring)
+
+        let database = client1.db(type(of: self).testDatabase)
+        let collection = database.collection(self.getCollectionName())
+        let session = try client1.startSession()
+
+        let doc: Document = ["a": 1]
+        let update: Document = ["$set": ["x": 1] as Document]
+        let model: WriteModel = MongoCollection<Document>.UpdateOneModel(filter: doc, update: update)
+        let models = (1...8).map { IndexModel(keys: ["x": $0 ]) }
+
+        let collectionCases = [
+            SessionsArgTest(name: "bulkWrite") { try collection.bulkWrite([model], session: $0) },
+            SessionsArgTest(name: "insertOne") { try collection.insertOne(doc, session: $0) },
+            SessionsArgTest(name: "insertMany") { try collection.insertMany([doc], session: $0) },
+            SessionsArgTest(name: "replaceOne") {
+                try collection.replaceOne(filter: doc, replacement: doc, session: $0)
+            },
+            SessionsArgTest(name: "updateOne") { try collection.updateOne(filter: doc, update: update, session: $0) },
+            SessionsArgTest(name: "updateMany") { try collection.updateMany(filter: doc, update: update, session: $0) },
+            SessionsArgTest(name: "deleteOne") { try collection.deleteOne(doc, session: $0) },
+            SessionsArgTest(name: "deleteMany") { try collection.deleteMany(doc, session: $0) },
+            SessionsArgTest(name: "find") { _ = try collection.find(doc, session: $0).next() },
+            SessionsArgTest(name: "aggregate") {
+                _ = try collection.aggregate([] as [Document], session: $0).next()
+            },
+            SessionsArgTest(name: "distinct") { _ = try collection.distinct(fieldName: "x", session: $0) },
+            SessionsArgTest(name: "findOneAndDelete") { try collection.findOneAndDelete(doc, session: $0) },
+            SessionsArgTest(name: "findOneAndReplace") {
+                try collection.findOneAndReplace(filter: doc, replacement: doc, session: $0)
+            },
+            SessionsArgTest(name: "findOneAndUpdate") {
+                try collection.findOneAndUpdate(filter: doc, update: update, session: $0)
+            },
+            SessionsArgTest(name: "createIndex") { try collection.createIndex(doc, session: $0) },
+            SessionsArgTest(name: "createIndex1") {
+                try collection.createIndex(IndexModel(keys: ["x": 1] as Document), session: $0)
+            },
+            SessionsArgTest(name: "createIndexes") { try collection.createIndexes(models, session: $0) },
+            SessionsArgTest(name: "dropIndex") { try collection.dropIndex(["x": 1], session: $0) },
+            SessionsArgTest(name: "dropIndex1") {
+                try collection.dropIndex(IndexModel(keys: ["x": 3] as Document), session: $0)
+            },
+            SessionsArgTest(name: "dropIndex2") { try collection.dropIndex("x_7", session: $0) },
+            SessionsArgTest(name: "dropIndexes") { try collection.dropIndexes(session: $0) },
+            SessionsArgTest(name: "listIndexes") { _ = try collection.listIndexes(session: $0).next() }
+        ]
+        try collectionCases.forEach { try $0.execute(session: session) }
+
+        try database.drop()
+
+        let databaseCases = [
+            SessionsArgTest(name: "runCommand") { try database.runCommand(["isMaster": 0], session: $0) },
+            SessionsArgTest(name: "createCollection") {
+                _ = try database.createCollection(self.getCollectionName(), session: $0)
+            },
+            SessionsArgTest(name: "createCollection1") {
+                _ = try database.createCollection(self.getCollectionName(), withType: Document.self, session: $0)
+            }
+        ]
+        try databaseCases.forEach { try $0.execute(session: session) }
+
+        // client case
+        try SessionsArgTest(name: "listDatabases") {
+            _ = try client1.listDatabases(session: $0).next()
+        }.execute(session: session)
+
+        try database.drop()
+    }
+
+    /// Test that a session can only be used with db's and collections that were derived from the same client.
+    func testSessionClientValidation() throws {
+        let client1 = try MongoClient(MongoSwiftTestCase.connStr)
+        let client2 = try MongoClient(MongoSwiftTestCase.connStr)
+
+        let database = client1.db(type(of: self).testDatabase)
+        let collection = database.collection(self.getCollectionName())
+
+        let session = try client2.startSession()
+        expect(try collection.insertOne(["x": 1], session: session))
+                .to(throwError(UserError.invalidArgumentError(message: "")))
+    }
+
+    /// Test that inactive sessions cannot be used.
+    func testInactiveSession() throws {
+        let client = try MongoClient(MongoSwiftTestCase.connStr)
+        let session1 = try client.startSession()
+
+        session1.end()
+        expect(session1.active).to(beFalse())
+        expect(try client.listDatabases(session: session1)).to(throwError(ClientSession.SessionInactiveError))
+
+        let session2 = try client.startSession()
+        let database = client.db(type(of: self).testDatabase)
+        let collection = database.collection(self.getCollectionName())
+
+        try (1...3).forEach { try collection.insertOne(["x": $0]) }
+
+        let cursor = try collection.find(session: session2)
+        expect(cursor.next()).toNot(beNil())
+        session2.end()
+        expect(try cursor.nextOrError()).to(throwError(ClientSession.SessionInactiveError))
+    }
+
+    /// Test cursors have the same lsid in the initial find command and in subsequent getMores.
+    func testSessionCursor() throws {
+        let client = try MongoClient(MongoSwiftTestCase.connStr, options: ClientOptions(eventMonitoring: true))
+        client.enableMonitoring(forEvents: .commandMonitoring)
+
+        let database = client.db(type(of: self).testDatabase)
+        let collection = database.collection(self.getCollectionName())
+        let session = try client.startSession()
+
+        for x in 1...3 {
+            try collection.insertOne(["x": x])
+        }
+
+        var id: Document?
+        var seenFind = false
+        var seenGetMore = false
+
+        let center = NotificationCenter.default
+        let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+            guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                return
+            }
+
+            if event.command["find"] != nil {
+                seenFind = true
+                if let id = id {
+                    expect(id).to(bsonEqual(event.command["lsid"]))
+                } else {
+                    expect(event.command["lsid"]).toNot(beNil())
+                    id = event.command["lsid"] as? Document
+                }
+            } else if event.command["getMore"] != nil {
+                seenGetMore = true
+                expect(id).toNot(beNil())
+                expect(event.command["lsid"]).toNot(beNil())
+                expect(event.command["lsid"]).to(bsonEqual(id))
+            }
+        }
+
+        // explicit
+        id = session.id
+        seenFind = false
+        seenGetMore = false
+        let cursor = try collection.find(options: FindOptions(batchSize: 2), session: session)
+        expect(cursor.next()).toNot(beNil())
+        expect(cursor.next()).toNot(beNil())
+        expect(cursor.next()).toNot(beNil())
+        expect(seenFind).to(beTrue())
+        expect(seenGetMore).to(beTrue())
+
+        // implicit
+        seenFind = false
+        seenGetMore = false
+        id = nil
+        let cursor1 = try collection.find(options: FindOptions(batchSize: 2))
+        expect(cursor1.next()).toNot(beNil())
+        expect(cursor1.next()).toNot(beNil())
+        expect(cursor1.next()).toNot(beNil())
+        expect(seenFind).to(beTrue())
+        expect(seenGetMore).to(beTrue())
+
+        center.removeObserver(observer)
+    }
+
+    /// Test that the clusterTime is reported properly.
+    func testClusterTime() throws {
+        guard MongoSwiftTestCase.topologyType == .sharded else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+
+        let client = try MongoClient(MongoSwiftTestCase.connStr)
+
+        try client.withSession { session in
+            expect(session.clusterTime).to(beNil())
+            _ = try client.listDatabases(session: session).next()
+            expect(session.clusterTime).toNot(beNil())
+        }
+
+        try client.withSession { session in
+            let date = Date()
+            expect(session.clusterTime).to(beNil())
+            let newTime: Document = ["clusterTime": Timestamp(timestamp: Int(date.timeIntervalSince1970), inc: 100)]
+            session.advanceClusterTime(to: newTime)
+            expect(session.clusterTime).to(bsonEqual(newTime))
+        }
+    }
+}

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -11,8 +11,8 @@ final class CodecTests: MongoSwiftTestCase {
             DecodingError.Context(codingPath: [], debugDescription: "dummy error"))
 
     func testEncodeListDatabasesOptions() throws {
-        let options = ListDatabasesOptions(filter: ["a": 10], nameOnly: true, session: ClientSession())
-        let expected: Document = ["filter": ["a": 10] as Document, "nameOnly": true, "session": Document()]
+        let options = ListDatabasesOptions(filter: ["a": 10], nameOnly: true)
+        let expected: Document = ["filter": ["a": 10] as Document, "nameOnly": true]
         expect(try BSONEncoder().encode(options)).to(equal(expected))
     }
 
@@ -919,7 +919,6 @@ final class CodecTests: MongoSwiftTestCase {
         let runCommand = RunCommandOptions(
                 readConcern: rc,
                 readPreference: rp,
-                session: ClientSession(),
                 writeConcern: wc
         )
 

--- a/Tests/MongoSwiftTests/MongoError+Equatable.swift
+++ b/Tests/MongoSwiftTests/MongoError+Equatable.swift
@@ -5,7 +5,8 @@ extension RuntimeError: Equatable {
     public static func == (lhs: RuntimeError, rhs: RuntimeError) -> Bool {
         switch (lhs, rhs) {
         case (.internalError(message: _), .internalError(message: _)),
-             (.authenticationError(message: _), .authenticationError(message: _)):
+             (.authenticationError(message: _), .authenticationError(message: _)),
+             (.compatibilityError(message: _), .compatibilityError(message: _)):
             return true
         case let (.connectionError(message: _, errorLabels: lhsLabels),
                   .connectionError(message: _, errorLabels: rhsLabels)):


### PR DESCRIPTION
This PR adds the implementation of client sessions as per the [design](https://docs.google.com/document/d/1n5N8f1Zgzd5Iow5gxiRSoj6FZ8-Gus8I5CUTrW1Gh3s/edit#heading=h.ky3pv4dt04e).

Deviations from the design:
- `session.sessionId` refactored to `session.id`, the "session" prefix seemed redundant
- `session.endSession` -> `session.end` ditto redundancy
- The test plan prescribed performing spec test 9 (ensure all sessions are cleaned up after each test), but without access to the underlying pool this is difficult
- The test plan states that many of the tests should run every function that takes in a session or against every topology with every read preference. This is overkill for what we're implementing. Assuming libmongoc is performing those tests at their level, all we need to do is ensure that every method that accepts a session properly passes it to libmongoc, which we verify in the `testSessionArguments` test. For the other tests, we just use a single method that takes in a session as a representative.
- I removed the `ClientSessionPointer` typealias, since libmongoc doesn't actually export the complete `mongoc_client_session_t` type. Regardless of compiler version, pointers to it will be imported to swift as `OpaquePointer`s. Since those pointers will always be mutable, I only defined `MutableClientSessionPointer`.
 