### PR TITLE
Swift-509 Rewrite ReadConcern in pure Swift

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -191,10 +191,8 @@ public class MongoClient {
         self.decoder = BSONDecoder(options: options)
 
         // if a readConcern is provided, set it on the client
-        if let rc = options?.readConcern {
-            try? rc.withMongocReadConcern { tmpReadConcernPtr in
-                mongoc_client_set_read_concern(self._client, tmpReadConcernPtr)
-            }
+        options?.readConcern?.withMongocReadConcern { tmpReadConcernPtr in
+            mongoc_client_set_read_concern(self._client, tmpReadConcernPtr)
         }
 
         // if a readPreference is provided, set it on the client

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -187,9 +187,14 @@ public class MongoClient {
             throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support")
         }
 
+        self.encoder = BSONEncoder(options: options)
+        self.decoder = BSONDecoder(options: options)
+
         // if a readConcern is provided, set it on the client
         if let rc = options?.readConcern {
-            mongoc_client_set_read_concern(self._client, rc._readConcern)
+            try? rc.withMongocReadConcern { tmpReadConcernPtr in
+                mongoc_client_set_read_concern(self._client, tmpReadConcernPtr)
+            }
         }
 
         // if a readPreference is provided, set it on the client
@@ -201,9 +206,6 @@ public class MongoClient {
         if let wc = options?.writeConcern {
             mongoc_client_set_write_concern(self._client, wc._writeConcern)
         }
-
-        self.encoder = BSONEncoder(options: options)
-        self.decoder = BSONDecoder(options: options)
 
         if options?.eventMonitoring == true { self.initializeMonitoring() }
 

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -57,10 +57,8 @@ public class MongoCollection<T: Codable> {
             fatalError("Could not get collection '\(name)'")
         }
 
-        if let rc = options?.readConcern {
-            try? rc.withMongocReadConcern { tmpReadConcernPtr in
-                mongoc_collection_set_read_concern(collection, tmpReadConcernPtr)
-            }
+        options?.readConcern?.withMongocReadConcern { tmpReadConcernPtr in
+            mongoc_collection_set_read_concern(collection, tmpReadConcernPtr)
         }
 
         if let rp = options?.readPreference {

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -58,7 +58,9 @@ public class MongoCollection<T: Codable> {
         }
 
         if let rc = options?.readConcern {
-            mongoc_collection_set_read_concern(collection, rc._readConcern)
+            try? rc.withMongocReadConcern { tmpReadConcernPtr in
+                mongoc_collection_set_read_concern(collection, tmpReadConcernPtr)
+            }
         }
 
         if let rp = options?.readPreference {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -103,7 +103,9 @@ public class MongoDatabase {
         }
 
         if let rc = options?.readConcern {
-            mongoc_database_set_read_concern(db, rc._readConcern)
+            try? rc.withMongocReadConcern { tmpReadConcernPtr in
+                mongoc_database_set_read_concern(db, tmpReadConcernPtr)
+            }
         }
 
         if let rp = options?.readPreference {
@@ -262,6 +264,7 @@ public class MongoDatabase {
     public func runCommand(_ command: Document,
                            options: RunCommandOptions? = nil,
                            session: ClientSession? = nil) throws -> Document {
+        print("level: \(options?.readConcern?.level)")
         let operation = RunCommandOperation(database: self, command: command, options: options, session: session)
         return try operation.execute()
     }

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -102,10 +102,8 @@ public class MongoDatabase {
             fatalError("Couldn't get database '\(name)'")
         }
 
-        if let rc = options?.readConcern {
-            try? rc.withMongocReadConcern { tmpReadConcernPtr in
-                mongoc_database_set_read_concern(db, tmpReadConcernPtr)
-            }
+        options?.readConcern?.withMongocReadConcern { tmpReadConcernPtr in
+            mongoc_database_set_read_concern(db, tmpReadConcernPtr)
         }
 
         if let rp = options?.readPreference {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -264,7 +264,6 @@ public class MongoDatabase {
     public func runCommand(_ command: Document,
                            options: RunCommandOptions? = nil,
                            session: ClientSession? = nil) throws -> Document {
-        print("level: \(options?.readConcern?.level)")
         let operation = RunCommandOperation(database: self, command: command, options: options, session: session)
         return try operation.execute()
     }

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -66,11 +66,6 @@ public struct ReadConcern: Codable {
         }
     }
 
-    /// Initializes a new `ReadConcern` by copying an existing `ReadConcern`.
-    public init(from readConcern: ReadConcern) {
-        self.level = readConcern.level
-    }
-
     /// Initialize a new `ReadConcern` with a `Level`.
     public init(_ level: Level) {
         self.level = level
@@ -108,9 +103,7 @@ public struct ReadConcern: Codable {
         if let level = self.level {
             mongoc_read_concern_set_level(readConcern, level.rawValue)
         }
-        defer {
-            mongoc_read_concern_destroy(readConcern)
-         }
+        defer { mongoc_read_concern_destroy(readConcern) }
         return try body(readConcern)
     }
 }

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -90,12 +90,8 @@ public struct ReadConcern: Codable {
         }
     }
 
-    private enum CodingKeys: String, CodingKey {
-        case level
-    }
-
     /**
-     * Creates a new `ReadConcern` with the provided options and passes it to the provided closure.
+     * Creates a new `mongoc_rad_concern_t` based on this `ReadConcern` and passes it to the provided closure.
      * The read concern is only valid within the body of the closure and will be ended after the body completes.
      */
     internal func withMongocReadConcern<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -93,7 +93,7 @@ public struct ReadConcern: Codable {
     }
 
     /**
-     * Creates a new `mongoc_rad_concern_t` based on this `ReadConcern` and passes it to the provided closure.
+     * Creates a new `mongoc_read_concern_t` based on this `ReadConcern` and passes it to the provided closure.
      * The pointer is only valid within the body of the closure and will be freed after the body completes.
      */
     internal func withMongocReadConcern<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -14,7 +14,9 @@ public struct ReadConcern: Codable {
         case linearizable
         /// See https://docs.mongodb.com/master/reference/read-concern-snapshot/
         case snapshot
-        /// Any other read concern level not covered by the other cases
+        /// Any other read concern level not covered by the other cases.
+        /// This case is present to provide forwards compatibility with any
+        /// future read concerns which may be added to new versions of MongoDB.
         case other(level: String)
 
         public var rawValue: String {
@@ -96,10 +98,10 @@ public struct ReadConcern: Codable {
      */
     internal func withMongocReadConcern<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {
         let readConcern: OpaquePointer = mongoc_read_concern_new()
+        defer { mongoc_read_concern_destroy(readConcern) }
         if let level = self.level {
             mongoc_read_concern_set_level(readConcern, level.rawValue)
         }
-        defer { mongoc_read_concern_destroy(readConcern) }
         return try body(readConcern)
     }
 }

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -14,7 +14,7 @@ public struct ReadConcern: Codable {
         case linearizable
         /// See https://docs.mongodb.com/master/reference/read-concern-snapshot/
         case snapshot
-        /// Unknown level
+        /// Any other read concern level not covered by the other cases
         case other(level: String)
 
         public var rawValue: String {

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -94,7 +94,7 @@ public struct ReadConcern: Codable {
 
     /**
      * Creates a new `mongoc_rad_concern_t` based on this `ReadConcern` and passes it to the provided closure.
-     * The read concern is only valid within the body of the closure and will be ended after the body completes.
+     * The pointer is only valid within the body of the closure and will be freed after the body completes.
      */
     internal func withMongocReadConcern<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {
         let readConcern: OpaquePointer = mongoc_read_concern_new()

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -1,9 +1,9 @@
 import mongoc
 
-/// A class to represent a MongoDB read concern.
-public class ReadConcern: Codable {
+/// A struct to represent a MongoDB read concern.
+public struct ReadConcern: Codable {
     /// An enumeration of possible ReadConcern levels.
-    public enum Level: String {
+    public enum Level: String, Encodable {
         /// See https://docs.mongodb.com/manual/reference/read-concern-local/
         case local
         /// See https://docs.mongodb.com/manual/reference/read-concern-available/
@@ -16,40 +16,50 @@ public class ReadConcern: Codable {
         case snapshot
     }
 
-    /// A pointer to a `mongoc_read_concern_t`.
-    internal var _readConcern: OpaquePointer?
-
     /// The level of this `ReadConcern`, or `nil` if the level is not set.
-    public var level: String? {
-        guard let level = mongoc_read_concern_get_level(self._readConcern) else {
-            return nil
-        }
-        return String(cString: level)
-    }
+    public var level: Level?
 
     /// Indicates whether this `ReadConcern` is the server default.
     public var isDefault: Bool {
-        return mongoc_read_concern_is_default(self._readConcern)
+       if level == nil {
+           return true
+       }
+       return false
     }
 
-    /// Initialize a new `ReadConcern` from a `ReadConcern.Level`.
-    public convenience init(_ level: Level) {
-        self.init(level.rawValue)
+    /// A pointer to a `mongoc_read_concern_t`.
+    internal var _readConcern: OpaquePointer?
+
+    /// Initializes a new `ReadConcern` by copying a `mongoc_read_concern_t`.
+    /// The caller is responsible for freeing the original `mongoc_read_concern_t`.
+    public init(from readConcern: OpaquePointer) {
+        if let level = mongoc_read_concern_get_level(self._readConcern) {
+            self.level = Level(rawValue: String(cString: level))
+        }
+    }
+
+    /// Initializes a new `ReadConcern` by copying an existing `ReadConcern`.
+    public init(from readConcern: ReadConcern) {
+        self.level = readConcern.level
+    }
+
+    /// Initialize a new `ReadConcern` with a `Level`.
+    public init(_ level: Level) {
+        self.level = level
     }
 
     /// Initialize a new `ReadConcern` from a `String` corresponding to a read concern level.
     public init(_ level: String) {
-        self._readConcern = mongoc_read_concern_new()
-        mongoc_read_concern_set_level(self._readConcern, level)
+        self.level = Level(rawValue: level)
     }
 
     /// Initialize a new empty `ReadConcern`.
     public init() {
-        self._readConcern = mongoc_read_concern_new()
+        self.level = nil
     }
 
     /// Initializes a new `ReadConcern` from a `Document`.
-    public convenience init(_ doc: Document) {
+    public init(_ doc: Document) {
         if let level = doc["level"] as? String {
             self.init(level)
         } else {
@@ -57,22 +67,11 @@ public class ReadConcern: Codable {
         }
     }
 
-    /// Initializes a new `ReadConcern` by copying an existing `ReadConcern`.
-    public init(from readConcern: ReadConcern) {
-        self._readConcern = mongoc_read_concern_copy(readConcern._readConcern)
-    }
-
-    /// Initializes a new `ReadConcern` by copying a `mongoc_read_concern_t`.
-    /// The caller is responsible for freeing the original `mongoc_read_concern_t`.
-    internal init(from readConcern: OpaquePointer?) {
-        self._readConcern = mongoc_read_concern_copy(readConcern)
-    }
-
     private enum CodingKeys: String, CodingKey {
         case level
     }
 
-    public required convenience init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         if let level = try container.decodeIfPresent(String.self, forKey: .level) {
             self.init(level)
@@ -84,15 +83,6 @@ public class ReadConcern: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(self.level, forKey: .level)
-    }
-
-    /// Cleans up internal state.
-    deinit {
-        guard let readConcern = self._readConcern else {
-            return
-        }
-        mongoc_read_concern_destroy(readConcern)
-        self._readConcern = nil
     }
 }
 

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -115,6 +115,10 @@ public struct ReadConcern: Codable {
         try container.encodeIfPresent(self.level, forKey: .level)
     }
 
+    /**
+     * Creates a new `ReadConcern` with the provided options and passes it to the provided closure.
+     * The read concern is only valid within the body of the closure and will be ended after the body completes.
+     */
     public func withMongocReadConcern<T>(_ body: (OpaquePointer) throws -> T) throws -> T {
         var readConcern: OpaquePointer = mongoc_read_concern_new()
         if let level = self.level {

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -32,8 +32,8 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         let rc = ReadConcern(.majority)
         expect(rc.level).to(equal(.majority))
 
-        // test copy init
-        let rc2 = ReadConcern(from: rc)
+        // test copy
+        let rc2 = rc
         expect(rc2.level).to(equal(.majority))
 
         // test empty init

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -32,26 +32,22 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         let rc = ReadConcern(.majority)
         expect(rc.level).to(equal(.majority))
 
-        // test copy
-        let rc2 = rc
-        expect(rc2.level).to(equal(.majority))
-
         // test empty init
-        let rc3 = ReadConcern()
-        expect(rc3.level).to(beNil())
-        expect(rc3.isDefault).to(beTrue())
+        let rc2 = ReadConcern()
+        expect(rc2.level).to(beNil())
+        expect(rc2.isDefault).to(beTrue())
 
         // test init from doc
-        let rc4 = ReadConcern(["level": "majority"])
-        expect(rc4.level).to(equal(.majority))
+        let rc3 = ReadConcern(["level": "majority"])
+        expect(rc3.level).to(equal(.majority))
 
         // test string init
-        let rc5 = ReadConcern("majority")
-        expect(rc5.level).to(equal(.majority))
+        let rc4 = ReadConcern("majority")
+        expect(rc4.level).to(equal(.majority))
 
         // test init with unknown level
-        let rc6 = ReadConcern("blah")
-        expect(rc6.level).to(equal(.other(level: "blah")))
+        let rc5 = ReadConcern("blah")
+        expect(rc5.level).to(equal(.other(level: "blah")))
     }
 
     func testWriteConcernType() throws {

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -30,11 +30,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     func testReadConcernType() throws {
         // check level var works as expected
         let rc = ReadConcern(.majority)
-        expect(rc.level).to(equal("majority"))
+        expect(rc.level).to(equal(ReadConcern.Level.majority))
 
         // test copy init
         let rc2 = ReadConcern(from: rc)
-        expect(rc2.level).to(equal("majority"))
+        expect(rc2.level).to(equal(ReadConcern.Level.majority))
 
         // test empty init
         let rc3 = ReadConcern()
@@ -42,7 +42,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
         // test init from doc
         let rc4 = ReadConcern(["level": "majority"])
-        expect(rc4.level).to(equal("majority"))
+        expect(rc4.level).to(equal(ReadConcern.Level.majority))
     }
 
     func testWriteConcernType() throws {
@@ -74,28 +74,28 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
             // expect that a DB created from this client can override the client's unset RC
             let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
-            expect(db2.readConcern?.level).to(equal("majority"))
+            expect(db2.readConcern?.level).to(equal(ReadConcern.Level.majority))
         }
 
         // test behavior of a client initialized with local RC
         do {
             let client = try MongoClient(options: ClientOptions(readConcern: ReadConcern(.local)))
             // although local is default, if it is explicitly provided it should be set
-            expect(client.readConcern?.level).to(equal("local"))
+            expect(client.readConcern?.level).to(equal(ReadConcern.Level.local))
 
             // expect that a DB created from this client inherits its local RC
             let db1 = client.db(type(of: self).testDatabase)
-            expect(db1.readConcern?.level).to(equal("local"))
+            expect(db1.readConcern?.level).to(equal(ReadConcern.Level.local))
 
             // expect that a DB created from this client can override the client's local RC
             let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
-            expect(db2.readConcern?.level).to(equal("majority"))
+            expect(db2.readConcern?.level).to(equal(ReadConcern.Level.majority))
         }
 
         // test behavior of a client initialized with majority RC
         do {
             let client = try MongoClient(options: ClientOptions(readConcern: majority))
-            expect(client.readConcern?.level).to(equal("majority"))
+            expect(client.readConcern?.level).to(equal(ReadConcern.Level.majority))
 
             // expect that a DB created from this client can override the client's majority RC with an unset one
             let db = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: ReadConcern()))
@@ -171,7 +171,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
                 self.getCollectionName(suffix: "2"),
                 options: CollectionOptions(readConcern: ReadConcern(.local))
         )
-        expect(coll2.readConcern?.level).to(equal("local"))
+        expect(coll2.readConcern?.level).to(equal(ReadConcern.Level.local))
 
         try db1.drop()
 
@@ -183,18 +183,18 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
         let coll3Name = self.getCollectionName(suffix: "3")
         // expect that a collection created from a DB with local RC also has local RC
         var coll3 = try db2.createCollection(coll3Name)
-        expect(coll3.readConcern?.level).to(equal("local"))
+        expect(coll3.readConcern?.level).to(equal(ReadConcern.Level.local))
 
         // expect that a collection retrieved from a DB with local RC also has local RC
         coll3 = db2.collection(coll3Name)
-        expect(coll3.readConcern?.level).to(equal("local"))
+        expect(coll3.readConcern?.level).to(equal(ReadConcern.Level.local))
 
         // expect that a collection retrieved from a DB with local RC can override the DB's RC
         let coll4 = db2.collection(
                 self.getCollectionName(suffix: "4"),
                 options: CollectionOptions(readConcern: ReadConcern(.majority))
         )
-        expect(coll4.readConcern?.level).to(equal("majority"))
+        expect(coll4.readConcern?.level).to(equal(ReadConcern.Level.majority))
     }
 
     func testDatabaseWriteConcern() throws {


### PR DESCRIPTION
Part 1 of SWIFT-509: Made changes to ReadConcern so that it no longer saves a pointer to monogc type.