### PR TITLE
Swift-311 Make ReadPrefrerence getters return non-optionals

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -142,7 +142,7 @@ public class MongoClient {
     }
 
     /// The `ReadPreference` set on this client
-    public var readPreference: ReadPreference? {
+    public var readPreference: ReadPreference {
         return ReadPreference(from: mongoc_client_get_read_prefs(self._client))
     }
 

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -37,7 +37,7 @@ extension MongoCollection {
     }
 
     private struct DeleteModelOptions: Encodable {
-        public var collation: Document?
+        public let collation: Document?
     }
 
     /// A model for a `deleteOne` operation within a bulk write.
@@ -154,8 +154,8 @@ extension MongoCollection {
     }
 
     private struct ReplaceOneModelOptions: Encodable {
-        public var collation: Document?
-        public var upsert: Bool?
+        public let collation: Document?
+        public let upsert: Bool?
     }
 
     /// A model for a `replaceOne` operation within a bulk write.

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -37,7 +37,7 @@ extension MongoCollection {
     }
 
     private struct DeleteModelOptions: Encodable {
-        public let collation: Document?
+        public var collation: Document?
     }
 
     /// A model for a `deleteOne` operation within a bulk write.
@@ -154,8 +154,8 @@ extension MongoCollection {
     }
 
     private struct ReplaceOneModelOptions: Encodable {
-        public let collation: Document?
-        public let upsert: Bool?
+        public var collation: Document?
+        public var upsert: Bool?
     }
 
     /// A model for a `replaceOne` operation within a bulk write.

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -39,7 +39,7 @@ public class MongoCollection<T: Codable> {
     }
 
     /// The `ReadPreference` set on this collection.
-    public var readPreference: ReadPreference? {
+    public var readPreference: ReadPreference {
         return ReadPreference(from: mongoc_collection_get_read_prefs(self._collection))
     }
 

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -85,7 +85,7 @@ public class MongoDatabase {
     }
 
     /// The `ReadPreference` set on this database
-    public var readPreference: ReadPreference? {
+    public var readPreference: ReadPreference {
         return ReadPreference(from: mongoc_database_get_read_prefs(self._database))
     }
 


### PR DESCRIPTION
ReadPreference getters in MongoClient, MongoCollection, and MongoDatabase should return non-optionals since their values will never be nil.