### PR TITLE
Fix a couple ReadPreference issues

### DIFF
--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -225,7 +225,7 @@ public class MongoDatabase {
 
     /// The `ReadPreference` set on this database
     public var readPreference: ReadPreference? {
-        return ReadPreference(from: mongoc_collection_get_read_prefs(self._database))
+        return ReadPreference(from: mongoc_database_get_read_prefs(self._database))
     }
 
     /// The `WriteConcern` set on this database, or `nil` if one is not set.
@@ -408,11 +408,11 @@ public class MongoDatabase {
      */
     @discardableResult
     public func runCommand(_ command: Document, options: RunCommandOptions? = nil) throws -> Document {
-        let rp = options?.readPreference?._readPreference
+        let rp = options?.readPreference ?? self.readPreference
         let opts = try self.encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        guard mongoc_database_command_with_opts(self._database, command.data, rp, opts?.data, reply.data, &error) else {
+        guard mongoc_database_command_with_opts(self._database, command.data, rp?._readPreference, opts?.data, reply.data, &error) else {
             throw getErrorFromReply(bsonError: error, from: reply)
         }
         return reply

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -412,7 +412,8 @@ public class MongoDatabase {
         let opts = try self.encoder.encode(options)
         let reply = Document()
         var error = bson_error_t()
-        guard mongoc_database_command_with_opts(self._database, command.data, rp?._readPreference, opts?.data, reply.data, &error) else {
+        guard mongoc_database_command_with_opts(
+            self._database, command.data, rp?._readPreference, opts?.data, reply.data, &error) else {
             throw getErrorFromReply(bsonError: error, from: reply)
         }
         return reply


### PR DESCRIPTION
Stemming from conversation on SWIFT-373 I fixed one ReadPreference issue there and happened to notice another.
I'm surprised we didn't catch the `MongoDatabase.readPreference` issue. I noticed our tests there are very lackluster and only test the type itself and not setting it on clients/DBs/colls or using it for commands or anything like that. I opened [SWIFT-447](https://jira.mongodb.org/browse/SWIFT-447) about remedying this.