### PR TITLE
SWIFT-508 Add check for all possible BSON values in AnyBSONValue.init(from: decoder)

### DIFF
--- a/Sources/MongoSwift/BSON/AnyBSONValue.swift
+++ b/Sources/MongoSwift/BSON/AnyBSONValue.swift
@@ -176,6 +176,12 @@ public struct AnyBSONValue: Codable, Equatable, Hashable {
             self.value = value.map { $0.value }
         } else if let value = try? container.decode(Document.self) {
             self.value = value
+        } else if let value = try? container.decode(Timestamp.self) {
+            self.value = value
+        } else if let value = try? container.decode(BSONUndefined.self) {
+            self.value = value
+        } else if let value = try? container.decode(DBPointer.self) {
+            self.value = value
         } else {
             throw DecodingError.typeMismatch(
                     AnyBSONValue.self,


### PR DESCRIPTION
Added checks for Timestamp, BSONUndefined, and DBPointer that were missing previously.