### PR TITLE
SWIFT-377 Refactor DB and collection initializers to take in options rather than libmongoc types

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -305,25 +305,6 @@ public class MongoClient {
      * - Returns: a `MongoDatabase` corresponding to the provided database name
      */
     public func db(_ name: String, options: DatabaseOptions? = nil) -> MongoDatabase {
-        guard let db = mongoc_client_get_database(self._client, name) else {
-            fatalError("Couldn't get database '\(name)'")
-        }
-
-        if let rc = options?.readConcern {
-            mongoc_database_set_read_concern(db, rc._readConcern)
-        }
-
-        if let rp = options?.readPreference {
-            mongoc_database_set_read_prefs(db, rp._readPreference)
-        }
-
-        if let wc = options?.writeConcern {
-            mongoc_database_set_write_concern(db, wc._writeConcern)
-        }
-
-        let encoder = BSONEncoder(copies: self.encoder, options: options)
-        let decoder = BSONDecoder(copies: self.decoder, options: options)
-
-        return MongoDatabase(fromDatabase: db, withClient: self, withEncoder: encoder, withDecoder: decoder)
+        return MongoDatabase(name: name, client: self, options: options)
     }
 }

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -51,14 +51,30 @@ public class MongoCollection<T: Codable> {
     }
 
     /// Initializes a new `MongoCollection` instance. Not meant to be instantiated directly by a user.
-    internal init(fromCollection: OpaquePointer,
-                  withClient: MongoClient,
-                  withEncoder: BSONEncoder,
-                  withDecoder: BSONDecoder) {
-        self._collection = fromCollection
-        self._client = withClient
-        self.encoder = withEncoder
-        self.decoder = withDecoder
+    internal convenience init(name: String, database: MongoDatabase, options: CollectionOptions?) {
+        guard let collection = mongoc_database_get_collection(database._database, name) else {
+            fatalError("Could not get collection '\(name)'")
+        }
+        self.init(collection: collection, database: database, options: options)
+    }
+
+    internal init(collection: OpaquePointer, database: MongoDatabase, options: CollectionOptions?) {
+        if let rc = options?.readConcern {
+            mongoc_collection_set_read_concern(collection, rc._readConcern)
+        }
+
+        if let rp = options?.readPreference {
+            mongoc_collection_set_read_prefs(collection, rp._readPreference)
+        }
+
+        if let wc = options?.writeConcern {
+            mongoc_collection_set_write_concern(collection, wc._writeConcern)
+        }
+
+        self._collection = collection
+        self._client = database._client
+        self.encoder = BSONEncoder(copies: database.encoder, options: options)
+        self.decoder = BSONDecoder(copies: database.decoder, options: options)
     }
 
     /// Cleans up internal state.

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -50,15 +50,13 @@ public class MongoCollection<T: Codable> {
         return wc.isDefault ? nil : wc
     }
 
-    /// Initializes a new `MongoCollection` instance. Not meant to be instantiated directly by a user.
-    internal convenience init(name: String, database: MongoDatabase, options: CollectionOptions?) {
+    /// Initializes a new `MongoCollection` instance corresponding to a collection with name `name` in database with
+    /// the provided options.
+    internal init(name: String, database: MongoDatabase, options: CollectionOptions?) {
         guard let collection = mongoc_database_get_collection(database._database, name) else {
             fatalError("Could not get collection '\(name)'")
         }
-        self.init(collection: collection, database: database, options: options)
-    }
 
-    internal init(collection: OpaquePointer, database: MongoDatabase, options: CollectionOptions?) {
         if let rc = options?.readConcern {
             mongoc_collection_set_read_concern(collection, rc._readConcern)
         }

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -133,14 +133,14 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
             throw parseMongocError(error)
         }
 
-        let encoder = BSONEncoder(copies: self.database.encoder, options: self.options)
-        let decoder = BSONDecoder(copies: self.database.decoder, options: self.options)
+        let collectionOptions = CollectionOptions(dateCodingStrategy: self.options?.dateCodingStrategy,
+                                                  uuidCodingStrategy: self.options?.uuidCodingStrategy,
+                                                  dataCodingStrategy: self.options?.dataCodingStrategy)
 
         return MongoCollection(
-                fromCollection: collection,
-                withClient: self.database._client,
-                withEncoder: encoder,
-                withDecoder: decoder
+                collection: collection,
+                database: self.database,
+                options: collectionOptions
         )
     }
 }

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -132,15 +132,12 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
             self.database._database, self.name, opts?.data, &error) else {
             throw parseMongocError(error)
         }
+        mongoc_collection_destroy(collection)
 
         let collectionOptions = CollectionOptions(dateCodingStrategy: self.options?.dateCodingStrategy,
                                                   uuidCodingStrategy: self.options?.uuidCodingStrategy,
                                                   dataCodingStrategy: self.options?.dataCodingStrategy)
 
-        return MongoCollection(
-                collection: collection,
-                database: self.database,
-                options: collectionOptions
-        )
+        return MongoCollection(name: self.name, database: self.database, options: collectionOptions)
     }
 }


### PR DESCRIPTION
This defers the creation of `mongoc_database_t`s and `mongoc_collection_t`s to the `MongoDatabase` and `MongoCollection` initializers, respectively.