### PR TITLE
SWIFT-374 Add ConnectionPool and Connection types

### DIFF
--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -1,0 +1,116 @@
+import mongoc
+
+/// A connection to the database.
+internal struct Connection {
+    /// Pointer to the underlying `mongoc_client_t`.
+    internal let clientHandle: OpaquePointer
+
+    internal init(_ clientHandle: OpaquePointer) {
+        self.clientHandle = clientHandle
+    }
+}
+
+/// A pool of one or more connections.
+internal class ConnectionPool {
+    /// Represents the mode of a `ConnectionPool`.
+    private enum Mode {
+        /// Indicates that we are in single-client mode using the associated pointer to a `mongoc_client_t`.
+        case single(client: OpaquePointer)
+        /// Indicates that we are in pooled mode using the associated pointer to a `mongoc_client_pool_t`.
+        case pooled(pool: OpaquePointer)
+        /// Indicates that the `ConnectionPool` has been closed.
+        case closed
+    }
+
+    /// The mode of this `ConnectionPool`.
+    private var mode: Mode
+
+    /// Initializes the pool in single mode using the provided pointer to a `mongoc_client_t`.
+    internal init(stealing pointer: OpaquePointer) {
+        self.mode = .single(client: pointer)
+
+        // This call may fail, and if it does, either the error api version was already set or the client was derived
+        // from a pool. In either case, the error handling in MongoSwift will be incorrect unless the correct api
+        // version was set by the caller.
+        mongoc_client_set_error_api(pointer, MONGOC_ERROR_API_VERSION_2)
+    }
+
+    /// Initializes the pool in pooled mode using the provided `ConnectionString`.
+    internal init(from connString: ConnectionString) throws {
+        // TODO SWIFT-374: this initializer should actually create a `mongoc_client_pool_t` and do appropriate setup
+        // on that.
+        guard let clientHandle = mongoc_client_new_from_uri(connString._uri) else {
+            throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support")
+        }
+
+        guard mongoc_client_set_error_api(clientHandle, MONGOC_ERROR_API_VERSION_2) else {
+            throw RuntimeError.internalError(message: "Could not configure error handling on client")
+        }
+
+        // TODO: mode should be pooled.
+        self.mode = .single(client: clientHandle)
+    }
+
+    /// Closes the pool if it has not been manually closed already.
+    deinit {
+        self.close()
+    }
+
+    /// Closes the pool, cleaning up underlying resources.
+    internal func close() {
+        switch self.mode {
+        case let .single(clientHandle):
+            mongoc_client_destroy(clientHandle)
+        case .pooled:
+            fatalError("Pooled mode is not yet implemented")
+        case .closed:
+            return
+        }
+        self.mode = .closed
+    }
+
+    /// Checks out a connection. This connection must be returned to the pool via `checkIn`.
+    internal func checkOut() throws -> Connection {
+        switch self.mode {
+        case let .single(clientHandle):
+            return Connection(clientHandle)
+        case .pooled:
+            fatalError("Pooled mode is not yet implemented")
+        case .closed:
+            throw RuntimeError.internalError(message: "ConnectionPool was already closed")
+        }
+    }
+
+    /// Returns a connection to the pool.
+    internal func checkIn(_ connection: Connection) {
+        switch self.mode {
+        case .single:
+            return
+        case .pooled:
+            fatalError("Pooled mode is not yet implemented")
+        case .closed:
+            fatalError("ConnectionPool was already closed")
+        }
+    }
+
+    /// Executes the given closure using a connection from the pool.
+    internal func withConnection<T>(body: (Connection) throws -> T) throws -> T {
+        let connection = try self.checkOut()
+        defer { self.checkIn(connection) }
+        return try body(connection)
+    }
+
+    /// Sets APM callbacks to be used for all connections in the pool.
+    internal func setAPMCallbacks(client: MongoClient, callbacks: OpaquePointer) {
+        switch self.mode {
+        case let .single(clientHandle):
+            // we can pass the MongoClient as unretained because the callbacks are stored on clientHandle, so if the
+            // callback is being executed, this pool and therefore its parent `MongoClient` must still be valid.
+            mongoc_client_set_apm_callbacks(clientHandle, callbacks, Unmanaged.passUnretained(client).toOpaque())
+        case .pooled:
+            fatalError("Pooled mode is not yet implemented")
+        case .closed:
+            fatalError("ConnectionPool was already closed")
+        }
+    }
+}

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -47,7 +47,6 @@ internal class ConnectionPool {
             throw RuntimeError.internalError(message: "Could not configure error handling on client")
         }
 
-        // TODO: mode should be pooled.
         self.mode = .single(client: clientHandle)
     }
 

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -18,8 +18,8 @@ internal class ConnectionPool {
         case single(client: OpaquePointer)
         /// Indicates that we are in pooled mode using the associated pointer to a `mongoc_client_pool_t`.
         case pooled(pool: OpaquePointer)
-        /// Indicates that the `ConnectionPool` has been closed.
-        case closed
+        /// Indicates that the `ConnectionPool` has been closed and contains no connections.
+        case none
     }
 
     /// The mode of this `ConnectionPool`.
@@ -62,10 +62,10 @@ internal class ConnectionPool {
             mongoc_client_destroy(clientHandle)
         case .pooled:
             fatalError("Pooled mode is not yet implemented")
-        case .closed:
+        case .none:
             return
         }
-        self.mode = .closed
+        self.mode = .none
     }
 
     /// Checks out a connection. This connection must be returned to the pool via `checkIn`.
@@ -75,7 +75,7 @@ internal class ConnectionPool {
             return Connection(clientHandle)
         case .pooled:
             fatalError("Pooled mode is not yet implemented")
-        case .closed:
+        case .none:
             throw RuntimeError.internalError(message: "ConnectionPool was already closed")
         }
     }
@@ -87,7 +87,7 @@ internal class ConnectionPool {
             return
         case .pooled:
             fatalError("Pooled mode is not yet implemented")
-        case .closed:
+        case .none:
             fatalError("ConnectionPool was already closed")
         }
     }
@@ -108,7 +108,7 @@ internal class ConnectionPool {
             mongoc_client_set_apm_callbacks(clientHandle, callbacks, Unmanaged.passUnretained(client).toOpaque())
         case .pooled:
             fatalError("Pooled mode is not yet implemented")
-        case .closed:
+        case .none:
             fatalError("ConnectionPool was already closed")
         }
     }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -120,6 +120,7 @@ public struct DatabaseOptions: CodingStrategyProvider {
 
 /// A MongoDB Client.
 public class MongoClient {
+    // TODO SWIFT-374: remove this property.
     internal let _client: OpaquePointer
 
     internal let connectionPool: ConnectionPool
@@ -173,11 +174,10 @@ public class MongoClient {
         // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
         initializeMongoc()
 
-        // TODO: when we stop storing _client, we will store these options and use them to determine the return values
-        // for MongoClient.readConcern, etc.
+        // TODO SWIFT-374: when we stop storing _client, we will store these options and use them to determine the
+        // return values for MongoClient.readConcern, etc.
         var options = options ?? ClientOptions()
         let connString = try ConnectionString(connectionString, options: &options)
-
         self.connectionPool = try ConnectionPool(from: connString)
 
         // temporarily retrieve the single client from the pool.
@@ -210,7 +210,6 @@ public class MongoClient {
      *   - pointer: the `mongoc_client_t` to store and use internally
      */
     public init(stealing pointer: OpaquePointer) {
-        // TODO SWIFT-374: stop storing _client.
         self._client = pointer
         self.connectionPool = ConnectionPool(stealing: pointer)
         self.encoder = BSONEncoder()

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -120,7 +120,9 @@ public struct DatabaseOptions: CodingStrategyProvider {
 
 /// A MongoDB Client.
 public class MongoClient {
-    internal var _client: OpaquePointer?
+    internal let _client: OpaquePointer
+
+    internal let connectionPool: ConnectionPool
 
     /// If command and/or server monitoring is enabled, stores the NotificationCenter events are posted to.
     internal var notificationCenter: NotificationCenter?
@@ -176,20 +178,15 @@ public class MongoClient {
         var options = options ?? ClientOptions()
         let connString = try ConnectionString(connectionString, options: &options)
 
-        self._client = mongoc_client_new_from_uri(connString._uri)
-        guard self._client != nil else {
-            throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support")
-        }
+        self.connectionPool = try ConnectionPool(from: connString)
+
+        // temporarily retrieve the single client from the pool.
+        self._client = try self.connectionPool.checkOut().clientHandle
 
         self.encoder = BSONEncoder(options: options)
         self.decoder = BSONDecoder(options: options)
 
         if options.eventMonitoring { self.initializeMonitoring() }
-
-        guard mongoc_client_set_error_api(self._client, MONGOC_ERROR_API_VERSION_2) else {
-            self.close()
-            throw RuntimeError.internalError(message: "Could not configure error handling on client")
-        }
     }
 
     /**
@@ -213,20 +210,11 @@ public class MongoClient {
      *   - pointer: the `mongoc_client_t` to store and use internally
      */
     public init(stealing pointer: OpaquePointer) {
+        // TODO SWIFT-374: stop storing _client.
         self._client = pointer
-
-        // This call may fail, and if it does, either the error api version was already set or the client was derived
-        // from a pool. In either case, the error handling in MongoSwift will be incorrect unless the correct api
-        // version was set by the caller.
-        mongoc_client_set_error_api(self._client, MONGOC_ERROR_API_VERSION_2)
-
+        self.connectionPool = ConnectionPool(stealing: pointer)
         self.encoder = BSONEncoder()
         self.decoder = BSONDecoder()
-    }
-
-    /// Cleans up internal state.
-    deinit {
-        close()
     }
 
     /**
@@ -251,21 +239,6 @@ public class MongoClient {
         let session = try ClientSession(client: self, options: options)
         defer { session.end() }
         return try sessionBody(session)
-    }
-
-    /**
-     * Closes the client.
-     */
-    public func close() {
-        guard let client = self._client else {
-            return
-        }
-
-        // this is defined in the APM extension to Client
-        self.disableMonitoring()
-
-        mongoc_client_destroy(client)
-        self._client = nil
     }
 
     /**

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -174,8 +174,8 @@ public class MongoClient {
         // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
         initializeMongoc()
 
-        // TODO SWIFT-374: when we stop storing _client, we will store these options and use them to determine the
-        // return values for MongoClient.readConcern, etc.
+        // TODO: when we stop storing _client, we will store these options and use them to determine the return values
+        // for MongoClient.readConcern, etc.
         var options = options ?? ClientOptions()
         let connString = try ConnectionString(connectionString, options: &options)
         self.connectionPool = try ConnectionPool(from: connString)


### PR DESCRIPTION
This PR introduces `Connection` and `ConnectionPool` types. `MongoClient` now stores a `ConnectionPool`.

For the moment, the `ConnectionPool` only supports single mode, and `MongoClient` continues to store a reference to the single `mongoc_client_t` so the rest of the code still works.

