### PR TITLE
SWIFT-178 Minor test utils improvements

### DIFF
--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -196,6 +196,18 @@ public struct TopologyDescription {
         case sharded = "Sharded"
         /// A topology whose type is not yet known.
         case unknown = "Unknown"
+
+        /// Internal initializer used for translating evergreen config and spec test topologies to a `TopologyType`
+        internal init(from str: String) {
+            switch str {
+            case "sharded", "sharded_cluster":
+                self = .sharded
+            case "replicaset", "replica_set":
+                self = .replicaSetWithPrimary
+            default:
+                self = .single
+            }
+        }
     }
 
     /// The type of this topology.

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -259,13 +259,6 @@ private class BulkWriteTest: CrudTest {
         return BulkWriteOptions(ordered: ordered)
     }
 
-    private typealias DeleteOneModel = MongoCollection<Document>.DeleteOneModel
-    private typealias DeleteManyModel = MongoCollection<Document>.DeleteManyModel
-    private typealias InsertOneModel = MongoCollection<Document>.InsertOneModel
-    private typealias ReplaceOneModel = MongoCollection<Document>.ReplaceOneModel
-    private typealias UpdateOneModel = MongoCollection<Document>.UpdateOneModel
-    private typealias UpdateManyModel = MongoCollection<Document>.UpdateManyModel
-
     private static func parseWriteModel(_ request: Document) throws -> WriteModel {
         let name: String = try request.get("name")
         let args: Document = try request.get("arguments")

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -38,7 +38,7 @@ final class MongoClientTests: MongoSwiftTestCase {
     }
 
     func testServerVersion() throws {
-        typealias Version = MongoClient.ServerVersion
+        typealias Version = ServerVersion
 
         expect(try MongoClient().serverVersion()).toNot(throwError())
 
@@ -55,36 +55,36 @@ final class MongoClientTests: MongoSwiftTestCase {
         expect(try Version("3.6.1.1")).to(equal(three61))
 
         // lt
-        expect(three6.isLessThan(three6)).to(beFalse())
-        expect(three6.isLessThan(three61)).to(beTrue())
-        expect(three61.isLessThan(three6)).to(beFalse())
-        expect(three61.isLessThan(three7)).to(beTrue())
-        expect(three7.isLessThan(three6)).to(beFalse())
-        expect(three7.isLessThan(three61)).to(beFalse())
+        expect(three6 < three6).to(beFalse())
+        expect(three6 < three61).to(beTrue())
+        expect(three61 < three6).to(beFalse())
+        expect(three61 < three7).to(beTrue())
+        expect(three7 < three6).to(beFalse())
+        expect(three7 < three61).to(beFalse())
 
         // lte
-        expect(three6.isLessThanOrEqualTo(three6)).to(beTrue())
-        expect(three6.isLessThanOrEqualTo(three61)).to(beTrue())
-        expect(three61.isLessThanOrEqualTo(three6)).to(beFalse())
-        expect(three61.isLessThanOrEqualTo(three7)).to(beTrue())
-        expect(three7.isLessThanOrEqualTo(three6)).to(beFalse())
-        expect(three7.isLessThanOrEqualTo(three61)).to(beFalse())
+        expect(three6 <= three6).to(beTrue())
+        expect(three6 <= three61).to(beTrue())
+        expect(three61 <= three6).to(beFalse())
+        expect(three61 <= three7).to(beTrue())
+        expect(three7 <= three6).to(beFalse())
+        expect(three7 <= three61).to(beFalse())
 
         // gt
-        expect(three6.isGreaterThan(three6)).to(beFalse())
-        expect(three6.isGreaterThan(three61)).to(beFalse())
-        expect(three61.isGreaterThan(three6)).to(beTrue())
-        expect(three61.isGreaterThan(three7)).to(beFalse())
-        expect(three7.isGreaterThan(three6)).to(beTrue())
-        expect(three7.isGreaterThan(three61)).to(beTrue())
+        expect(three6 > three6).to(beFalse())
+        expect(three6 > three61).to(beFalse())
+        expect(three61 > three6).to(beTrue())
+        expect(three61 > three7).to(beFalse())
+        expect(three7 > three6).to(beTrue())
+        expect(three7 > three61).to(beTrue())
 
         // gte
-        expect(three6.isGreaterThanOrEqualTo(three6)).to(beTrue())
-        expect(three6.isGreaterThanOrEqualTo(three61)).to(beFalse())
-        expect(three61.isGreaterThanOrEqualTo(three6)).to(beTrue())
-        expect(three61.isGreaterThanOrEqualTo(three7)).to(beFalse())
-        expect(three7.isGreaterThanOrEqualTo(three6)).to(beTrue())
-        expect(three7.isGreaterThanOrEqualTo(three61)).to(beTrue())
+        expect(three6 >= three6).to(beTrue())
+        expect(three6 >= three61).to(beFalse())
+        expect(three61 >= three6).to(beTrue())
+        expect(three61 >= three7).to(beFalse())
+        expect(three7 >= three6).to(beTrue())
+        expect(three7 >= three61).to(beTrue())
 
         // invalid strings
         expect(try Version("hi")).to(throwError())


### PR DESCRIPTION
This is the second in a series of PR's for implementing the retryable writes spec tests and updating our test runner framework.

This PR updates the test utils to be more usable for the new runner.
In total: 
- moves `ServerVersion` out of a client extension such that it is its own type
- adds `Comparable` conformance to `ServerVersion` so we don't need to implement/use the various `isGreaterThan`, `isLessThan`, etc. methods
- adds an initializer to `TopologyType` for use in testing
- adds an internal `sortedEquals` method to a `Document` extension for testing purposes (so we don't need to use an `expect` to get sorted equality)
- moves the `WriteModel` typealiases into `TestUtils.swift`