### PR TITLE
Add empty deprecated initialize() and deprecated cleanup()

### DIFF
--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -14,6 +14,12 @@ private final class MongocInitializer {
 @available(*, deprecated, message: "Calling this method no longer has any effect.")
 public func initialize() {}
 
+/// :nodoc:
+@available(*, deprecated, message: "Use cleanupMongoSwift() instead.")
+public func cleanup() {
+    cleanupMongoSwift()
+}
+
 /// Initializes libmongoc. Repeated calls to this method have no effect.
 internal func initializeMongoc() {
     _ = MongocInitializer.shared

--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -10,6 +10,10 @@ private final class MongocInitializer {
     }
 }
 
+/// :nodoc:
+@available(*, deprecated, message: "Calling this method no longer has any effect.")
+public func initialize() {}
+
 /// Initializes libmongoc. Repeated calls to this method have no effect.
 internal func initializeMongoc() {
     _ = MongocInitializer.shared


### PR DESCRIPTION
So I realized we had renamed the actual initialization method to `initializeMongoc`, so I just added an empty `initialize()` method.
I tested this locally, and if you have a call to `MongoSwift.initialize()` you will now get the following compiler warning:
```
/Users/kaitlinmahar/TestProject/Sources/TestProject/main.swift:3:12: warning: 'initialize()' is deprecated: Calling this method no longer has any effect.
MongoSwift.initialize()
           ^
```