### PR TITLE
SWIFT-489 Include codeName in server error types

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -132,7 +132,7 @@ public struct CommandFailedEvent: MongoEvent, InitializableFromOpaquePointer {
         self.commandName = String(cString: mongoc_apm_command_failed_get_command_name(event))
         var error = bson_error_t()
         mongoc_apm_command_failed_get_error(event, &error)
-        self.failure = parseMongocError(error) // should always return a ServerError.commandError
+        self.failure = getMongoError(error: error) // should always return a ServerError.commandError
         self.requestId = mongoc_apm_command_failed_get_request_id(event)
         self.operationId = mongoc_apm_command_failed_get_operation_id(event)
         self.connectionId = ConnectionId(mongoc_apm_command_failed_get_host(event))
@@ -359,7 +359,7 @@ public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePoi
         self.duration = mongoc_apm_server_heartbeat_failed_get_duration(event)
         var error = bson_error_t()
         mongoc_apm_server_heartbeat_failed_get_error(event, &error)
-        self.failure = parseMongocError(error)
+        self.failure = getMongoError(error: error)
         self.connectionId = ConnectionId(mongoc_apm_server_heartbeat_failed_get_host(event))
     }
 }

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -132,7 +132,7 @@ public struct CommandFailedEvent: MongoEvent, InitializableFromOpaquePointer {
         self.commandName = String(cString: mongoc_apm_command_failed_get_command_name(event))
         var error = bson_error_t()
         mongoc_apm_command_failed_get_error(event, &error)
-        self.failure = getMongoError(error: error) // should always return a ServerError.commandError
+        self.failure = extractMongoError(error: error) // should always return a ServerError.commandError
         self.requestId = mongoc_apm_command_failed_get_request_id(event)
         self.operationId = mongoc_apm_command_failed_get_operation_id(event)
         self.connectionId = ConnectionId(mongoc_apm_command_failed_get_host(event))
@@ -359,7 +359,7 @@ public struct ServerHeartbeatFailedEvent: MongoEvent, InitializableFromOpaquePoi
         self.duration = mongoc_apm_server_heartbeat_failed_get_duration(event)
         var error = bson_error_t()
         mongoc_apm_server_heartbeat_failed_get_error(event, &error)
-        self.failure = getMongoError(error: error)
+        self.failure = extractMongoError(error: error)
         self.connectionId = ConnectionId(mongoc_apm_server_heartbeat_failed_get_host(event))
     }
 }

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -102,7 +102,7 @@ public final class ClientSession {
         self._session = try withSessionOpts(wrapping: options) { opts in
             var error = bson_error_t()
             guard let session = mongoc_client_start_session(client._client, opts, &error) else {
-                throw getMongoError(error: error)
+                throw extractMongoError(error: error)
             }
             return session
         }
@@ -158,7 +158,7 @@ public final class ClientSession {
         var error = bson_error_t()
         try withMutableBSONPointer(to: &doc) { docPtr in
             guard mongoc_client_session_append(self._session, docPtr, &error) else {
-                throw getMongoError(error: error)
+                throw extractMongoError(error: error)
             }
         }
     }

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -102,7 +102,7 @@ public final class ClientSession {
         self._session = try withSessionOpts(wrapping: options) { opts in
             var error = bson_error_t()
             guard let session = mongoc_client_start_session(client._client, opts, &error) else {
-                throw parseMongocError(error)
+                throw getMongoError(error: error)
             }
             return session
         }
@@ -158,7 +158,7 @@ public final class ClientSession {
         var error = bson_error_t()
         try withMutableBSONPointer(to: &doc) { docPtr in
             guard mongoc_client_session_append(self._session, docPtr, &error) else {
-                throw parseMongocError(error)
+                throw getMongoError(error: error)
             }
         }
     }

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -10,7 +10,7 @@ internal class ConnectionString {
     internal init(_ connectionString: String, options: inout ClientOptions) throws {
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
-            throw parseMongocError(error)
+            throw extractMongoError(error: error)
         }
         self._uri = uri
 

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -400,10 +400,10 @@ public class BulkWriteOperation: Operation {
         let result = try BulkWriteResult(reply: reply, insertedIds: self.insertedIds)
 
         guard serverId != 0 else {
-            throw extractMongoError(error: error,
+            throw extractMongoError(bulkOp: self,
+                                    error: error,
                                     reply: reply,
-                                    bulkOp: self,
-                                    result: self.isAcknowledged ? result : nil)
+                                    partialResult: self.isAcknowledged ? result : nil)
         }
 
         return self.isAcknowledged ? result : nil

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -73,7 +73,7 @@ extension MongoCollection {
 
             guard mongoc_bulk_operation_remove_one_with_opts(
                 bulk.bulk, self.filter._bson, opts._bson, &error) else {
-                throw getMongoError(error: error) // Should be invalidArgumentError
+                throw extractMongoError(error: error) // Should be invalidArgumentError
             }
         }
     }
@@ -110,7 +110,7 @@ extension MongoCollection {
             let opts = try bulk.encoder.encode(DeleteModelOptions(collation: self.collation))
 
             guard mongoc_bulk_operation_remove_many_with_opts(bulk.bulk, self.filter._bson, opts._bson, &error) else {
-                throw getMongoError(error: error) // should be invalidArgumentError
+                throw extractMongoError(error: error) // should be invalidArgumentError
             }
         }
     }
@@ -141,7 +141,7 @@ extension MongoCollection {
             let document = try bulk.encoder.encode(self.document).withID()
             var error = bson_error_t()
             guard mongoc_bulk_operation_insert_with_opts(bulk.bulk, document._bson, nil, &error) else {
-                throw getMongoError(error: error) // should be invalidArgumentError
+                throw extractMongoError(error: error) // should be invalidArgumentError
             }
 
             guard let insertedId = try document.getValue(for: "_id") else {
@@ -205,7 +205,7 @@ extension MongoCollection {
                                                               replacement._bson,
                                                               opts._bson,
                                                               &error) else {
-                throw getMongoError(error: error) // should be invalidArgumentError
+                throw extractMongoError(error: error) // should be invalidArgumentError
             }
         }
     }
@@ -273,7 +273,7 @@ extension MongoCollection {
                                                              self.update._bson,
                                                              opts._bson,
                                                              &error) else {
-                throw getMongoError(error: error) // should be invalidArgumentError
+                throw extractMongoError(error: error) // should be invalidArgumentError
             }
         }
     }
@@ -335,7 +335,7 @@ extension MongoCollection {
                                                               self.update._bson,
                                                               opts._bson,
                                                               &error) else {
-                throw getMongoError(error: error) // should be invalidArgumentError
+                throw extractMongoError(error: error) // should be invalidArgumentError
             }
         }
     }
@@ -400,7 +400,10 @@ public class BulkWriteOperation: Operation {
         let result = try BulkWriteResult(reply: reply, insertedIds: self.insertedIds)
 
         guard serverId != 0 else {
-            throw getMongoError(error: error, reply: reply, bulkOp: self, result: self.isAcknowledged ? result : nil)
+            throw extractMongoError(error: error,
+                                    reply: reply,
+                                    bulkOp: self,
+                                    result: self.isAcknowledged ? result : nil)
         }
 
         return self.isAcknowledged ? result : nil

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -73,7 +73,7 @@ extension MongoCollection {
 
             guard mongoc_bulk_operation_remove_one_with_opts(
                 bulk.bulk, self.filter._bson, opts._bson, &error) else {
-                throw parseMongocError(error) // Should be invalidArgumentError
+                throw getMongoError(error: error) // Should be invalidArgumentError
             }
         }
     }
@@ -110,7 +110,7 @@ extension MongoCollection {
             let opts = try bulk.encoder.encode(DeleteModelOptions(collation: self.collation))
 
             guard mongoc_bulk_operation_remove_many_with_opts(bulk.bulk, self.filter._bson, opts._bson, &error) else {
-                throw parseMongocError(error) // should be invalidArgumentError
+                throw getMongoError(error: error) // should be invalidArgumentError
             }
         }
     }
@@ -141,7 +141,7 @@ extension MongoCollection {
             let document = try bulk.encoder.encode(self.document).withID()
             var error = bson_error_t()
             guard mongoc_bulk_operation_insert_with_opts(bulk.bulk, document._bson, nil, &error) else {
-                throw parseMongocError(error) // should be invalidArgumentError
+                throw getMongoError(error: error) // should be invalidArgumentError
             }
 
             guard let insertedId = try document.getValue(for: "_id") else {
@@ -205,7 +205,7 @@ extension MongoCollection {
                                                               replacement._bson,
                                                               opts._bson,
                                                               &error) else {
-                throw parseMongocError(error) // should be invalidArgumentError
+                throw getMongoError(error: error) // should be invalidArgumentError
             }
         }
     }
@@ -273,7 +273,7 @@ extension MongoCollection {
                                                              self.update._bson,
                                                              opts._bson,
                                                              &error) else {
-                throw parseMongocError(error) // should be invalidArgumentError
+                throw getMongoError(error: error) // should be invalidArgumentError
             }
         }
     }
@@ -335,7 +335,7 @@ extension MongoCollection {
                                                               self.update._bson,
                                                               opts._bson,
                                                               &error) else {
-                throw parseMongocError(error) // should be invalidArgumentError
+                throw getMongoError(error: error) // should be invalidArgumentError
             }
         }
     }
@@ -400,11 +400,7 @@ public class BulkWriteOperation: Operation {
         let result = try BulkWriteResult(reply: reply, insertedIds: self.insertedIds)
 
         guard serverId != 0 else {
-            throw getErrorFromReply(
-                    bsonError: error,
-                    from: reply,
-                    forBulkWrite: self,
-                    withResult: self.isAcknowledged ? result : nil)
+            throw getMongoError(error: error, reply: reply, bulkOp: self, result: self.isAcknowledged ? result : nil)
         }
 
         return self.isAcknowledged ? result : nil

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -105,12 +105,12 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
         if let docPtr = replyPtr.pointee {
             // we have to copy because libmongoc owns the pointer.
             let reply = Document(copying: docPtr)
-            return parseMongocError(error, errorLabels: reply["errorLabels"] as? [String])
+            return getMongoError(error: error, reply: reply)
         }
 
         // Otherwise, the only feasible error is that the user tried to advance a dead cursor, which is a logic error.
         // We will still parse the mongoc error to cover all cases.
-        return parseMongocError(error)
+        return getMongoError(error: error)
     }
 
     /// Returns the next `Document` in this cursor, or nil. Once this function returns `nil`, the caller should use

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -105,12 +105,12 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
         if let docPtr = replyPtr.pointee {
             // we have to copy because libmongoc owns the pointer.
             let reply = Document(copying: docPtr)
-            return getMongoError(error: error, reply: reply)
+            return extractMongoError(error: error, reply: reply)
         }
 
         // Otherwise, the only feasible error is that the user tried to advance a dead cursor, which is a logic error.
         // We will still parse the mongoc error to cover all cases.
-        return getMongoError(error: error)
+        return extractMongoError(error: error)
     }
 
     /// Returns the next `Document` in this cursor, or nil. Once this function returns `nil`, the caller should use

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -178,7 +178,7 @@ public struct BulkWriteError: Codable {
     }
 
     // TODO: can remove this once SERVER-36755 is resolved
-    public init(code: ServerErrorCode, codeName: String, message: String, index: Int) {
+    internal init(code: ServerErrorCode, codeName: String, message: String, index: Int) {
         self.code = code
         self.codeName = codeName
         self.message = message

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -118,7 +118,7 @@ public struct WriteError: Codable {
     }
 
     // TODO: can remove this once SERVER-36755 is resolved
-    public init(code: ServerErrorCode, codeName: String, message: String) {
+    internal init(code: ServerErrorCode, codeName: String, message: String) {
         self.code = code
         self.codeName = codeName
         self.message = message

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -98,8 +98,6 @@ public struct WriteError: Codable {
     public let code: ServerErrorCode
 
     /// A human-readable string identifying the error.
-    /// Note: due to a bug in the server, this field will be empty except in sharded clusters.
-    /// - SeeAlso: https://jira.mongodb.org/browse/SERVER-36755
     public let codeName: String
 
     /// A description of the error.
@@ -232,10 +230,10 @@ private func parseMongocError(_ error: bson_error_t, reply: Document?) -> MongoE
 }
 
 /// Internal function used to get an appropriate error from a libmongoc error and/or a server reply to a command.
-internal func getMongoError(error bsonError: bson_error_t,
-                            reply: Document? = nil,
-                            bulkOp bulkWrite: BulkWriteOperation? = nil,
-                            result: BulkWriteResult? = nil) -> MongoError {
+internal func extractMongoError(error bsonError: bson_error_t,
+                                reply: Document? = nil,
+                                bulkOp bulkWrite: BulkWriteOperation? = nil,
+                                result: BulkWriteResult? = nil) -> MongoError {
     // if the reply is nil or writeErrors or writeConcernErrors aren't present, then this is likely a commandError.
     guard let serverReply = reply,
           !(serverReply["writeErrors"] as? [BSONValue] ?? []).isEmpty ||

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -153,8 +153,6 @@ public struct BulkWriteError: Codable {
     public let code: ServerErrorCode
 
     /// A human-readable string identifying the error.
-    /// Note: due to a bug in the server, this field will be empty except in sharded clusters.
-    /// - SeeAlso: https://jira.mongodb.org/browse/SERVER-36755
     public let codeName: String
 
     /// A description of the error.

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -73,7 +73,7 @@ internal struct CountOperation<T: Codable>: Operation {
         let count = mongoc_collection_count_with_opts(
             self.collection._collection, MONGOC_QUERY_NONE, self.filter._bson, 0, 0, opts?._bson, rp, &error)
 
-        if count == -1 { throw getMongoError(error: error) }
+        guard count != -1 else { throw extractMongoError(error: error) }
 
         return Int(count)
     }

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -73,7 +73,7 @@ internal struct CountOperation<T: Codable>: Operation {
         let count = mongoc_collection_count_with_opts(
             self.collection._collection, MONGOC_QUERY_NONE, self.filter._bson, 0, 0, opts?._bson, rp, &error)
 
-        if count == -1 { throw parseMongocError(error) }
+        if count == -1 { throw getMongoError(error: error) }
 
         return Int(count)
     }

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -130,7 +130,7 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
 
         guard let collection = mongoc_database_create_collection(
             self.database._database, self.name, opts?._bson, &error) else {
-            throw getMongoError(error: error)
+            throw extractMongoError(error: error)
         }
         mongoc_collection_destroy(collection)
 

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -130,7 +130,7 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
 
         guard let collection = mongoc_database_create_collection(
             self.database._database, self.name, opts?._bson, &error) else {
-            throw parseMongocError(error)
+            throw getMongoError(error: error)
         }
         mongoc_collection_destroy(collection)
 

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -49,7 +49,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
                 self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getMongoError(error: error, reply: reply)
+            throw extractMongoError(error: error, reply: reply)
         }
 
         return self.models.map { $0.options?.name ?? $0.defaultName }

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -49,7 +49,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
                 self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getErrorFromReply(bsonError: error, from: reply)
+            throw getMongoError(error: error, reply: reply)
         }
 
         return self.models.map { $0.options?.name ?? $0.defaultName }

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -69,7 +69,7 @@ internal struct DistinctOperation<T: Codable> {
             self.collection._collection, command._bson, rp, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw parseMongocError(error, errorLabels: reply["errorLabels"] as? [String])
+            throw getMongoError(error: error, reply: reply)
         }
 
         guard let values = try reply.getValue(for: "values") as? [BSONValue] else {

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -69,7 +69,7 @@ internal struct DistinctOperation<T: Codable> {
             self.collection._collection, command._bson, rp, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getMongoError(error: error, reply: reply)
+            throw extractMongoError(error: error, reply: reply)
         }
 
         guard let values = try reply.getValue(for: "values") as? [BSONValue] else {

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -23,7 +23,7 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
                     self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getMongoError(error: error, reply: reply)
+            throw extractMongoError(error: error, reply: reply)
         }
     }
 }

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -23,7 +23,7 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
                     self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getErrorFromReply(bsonError: error, from: reply)
+            throw getMongoError(error: error)
         }
     }
 }

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -23,7 +23,7 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
                     self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getMongoError(error: error)
+            throw getMongoError(error: error, reply: reply)
         }
     }
 }

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -23,7 +23,7 @@ internal struct DropDatabaseOperation: Operation {
                     self.database._database, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getMongoError(error: error)
+            throw getMongoError(error: error, reply: reply)
         }
     }
 }

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -23,7 +23,7 @@ internal struct DropDatabaseOperation: Operation {
                     self.database._database, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getMongoError(error: error, reply: reply)
+            throw extractMongoError(error: error, reply: reply)
         }
     }
 }

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -23,7 +23,7 @@ internal struct DropDatabaseOperation: Operation {
                     self.database._database, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getErrorFromReply(bsonError: error, from: reply)
+            throw getMongoError(error: error)
         }
     }
 }

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -38,7 +38,7 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
                 self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getMongoError(error: error, reply: reply)
+            throw extractMongoError(error: error, reply: reply)
         }
 
         return reply

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -38,7 +38,7 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
                 self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getErrorFromReply(bsonError: error, from: reply)
+            throw getMongoError(error: error, reply: reply)
         }
 
         return reply

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -153,7 +153,7 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
                                                         &error)
         }
         guard success else {
-            throw getErrorFromReply(bsonError: error, from: reply)
+            throw getMongoError(error: error, reply: reply)
         }
 
         guard let value = try reply.getValue(for: "value") as? Document else {

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -153,7 +153,7 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
                                                         &error)
         }
         guard success else {
-            throw getMongoError(error: error, reply: reply)
+            throw extractMongoError(error: error, reply: reply)
         }
 
         guard let value = try reply.getValue(for: "value") as? Document else {

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -52,7 +52,7 @@ internal struct RunCommandOperation: Operation {
                 self.database._database, self.command._bson, rp, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getErrorFromReply(bsonError: error, from: reply)
+            throw getMongoError(error: error, reply: reply)
         }
         return reply
     }

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -52,7 +52,7 @@ internal struct RunCommandOperation: Operation {
                 self.database._database, self.command._bson, rp, opts?._bson, replyPtr, &error)
         }
         guard success else {
-            throw getMongoError(error: error, reply: reply)
+            throw extractMongoError(error: error, reply: reply)
         }
         return reply
     }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -211,6 +211,7 @@ extension ReadWriteConcernTests {
         ("testDatabaseReadConcern", testDatabaseReadConcern),
         ("testDatabaseWriteConcern", testDatabaseWriteConcern),
         ("testOperationReadConcerns", testOperationReadConcerns),
+        ("testWriteConcernErrors", testWriteConcernErrors),
         ("testOperationWriteConcerns", testOperationWriteConcerns),
         ("testConnectionStrings", testConnectionStrings),
         ("testDocuments", testDocuments),

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -8,7 +8,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
         do {
             let client = try MongoClient(MongoSwiftTestCase.connStr)
             try client.db(type(of: self).testDatabase).drop()
-        } catch let ServerError.commandError(code, _, _) where code == 26 {
+        } catch let ServerError.commandError(code, _, _, _) where code == 26 {
             // skip database not found errors
         } catch {
             fail("encountered error when tearing down: \(error)")

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -15,7 +15,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         let connectionString = MongoSwiftTestCase.connStr
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
-            throw parseMongocError(error)
+            throw getMongoError(error: error)
         }
 
         guard let client_t = mongoc_client_new_from_uri(uri) else {

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -15,7 +15,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         let connectionString = MongoSwiftTestCase.connStr
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
-            throw getMongoError(error: error)
+            throw extractMongoError(error: error)
         }
 
         guard let client_t = mongoc_client_new_from_uri(uri) else {

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -32,7 +32,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
     override func tearDown() {
         do {
             try coll.drop()
-        } catch let ServerError.commandError(code, _, _) where code == 26 {
+        } catch let ServerError.commandError(code, _, _, _) where code == 26 {
             // ignore ns not found errors
         } catch {
             fail("encountered error when tearing down: \(error)")

--- a/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+BulkWriteTests.swift
@@ -106,7 +106,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
 
         // Expect a duplicate key error (11000)
         let expectedError = ServerError.bulkWriteError(
-                writeErrors: [BulkWriteError(code: 11000, message: "", index: 1)],
+                writeErrors: [BulkWriteError(code: 11000, codeName: "DuplicateKey", message: "", index: 1)],
                 writeConcernError: nil,
                 result: expectedResult,
                 errorLabels: nil)

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -83,7 +83,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
         // error code 11000: DuplicateKey
         let expectedError = ServerError.writeError(
-                writeError: WriteError(code: 11000, message: ""),
+                writeError: WriteError(code: 11000, codeName: "DuplicateKey", message: ""),
                 writeConcernError: nil,
                 errorLabels: nil
         )
@@ -170,7 +170,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
         let expectedResultOrdered = BulkWriteResult(insertedCount: 1, insertedIds: [0: newDoc1["_id"]!])
         let expectedErrorsOrdered = [
-            BulkWriteError(code: 11000, message: "", index: 1)
+            BulkWriteError(code: 11000, codeName: "DuplicateKey", message: "", index: 1)
         ]
 
         let expectedErrorOrdered = ServerError.bulkWriteError(
@@ -182,8 +182,8 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.insertMany([newDoc1, docId1, newDoc2, docId2])).to(throwError(expectedErrorOrdered))
 
         let expectedErrors = [
-            BulkWriteError(code: 11000, message: "", index: 1),
-            BulkWriteError(code: 11000, message: "", index: 3)
+            BulkWriteError(code: 11000, codeName: "DuplicateKey", message: "", index: 1),
+            BulkWriteError(code: 11000, codeName: "DuplicateKey", message: "", index: 3)
         ]
         let expectedResult = BulkWriteResult(insertedCount: 2, insertedIds: [0: newDoc3["_id"]!, 2: newDoc4["_id"]!])
         let expectedError = ServerError.bulkWriteError(

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -39,7 +39,10 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
 
         // error code 59: CommandNotFound
         expect(try db.runCommand(["asdfsadf": ObjectId()]))
-                .to(throwError(ServerError.commandError(code: 59, message: "", errorLabels: nil)))
+                .to(throwError(ServerError.commandError(code: 59,
+                                                        codeName: "CommandNotFound",
+                                                        message: "",
+                                                        errorLabels: nil)))
     }
 
     func testDropDatabase() throws {

--- a/Tests/MongoSwiftTests/MongoError+Equatable.swift
+++ b/Tests/MongoSwiftTests/MongoError+Equatable.swift
@@ -20,9 +20,10 @@ extension RuntimeError: Equatable {
 extension ServerError: Equatable {
     public static func == (lhs: ServerError, rhs: ServerError) -> Bool {
         switch (lhs, rhs) {
-        case let (.commandError(code: lhsCode, message: _, errorLabels: lhsErrorLabels),
-                  .commandError(code: rhsCode, message: _, errorLabels: rhsErrorLabels)):
+        case let (.commandError(code: lhsCode, codeName: lhsCodeName, message: _, errorLabels: lhsErrorLabels),
+                  .commandError(code: rhsCode, codeName: rhsCodeName, message: _, errorLabels: rhsErrorLabels)):
             return lhsCode == rhsCode
+                    && lhsCodeName == rhsCodeName
                     && sortAndCompareOptionalArrays(lhs: lhsErrorLabels, rhs: rhsErrorLabels, cmp: { $0 < $1 })
         case let (.writeError(writeError: lhsWriteError, writeConcernError: lhsWCError, errorLabels: lhsErrorLabels),
                   .writeError(writeError: rhsWriteError, writeConcernError: rhsWCError, errorLabels: rhsErrorLabels)):

--- a/Tests/MongoSwiftTests/MongoError+Equatable.swift
+++ b/Tests/MongoSwiftTests/MongoError+Equatable.swift
@@ -76,12 +76,14 @@ extension UserError: Equatable {
     }
 }
 
+// TODO: start comparing codeName once it is returned more consistently (SERVER-36755)
 extension WriteError: Equatable {
     public static func == (lhs: WriteError, rhs: WriteError) -> Bool {
         return lhs.code == rhs.code
     }
 }
 
+// TODO: start comparing codeName once it is returned more consistently (SERVER-36755)
 extension BulkWriteError: Equatable {
     public static func == (lhs: BulkWriteError, rhs: BulkWriteError) -> Bool {
         return lhs.code == rhs.code && lhs.index == rhs.index
@@ -90,7 +92,7 @@ extension BulkWriteError: Equatable {
 
 extension WriteConcernError: Equatable {
     public static func == (lhs: WriteConcernError, rhs: WriteConcernError) -> Bool {
-        return lhs.code == rhs.code && lhs.details == rhs.details
+        return lhs.code == rhs.code && lhs.codeName == rhs.codeName && lhs.details == rhs.details
     }
 }
 

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -302,7 +302,10 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         let options3 = RunCommandOptions(readConcern: ReadConcern("blah"))
         // error code 9: FailedToParse
         expect(try db.runCommand(command, options: options3))
-                .to(throwError(ServerError.commandError(code: 9, message: "", errorLabels: nil)))
+                .to(throwError(ServerError.commandError(code: 9,
+                                                        codeName: "FailedToParse",
+                                                        message: "",
+                                                        errorLabels: nil)))
 
         // try various command + read concern pairs to make sure they work
         expect(try coll.find(options: FindOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
@@ -314,6 +317,34 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         expect(try coll.distinct(fieldName: "a",
                                  options: DistinctOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
+    }
+
+    typealias InsertOneModel = MongoCollection<Document>.InsertOneModel
+    func testWriteConcernErrors() throws {
+        guard MongoSwiftTestCase.topologyType == .replicaSetWithPrimary else {
+            print("Skipping \(self.name) because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+
+        let wc = try WriteConcern(w: .number(100))
+        let wcError = WriteConcernError(code: 100, codeName: "CannotSatisfyWriteConcern", details: nil, message: "")
+        let writeError = ServerError.writeError(writeError: nil, writeConcernError: wcError, errorLabels: nil)
+        let bulkResult = BulkWriteResult(insertedCount: 1, insertedIds: [0: 1])
+        let bulkError = ServerError.bulkWriteError(writeErrors: [],
+                                                   writeConcernError: wcError,
+                                                   result: bulkResult,
+                                                   errorLabels: nil)
+
+        let client = try MongoClient(MongoSwiftTestCase.connStr)
+        let database = client.db(type(of: self).testDatabase)
+        let collection = database.collection(self.getCollectionName())
+        defer { try? collection.drop() }
+
+        expect(try collection.insertOne(["x": 1], options: InsertOneOptions(writeConcern: wc)))
+                .to(throwError(writeError))
+
+        expect(try collection.bulkWrite([InsertOneModel(["_id": 1])], options: BulkWriteOptions(writeConcern: wc)))
+                .to(throwError(bulkError))
     }
 
     func testOperationWriteConcerns() throws {


### PR DESCRIPTION
[SWIFT-489](https://jira.mongodb.org/browse/SWIFT-489)

This PR adds a `codeName` field to the various `ServerError` types (`WriteError`, `WriteConcernError`, and `BulkWriteError` structs and the `.commandError` case). Additionally, I added a small test that verifies write concern errors are parsed properly, as we were missing such a test before.

This PR also reworks the internal API for getting a `MongoError`. Previously, there were two separate functions for getting an error, depending on whether you had a reply or not. Now, all errors are returned from `getMongoError`. Additionally, I refactored the private helpers a bit to be more streamlined and readable.

**Cases when codeName is not reported:**
- Until [SERVER-36755](https://jira.mongodb.org/browse/SERVER-36755) is fixed, `codeName` on `WriteError` and `BulkWriteError` will only be filled out on sharded topologies. Since it's _supposed_ to always be there, I did not make any of the new fields optional. Unfortunately, this means that on non-sharded topologies, the code name will be the empty string on those structs.

- Additionally, when command errors are reported by libmongoc in write functions (e.g. `mongoc_collection_insert_one`), the reply does not get filled out with error information. Thus, the `codeName` on `.commandError` will be the empty string if it's thrown from a writing operation. I filed [CDRIVER-3147](https://jira.mongodb.org/browse/CDRIVER-3147) for this.