### PR TITLE
SWIFT-355 Make option properties mutable

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -4,19 +4,19 @@ import mongoc
 /// Options to use when creating a `MongoClient`.
 public struct ClientOptions: CodingStrategyProvider, Decodable {
     /// Determines whether the client should retry supported write operations.
-    public let retryWrites: Bool?
+    public var retryWrites: Bool?
 
     /// Indicates whether this client should be set up to enable monitoring command and server discovery and monitoring
     /// events.
-    public let eventMonitoring: Bool
+    public var eventMonitoring: Bool
 
     /// Specifies a ReadConcern to use for the client. If one is not specified, the server's default read concern will
     /// be used.
-    public let readConcern: ReadConcern?
+    public var readConcern: ReadConcern?
 
     /// Specifies a WriteConcern to use for the client. If one is not specified, the server's default write concern
     /// will be used.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     // swiftlint:disable redundant_optional_initialization
 
@@ -64,10 +64,10 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
 /// Options to use when listing available databases.
 public struct ListDatabasesOptions: Encodable {
     /// An optional filter for the returned databases.
-    public let filter: Document?
+    public var filter: Document?
 
     /// Optionally indicate whether only names should be returned.
-    public let nameOnly: Bool?
+    public var nameOnly: Bool?
 
     /// Convenience constructor for basic construction
     public init(filter: Document? = nil, nameOnly: Bool? = nil) {
@@ -80,27 +80,27 @@ public struct ListDatabasesOptions: Encodable {
 public struct DatabaseOptions: CodingStrategyProvider {
     /// A read concern to set on the retrieved database. If one is not specified, the database will inherit the
     /// client's read concern.
-    public let readConcern: ReadConcern?
+    public var readConcern: ReadConcern?
 
     /// A read preference to set on the retrieved database. If one is not specified, the database will inherit the
     /// client's read preference.
-    public let readPreference: ReadPreference?
+    public var readPreference: ReadPreference?
 
     /// A write concern to set on the retrieved database. If one is not specified, the database will inherit the
     /// client's write concern.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this database and
     /// any collections that derive from it.
-    public let dateCodingStrategy: DateCodingStrategy?
+    public var dateCodingStrategy: DateCodingStrategy?
 
     /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this database and
     /// any collections that derive from it.
-    public let uuidCodingStrategy: UUIDCodingStrategy?
+    public var uuidCodingStrategy: UUIDCodingStrategy?
 
     /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this database and
     /// any collections that derive from it.
-    public let dataCodingStrategy: DataCodingStrategy?
+    public var dataCodingStrategy: DataCodingStrategy?
 
     /// Convenience initializer allowing any/all arguments to be omitted or optional.
     public init(readConcern: ReadConcern? = nil,

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -37,7 +37,7 @@ extension MongoCollection {
     }
 
     private struct DeleteModelOptions: Encodable {
-        public var collation: Document?
+        public let collation: Document?
     }
 
     /// A model for a `deleteOne` operation within a bulk write.
@@ -154,8 +154,8 @@ extension MongoCollection {
     }
 
     private struct ReplaceOneModelOptions: Encodable {
-        public var collation: Document?
-        public var upsert: Bool?
+        public let collation: Document?
+        public let upsert: Bool?
     }
 
     /// A model for a `replaceOne` operation within a bulk write.

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -37,7 +37,7 @@ extension MongoCollection {
     }
 
     private struct DeleteModelOptions: Encodable {
-        public let collation: Document?
+        public var collation: Document?
     }
 
     /// A model for a `deleteOne` operation within a bulk write.
@@ -154,8 +154,8 @@ extension MongoCollection {
     }
 
     private struct ReplaceOneModelOptions: Encodable {
-        public let collation: Document?
-        public let upsert: Bool?
+        public var collation: Document?
+        public var upsert: Bool?
     }
 
     /// A model for a `replaceOne` operation within a bulk write.
@@ -423,7 +423,7 @@ public class BulkWriteOperation: Operation {
 /// Options to use when performing a bulk write operation on a `MongoCollection`.
 public struct BulkWriteOptions: Codable {
     /// If `true`, allows the write to opt-out of document level validation.
-    public let bypassDocumentValidation: Bool?
+    public var bypassDocumentValidation: Bool?
 
     /**
      * If `true` (the default), operations will be executed serially in order
@@ -432,10 +432,10 @@ public struct BulkWriteOptions: Codable {
      * not stop after encountering a write error (i.e. multiple errors may be
      * reported after all operations have been attempted).
      */
-    public let ordered: Bool
+    public var ordered: Bool
 
     /// An optional WriteConcern to use for the bulk write.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional
     public init(bypassDocumentValidation: Bool? = nil, ordered: Bool? = nil, writeConcern: WriteConcern? = nil) {

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -123,19 +123,19 @@ internal protocol FindAndModifyOptionsConvertible {
 /// Options to use when executing a `findOneAndDelete` command on a `MongoCollection`.
 public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible, Decodable {
     /// Specifies a collation to use.
-    public let collation: Document?
+    public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public let maxTimeMS: Int64?
+    public var maxTimeMS: Int64?
 
     /// Limits the fields to return for the matching document.
-    public let projection: Document?
+    public var projection: Document?
 
     /// Determines which document the operation modifies if the query selects multiple documents.
-    public let sort: Document?
+    public var sort: Document?
 
     /// An optional `WriteConcern` to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     internal func asFindAndModifyOptions() throws -> FindAndModifyOptions {
         return try FindAndModifyOptions(collation: collation,
@@ -163,28 +163,28 @@ public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible, Decodabl
 /// Options to use when executing a `findOneAndReplace` command on a `MongoCollection`.
 public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible, Decodable {
     /// If `true`, allows the write to opt-out of document level validation.
-    public let bypassDocumentValidation: Bool?
+    public var bypassDocumentValidation: Bool?
 
     /// Specifies a collation to use.
-    public let collation: Document?
+    public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public let maxTimeMS: Int64?
+    public var maxTimeMS: Int64?
 
     /// Limits the fields to return for the matching document.
-    public let projection: Document?
+    public var projection: Document?
 
     /// When `ReturnDocument.After`, returns the replaced or inserted document rather than the original.
-    public let returnDocument: ReturnDocument?
+    public var returnDocument: ReturnDocument?
 
     /// Determines which document the operation modifies if the query selects multiple documents.
-    public let sort: Document?
+    public var sort: Document?
 
     /// When `true`, creates a new document if no document matches the query.
-    public let upsert: Bool?
+    public var upsert: Bool?
 
     /// An optional `WriteConcern` to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     internal func asFindAndModifyOptions() throws -> FindAndModifyOptions {
         return try FindAndModifyOptions(bypassDocumentValidation: bypassDocumentValidation,
@@ -220,31 +220,31 @@ public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible, Decodab
 /// Options to use when executing a `findOneAndUpdate` command on a `MongoCollection`.
 public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible, Decodable {
     /// A set of filters specifying to which array elements an update should apply.
-    public let arrayFilters: [Document]?
+    public var arrayFilters: [Document]?
 
     /// If `true`, allows the write to opt-out of document level validation.
-    public let bypassDocumentValidation: Bool?
+    public var bypassDocumentValidation: Bool?
 
     /// Specifies a collation to use.
-    public let collation: Document?
+    public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public let maxTimeMS: Int64?
+    public var maxTimeMS: Int64?
 
     /// Limits the fields to return for the matching document.
-    public let projection: Document?
+    public var projection: Document?
 
     /// When`ReturnDocument.After`, returns the updated or inserted document rather than the original.
-    public let returnDocument: ReturnDocument?
+    public var returnDocument: ReturnDocument?
 
     /// Determines which document the operation modifies if the query selects multiple documents.
-    public let sort: Document?
+    public var sort: Document?
 
     /// When `true`, creates a new document if no document matches the query.
-    public let upsert: Bool?
+    public var upsert: Bool?
 
     /// An optional `WriteConcern` to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     internal func asFindAndModifyOptions() throws -> FindAndModifyOptions {
         return try FindAndModifyOptions(arrayFilters: arrayFilters,

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -34,10 +34,10 @@ public struct IndexModel: Encodable {
 /// Options to use when creating an index for a collection.
 public struct IndexOptions: Codable {
     /// Optionally tells the server to build the index in the background and not block other tasks.
-    public let background: Bool?
+    public var background: Bool?
 
     /// Optionally specifies the length in time, in seconds, for documents to remain in a collection.
-    public let expireAfterSeconds: Int32?
+    public var expireAfterSeconds: Int32?
 
     /**
      * Optionally specify a specific name for the index outside of the default generated name. If none is provided then
@@ -51,54 +51,54 @@ public struct IndexOptions: Codable {
     public var name: String?
 
     /// Optionally tells the index to only reference documents with the specified field in the index.
-    public let sparse: Bool?
+    public var sparse: Bool?
 
     /// Optionally used only in MongoDB 3.0.0 and higher. Allows users to configure the storage engine on a per-index
     /// basis when creating an index.
-    public let storageEngine: Document?
+    public var storageEngine: Document?
 
     /// Optionally forces the index to be unique.
-    public let unique: Bool?
+    public var unique: Bool?
 
     /// Optionally specifies the index version number, either 0 or 1.
     public var indexVersion: Int32?
 
     /// Optionally specifies the default language for text indexes. Is 'english' if none is provided.
-    public let defaultLanguage: String?
+    public var defaultLanguage: String?
 
     /// Optionally specifies the field in the document to override the language.
-    public let languageOverride: String?
+    public var languageOverride: String?
 
     /// Optionally provides the text index version number. MongoDB 2.4 can only support version 1. MongoDB 2.6 and
     /// higher may support version 1 or 2.
-    public let textIndexVersion: Int32?
+    public var textIndexVersion: Int32?
 
     /// Optionally specifies fields in the index and their corresponding weight values.
-    public let weights: Document?
+    public var weights: Document?
 
     /// Optionally specifies the 2dsphere index version number. MongoDB 2.4 can only support version 1. MongoDB 2.6 and
     /// higher may support version 1 or 2.
-    public let sphereIndexVersion: Int32?
+    public var sphereIndexVersion: Int32?
 
     /// Optionally specifies the precision of the stored geo hash in the 2d index, from 1 to 32.
-    public let bits: Int32?
+    public var bits: Int32?
 
     /// Optionally sets the maximum boundary for latitude and longitude in the 2d index.
-    public let max: Double?
+    public var max: Double?
 
     /// Optionally sets the minimum boundary for latitude and longitude in the index in a 2d index.
-    public let min: Double?
+    public var min: Double?
 
     /// Optionally specifies the number of units within which to group the location values in a geo haystack index.
-    public let bucketSize: Int32?
+    public var bucketSize: Int32?
 
     /// Optionally specifies a filter for use in a partial index. Only documents that match the filter expression are
     /// included in the index. New in MongoDB 3.2.
-    public let partialFilterExpression: Document?
+    public var partialFilterExpression: Document?
 
     /// Optionally specifies a collation to use for the index in MongoDB 3.4 and higher. If not specified, no collation
     /// is sent and the default collation of the collection server-side is used.
-    public let collation: Document?
+    public var collation: Document?
 
     /// Convenience initializer allowing any/all parameters to be omitted.
     public init(background: Bool? = nil,

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -421,7 +421,7 @@ public struct FindOptions: Codable {
         self.sort = sort
     }
 
-    // Encode everything except `self.cursorType`, as we only store it for debugging purposes
+    // Encode everything except `self.readPreference`, because this is sent to libmongoc separately
     private enum CodingKeys: String, CodingKey {
         case allowPartialResults, awaitData, batchSize, collation, comment, hint, limit, max, maxAwaitTimeMS,
             maxScan, maxTimeMS, min, noCursorTimeout, projection, readConcern, returnKey, showRecordId, tailable, skip,

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -352,10 +352,10 @@ public struct FindOptions: Codable {
                 return nil
             }
 
-            if self.tailable == true && self.awaitData == true  {
+            if self.tailable == true && self.awaitData == true {
                 return .tailableAwait
             }
-            
+
             if self.tailable == true {
                 return .tailable
             }
@@ -373,7 +373,6 @@ public struct FindOptions: Codable {
             }
         }
     }
-    
 
     // swiftlint:enable redundant_optional_initialization
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -402,7 +402,6 @@ public struct FindOptions: Codable {
         self.batchSize = batchSize
         self.collation = collation
         self.comment = comment
-        // although this does not get encoded, we store it for debugging purposes
         self.cursorType = cursorType
         self.hint = hint
         self.limit = limit

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -168,30 +168,30 @@ public enum Hint: Codable {
 public struct AggregateOptions: Codable {
     /// Enables writing to temporary files. When set to true, aggregation stages
     /// can write data to the _tmp subdirectory in the dbPath directory.
-    public let allowDiskUse: Bool?
+    public var allowDiskUse: Bool?
 
     /// The number of `Document`s to return per batch.
-    public let batchSize: Int32?
+    public var batchSize: Int32?
 
     /// If true, allows the write to opt-out of document level validation. This only applies
     /// when the $out stage is specified.
-    public let bypassDocumentValidation: Bool?
+    public var bypassDocumentValidation: Bool?
 
     /// Specifies a collation.
-    public let collation: Document?
+    public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public let maxTimeMS: Int64?
+    public var maxTimeMS: Int64?
 
     /// Enables users to specify an arbitrary string to help trace the operation through
     /// the database profiler, currentOp and logs. The default is to not send a value.
-    public let comment: String?
+    public var comment: String?
 
     /// The index hint to use for the aggregation. The hint does not apply to $lookup and $graphLookup stages.
-    public let hint: Hint?
+    public var hint: Hint?
 
     /// A `ReadConcern` to use in read stages of this operation.
-    public let readConcern: ReadConcern?
+    public var readConcern: ReadConcern?
 
     // swiftlint:disable redundant_optional_initialization
     /// A ReadPreference to use for this operation.
@@ -199,7 +199,7 @@ public struct AggregateOptions: Codable {
     // swiftlint:enable redundant_optional_initialization
 
     /// A `WriteConcern` to use in `$out` stages of this operation.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(allowDiskUse: Bool? = nil,
@@ -278,67 +278,67 @@ public enum CursorType {
 /// Options to use when executing a `find` command on a `MongoCollection`.
 public struct FindOptions: Codable {
     /// Get partial results from a mongos if some shards are down (instead of throwing an error).
-    public let allowPartialResults: Bool?
+    public var allowPartialResults: Bool?
 
     /// The number of documents to return per batch.
-    public let batchSize: Int32?
+    public var batchSize: Int32?
 
     /// Specifies a collation.
-    public let collation: Document?
+    public var collation: Document?
 
     /// Attaches a comment to the query.
-    public let comment: String?
+    public var comment: String?
 
     /// If a `CursorType` is provided, indicates whether it is `.tailable` or .`tailableAwait`.
-    private let tailable: Bool?
+    private var tailable: Bool?
 
     /// If a `CursorType` is provided, indicates whether it is `.tailableAwait`.
-    private let awaitData: Bool?
+    private var awaitData: Bool?
 
     /// A hint for the index to use.
-    public let hint: Hint?
+    public var hint: Hint?
 
     /// The maximum number of documents to return.
-    public let limit: Int64?
+    public var limit: Int64?
 
     /// The exclusive upper bound for a specific index.
-    public let max: Document?
+    public var max: Document?
 
     /// The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor
     /// query. This only applies when used with `CursorType.tailableAwait`. Otherwise, this option is ignored.
-    public let maxAwaitTimeMS: Int64?
+    public var maxAwaitTimeMS: Int64?
 
     /// Maximum number of documents or index keys to scan when executing the query.
-    public let maxScan: Int64?
+    public var maxScan: Int64?
 
     /// The maximum amount of time to allow the query to run.
-    public let maxTimeMS: Int64?
+    public var maxTimeMS: Int64?
 
     /// The inclusive lower bound for a specific index.
-    public let min: Document?
+    public var min: Document?
 
     /// The server normally times out idle cursors after an inactivity period (10 minutes)
     /// to prevent excess memory use. Set this option to prevent that.
-    public let noCursorTimeout: Bool?
+    public var noCursorTimeout: Bool?
 
     /// Limits the fields to return for all matching documents.
-    public let projection: Document?
+    public var projection: Document?
 
     /// If true, returns only the index keys in the resulting documents.
-    public let returnKey: Bool?
+    public var returnKey: Bool?
 
     /// Determines whether to return the record identifier for each document. If true, adds a field $recordId
     /// to the returned documents.
-    public let showRecordId: Bool?
+    public var showRecordId: Bool?
 
     /// The number of documents to skip before returning.
-    public let skip: Int64?
+    public var skip: Int64?
 
     /// The order in which to return matching documents.
-    public let sort: Document?
+    public var sort: Document?
 
     /// A ReadConcern to use for this operation.
-    public let readConcern: ReadConcern?
+    public var readConcern: ReadConcern?
 
     // swiftlint:disable redundant_optional_initialization
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -346,7 +346,38 @@ public struct FindOptions: Codable {
     public var readPreference: ReadPreference? = nil
 
     /// Indicates the type of cursor to use. This value includes both the tailable and awaitData options.
-    public var cursorType: CursorType? = nil
+    public var cursorType: CursorType? {
+        get {
+            if(self.tailable == nil && self.awaitData == nil) {
+                return nil
+            }
+
+            if(self.tailable == true && self.awaitData == true) {
+                return .tailableAwait
+            }
+            
+            if(self.tailable == true) {
+                return .tailable
+            }
+
+            if(self.awaitData == true) {
+                return .tailableAwait
+            }
+
+            return .nonTailable
+        }
+
+        set(newCursorType) {
+            if(newCursorType == nil) {
+                self.tailable = nil
+                self.awaitData = nil
+            } else {
+                self.tailable = newCursorType == .tailable || newCursorType == .tailableAwait
+                self.awaitData = newCursorType == .tailableAwait
+            }
+        }
+    }
+    
 
     // swiftlint:enable redundant_optional_initialization
 
@@ -377,8 +408,6 @@ public struct FindOptions: Codable {
         self.comment = comment
         // although this does not get encoded, we store it for debugging purposes
         self.cursorType = cursorType
-        self.tailable = cursorType == .tailable || cursorType == .tailableAwait
-        self.awaitData = cursorType == .tailableAwait
         self.hint = hint
         self.limit = limit
         self.max = max

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -348,27 +348,23 @@ public struct FindOptions: Codable {
     /// Indicates the type of cursor to use. This value includes both the tailable and awaitData options.
     public var cursorType: CursorType? {
         get {
-            if(self.tailable == nil && self.awaitData == nil) {
+            if self.tailable == nil && self.awaitData == nil {
                 return nil
             }
 
-            if(self.tailable == true && self.awaitData == true) {
+            if self.tailable == true && self.awaitData == true  {
                 return .tailableAwait
             }
             
-            if(self.tailable == true) {
+            if self.tailable == true {
                 return .tailable
-            }
-
-            if(self.awaitData == true) {
-                return .tailableAwait
             }
 
             return .nonTailable
         }
 
         set(newCursorType) {
-            if(newCursorType == nil) {
+            if newCursorType == nil {
                 self.tailable = nil
                 self.awaitData = nil
             } else {

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -235,10 +235,10 @@ private extension BulkWriteOptionsConvertible {
 /// Options to use when executing an `insertOne` command on a `MongoCollection`.
 public struct InsertOneOptions: Codable, BulkWriteOptionsConvertible {
     /// If true, allows the write to opt-out of document level validation.
-    public let bypassDocumentValidation: Bool?
+    public var bypassDocumentValidation: Bool?
 
     /// An optional WriteConcern to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Convenience initializer allowing bypassDocumentValidation to be omitted or optional
     public init(bypassDocumentValidation: Bool? = nil, writeConcern: WriteConcern? = nil) {
@@ -253,19 +253,19 @@ public typealias InsertManyOptions = BulkWriteOptions
 /// Options to use when executing an `update` command on a `MongoCollection`.
 public struct UpdateOptions: Codable, BulkWriteOptionsConvertible {
     /// A set of filters specifying to which array elements an update should apply.
-    public let arrayFilters: [Document]?
+    public var arrayFilters: [Document]?
 
     /// If true, allows the write to opt-out of document level validation.
-    public let bypassDocumentValidation: Bool?
+    public var bypassDocumentValidation: Bool?
 
     /// Specifies a collation.
-    public let collation: Document?
+    public var collation: Document?
 
     /// When true, creates a new document if no document matches the query.
-    public let upsert: Bool?
+    public var upsert: Bool?
 
     /// An optional WriteConcern to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(arrayFilters: [Document]? = nil,
@@ -284,16 +284,16 @@ public struct UpdateOptions: Codable, BulkWriteOptionsConvertible {
 /// Options to use when executing a `replace` command on a `MongoCollection`.
 public struct ReplaceOptions: Codable, BulkWriteOptionsConvertible {
     /// If true, allows the write to opt-out of document level validation.
-    public let bypassDocumentValidation: Bool?
+    public var bypassDocumentValidation: Bool?
 
     /// Specifies a collation.
-    public let collation: Document?
+    public var collation: Document?
 
     /// When true, creates a new document if no document matches the query.
-    public let upsert: Bool?
+    public var upsert: Bool?
 
     /// An optional `WriteConcern` to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(bypassDocumentValidation: Bool? = nil,
@@ -310,10 +310,10 @@ public struct ReplaceOptions: Codable, BulkWriteOptionsConvertible {
 /// Options to use when executing a `delete` command on a `MongoCollection`.
 public struct DeleteOptions: Codable, BulkWriteOptionsConvertible {
     /// Specifies a collation.
-    public let collation: Document?
+    public var collation: Document?
 
     /// An optional `WriteConcern` to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
      /// Convenience initializer allowing collation to be omitted or optional
     public init(collation: Document? = nil, writeConcern: WriteConcern? = nil) {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -3,10 +3,10 @@ import mongoc
 /// Options to use when executing a `listCollections` command on a `MongoDatabase`.
 public struct ListCollectionsOptions: Encodable {
     /// A filter to match collections against.
-    public let filter: Document?
+    public var filter: Document?
 
     /// The batchSize for the returned cursor.
-    public let batchSize: Int?
+    public var batchSize: Int?
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional
     public init(batchSize: Int? = nil, filter: Document? = nil) {
@@ -19,30 +19,30 @@ public struct ListCollectionsOptions: Encodable {
 public struct CollectionOptions: CodingStrategyProvider {
     /// A read concern to set on the returned collection. If one is not specified, the collection will inherit the
     /// database's read concern.
-    public let readConcern: ReadConcern?
+    public var readConcern: ReadConcern?
 
     /// A read preference to set on the returned collection. If one is not specified, the collection will inherit the
     /// database's read preference.
-    public let readPreference: ReadPreference?
+    public var readPreference: ReadPreference?
 
     /// A write concern to set on the returned collection. If one is not specified, the collection will inherit the
     /// database's write concern.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Specifies the `DateCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
     /// It is the responsibility of the user to ensure that any `Date`s already stored in this collection can be
     /// decoded using this strategy.
-    public let dateCodingStrategy: DateCodingStrategy?
+    public var dateCodingStrategy: DateCodingStrategy?
 
     /// Specifies the `UUIDCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
     /// It is the responsibility of the user to ensure that any `UUID`s already stored in this collection can be
     /// decoded using this strategy.
-    public let uuidCodingStrategy: UUIDCodingStrategy?
+    public var uuidCodingStrategy: UUIDCodingStrategy?
 
     /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this collection.
     /// It is the responsibility of the user to ensure that any `Data`s already stored in this collection can be
     /// decoded using this strategy.
-    public let dataCodingStrategy: DataCodingStrategy?
+    public var dataCodingStrategy: DataCodingStrategy?
 
     /// Convenience initializer allowing any/all arguments to be omitted or optional.
     public init(readConcern: ReadConcern? = nil,

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -3,22 +3,22 @@ import mongoc
 /// Options to use when executing a `count` command on a `MongoCollection`.
 public struct CountOptions: Codable {
     /// Specifies a collation.
-    public let collation: Document?
+    public var collation: Document?
 
     /// A hint for the index to use.
-    public let hint: Hint?
+    public var hint: Hint?
 
     /// The maximum number of documents to count.
-    public let limit: Int64?
+    public var limit: Int64?
 
     /// The maximum amount of time to allow the query to run.
-    public let maxTimeMS: Int64?
+    public var maxTimeMS: Int64?
 
     /// The number of documents to skip before counting.
-    public let skip: Int64?
+    public var skip: Int64?
 
     /// A ReadConcern to use for this operation.
-    public let readConcern: ReadConcern?
+    public var readConcern: ReadConcern?
 
     // swiftlint:disable redundant_optional_initialization
     /// A ReadPreference to use for this operation.

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -3,46 +3,46 @@ import mongoc
 /// Options to use when executing a `createCollection` command on a `MongoDatabase`.
 public struct CreateCollectionOptions: Codable, CodingStrategyProvider {
     /// Indicates whether this will be a capped collection.
-    public let capped: Bool?
+    public var capped: Bool?
 
     /// Whether or not this collection will automatically generate an index on _id.
-    public let autoIndexId: Bool?
+    public var autoIndexId: Bool?
 
     /// Maximum size, in bytes, of this collection (if capped).
-    public let size: Int64?
+    public var size: Int64?
 
     /// Maximum number of documents allowed in the collection (if capped).
-    public let max: Int64?
+    public var max: Int64?
 
     /// Specifies storage engine configuration for this collection.
-    public let storageEngine: Document?
+    public var storageEngine: Document?
 
     /// What validator should be used for the collection.
-    public let validator: Document?
+    public var validator: Document?
 
     /// Determines how strictly MongoDB applies the validation rules to existing documents during an update.
-    public let validationLevel: String?
+    public var validationLevel: String?
 
     /// Determines whether to error on invalid documents or just warn about the violations but allow invalid documents
     /// to be inserted.
-    public let validationAction: String?
+    public var validationAction: String?
 
     /// Specify a default configuration for indexes created on this collection.
-    public let indexOptionDefaults: Document?
+    public var indexOptionDefaults: Document?
 
     /// The name of the source collection or view from which to create the view.
-    public let viewOn: String?
+    public var viewOn: String?
 
     /// An array consisting of aggregation pipeline stages. When used with `viewOn`, will create the view by applying
     /// this pipeline to the source collection or view.
-    public let pipeline: [Document]?
+    public var pipeline: [Document]?
 
     /// Specifies the default collation for the collection.
-    public let collation: Document?
+    public var collation: Document?
 
     /// A write concern to use when executing this command. To set a read or write concern for the collection itself,
     /// retrieve the collection using `MongoDatabase.collection`.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     // swiftlint:disable redundant_optional_initialization
     // to get synthesized decodable conformance for the struct, these strategies need default values.

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -3,7 +3,7 @@ import mongoc
 /// Options to use when creating a new index on a `MongoCollection`.
 public struct CreateIndexOptions: Encodable {
     /// An optional `WriteConcern` to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Initializer allowing any/all parameters to be omitted.
     public init(writeConcern: WriteConcern? = nil) {

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -3,13 +3,13 @@ import mongoc
 /// Options to use when executing a `distinct` command on a `MongoCollection`.
 public struct DistinctOptions: Codable {
     /// Specifies a collation.
-    public let collation: Document?
+    public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public let maxTimeMS: Int64?
+    public var maxTimeMS: Int64?
 
     /// A ReadConcern to use for this operation.
-    public let readConcern: ReadConcern?
+    public var readConcern: ReadConcern?
 
     // swiftlint:disable redundant_optional_initialization
     /// A ReadPreference to use for this operation.

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -3,7 +3,7 @@ import mongoc
 /// Options to use when dropping an index from a `MongoCollection`.
 public struct DropIndexOptions: Encodable {
     /// An optional `WriteConcern` to use for the command.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Initializer allowing any/all parameters to be omitted.
     public init(writeConcern: WriteConcern? = nil) {

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -4,15 +4,15 @@ import mongoc
 public struct RunCommandOptions: Encodable {
     /// An optional `ReadConcern` to use for this operation. This option should only be used when executing a command
     /// that reads.
-    public let readConcern: ReadConcern?
+    public var readConcern: ReadConcern?
 
     /// An optional `ReadPreference` to use for this operation. This option should only be used when executing a
     /// command that reads.
-    public let readPreference: ReadPreference?
+    public var readPreference: ReadPreference?
 
     /// An optional `WriteConcern` to use for this operation. This option should only be used when executing a command
     /// that writes.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern?
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(readConcern: ReadConcern? = nil,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -151,7 +151,7 @@ extension MongoCollectionTests {
         ("testGetName", testGetName),
         ("testCursorIteration", testCursorIteration),
         ("testCodableCollection", testCodableCollection),
-        ("testEncodeCursorType", testEncodeCursorType),
+        ("testCursorType", testCursorType),
         ("testEncodeHint", testEncodeHint),
         ("testFindOneAndDelete", testFindOneAndDelete),
         ("testFindOneAndReplace", testFindOneAndReplace),

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -330,8 +330,22 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try encoder.encode(tailableAwait)).to(equal(["awaitData": false, "tailable": true ]))
 
         // test nill cursorType
+
+        tailableAwait.cursorType = nil
+        expect(try encoder.encode(tailableAwait)).to(beNil())
+
         var nilTailable = FindOptions(cursorType: nil)
         expect(try encoder.encode(nilTailable)).to(beNil())
+
+        nilTailable.cursorType = .tailable
+        expect(try encoder.encode(nilTailable)).to(equal(["awaitData": false, "tailable": true ]))
+
+        nilTailable.cursorType = nil
+        expect(try encoder.encode(nilTailable)).to(beNil())
+
+        nilTailable.cursorType = .tailableAwait
+        expect(try encoder.encode(nilTailable)).to(equal(["awaitData": true, "tailable": true ]))
+
     }
 
     func testEncodeHint() throws {

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -330,7 +330,6 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try encoder.encode(tailableAwait)).to(equal(["awaitData": false, "tailable": true ]))
 
         // test nill cursorType
-
         tailableAwait.cursorType = nil
         expect(try encoder.encode(tailableAwait)).to(beNil())
 
@@ -345,7 +344,6 @@ final class MongoCollectionTests: MongoSwiftTestCase {
 
         nilTailable.cursorType = .tailableAwait
         expect(try encoder.encode(nilTailable)).to(equal(["awaitData": true, "tailable": true ]))
-
     }
 
     func testEncodeHint() throws {

--- a/Tests/MongoSwiftTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollectionTests.swift
@@ -307,17 +307,31 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try coll1.findOneAndDelete(["x": 4])).to(equal(b4))
     }
 
-    func testEncodeCursorType() throws {
+    func testCursorType() throws {
         let encoder = BSONEncoder()
 
-        let nonTailable = FindOptions(cursorType: .nonTailable)
+        var nonTailable = FindOptions(cursorType: .nonTailable)
         expect(try encoder.encode(nonTailable)).to(equal(["awaitData": false, "tailable": false]))
 
-        let tailable = FindOptions(cursorType: .tailable)
+        // test mutated cursorType
+        nonTailable.cursorType = .tailable
+        expect(try encoder.encode(nonTailable)).to(equal(["awaitData": false, "tailable": true ]))
+
+        var tailable = FindOptions(cursorType: .tailable)
         expect(try encoder.encode(tailable)).to(equal(["awaitData": false, "tailable": true ]))
 
-        let tailableAwait = FindOptions(cursorType: .tailableAwait)
+        tailable.cursorType = .nonTailable
+        expect(try encoder.encode(tailable)).to(equal(["awaitData": false, "tailable": false ]))
+
+        var tailableAwait = FindOptions(cursorType: .tailableAwait)
         expect(try encoder.encode(tailableAwait)).to(equal(["awaitData": true, "tailable": true ]))
+
+        tailableAwait.cursorType = .tailable
+        expect(try encoder.encode(tailableAwait)).to(equal(["awaitData": false, "tailable": true ]))
+
+        // test nill cursorType
+        var nilTailable = FindOptions(cursorType: nil)
+        expect(try encoder.encode(nilTailable)).to(beNil())
     }
 
     func testEncodeHint() throws {


### PR DESCRIPTION
Makes all option properties mutable. Option properties are declared with 'var' instead of 'let'.