### PR TITLE
Convert FindAndModify to use an Operation

### DIFF
--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -95,11 +95,10 @@ extension MongoCollection {
                                update: Document? = nil,
                                options: FindAndModifyOptionsConvertible? = nil,
                                session: ClientSession?) throws -> CollectionType? {
-        let opts = try options?.asFindAndModifyOptions()
         let operation = FindAndModifyOperation(collection: self,
                                                filter: filter,
                                                update: update,
-                                               options: opts,
+                                               options: options,
                                                session: session)
         return try operation.execute()
     }

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -95,29 +95,13 @@ extension MongoCollection {
                                update: Document? = nil,
                                options: FindAndModifyOptionsConvertible? = nil,
                                session: ClientSession?) throws -> CollectionType? {
-        // encode provided options, or create empty ones. we always need
-        // to send *something*, as findAndModify requires one of "remove"
-        // or "update" to be set.
-        let opts = try options?.asOpts() ?? FindAndModifyOptions()
-        if let session = session { try opts.setSession(session) }
-        if let update = update { try opts.setUpdate(update) }
-
-        let reply = Document()
-        var error = bson_error_t()
-
-        guard mongoc_collection_find_and_modify_with_opts(self._collection,
-                                                          filter.data,
-                                                          opts._options,
-                                                          reply.data,
-                                                          &error) else {
-            throw getErrorFromReply(bsonError: error, from: reply)
-        }
-
-        guard let value = try reply.getValue(for: "value") as? Document else {
-            return nil
-        }
-
-        return try self.decoder.decode(CollectionType.self, from: value)
+        let opts = try options?.asFindAndModifyOptions()
+        let operation = FindAndModifyOperation(collection: self,
+                                               filter: filter,
+                                               update: update,
+                                               options: opts,
+                                               session: session)
+        return try operation.execute()
     }
 }
 
@@ -130,11 +114,11 @@ public enum ReturnDocument {
 }
 
 /// Indicates that an options type can be represented as a `FindAndModifyOptions`
-private protocol FindAndModifyOptionsConvertible {
+internal protocol FindAndModifyOptionsConvertible {
     /// Converts `self` to a `FindAndModifyOptions`
     ///
     /// - Throws: `UserError.invalidArgumentError` if any of the options are invalid.
-    func asOpts() throws -> FindAndModifyOptions
+    func asFindAndModifyOptions() throws -> FindAndModifyOptions
 }
 
 /// Options to use when executing a `findOneAndDelete` command on a `MongoCollection`.
@@ -154,7 +138,7 @@ public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible {
     /// An optional `WriteConcern` to use for the command.
     public let writeConcern: WriteConcern?
 
-    fileprivate func asOpts() throws -> FindAndModifyOptions {
+    internal func asFindAndModifyOptions() throws -> FindAndModifyOptions {
         return try FindAndModifyOptions(collation: collation,
                                         maxTimeMS: maxTimeMS,
                                         projection: projection,
@@ -203,7 +187,7 @@ public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible {
     /// An optional `WriteConcern` to use for the command.
     public let writeConcern: WriteConcern?
 
-    fileprivate func asOpts() throws -> FindAndModifyOptions {
+    internal func asFindAndModifyOptions() throws -> FindAndModifyOptions {
         return try FindAndModifyOptions(bypassDocumentValidation: bypassDocumentValidation,
                                         collation: collation,
                                         maxTimeMS: maxTimeMS,
@@ -263,7 +247,7 @@ public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible {
     /// An optional `WriteConcern` to use for the command.
     public let writeConcern: WriteConcern?
 
-    fileprivate func asOpts() throws -> FindAndModifyOptions {
+    internal func asFindAndModifyOptions() throws -> FindAndModifyOptions {
         return try FindAndModifyOptions(arrayFilters: arrayFilters,
                                         bypassDocumentValidation: bypassDocumentValidation,
                                         collation: collation,
@@ -294,121 +278,5 @@ public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible {
         self.sort = sort
         self.upsert = upsert
         self.writeConcern = writeConcern
-    }
-}
-
-/// A class wrapping a `mongoc_find_and_modify_opts_t`, for use with `MongoCollection.findAndModify`
-private class FindAndModifyOptions {
-    // an `OpaquePointer` to a `mongoc_find_and_modify_opts_t`
-    var _options: OpaquePointer?
-
-    init() {
-        self._options = mongoc_find_and_modify_opts_new()
-    }
-
-    /// Initializes a new `FindAndModifyOptions` with the given settings.
-    ///
-    /// - Throws: `UserError.invalidArgumentError` if any of the options are invalid.
-    // swiftlint:disable:next cyclomatic_complexity
-    init(arrayFilters: [Document]? = nil,
-         bypassDocumentValidation: Bool? = nil,
-         collation: Document?,
-         maxTimeMS: Int64?,
-         projection: Document?,
-         remove: Bool? = nil,
-         returnDocument: ReturnDocument? = nil,
-         sort: Document?,
-         upsert: Bool? = nil,
-         writeConcern: WriteConcern?) throws {
-        self._options = mongoc_find_and_modify_opts_new()
-
-        if let bypass = bypassDocumentValidation,
-        !mongoc_find_and_modify_opts_set_bypass_document_validation(self._options, bypass) {
-            throw UserError.invalidArgumentError(message: "Error setting bypassDocumentValidation to \(bypass)")
-        }
-
-        if let fields = projection {
-            guard mongoc_find_and_modify_opts_set_fields(self._options, fields.data) else {
-                throw UserError.invalidArgumentError(message: "Error setting fields to \(fields)")
-            }
-        }
-
-        // build a mongoc_find_and_modify_flags_t
-        var flags = MONGOC_FIND_AND_MODIFY_NONE.rawValue
-        if remove == true { flags |= MONGOC_FIND_AND_MODIFY_REMOVE.rawValue }
-        if upsert == true { flags |= MONGOC_FIND_AND_MODIFY_UPSERT.rawValue }
-        if returnDocument == .after { flags |= MONGOC_FIND_AND_MODIFY_RETURN_NEW.rawValue }
-        let mongocFlags = mongoc_find_and_modify_flags_t(rawValue: flags)
-
-        if mongocFlags != MONGOC_FIND_AND_MODIFY_NONE
-        && !mongoc_find_and_modify_opts_set_flags(self._options, mongocFlags) {
-            let remStr = String(describing: remove)
-            let upsStr = String(describing: upsert)
-            let retStr = String(describing: returnDocument)
-            throw UserError.invalidArgumentError(message:
-                "Error setting flags to \(flags); remove=\(remStr), upsert=\(upsStr), returnDocument=\(retStr)")
-        }
-
-        if let sort = sort {
-            guard mongoc_find_and_modify_opts_set_sort(self._options, sort.data) else {
-                throw UserError.invalidArgumentError(message: "Error setting sort to \(sort)")
-            }
-        }
-
-        // build an "extra" document of fields without their own setters
-        var extra = Document()
-        if let filters = arrayFilters { try extra.setValue(for: "arrayFilters", to: filters) }
-        if let coll = collation { try extra.setValue(for: "collation", to: coll) }
-
-        // note: mongoc_find_and_modify_opts_set_max_time_ms() takes in a
-        // uint32_t, but it should be a positive 64-bit integer, so we
-        // set maxTimeMS by directly appending it instead. see CDRIVER-1329
-        if let maxTime = maxTimeMS {
-            guard maxTime > 0 else {
-                throw UserError.invalidArgumentError(message: "maxTimeMS must be positive, but got value \(maxTime)")
-            }
-            try extra.setValue(for: "maxTimeMS", to: maxTime)
-        }
-
-        if let wc = writeConcern {
-            do {
-                try extra.setValue(for: "writeConcern", to: try BSONEncoder().encode(wc))
-            } catch {
-                throw RuntimeError.internalError(message: "Error encoding WriteConcern \(wc): \(error)")
-            }
-        }
-
-        guard extra.isEmpty || mongoc_find_and_modify_opts_append(self._options, extra.data) else {
-            throw UserError.invalidArgumentError(message: "Error appending extra fields \(extra)")
-        }
-    }
-
-    /// Sets the `update` value on a `mongoc_find_and_modify_opts_t`. We need to have this separate from the
-    /// initializer because its value comes from the API methods rather than their options types.
-    fileprivate func setUpdate(_ update: Document) throws {
-        guard mongoc_find_and_modify_opts_set_update(self._options, update.data) else {
-            throw UserError.invalidArgumentError(message: "Error setting update to \(update)")
-        }
-    }
-
-    fileprivate func setSession(_ session: ClientSession?) throws {
-        guard let session = session else {
-            return
-        }
-        var doc = Document()
-        try session.append(to: &doc)
-
-        guard mongoc_find_and_modify_opts_append(self._options, doc.data) else {
-            throw RuntimeError.internalError(message: "Couldn't read session information")
-        }
-    }
-
-    /// Cleans up internal state.
-    deinit {
-        guard let options = self._options else {
-            return
-        }
-        mongoc_find_and_modify_opts_destroy(options)
-        self._options = nil
     }
 }

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -1,0 +1,162 @@
+import mongoc
+
+/// A class wrapping a `mongoc_find_and_modify_opts_t`, for use with `MongoCollection.findAndModify`
+internal class FindAndModifyOptions {
+    // an `OpaquePointer` to a `mongoc_find_and_modify_opts_t`
+    var _options: OpaquePointer?
+
+    init() {
+        self._options = mongoc_find_and_modify_opts_new()
+    }
+
+    /// Initializes a new `FindAndModifyOptions` with the given settings.
+    ///
+    /// - Throws: `UserError.invalidArgumentError` if any of the options are invalid.
+    // swiftlint:disable:next cyclomatic_complexity
+    init(arrayFilters: [Document]? = nil,
+         bypassDocumentValidation: Bool? = nil,
+         collation: Document?,
+         maxTimeMS: Int64?,
+         projection: Document?,
+         remove: Bool? = nil,
+         returnDocument: ReturnDocument? = nil,
+         sort: Document?,
+         upsert: Bool? = nil,
+         writeConcern: WriteConcern?) throws {
+        self._options = mongoc_find_and_modify_opts_new()
+
+        if let bypass = bypassDocumentValidation,
+        !mongoc_find_and_modify_opts_set_bypass_document_validation(self._options, bypass) {
+            throw UserError.invalidArgumentError(message: "Error setting bypassDocumentValidation to \(bypass)")
+        }
+
+        if let fields = projection {
+            guard mongoc_find_and_modify_opts_set_fields(self._options, fields.data) else {
+                throw UserError.invalidArgumentError(message: "Error setting fields to \(fields)")
+            }
+        }
+
+        // build a mongoc_find_and_modify_flags_t
+        var flags = MONGOC_FIND_AND_MODIFY_NONE.rawValue
+        if remove == true { flags |= MONGOC_FIND_AND_MODIFY_REMOVE.rawValue }
+        if upsert == true { flags |= MONGOC_FIND_AND_MODIFY_UPSERT.rawValue }
+        if returnDocument == .after { flags |= MONGOC_FIND_AND_MODIFY_RETURN_NEW.rawValue }
+        let mongocFlags = mongoc_find_and_modify_flags_t(rawValue: flags)
+
+        if mongocFlags != MONGOC_FIND_AND_MODIFY_NONE
+        && !mongoc_find_and_modify_opts_set_flags(self._options, mongocFlags) {
+            let remStr = String(describing: remove)
+            let upsStr = String(describing: upsert)
+            let retStr = String(describing: returnDocument)
+            throw UserError.invalidArgumentError(message:
+                "Error setting flags to \(flags); remove=\(remStr), upsert=\(upsStr), returnDocument=\(retStr)")
+        }
+
+        if let sort = sort {
+            guard mongoc_find_and_modify_opts_set_sort(self._options, sort.data) else {
+                throw UserError.invalidArgumentError(message: "Error setting sort to \(sort)")
+            }
+        }
+
+        // build an "extra" document of fields without their own setters
+        var extra = Document()
+        if let filters = arrayFilters { try extra.setValue(for: "arrayFilters", to: filters) }
+        if let coll = collation { try extra.setValue(for: "collation", to: coll) }
+
+        // note: mongoc_find_and_modify_opts_set_max_time_ms() takes in a
+        // uint32_t, but it should be a positive 64-bit integer, so we
+        // set maxTimeMS by directly appending it instead. see CDRIVER-1329
+        if let maxTime = maxTimeMS {
+            guard maxTime > 0 else {
+                throw UserError.invalidArgumentError(message: "maxTimeMS must be positive, but got value \(maxTime)")
+            }
+            try extra.setValue(for: "maxTimeMS", to: maxTime)
+        }
+
+        if let wc = writeConcern {
+            do {
+                try extra.setValue(for: "writeConcern", to: try BSONEncoder().encode(wc))
+            } catch {
+                throw RuntimeError.internalError(message: "Error encoding WriteConcern \(wc): \(error)")
+            }
+        }
+
+        guard extra.isEmpty || mongoc_find_and_modify_opts_append(self._options, extra.data) else {
+            throw UserError.invalidArgumentError(message: "Error appending extra fields \(extra)")
+        }
+    }
+
+    /// Sets the `update` value on a `mongoc_find_and_modify_opts_t`. We need to have this separate from the
+    /// initializer because its value comes from the API methods rather than their options types.
+    fileprivate func setUpdate(_ update: Document) throws {
+        guard mongoc_find_and_modify_opts_set_update(self._options, update.data) else {
+            throw UserError.invalidArgumentError(message: "Error setting update to \(update)")
+        }
+    }
+
+    fileprivate func setSession(_ session: ClientSession?) throws {
+        guard let session = session else {
+            return
+        }
+        var doc = Document()
+        try session.append(to: &doc)
+
+        guard mongoc_find_and_modify_opts_append(self._options, doc.data) else {
+            throw RuntimeError.internalError(message: "Couldn't read session information")
+        }
+    }
+
+    /// Cleans up internal state.
+    deinit {
+        guard let options = self._options else {
+            return
+        }
+        mongoc_find_and_modify_opts_destroy(options)
+        self._options = nil
+    }
+}
+
+internal struct FindAndModifyOperation<T: Codable>: Operation {
+    private let collection: MongoCollection<T>
+    private let filter: Document
+    private let update: Document?
+    private let options: FindAndModifyOptions?
+    private let session: ClientSession?
+
+    internal init(collection: MongoCollection<T>,
+                  filter: Document,
+                  update: Document?,
+                  options: FindAndModifyOptions?,
+                  session: ClientSession?) {
+        self.collection = collection
+        self.filter = filter
+        self.update = update
+        self.options = options
+        self.session = session
+    }
+
+    internal func execute() throws -> T? {
+        // we always need to send *something*, as findAndModify requires one of "remove"
+        // or "update" to be set.
+        let opts = self.options ?? FindAndModifyOptions()
+        if let session = self.session { try opts.setSession(session) }
+        if let update = self.update { try opts.setUpdate(update) }
+
+        let reply = Document()
+        var error = bson_error_t()
+
+        guard mongoc_collection_find_and_modify_with_opts(self.collection._collection,
+                                                          self.filter.data,
+                                                          opts._options,
+                                                          reply.data,
+                                                          &error) else {
+            throw getErrorFromReply(bsonError: error, from: reply)
+        }
+
+        guard let value = try reply.getValue(for: "value") as? Document else {
+            return nil
+        }
+
+        return try self.collection.decoder.decode(T.self, from: value)
+    }
+}

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -2,10 +2,10 @@ import mongoc
 
 /// A class wrapping a `mongoc_find_and_modify_opts_t`, for use with `MongoCollection.findAndModify`
 internal class FindAndModifyOptions {
-    // an `OpaquePointer` to a `mongoc_find_and_modify_opts_t`
-    var _options: OpaquePointer?
+    /// an `OpaquePointer` to a `mongoc_find_and_modify_opts_t`
+    fileprivate var _options: OpaquePointer?
 
-    init() {
+    fileprivate init() {
         self._options = mongoc_find_and_modify_opts_new()
     }
 
@@ -13,16 +13,16 @@ internal class FindAndModifyOptions {
     ///
     /// - Throws: `UserError.invalidArgumentError` if any of the options are invalid.
     // swiftlint:disable:next cyclomatic_complexity
-    init(arrayFilters: [Document]? = nil,
-         bypassDocumentValidation: Bool? = nil,
-         collation: Document?,
-         maxTimeMS: Int64?,
-         projection: Document?,
-         remove: Bool? = nil,
-         returnDocument: ReturnDocument? = nil,
-         sort: Document?,
-         upsert: Bool? = nil,
-         writeConcern: WriteConcern?) throws {
+    internal init(arrayFilters: [Document]? = nil,
+                  bypassDocumentValidation: Bool? = nil,
+                  collation: Document?,
+                  maxTimeMS: Int64?,
+                  projection: Document?,
+                  remove: Bool? = nil,
+                  returnDocument: ReturnDocument? = nil,
+                  sort: Document?,
+                  upsert: Bool? = nil,
+                  writeConcern: WriteConcern?) throws {
         self._options = mongoc_find_and_modify_opts_new()
 
         if let bypass = bypassDocumentValidation,

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -120,13 +120,13 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
     private let filter: Document
     private let update: Document?
-    private let options: FindAndModifyOptions?
+    private let options: FindAndModifyOptionsConvertible?
     private let session: ClientSession?
 
     internal init(collection: MongoCollection<T>,
                   filter: Document,
                   update: Document?,
-                  options: FindAndModifyOptions?,
+                  options: FindAndModifyOptionsConvertible?,
                   session: ClientSession?) {
         self.collection = collection
         self.filter = filter
@@ -138,7 +138,7 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
     internal func execute() throws -> T? {
         // we always need to send *something*, as findAndModify requires one of "remove"
         // or "update" to be set.
-        let opts = self.options ?? FindAndModifyOptions()
+        let opts = try self.options?.asFindAndModifyOptions() ?? FindAndModifyOptions()
         if let session = self.session { try opts.setSession(session) }
         if let update = self.update { try opts.setUpdate(update) }
 

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -116,6 +116,7 @@ internal class FindAndModifyOptions {
     }
 }
 
+/// An operation corresponding to a "findAndModify" command.
 internal struct FindAndModifyOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
     private let filter: Document

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -5,6 +5,15 @@ internal class FindAndModifyOptions {
     /// an `OpaquePointer` to a `mongoc_find_and_modify_opts_t`
     fileprivate var _options: OpaquePointer?
 
+    /// Cleans up internal state.
+    deinit {
+        guard let options = self._options else {
+            return
+        }
+        mongoc_find_and_modify_opts_destroy(options)
+        self._options = nil
+    }
+
     fileprivate init() {
         self._options = mongoc_find_and_modify_opts_new()
     }
@@ -104,15 +113,6 @@ internal class FindAndModifyOptions {
         guard mongoc_find_and_modify_opts_append(self._options, doc.data) else {
             throw RuntimeError.internalError(message: "Couldn't read session information")
         }
-    }
-
-    /// Cleans up internal state.
-    deinit {
-        guard let options = self._options else {
-            return
-        }
-        mongoc_find_and_modify_opts_destroy(options)
-        self._options = nil
     }
 }
 


### PR DESCRIPTION
Moves the private `findAndModify` method code to a new `FindAndModifyOperation`.

`FindAndModifyOptionsConvertible` needed to become `internal` so we could use it in that file, and I renamed its `asOpts` methods to `asFindAndModifyOptions` for consistency with our `BulkWriteOptionsConvertible` protocol. 
Similarly, `FindAndModifyOptions` had to become `internal` since its now defined in the new file but used in the original file.