### PR TITLE
SWIFT-402 Resolve MongoSwift namespace issues

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -213,7 +213,8 @@ public class MongoClient {
      * :nodoc:
      * Create a new client from an existing `mongoc_client_t`. The new client will destroy the `mongoc_client_t` upon
      * deinitialization.
-     * Do not use this initializer unless you know what you are doing.
+     * Do not use this initializer unless you know what you are doing. You *must* call libmongoc_init *before* using
+     * this initializer for the first time.
      *
      * If this client was derived from a pool, ensure that the error api version was set to 2 on the pool.
      *
@@ -221,9 +222,6 @@ public class MongoClient {
      *   - pointer: the `mongoc_client_t` to store and use internally
      */
     public init(stealing pointer: OpaquePointer) {
-        // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
-        initializeMongoc()
-
         self._client = pointer
 
         // This call may fail, and if it does, either the error api version was already set or the client was derived

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -164,6 +164,9 @@ public class MongoClient {
      *     built with TLS support.
      */
     public init(_ connectionString: String = "mongodb://localhost:27017", options: ClientOptions? = nil) throws {
+        // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
+        initializeMongoc()
+
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
             throw parseMongocError(error)
@@ -208,16 +211,20 @@ public class MongoClient {
 
     /**
      * :nodoc:
-     * Create a new client from an existing `mongoc_client_t`.
+     * Create a new client from an existing `mongoc_client_t`. The new client will destroy the `mongoc_client_t` upon
+     * deinitialization.
      * Do not use this initializer unless you know what you are doing.
      *
      * If this client was derived from a pool, ensure that the error api version was set to 2 on the pool.
      *
      * - Parameters:
-     *   - fromPointer: the `mongoc_client_t` to store and use internally
+     *   - pointer: the `mongoc_client_t` to store and use internally
      */
-    public init(fromPointer: OpaquePointer) {
-        self._client = fromPointer
+    public init(stealing pointer: OpaquePointer) {
+        // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
+        initializeMongoc()
+
+        self._client = pointer
 
         // This call may fail, and if it does, either the error api version was already set or the client was derived
         // from a pool. In either case, the error handling in MongoSwift will be incorrect unless the correct api

--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -16,12 +16,12 @@ internal func initializeMongoc() {
 }
 
 /**
- * Release all memory and other resources allocated by libmongoc.
+ * Release all internal memory and other resources allocated by MongoSwift.
  *
  * This function should be called once at the end of the application. Users
  * should not interact with the driver after calling this function.
  */
-public func cleanupMongoc() {
+public func cleanupMongoSwift() {
     /* Note: ideally, this would be called from MongocInitializer's deinit,
      * but Swift does not currently handle deinitialization of singletons.
      * See: https://bugs.swift.org/browse/SR-2500 */

--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -1,39 +1,29 @@
 import mongoc
 
-/// A utility class for libmongoc initialization and cleanup.
-public final class MongoSwift {
-    /// The version of `MongoSwift`.
-    public static let versionString = "0.1.0"
+private final class MongocInitializer {
+    private static let versionString = "0.1.0"
+    internal static let shared = MongocInitializer()
 
-    private final class MongocInitializer {
-        static let shared = MongocInitializer()
-
-        init() {
-            mongoc_init()
-            mongoc_handshake_data_append("MongoSwift", versionString, nil)
-        }
+    private init() {
+        mongoc_init()
+        mongoc_handshake_data_append("MongoSwift", MongocInitializer.versionString, nil)
     }
+}
 
-    /**
-     * Initializes libmongoc.
-     *
-     * This function should be called once at the start of the application
-     * before interacting with the driver.
-     */
-    public static func initialize() {
-        _ = MongocInitializer.shared
-    }
+/// Initializes libmongoc. Repeated calls to this method have no effect.
+internal func initializeMongoc() {
+    _ = MongocInitializer.shared
+}
 
-    /**
-     * Cleans up libmongoc.
-     *
-     * This function should be called once at the end of the application. Users
-     * should not interact with the driver after calling this function.
-     */
-    public static func cleanup() {
-        /* Note: ideally, this would be called from MongocInitializer's deinit,
-         * but Swift does not currently handle deinitialization of singletons.
-         * See: https://bugs.swift.org/browse/SR-2500 */
-        mongoc_cleanup()
-    }
+/**
+ * Release all memory and other resources allocated by libmongoc.
+ *
+ * This function should be called once at the end of the application. Users
+ * should not interact with the driver after calling this function.
+ */
+public func cleanupMongoc() {
+    /* Note: ideally, this would be called from MongocInitializer's deinit,
+     * but Swift does not currently handle deinitialization of singletons.
+     * See: https://bugs.swift.org/browse/SR-2500 */
+    mongoc_cleanup()
 }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -22,7 +22,7 @@ final class MongoClientTests: MongoSwiftTestCase {
             throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support.")
         }
 
-        let client = MongoClient(fromPointer: client_t)
+        let client = MongoClient(stealing: client_t)
         let db = client.db(type(of: self).testDatabase)
         let coll = db.collection(self.getCollectionName())
         let insertResult = try coll.insertOne([ "test": 42 ])

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -6,14 +6,6 @@ import XCTest
 
 // sourcery: disableTests
 class MongoSwiftTestCase: XCTestCase {
-    /* Ensure libmongoc is initialized. This will be called multiple times, but that's ok
-     * as repeated calls have no effect. There is no way to call final cleanup code just
-     * once at the very end, either explicitly or with a deinit. This may appear as a
-     * memory leak. */
-    override class func setUp() {
-        MongoSwift.initialize()
-    }
-
     /// Gets the name of the database the test case is running against.
     internal class var testDatabase: String {
         return "test"


### PR DESCRIPTION
Gets rid of the `MongoSwift` class and moves the init/cleanup methods to be free-floating.

