### PR TITLE
Don't use DB default read preference

### DIFF
--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -2,13 +2,16 @@ import mongoc
 
 /// Options to use when running a command against a `MongoDatabase`.
 public struct RunCommandOptions: Encodable {
-    /// An optional `ReadConcern` to use for this operation.
+    /// An optional `ReadConcern` to use for this operation. This option should only be used when executing a command
+    /// that reads.
     public let readConcern: ReadConcern?
 
-    /// An optional `ReadPreference` to use for this operation.
+    /// An optional `ReadPreference` to use for this operation. This option should only be used when executing a
+    /// command that reads.
     public let readPreference: ReadPreference?
 
-    /// An optional `WriteConcern` to use for this operation.
+    /// An optional `WriteConcern` to use for this operation. This option should only be used when executing a command
+    /// that writes.
     public let writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
@@ -40,7 +43,7 @@ internal struct RunCommandOperation: Operation {
     }
 
     internal func execute() throws -> Document {
-        let rp = self.options?.readPreference ?? self.database.readPreference
+        let rp = self.options?.readPreference
         let opts = try encodeOptions(options: self.options, session: self.session)
         let reply = Document()
         var error = bson_error_t()


### PR DESCRIPTION
Per conversation on Slack and on [CDRIVER-3117](https://jira.mongodb.org/browse/CDRIVER-3117), the SDAM spec says:
> The generic command method has a default read preference of mode 'primary'. The generic command method MUST ignore any default read preference from client, database or collection configuration. The generic command method SHOULD allow an optional read preference argument.

so, this was right the first time. very good call on not using this helper for other methods though @mbroadst. I think maybe we will eventually end up with WriteCommandOperation and ReadCommandOperation that call the read/write specific mongoc command helpers.