### PR TITLE
SWIFT-178 Conform various options/result types to Decodable

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -2,7 +2,7 @@ import Foundation
 import mongoc
 
 /// Options to use when creating a `MongoClient`.
-public struct ClientOptions: CodingStrategyProvider {
+public struct ClientOptions: CodingStrategyProvider, Decodable {
     /// Determines whether the client should retry supported write operations.
     public let retryWrites: Bool?
 
@@ -14,24 +14,32 @@ public struct ClientOptions: CodingStrategyProvider {
     /// be used.
     public let readConcern: ReadConcern?
 
-    /// Specifies a ReadPreference to use for the client.
-    public let readPreference: ReadPreference?
-
     /// Specifies a WriteConcern to use for the client. If one is not specified, the server's default write concern
     /// will be used.
     public let writeConcern: WriteConcern?
 
+    // swiftlint:disable redundant_optional_initialization
+
+    /// Specifies a ReadPreference to use for the client.
+    public var readPreference: ReadPreference? = nil
+
     /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
     /// databases or collections that derive from it.
-    public let dateCodingStrategy: DateCodingStrategy?
+    public var dateCodingStrategy: DateCodingStrategy? = nil
 
     /// Specifies the `UUIDCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
     /// databases or collections that derive from it.
-    public let uuidCodingStrategy: UUIDCodingStrategy?
+    public var uuidCodingStrategy: UUIDCodingStrategy? = nil
 
     /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
     /// databases or collections that derive from it.
-    public let dataCodingStrategy: DataCodingStrategy?
+    public var dataCodingStrategy: DataCodingStrategy? = nil
+
+    // swiftlint:enable redundant_optional_initialization
+
+    private enum CodingKeys: CodingKey {
+        case retryWrites, eventMonitoring, readConcern, writeConcern
+    }
 
     /// Convenience initializer allowing any/all to be omitted or optional.
     public init(eventMonitoring: Bool = false,

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -122,11 +122,11 @@ extension MongoCollection {
 }
 
 /// Indicates which document to return in a find and modify operation.
-public enum ReturnDocument {
+public enum ReturnDocument: String, Decodable {
     /// Indicates to return the document before the update, replacement, or insert occurred.
-    case before
+    case before = "Before"
     ///  Indicates to return the document after the update, replacement, or insert occurred.
-    case after
+    case after = "After"
 }
 
 /// Indicates that an options type can be represented as a `FindAndModifyOptions`
@@ -138,7 +138,7 @@ private protocol FindAndModifyOptionsConvertible {
 }
 
 /// Options to use when executing a `findOneAndDelete` command on a `MongoCollection`.
-public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible {
+public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible, Decodable {
     /// Specifies a collation to use.
     public let collation: Document?
 
@@ -178,7 +178,7 @@ public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible {
 }
 
 /// Options to use when executing a `findOneAndReplace` command on a `MongoCollection`.
-public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible {
+public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible, Decodable {
     /// If `true`, allows the write to opt-out of document level validation.
     public let bypassDocumentValidation: Bool?
 
@@ -235,7 +235,7 @@ public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible {
 }
 
 /// Options to use when executing a `findOneAndUpdate` command on a `MongoCollection`.
-public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible {
+public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible, Decodable {
     /// A set of filters specifying to which array elements an update should apply.
     public let arrayFilters: [Document]?
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -193,9 +193,10 @@ public struct AggregateOptions: Codable {
     /// A `ReadConcern` to use in read stages of this operation.
     public let readConcern: ReadConcern?
 
+    // swiftlint:disable redundant_optional_initialization
     /// A ReadPreference to use for this operation.
-    // swiftlint:disable:next redundant_optional_initialization
     public var readPreference: ReadPreference? = nil
+    // swiftlint:enable redundant_optional_initialization
 
     /// A `WriteConcern` to use in `$out` stages of this operation.
     public let writeConcern: WriteConcern?
@@ -288,10 +289,6 @@ public struct FindOptions: Codable {
     /// Attaches a comment to the query.
     public let comment: String?
 
-    /// Indicates the type of cursor to use. This value includes both the tailable and awaitData options.
-    // swiftlint:disable:next redundant_optional_initialization
-    public var cursorType: CursorType? = nil
-
     /// If a `CursorType` is provided, indicates whether it is `.tailable` or .`tailableAwait`.
     private let tailable: Bool?
 
@@ -343,9 +340,15 @@ public struct FindOptions: Codable {
     /// A ReadConcern to use for this operation.
     public let readConcern: ReadConcern?
 
+    // swiftlint:disable redundant_optional_initialization
+
     /// A ReadPreference to use for this operation.
-    // swiftlint:disable:next redundant_optional_initialization
     public var readPreference: ReadPreference? = nil
+
+    /// Indicates the type of cursor to use. This value includes both the tailable and awaitData options.
+    public var cursorType: CursorType? = nil
+
+    // swiftlint:enable redundant_optional_initialization
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(allowPartialResults: Bool? = nil,

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -138,7 +138,7 @@ extension MongoCollection {
 }
 
 /// An index to "hint" or force MongoDB to use when performing a query.
-public enum Hint: Encodable {
+public enum Hint: Codable {
     /// Specifies an index to use by its name.
     case indexName(String)
     /// Specifies an index to use by a specification `Document` containing the index key(s).
@@ -153,10 +153,19 @@ public enum Hint: Encodable {
             try container.encode(doc)
         }
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let str = try? container.decode(String.self) {
+            self = .indexName(str)
+        } else {
+            self = .indexSpec(try container.decode(Document.self))
+        }
+    }
 }
 
 /// Options to use when executing an `aggregate` command on a `MongoCollection`.
-public struct AggregateOptions: Encodable {
+public struct AggregateOptions: Codable {
     /// Enables writing to temporary files. When set to true, aggregation stages
     /// can write data to the _tmp subdirectory in the dbPath directory.
     public let allowDiskUse: Bool?
@@ -185,7 +194,8 @@ public struct AggregateOptions: Encodable {
     public let readConcern: ReadConcern?
 
     /// A ReadPreference to use for this operation.
-    public let readPreference: ReadPreference?
+    // swiftlint:disable:next redundant_optional_initialization
+    public var readPreference: ReadPreference? = nil
 
     /// A `WriteConcern` to use in `$out` stages of this operation.
     public let writeConcern: WriteConcern?
@@ -265,7 +275,7 @@ public enum CursorType {
 }
 
 /// Options to use when executing a `find` command on a `MongoCollection`.
-public struct FindOptions: Encodable {
+public struct FindOptions: Codable {
     /// Get partial results from a mongos if some shards are down (instead of throwing an error).
     public let allowPartialResults: Bool?
 
@@ -279,7 +289,8 @@ public struct FindOptions: Encodable {
     public let comment: String?
 
     /// Indicates the type of cursor to use. This value includes both the tailable and awaitData options.
-    public let cursorType: CursorType?
+    // swiftlint:disable:next redundant_optional_initialization
+    public var cursorType: CursorType? = nil
 
     /// If a `CursorType` is provided, indicates whether it is `.tailable` or .`tailableAwait`.
     private let tailable: Bool?
@@ -333,7 +344,8 @@ public struct FindOptions: Encodable {
     public let readConcern: ReadConcern?
 
     /// A ReadPreference to use for this operation.
-    public let readPreference: ReadPreference?
+    // swiftlint:disable:next redundant_optional_initialization
+    public var readPreference: ReadPreference? = nil
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(allowPartialResults: Bool? = nil,

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -233,7 +233,7 @@ private extension BulkWriteOptionsConvertible {
 // Write command options structs
 
 /// Options to use when executing an `insertOne` command on a `MongoCollection`.
-public struct InsertOneOptions: Encodable, BulkWriteOptionsConvertible {
+public struct InsertOneOptions: Codable, BulkWriteOptionsConvertible {
     /// If true, allows the write to opt-out of document level validation.
     public let bypassDocumentValidation: Bool?
 
@@ -251,7 +251,7 @@ public struct InsertOneOptions: Encodable, BulkWriteOptionsConvertible {
 public typealias InsertManyOptions = BulkWriteOptions
 
 /// Options to use when executing an `update` command on a `MongoCollection`.
-public struct UpdateOptions: Encodable, BulkWriteOptionsConvertible {
+public struct UpdateOptions: Codable, BulkWriteOptionsConvertible {
     /// A set of filters specifying to which array elements an update should apply.
     public let arrayFilters: [Document]?
 
@@ -282,7 +282,7 @@ public struct UpdateOptions: Encodable, BulkWriteOptionsConvertible {
 }
 
 /// Options to use when executing a `replace` command on a `MongoCollection`.
-public struct ReplaceOptions: Encodable, BulkWriteOptionsConvertible {
+public struct ReplaceOptions: Codable, BulkWriteOptionsConvertible {
     /// If true, allows the write to opt-out of document level validation.
     public let bypassDocumentValidation: Bool?
 
@@ -308,7 +308,7 @@ public struct ReplaceOptions: Encodable, BulkWriteOptionsConvertible {
 }
 
 /// Options to use when executing a `delete` command on a `MongoCollection`.
-public struct DeleteOptions: Encodable, BulkWriteOptionsConvertible {
+public struct DeleteOptions: Codable, BulkWriteOptionsConvertible {
     /// Specifies a collation.
     public let collation: Document?
 
@@ -328,7 +328,11 @@ public struct DeleteOptions: Encodable, BulkWriteOptionsConvertible {
 // Write command results structs
 
 /// The result of an `insertOne` command on a `MongoCollection`.
-public struct InsertOneResult {
+public struct InsertOneResult: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case insertedId
+    }
+
     /// The identifier that was inserted. If the document doesn't have an identifier, this value
     /// will be generated and added to the document before insertion.
     public let insertedId: BSONValue
@@ -341,6 +345,12 @@ public struct InsertOneResult {
             throw RuntimeError.internalError(message: "BulkWriteResult missing _id for inserted document")
         }
         self.insertedId = id
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let abv = try container.decode(AnyBSONValue.self, forKey: .insertedId)
+        self.insertedId = abv.value
     }
 }
 

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -1,7 +1,7 @@
 import mongoc
 
 /// Options to use when executing a `count` command on a `MongoCollection`.
-public struct CountOptions: Encodable {
+public struct CountOptions: Codable {
     /// Specifies a collation.
     public let collation: Document?
 
@@ -21,7 +21,8 @@ public struct CountOptions: Encodable {
     public let readConcern: ReadConcern?
 
     /// A ReadPreference to use for this operation.
-    public let readPreference: ReadPreference?
+    // swiftlint:disable:next redundant_optional_initialization
+    public var readPreference: ReadPreference? = nil
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(collation: Document? = nil,

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -20,9 +20,10 @@ public struct CountOptions: Codable {
     /// A ReadConcern to use for this operation.
     public let readConcern: ReadConcern?
 
+    // swiftlint:disable redundant_optional_initialization
     /// A ReadPreference to use for this operation.
-    // swiftlint:disable:next redundant_optional_initialization
     public var readPreference: ReadPreference? = nil
+    // swiftlint:enable redundant_optional_initialization
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(collation: Document? = nil,

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -1,7 +1,7 @@
 import mongoc
 
 /// Options to use when executing a `distinct` command on a `MongoCollection`.
-public struct DistinctOptions: Encodable {
+public struct DistinctOptions: Codable {
     /// Specifies a collation.
     public let collation: Document?
 
@@ -12,7 +12,8 @@ public struct DistinctOptions: Encodable {
     public let readConcern: ReadConcern?
 
     /// A ReadPreference to use for this operation.
-    public let readPreference: ReadPreference?
+    // swiftlint:disable:next redundant_optional_initialization
+    public var readPreference: ReadPreference? = nil
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(collation: Document? = nil,

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -11,9 +11,10 @@ public struct DistinctOptions: Codable {
     /// A ReadConcern to use for this operation.
     public let readConcern: ReadConcern?
 
+    // swiftlint:disable redundant_optional_initialization
     /// A ReadPreference to use for this operation.
-    // swiftlint:disable:next redundant_optional_initialization
     public var readPreference: ReadPreference? = nil
+    // swiftlint:enable redundant_optional_initialization
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(collation: Document? = nil,


### PR DESCRIPTION
This is part of a series of reviews that make up [SWIFT-178](https://jira.mongodb.org/browse/SWIFT-178)

This PR adds `Decodable` conformance to options and result types that will eventually be decoded from JSON spec test files. It also improves the error parser to be more flexible when decoding from server replies.