### PR TITLE
SWIFT-175 Causal consistency support

### DIFF
--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -18,10 +18,10 @@ private func withSessionOpts<T>(wrapping options: ClientSessionOptions?,
                                 _ body: (OpaquePointer) throws -> T) rethrows -> T {
     // swiftlint:disable:next force_unwrapping
     var opts = mongoc_session_opts_new()! // always returns a value
+    defer { mongoc_session_opts_destroy(opts) }
     if let causalConsistency = options?.causalConsistency {
         mongoc_session_opts_set_causal_consistency(opts, causalConsistency)
     }
-    defer { mongoc_session_opts_destroy(opts) }
     return try body(opts)
 }
 

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -2,7 +2,15 @@ import Foundation
 import mongoc
 
 /// Options to use when creating a ClientSession.
-public struct ClientSessionOptions {}
+public struct ClientSessionOptions {
+    /// Whether to enable causal consistency for this session. By default, causal consistency is enabled.
+    public let causalConsistency: Bool?
+
+    /// Convenience initializer allowing any/all parameters to be omitted.
+    public init(causalConsistency: Bool? = nil) {
+        self.causalConsistency = causalConsistency
+    }
+}
 
 /// Private helper for providing a `mongoc_session_opt_t` that is only valid within the body of the provided
 /// closure.
@@ -10,12 +18,41 @@ private func withSessionOpts<T>(wrapping options: ClientSessionOptions?,
                                 _ body: (OpaquePointer) throws -> T) rethrows -> T {
     // swiftlint:disable:next force_unwrapping
     var opts = mongoc_session_opts_new()! // always returns a value
+    if let causalConsistency = options?.causalConsistency {
+        mongoc_session_opts_set_causal_consistency(opts, causalConsistency)
+    }
     defer { mongoc_session_opts_destroy(opts) }
     return try body(opts)
 }
 
-/// A MongoDB client session.
-/// This class represents a logical session used for ordering sequential operations.
+/**
+ * A MongoDB client session.
+ * This class represents a logical session used for ordering sequential operations.
+ *
+ * To create a client session, use `startSession` or `withSession` on a `MongoClient`.
+ *
+ * If `causalConsistency` is not set to `false` when starting a session, read and write operations that use the session
+ * will be provided causal consistency guarantees depending on the read and write concerns used. Using "majority"
+ * read and write preferences will provide the full set of guarantees. See
+ * https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#sessions for more details.
+ *
+ * e.g.
+ *   ```
+ *   let opts = CollectionOptions(readConcern: ReadConcern(.majority), writeConcern: try WriteConcern(w: .majority))
+ *   let collection = database.collection("mycoll", options: opts)
+ *   try client.withSession { session in
+ *       try collection.insertOne(["x": 1], session: session)
+ *       try collection.find(["x": 1], session: session)
+ *   }
+ *   ```
+ *
+ * To disable causal consistency, set `causalConsistency` to `false` in the `ClientSessionOptions` passed in to either
+ * `withSession` or `startSession`.
+ *
+ * - SeeAlso:
+ *   - https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#sessions
+ *   - https://docs.mongodb.com/manual/core/causal-consistency-read-write-concerns/
+ */
 public final class ClientSession {
     /// Error thrown when an inactive session is used.
     internal static var SessionInactiveError = UserError.logicError(message: "Tried to use an inactive session")
@@ -40,6 +77,18 @@ public final class ClientSession {
             return nil
         }
         return Document(copying: time)
+    }
+
+    /// The operation time of the most recent operation performed using this session.
+    public var operationTime: Timestamp? {
+        var timestamp: UInt32 = 0
+        var increment: UInt32 = 0
+        mongoc_client_session_get_operation_time(self._session, &timestamp, &increment)
+
+        guard timestamp != 0 && increment != 0 else {
+            return nil
+        }
+        return Timestamp(timestamp: timestamp, inc: increment)
     }
 
     /// The options used to start this session.
@@ -85,6 +134,17 @@ public final class ClientSession {
      */
     public func advanceClusterTime(to clusterTime: Document) {
         mongoc_client_session_advance_cluster_time(self._session, clusterTime.storage.pointer)
+    }
+
+    /**
+     * Advances the operationTime for this session to the given time if it is greater than the current operationTime.
+     * If the provided operationTime is less than the current operationTime, this method has no effect.
+     *
+     * - Parameters:
+     *   - operationTime: The session's new operationTime
+     */
+    public func advanceOperationTime(to operationTime: Timestamp) {
+        mongoc_client_session_advance_operation_time(self._session, operationTime.timestamp, operationTime.increment)
     }
 
     /// Appends this provided session to an options document for libmongoc interoperability.

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -26,6 +26,8 @@ extension ClientSessionTests {
         ("testInactiveSession", testInactiveSession),
         ("testSessionCursor", testSessionCursor),
         ("testClusterTime", testClusterTime),
+        ("testCausalConsistency", testCausalConsistency),
+        ("testCausalConsistencyStandalone", testCausalConsistencyStandalone),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -28,6 +28,7 @@ extension ClientSessionTests {
         ("testClusterTime", testClusterTime),
         ("testCausalConsistency", testCausalConsistency),
         ("testCausalConsistencyStandalone", testCausalConsistencyStandalone),
+        ("testCausalConsistencyAnyTopology", testCausalConsistencyAnyTopology),
     ]
 }
 

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -14,7 +14,73 @@ final class ClientSessionTests: MongoSwiftTestCase {
         super.tearDown()
     }
 
-    /// Test that sessions are properly returned to the pool when ended.
+    typealias CollectionSessionOp = (name: String, body: (MongoCollection<Document>, ClientSession?) throws -> Void)
+    typealias DatabaseSessionOp = (name: String, body: (MongoDatabase, ClientSession?) throws -> Void)
+    typealias ClientSessionOp = (name: String, body: (MongoClient, ClientSession?) throws -> Void)
+    typealias SessionOp = (name: String, body: (ClientSession?) throws -> Void)
+
+    typealias InsertOneModel = MongoCollection<Document>.InsertOneModel
+
+    // list of read only operations on MongoCollection that take in a session
+    let collectionSessionReadOps: [CollectionSessionOp] = [
+        (name: "find", body: { _ = try $0.find([:], session: $1).nextOrError() }),
+        (name: "aggregate", body: { _ = try $0.aggregate([], session: $1).nextOrError() }),
+        (name: "distinct", body: { _ = try $0.distinct(fieldName: "x", session: $1) }),
+        (name: "count", body: { _ = try $0.count(session: $1) })
+    ]
+
+    // list of write operations on MongoCollection that take in a session
+    let collectionSessionWriteOps: [CollectionSessionOp] = [
+        (name: "bulkWrite", body: { _ = try $0.bulkWrite([InsertOneModel([:])], session: $1) }),
+        (name: "insertOne", body: { _ = try $0.insertOne([:], session: $1) }),
+        (name: "insertMany", body: { _ = try $0.insertMany([[:]], session: $1) }),
+        (name: "replaceOne", body: { _ = try $0.replaceOne(filter: [:], replacement: [:], session: $1) }),
+        (name: "updateOne", body: { _ = try $0.updateOne(filter: [:], update: [:], session: $1) }),
+        (name: "updateMany", body: { _ = try $0.updateMany(filter: [:], update: [:], session: $1) }),
+        (name: "deleteOne", body: { _ = try $0.deleteOne([:], session: $1) }),
+        (name: "deleteMany", body: { _ = try $0.deleteMany([:], session: $1) }),
+        (name: "createIndex", body: { _ = try $0.createIndex([:], session: $1) }),
+        (name: "createIndex1", body: { _ = try $0.createIndex(IndexModel(keys: ["x": 1] as Document), session: $1) }),
+        (name: "createIndexes", body: { _ = try $0.createIndexes([], session: $1) }),
+        (name: "dropIndex", body: { _ = try $0.dropIndex(["x": 1], session: $1) }),
+        (name: "dropIndex1", body: { _ = try $0.dropIndex(IndexModel(keys: ["x": 3] as Document), session: $1) }),
+        (name: "dropIndex2", body: { _ = try $0.dropIndex("x_7", session: $1) }),
+        (name: "dropIndexes", body: { _ = try $0.dropIndexes(session: $1) }),
+        (name: "listIndexes", body: { _ = try $0.listIndexes(session: $1).next() }),
+        (name: "findOneAndDelete", body: { _ = try $0.findOneAndDelete([:], session: $1) }),
+        (name: "findOneAndReplace", body: { _ = try $0.findOneAndReplace(filter: [:], replacement: [:], session: $1) }),
+        (name: "findOneAndUpdate", body: { _ = try $0.findOneAndUpdate(filter: [:], update: [:], session: $1) })
+    ]
+
+    // list of operations on MongoDatabase that take in a session
+    let databaseSessionOps: [DatabaseSessionOp] = [
+        (name: "runCommand", { try $0.runCommand(["isMaster": 0], session: $1) }),
+        (name: "createCollection", body: { _ = try $0.createCollection("asdf", session: $1) }),
+        (name: "createCollection1", body: { _ = try $0.createCollection("asdf", withType: Document.self, session: $1) })
+    ]
+
+    // list of operatoins on MongoClient that take in a session
+    let clientSessionOps: [ClientSessionOp] = [
+        (name: "listDatabases", { _ = try $0.listDatabases(session: $1).nextOrError() })
+    ]
+
+    // iterate over all the different session op types, passing in the provided client/db/collection as needed.
+    func forEachSessionOp(client: MongoClient,
+                          database: MongoDatabase,
+                          collection: MongoCollection<Document>,
+                          _ body: (SessionOp) throws -> Void) rethrows {
+        try (collectionSessionReadOps + collectionSessionWriteOps).forEach { op in
+            try body((name: op.name, body: { try op.body(collection, $0) }))
+        }
+        try databaseSessionOps.forEach { op in
+            try body((name: op.name, body: { try op.body(database, $0) }))
+        }
+        try clientSessionOps.forEach { op in
+            try body((name: op.name, body: { try op.body(client, $0) }))
+        }
+    }
+
+    /// Sessions spec test 1: Test that sessions are properly returned to the pool when ended.
     func testSessionCleanup() throws {
         let client = try MongoClient(MongoSwiftTestCase.connStr)
 
@@ -62,43 +128,40 @@ final class ClientSessionTests: MongoSwiftTestCase {
         }
     }
 
-    struct SessionsArgTest {
-        let name: String
-        let body: (ClientSession?) throws -> Void
+    // Executes the body twice, once with the supplied session and once without, verifying that a correct lsid is
+    // seen both times.
+    func runArgTest(session: ClientSession, op: SessionOp) throws {
+        let center = NotificationCenter.default
 
-        // Executes the body twice, once with the supplied session and once without, verifying that a correct lsid is
-        // seen both times.
-        func execute(session: ClientSession) throws {
-            let center = NotificationCenter.default
-
-            var seenExplicit = false
-            var seenImplicit = false
-            let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
-                guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
-                    return
-                }
-                expect(event.command["lsid"]).toNot(beNil(), description: self.name)
-                if !seenExplicit {
-                    expect(event.command["lsid"]).to(bsonEqual(session.id), description: self.name)
-                    seenExplicit = true
-                } else {
-                    expect(seenImplicit).to(beFalse())
-                    expect(event.command["lsid"]).toNot(bsonEqual(session.id), description: self.name)
-                    seenImplicit = true
-                }
+        var seenExplicit = false
+        var seenImplicit = false
+        let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+            guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                return
             }
-            // We don't care if they succeed (e.g. a drop index may fail if index doesn't exist)
-            try? self.body(session)
-            try? self.body(nil)
 
-            expect(seenImplicit).to(beTrue(), description: self.name)
-            expect(seenExplicit).to(beTrue(), description: self.name)
-
-            center.removeObserver(observer)
+            expect(event.command["lsid"]).toNot(beNil(), description: op.name)
+            if !seenExplicit {
+                expect(event.command["lsid"]).to(bsonEqual(session.id), description: op.name)
+                seenExplicit = true
+            } else {
+                expect(seenImplicit).to(beFalse())
+                expect(event.command["lsid"]).toNot(bsonEqual(session.id), description: op.name)
+                seenImplicit = true
+            }
         }
+        // We don't care if they succeed (e.g. a drop index may fail if index doesn't exist)
+        try? op.body(session)
+        try? op.body(nil)
+
+        expect(seenImplicit).to(beTrue(), description: op.name)
+        expect(seenExplicit).to(beTrue(), description: op.name)
+
+        center.removeObserver(observer)
     }
 
-    /// Test that every function that takes a session parameter passes the sends implicit and explicit lsids to server.
+    /// Sessions spec test 3: test that every function that takes a session parameter passes the sends implicit and
+    /// explicit lsids to server.
     func testSessionArguments() throws {
         let client1 = try MongoClient(MongoSwiftTestCase.connStr, options: ClientOptions(eventMonitoring: true))
         client1.enableMonitoring(forEvents: .commandMonitoring)
@@ -107,98 +170,50 @@ final class ClientSessionTests: MongoSwiftTestCase {
         let collection = database.collection(self.getCollectionName())
         let session = try client1.startSession()
 
-        let doc: Document = ["a": 1]
-        let update: Document = ["$set": ["x": 1] as Document]
-        let model: WriteModel = MongoCollection<Document>.UpdateOneModel(filter: doc, update: update)
-        let models = (1...8).map { IndexModel(keys: ["x": $0 ]) }
-
-        let collectionCases = [
-            SessionsArgTest(name: "bulkWrite") { try collection.bulkWrite([model], session: $0) },
-            SessionsArgTest(name: "insertOne") { try collection.insertOne(doc, session: $0) },
-            SessionsArgTest(name: "insertMany") { try collection.insertMany([doc], session: $0) },
-            SessionsArgTest(name: "replaceOne") {
-                try collection.replaceOne(filter: doc, replacement: doc, session: $0)
-            },
-            SessionsArgTest(name: "updateOne") { try collection.updateOne(filter: doc, update: update, session: $0) },
-            SessionsArgTest(name: "updateMany") { try collection.updateMany(filter: doc, update: update, session: $0) },
-            SessionsArgTest(name: "deleteOne") { try collection.deleteOne(doc, session: $0) },
-            SessionsArgTest(name: "deleteMany") { try collection.deleteMany(doc, session: $0) },
-            SessionsArgTest(name: "find") { _ = try collection.find(doc, session: $0).next() },
-            SessionsArgTest(name: "aggregate") {
-                _ = try collection.aggregate([] as [Document], session: $0).next()
-            },
-            SessionsArgTest(name: "distinct") { _ = try collection.distinct(fieldName: "x", session: $0) },
-            SessionsArgTest(name: "findOneAndDelete") { try collection.findOneAndDelete(doc, session: $0) },
-            SessionsArgTest(name: "findOneAndReplace") {
-                try collection.findOneAndReplace(filter: doc, replacement: doc, session: $0)
-            },
-            SessionsArgTest(name: "findOneAndUpdate") {
-                try collection.findOneAndUpdate(filter: doc, update: update, session: $0)
-            },
-            SessionsArgTest(name: "createIndex") { try collection.createIndex(doc, session: $0) },
-            SessionsArgTest(name: "createIndex1") {
-                try collection.createIndex(IndexModel(keys: ["x": 1] as Document), session: $0)
-            },
-            SessionsArgTest(name: "createIndexes") { try collection.createIndexes(models, session: $0) },
-            SessionsArgTest(name: "dropIndex") { try collection.dropIndex(["x": 1], session: $0) },
-            SessionsArgTest(name: "dropIndex1") {
-                try collection.dropIndex(IndexModel(keys: ["x": 3] as Document), session: $0)
-            },
-            SessionsArgTest(name: "dropIndex2") { try collection.dropIndex("x_7", session: $0) },
-            SessionsArgTest(name: "dropIndexes") { try collection.dropIndexes(session: $0) },
-            SessionsArgTest(name: "listIndexes") { _ = try collection.listIndexes(session: $0).next() },
-            SessionsArgTest(name: "count") { _ = try collection.count(session: $0) }
-        ]
-        try collectionCases.forEach { try $0.execute(session: session) }
-
-        try database.drop()
-
-        let databaseCases = [
-            SessionsArgTest(name: "runCommand") { try database.runCommand(["isMaster": 0], session: $0) },
-            SessionsArgTest(name: "createCollection") {
-                _ = try database.createCollection(self.getCollectionName(), session: $0)
-            },
-            SessionsArgTest(name: "createCollection1") {
-                _ = try database.createCollection(self.getCollectionName(), withType: Document.self, session: $0)
-            }
-        ]
-        try databaseCases.forEach { try $0.execute(session: session) }
-
-        // client case
-        try SessionsArgTest(name: "listDatabases") {
-            _ = try client1.listDatabases(session: $0).next()
-        }.execute(session: session)
+        try forEachSessionOp(client: client1, database: database, collection: collection) { op in
+            try runArgTest(session: session, op: op)
+        }
 
         try database.drop()
     }
 
-    /// Test that a session can only be used with db's and collections that were derived from the same client.
+    /// Sessions spec test 4: test that a session can only be used with db's and collections that were derived from the
+    /// same client.
     func testSessionClientValidation() throws {
         let client1 = try MongoClient(MongoSwiftTestCase.connStr)
         let client2 = try MongoClient(MongoSwiftTestCase.connStr)
 
         let database = client1.db(type(of: self).testDatabase)
+        defer { try database.drop() }
         let collection = database.collection(self.getCollectionName())
 
         let session = try client2.startSession()
-        expect(try collection.insertOne(["x": 1], session: session))
-                .to(throwError(UserError.invalidArgumentError(message: "")))
+        try forEachSessionOp(client: client1, database: database, collection: collection) { op in
+            expect(try op.body(session))
+                    .to(throwError(UserError.invalidArgumentError(message: "")), description: op.name)
+        }
     }
 
-    /// Test that inactive sessions cannot be used.
+    /// Sessions spec test 5: Test that inactive sessions cannot be used.
     func testInactiveSession() throws {
         let client = try MongoClient(MongoSwiftTestCase.connStr)
+        let db = client.db(type(of: self).testDatabase)
+        defer { try db.drop() }
+        let collection = db.collection(self.getCollectionName())
         let session1 = try client.startSession()
 
         session1.end()
         expect(session1.active).to(beFalse())
-        expect(try client.listDatabases(session: session1)).to(throwError(ClientSession.SessionInactiveError))
+
+        try forEachSessionOp(client: client, database: db, collection: collection) { op in
+            expect(try op.body(session1)).to(throwError(ClientSession.SessionInactiveError), description: op.name)
+        }
 
         let session2 = try client.startSession()
         let database = client.db(type(of: self).testDatabase)
-        let collection = database.collection(self.getCollectionName())
+        let collection1 = database.collection(self.getCollectionName())
 
-        try (1...3).forEach { try collection.insertOne(["x": $0]) }
+        try (1...3).forEach { try collection1.insertOne(["x": $0]) }
 
         let cursor = try collection.find(session: session2)
         expect(cursor.next()).toNot(beNil())
@@ -206,7 +221,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
         expect(try cursor.nextOrError()).to(throwError(ClientSession.SessionInactiveError))
     }
 
-    /// Test cursors have the same lsid in the initial find command and in subsequent getMores.
+    /// Sessions spec test 10: Test cursors have the same lsid in the initial find command and in subsequent getMores.
     func testSessionCursor() throws {
         let client = try MongoClient(MongoSwiftTestCase.connStr, options: ClientOptions(eventMonitoring: true))
         client.enableMonitoring(forEvents: .commandMonitoring)
@@ -270,9 +285,9 @@ final class ClientSessionTests: MongoSwiftTestCase {
         center.removeObserver(observer)
     }
 
-    /// Test that the clusterTime is reported properly.
+    /// Sessions spec test 11: Test that the clusterTime is reported properly.
     func testClusterTime() throws {
-        guard MongoSwiftTestCase.topologyType == .sharded else {
+        guard MongoSwiftTestCase.topologyType != .single else {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
@@ -291,6 +306,214 @@ final class ClientSessionTests: MongoSwiftTestCase {
             let newTime: Document = ["clusterTime": Timestamp(timestamp: Int(date.timeIntervalSince1970), inc: 100)]
             session.advanceClusterTime(to: newTime)
             expect(session.clusterTime).to(bsonEqual(newTime))
+        }
+    }
+
+    /// Test that causal consistency guarantees are met.
+    func testCausalConsistency() throws {
+        guard MongoSwiftTestCase.topologyType != .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+
+        let center = NotificationCenter.default
+        let client = try MongoClient(MongoSwiftTestCase.connStr, options: ClientOptions(eventMonitoring: true))
+        client.enableMonitoring()
+        let db = client.db(type(of: self).testDatabase)
+        defer { try db.drop() }
+        let collection = db.collection(self.getCollectionName())
+
+        // spec test 1
+        let session1 = try client.startSession()
+        expect(session1.operationTime).to(beNil())
+        session1.end()
+
+        // spec test 2 + 3
+        try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
+            var seenCommand = false
+            let startObserver = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                    return
+                }
+                expect((event.command["readConcern"] as? Document)?["afterClusterTime"]).to(beNil())
+                seenCommand = true
+            }
+            defer { center.removeObserver(startObserver) }
+
+            var replyOpTime: Timestamp?
+            let succeedObserver = center.addObserver(forName: .commandSucceeded, object: nil, queue: nil) { notif in
+                guard let event = notif.userInfo?["event"] as? CommandSucceededEvent else {
+                    return
+                }
+                expect(seenCommand).to(beTrue())
+                replyOpTime = event.reply["operationTime"] as? Timestamp
+            }
+            defer { center.removeObserver(succeedObserver) }
+
+            _ = try collection.find(session: session).next()
+            expect(seenCommand).to(beTrue())
+            expect(replyOpTime).toNot(beNil())
+            expect(replyOpTime).to(bsonEqual(session.operationTime))
+        }
+
+        // spec test 4 + 8
+        try collectionSessionReadOps.forEach { op in
+            try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
+                _ = try collection.find(session: session).next()
+                let opTime = session.operationTime
+                var seenCommand = false
+                let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                    guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                        return
+                    }
+                    let readConcern = event.command["readConcern"] as? Document
+                    expect(readConcern).toNot(beNil(), description: op.name)
+                    expect(readConcern!["afterClusterTime"]).to(bsonEqual(opTime), description: op.name)
+                    expect(readConcern!["level"]).to(beNil(), description: op.name)
+                    seenCommand = true
+                }
+                defer { center.removeObserver(observer) }
+                try op.body(collection, session)
+                expect(seenCommand).to(beTrue(), description: op.name)
+            }
+        }
+
+        // spec test 5
+        try collectionSessionWriteOps.forEach { op in
+            try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
+                try? op.body(collection, session)
+                let opTime = session.operationTime
+
+                var seenCommand = false
+                let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                    guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                        return
+                    }
+                    expect((event.command["readConcern"] as? Document)?["afterClusterTime"])
+                            .to(bsonEqual(opTime), description: op.name)
+                    seenCommand = true
+                }
+                defer {
+                    center.removeObserver(observer)
+                }
+                _ = try collection.find(session: session).next()
+                expect(seenCommand).to(beTrue(), description: op.name)
+            }
+        }
+
+        // spec test 6
+        try client.withSession(options: ClientSessionOptions(causalConsistency: false)) { session in
+            var seenCommand = false
+            _ = try collection.find(session: session).next()
+            let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                    return
+                }
+                expect((event.command["readConcern"] as? Document)?["afterClusterTime"]).to(beNil())
+                seenCommand = true
+            }
+            defer { center.removeObserver(observer) }
+            _ = try collection.aggregate([["$match": ["x": 1] as Document]], session: session).next()
+            expect(seenCommand).to(beTrue())
+        }
+
+        // spec test 9
+        try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
+            let collection1 = db.collection(self.getCollectionName(),
+                                            options: CollectionOptions(readConcern: ReadConcern(.snapshot)))
+            _ = try collection1.find(session: session).next()
+            let opTime = session.operationTime
+
+            var seenCommand = false
+            let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                    return
+                }
+                let readConcern = event.command["readConcern"] as? Document
+                expect(readConcern).toNot(beNil())
+                expect(readConcern!["afterClusterTime"]).to(bsonEqual(opTime))
+                expect(readConcern!["level"]).to(bsonEqual("snapshot"))
+                seenCommand = true
+            }
+            defer { center.removeObserver(observer) }
+            _ = try collection1.find(session: session).next()
+            expect(seenCommand).to(beTrue())
+        }
+
+        // spec test 10
+        try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
+            let collection1 = db.collection(self.getCollectionName(),
+                                            options: CollectionOptions(writeConcern: try WriteConcern(w: .number(0))))
+            try collection1.insertOne(["x": 3])
+            expect(session.operationTime).to(beNil())
+        }
+
+        // spec test 12
+        try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
+            let collection1 = db.collection(self.getCollectionName(),
+                                            options: CollectionOptions(readConcern: ReadConcern(.snapshot)))
+
+            var seenCommand = false
+            let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                    return
+                }
+                expect(event.command["$clusterTime"]).toNot(beNil())
+                seenCommand = true
+            }
+            defer { center.removeObserver(observer) }
+            _ = try collection1.find(session: session).next()
+            expect(seenCommand).to(beTrue())
+        }
+    }
+
+    /// Test causal consistent behavior on a topology that doesn't support cluster time.
+    func testCausalConsistencyStandalone() throws {
+        guard MongoSwiftTestCase.topologyType == .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+
+        let center = NotificationCenter.default
+        let client = try MongoClient(MongoSwiftTestCase.connStr, options: ClientOptions(eventMonitoring: true))
+        client.enableMonitoring()
+        let db = client.db(type(of: self).testDatabase)
+        defer { try db.drop() }
+        let collection = db.collection(self.getCollectionName())
+
+        // spec test 7
+        try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
+            _ = try collection.find(session: session).next()
+
+            var seenCommand = false
+            let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                    return
+                }
+                expect((event.command["readConcern"] as? Document)?["afterClusterTime"]).to(beNil())
+                seenCommand = true
+            }
+            defer { center.removeObserver(observer) }
+            _ = try collection.listIndexes(session: session).next()
+            expect(seenCommand).to(beTrue())
+        }
+
+        // spec test 11
+        try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
+            _ = try collection.insertOne([:], session: session)
+            let opTime = session.operationTime
+
+            var seenCommand = false
+            let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
+                guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+                    return
+                }
+                expect(event.command["$clusterTime"]).to(beNil())
+                seenCommand = true
+            }
+            defer { center.removeObserver(observer) }
+            _ = try collection.listIndexes(session: session).next()
+            expect(seenCommand).to(beTrue())
         }
     }
 }

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -393,9 +393,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
                             .to(bsonEqual(opTime), description: op.name)
                     seenCommand = true
                 }
-                defer {
-                    center.removeObserver(observer)
-                }
+                defer { center.removeObserver(observer) }
                 _ = try collection.find(session: session).next()
                 expect(seenCommand).to(beTrue(), description: op.name)
             }
@@ -450,9 +448,6 @@ final class ClientSessionTests: MongoSwiftTestCase {
 
         // spec test 12
         try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
-            let collection1 = db.collection(self.getCollectionName(),
-                                            options: CollectionOptions(readConcern: ReadConcern(.snapshot)))
-
             var seenCommand = false
             let observer = center.addObserver(forName: .commandStarted, object: nil, queue: nil) { notif in
                 guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
@@ -462,7 +457,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
                 seenCommand = true
             }
             defer { center.removeObserver(observer) }
-            _ = try collection1.find(session: session).next()
+            _ = try collection.find(session: session).next()
             expect(seenCommand).to(beTrue())
         }
     }

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -184,7 +184,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
         let client2 = try MongoClient(MongoSwiftTestCase.connStr)
 
         let database = client1.db(type(of: self).testDatabase)
-        defer { try database.drop() }
+        defer { try? database.drop() }
         let collection = database.collection(self.getCollectionName())
 
         let session = try client2.startSession()
@@ -198,7 +198,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
     func testInactiveSession() throws {
         let client = try MongoClient(MongoSwiftTestCase.connStr)
         let db = client.db(type(of: self).testDatabase)
-        defer { try db.drop() }
+        defer { try? db.drop() }
         let collection = db.collection(self.getCollectionName())
         let session1 = try client.startSession()
 
@@ -320,7 +320,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
         let client = try MongoClient(MongoSwiftTestCase.connStr, options: ClientOptions(eventMonitoring: true))
         client.enableMonitoring()
         let db = client.db(type(of: self).testDatabase)
-        defer { try db.drop() }
+        defer { try? db.drop() }
         let collection = db.collection(self.getCollectionName())
 
         // spec test 1
@@ -478,7 +478,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
         let client = try MongoClient(MongoSwiftTestCase.connStr, options: ClientOptions(eventMonitoring: true))
         client.enableMonitoring()
         let db = client.db(type(of: self).testDatabase)
-        defer { try db.drop() }
+        defer { try? db.drop() }
         let collection = db.collection(self.getCollectionName())
 
         // spec test 7


### PR DESCRIPTION
[SWIFT-175](https://jira.mongodb.org/browse/SWIFT-175)

This PR also reworks the previous sessions test so that it's easier for more tests to cover every client/db/collection method that takes in a session. 
