### PR TITLE
SWIFT-374 Operation layer changes

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -125,7 +125,7 @@ public class MongoClient {
 
     internal let connectionPool: ConnectionPool
 
-    private let executor = DefaultOperationExecutor()
+    private let operationExecutor: OperationExecutor = DefaultOperationExecutor()
 
     /// If command and/or server monitoring is enabled, stores the NotificationCenter events are posted to.
     internal var notificationCenter: NotificationCenter?
@@ -280,6 +280,6 @@ public class MongoClient {
     /// Executes an `Operation` using this `MongoClient` and an optionally provided session.
     internal func executeOperation<T: Operation>(_ operation: T,
                                                  session: ClientSession? = nil) throws -> T.OperationResult {
-        return try self.executor.execute(operation, client: self, session: session)
+        return try self.operationExecutor.execute(operation, client: self, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -125,6 +125,8 @@ public class MongoClient {
 
     internal let connectionPool: ConnectionPool
 
+    private let executor = DefaultOperationExecutor()
+
     /// If command and/or server monitoring is enabled, stores the NotificationCenter events are posted to.
     internal var notificationCenter: NotificationCenter?
 
@@ -273,5 +275,11 @@ public class MongoClient {
      */
     public func db(_ name: String, options: DatabaseOptions? = nil) -> MongoDatabase {
         return MongoDatabase(name: name, client: self, options: options)
+    }
+
+    /// Executes an `Operation` using this `MongoClient` and an optionally provided session.
+    internal func executeOperation<T: Operation>(_ operation: T,
+                                                 session: ClientSession? = nil) throws -> T.OperationResult {
+        return try self.executor.execute(operation, client: self, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -33,7 +33,7 @@ extension MongoCollection {
             try model.addToBulkWrite(bulk: bulk, index: index)
         }
 
-        return try bulk.execute()
+        return try self._client.executeOperation(bulk, session: session)
     }
 
     private struct DeleteModelOptions: Encodable {
@@ -390,7 +390,9 @@ public class BulkWriteOperation: Operation {
      *   - `ServerError.commandError` if an error occurs that prevents the operation from executing.
      *   - `ServerError.bulkWriteError` if an error occurs while performing the writes.
      */
-    internal func execute() throws -> BulkWriteResult? {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> BulkWriteResult? {
+        // TODO SWIFT-374: this method does not actually use either of the parameters passed in here. they will be
+        // utilized once we fix up BulkWriteOperation to look like the rest of the operations.
         var reply = Document()
         var error = bson_error_t()
         let serverId = withMutableBSONPointer(to: &reply) { replyPtr in

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -100,7 +100,7 @@ extension MongoCollection {
                                                update: update,
                                                options: options,
                                                session: session)
-        return try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -95,11 +95,7 @@ extension MongoCollection {
                                update: Document? = nil,
                                options: FindAndModifyOptionsConvertible? = nil,
                                session: ClientSession?) throws -> CollectionType? {
-        let operation = FindAndModifyOperation(collection: self,
-                                               filter: filter,
-                                               update: update,
-                                               options: options,
-                                               session: session)
+        let operation = FindAndModifyOperation(collection: self, filter: filter, update: update, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -219,7 +219,7 @@ extension MongoCollection {
     public func createIndexes(_ models: [IndexModel],
                               options: CreateIndexOptions? = nil,
                               session: ClientSession? = nil) throws -> [String] {
-        let operation = CreateIndexesOperation(collection: self, models: models, options: options, session: session)
+        let operation = CreateIndexesOperation(collection: self, models: models, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 
@@ -318,7 +318,7 @@ extension MongoCollection {
     private func _dropIndexes(index: BSONValue,
                               options: DropIndexOptions?,
                               session: ClientSession?) throws -> Document {
-        let operation = DropIndexesOperation(collection: self, index: index, options: options, session: session)
+        let operation = DropIndexesOperation(collection: self, index: index, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -220,7 +220,7 @@ extension MongoCollection {
                               options: CreateIndexOptions? = nil,
                               session: ClientSession? = nil) throws -> [String] {
         let operation = CreateIndexesOperation(collection: self, models: models, options: options, session: session)
-        return try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 
     /**
@@ -319,7 +319,7 @@ extension MongoCollection {
                               options: DropIndexOptions?,
                               session: ClientSession?) throws -> Document {
         let operation = DropIndexesOperation(collection: self, index: index, options: options, session: session)
-        return try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 
     /**

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -74,7 +74,7 @@ extension MongoCollection {
     public func count(_ filter: Document = [:],
                       options: CountOptions? = nil,
                       session: ClientSession? = nil) throws -> Int {
-        let operation = CountOperation(collection: self, filter: filter, options: options, session: session)
+        let operation = CountOperation(collection: self, filter: filter, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 
@@ -128,11 +128,7 @@ extension MongoCollection {
                          filter: Document = [:],
                          options: DistinctOptions? = nil,
                          session: ClientSession? = nil) throws -> [BSONValue] {
-        let operation = DistinctOperation(collection: self,
-                                          fieldName: fieldName,
-                                          filter: filter,
-                                          options: options,
-                                          session: session)
+        let operation = DistinctOperation(collection: self, fieldName: fieldName, filter: filter, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -75,7 +75,7 @@ extension MongoCollection {
                       options: CountOptions? = nil,
                       session: ClientSession? = nil) throws -> Int {
         let operation = CountOperation(collection: self, filter: filter, options: options, session: session)
-        return try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 
     /**
@@ -133,7 +133,7 @@ extension MongoCollection {
                                           filter: filter,
                                           options: options,
                                           session: session)
-        return try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -106,6 +106,6 @@ public class MongoCollection<T: Codable> {
     */
     public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) throws {
         let operation = DropCollectionOperation(collection: self, options: options, session: session)
-        try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -105,7 +105,7 @@ public class MongoCollection<T: Codable> {
     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
     */
     public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) throws {
-        let operation = DropCollectionOperation(collection: self, options: options, session: session)
+        let operation = DropCollectionOperation(collection: self, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -119,7 +119,7 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
         do {
             let operation = NextOperation(cursor: self)
             // TODO SWIFT-374: we temporarily use a fake connection here. eventually MongoCursor will store its source
-            // connection and we can pass that in here instead (though the execute method still won't use it.) 
+            // connection and we can pass that in here instead (though the execute method still won't use it.)
             // we want to pass in a specific connection and call execute() ourselves rather than using an operation
             // executor as that would require checking out a separate, unused connection for every single next() call.
             // the force unwrap is safe as this bitPattern is always valid.

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -4,7 +4,7 @@ import mongoc
 public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
     internal var _cursor: OpaquePointer?
     private var _client: MongoClient?
-    internal var _session: ClientSession?
+    private var _session: ClientSession?
 
     private var swiftError: Error?
 
@@ -118,7 +118,13 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
     public func next() -> T? {
         do {
             let operation = NextOperation(cursor: self)
-            let out = try operation.execute()
+            // TODO SWIFT-374: we temporarily use a fake connection here. eventually MongoCursor will store its source
+            // connection and we can pass that in here instead (though the execute method still won't use it.) 
+            // we want to pass in a specific connection and call execute() ourselves rather than using an operation
+            // executor as that would require checking out a separate, unused connection for every single next() call.
+            // the force unwrap is safe as this bitPattern is always valid.
+            // swiftlint:disable:next force_unwrapping
+            let out = try operation.execute(using: Connection(OpaquePointer(bitPattern: 1)!), session: self._session)
             self.swiftError = nil
             return out
         } catch {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -150,7 +150,7 @@ public class MongoDatabase {
     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
     */
     public func drop(options: DropDatabaseOptions? = nil, session: ClientSession? = nil) throws {
-        let operation = DropDatabaseOperation(database: self, options: options, session: session)
+        let operation = DropDatabaseOperation(database: self, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 
@@ -227,11 +227,7 @@ public class MongoDatabase {
                                              withType type: T.Type,
                                              options: CreateCollectionOptions? = nil,
                                              session: ClientSession? = nil) throws -> MongoCollection<T> {
-        let operation = CreateCollectionOperation(database: self,
-                                                  name: name,
-                                                  type: type,
-                                                  options: options,
-                                                  session: session)
+        let operation = CreateCollectionOperation(database: self, name: name, type: type, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 
@@ -279,7 +275,7 @@ public class MongoDatabase {
     public func runCommand(_ command: Document,
                            options: RunCommandOptions? = nil,
                            session: ClientSession? = nil) throws -> Document {
-        let operation = RunCommandOperation(database: self, command: command, options: options, session: session)
+        let operation = RunCommandOperation(database: self, command: command, options: options)
         return try self._client.executeOperation(operation, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -151,7 +151,7 @@ public class MongoDatabase {
     */
     public func drop(options: DropDatabaseOptions? = nil, session: ClientSession? = nil) throws {
         let operation = DropDatabaseOperation(database: self, options: options, session: session)
-        try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 
     /**
@@ -232,7 +232,7 @@ public class MongoDatabase {
                                                   type: type,
                                                   options: options,
                                                   session: session)
-        return try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 
     /**
@@ -280,6 +280,6 @@ public class MongoDatabase {
                            options: RunCommandOptions? = nil,
                            session: ClientSession? = nil) throws -> Document {
         let operation = RunCommandOperation(database: self, command: command, options: options, session: session)
-        return try operation.execute()
+        return try self._client.executeOperation(operation, session: session)
     }
 }

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -64,8 +64,8 @@ internal struct CountOperation<T: Codable>: Operation {
         self.session = session
     }
 
-    internal func execute() throws -> Int {
-        let opts = try encodeOptions(options: options, session: session)
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> Int {
+        let opts = try encodeOptions(options: options, session: self.session)
         let rp = self.options?.readPreference?._readPreference
         var error = bson_error_t()
         // because we already encode skip and limit in the options,

--- a/Sources/MongoSwift/Operations/CountOperation.swift
+++ b/Sources/MongoSwift/Operations/CountOperation.swift
@@ -52,20 +52,15 @@ internal struct CountOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
     private let filter: Document
     private let options: CountOptions?
-    private let session: ClientSession?
 
-    internal init(collection: MongoCollection<T>,
-                  filter: Document,
-                  options: CountOptions?,
-                  session: ClientSession?) {
+    internal init(collection: MongoCollection<T>, filter: Document, options: CountOptions?) {
         self.collection = collection
         self.filter = filter
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> Int {
-        let opts = try encodeOptions(options: options, session: self.session)
+        let opts = try encodeOptions(options: options, session: session)
         let rp = self.options?.readPreference?._readPreference
         var error = bson_error_t()
         // because we already encode skip and limit in the options,

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -110,22 +110,16 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
     private let name: String
     private let type: T.Type
     private let options: CreateCollectionOptions?
-    private let session: ClientSession?
 
-    internal init(database: MongoDatabase,
-                  name: String,
-                  type: T.Type,
-                  options: CreateCollectionOptions?,
-                  session: ClientSession?) {
+    internal init(database: MongoDatabase, name: String, type: T.Type, options: CreateCollectionOptions?) {
         self.database = database
         self.name = name
         self.type = type
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> MongoCollection<T> {
-        let opts = try encodeOptions(options: self.options, session: self.session)
+        let opts = try encodeOptions(options: self.options, session: session)
         var error = bson_error_t()
 
         guard let collection = mongoc_database_create_collection(

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -124,7 +124,7 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
         self.session = session
     }
 
-    internal func execute() throws -> MongoCollection<T> {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> MongoCollection<T> {
         let opts = try encodeOptions(options: self.options, session: self.session)
         var error = bson_error_t()
 

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -28,7 +28,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
         self.session = session
     }
 
-    internal func execute() throws -> [String] {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> [String] {
         var indexData = [Document]()
         for index in self.models {
             var indexDoc = try self.collection.encoder.encode(index)
@@ -40,7 +40,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
 
         let command: Document = ["createIndexes": self.collection.name, "indexes": indexData]
 
-        let opts = try encodeOptions(options: options, session: session)
+        let opts = try encodeOptions(options: options, session: self.session)
 
         var reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -16,16 +16,11 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
     private let models: [IndexModel]
     private let options: CreateIndexOptions?
-    private let session: ClientSession?
 
-    internal init(collection: MongoCollection<T>,
-                  models: [IndexModel],
-                  options: CreateIndexOptions?,
-                  session: ClientSession?) {
+    internal init(collection: MongoCollection<T>, models: [IndexModel], options: CreateIndexOptions?) {
         self.collection = collection
         self.models = models
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> [String] {
@@ -40,7 +35,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
 
         let command: Document = ["createIndexes": self.collection.name, "indexes": indexData]
 
-        let opts = try encodeOptions(options: options, session: self.session)
+        let opts = try encodeOptions(options: options, session: session)
 
         var reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -38,18 +38,12 @@ internal struct DistinctOperation<T: Codable>: Operation {
     private let fieldName: String
     private let filter: Document
     private let options: DistinctOptions?
-    private let session: ClientSession?
 
-    internal init(collection: MongoCollection<T>,
-                  fieldName: String,
-                  filter: Document,
-                  options: DistinctOptions?,
-                  session: ClientSession?) {
+    internal init(collection: MongoCollection<T>, fieldName: String, filter: Document, options: DistinctOptions?) {
         self.collection = collection
         self.fieldName = fieldName
         self.filter = filter
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> [BSONValue] {
@@ -60,7 +54,7 @@ internal struct DistinctOperation<T: Codable>: Operation {
             "query": self.filter
         ]
 
-        let opts = try encodeOptions(options: self.options, session: self.session)
+        let opts = try encodeOptions(options: self.options, session: session)
         let rp = self.options?.readPreference?._readPreference
         var reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -33,7 +33,7 @@ public struct DistinctOptions: Codable {
 }
 
 /// An operation corresponding to a "distinct" command on a collection.
-internal struct DistinctOperation<T: Codable> {
+internal struct DistinctOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
     private let fieldName: String
     private let filter: Document
@@ -52,7 +52,7 @@ internal struct DistinctOperation<T: Codable> {
         self.session = session
     }
 
-    internal func execute() throws -> [BSONValue] {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> [BSONValue] {
         let collName = String(cString: mongoc_collection_get_name(self.collection._collection))
         let command: Document = [
             "distinct": collName,

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -3,18 +3,16 @@ import mongoc
 /// An operation corresponding to a "drop" command on a MongoCollection.
 internal struct DropCollectionOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
-    private let session: ClientSession?
     private let options: DropCollectionOptions?
 
-    internal init(collection: MongoCollection<T>, options: DropCollectionOptions?, session: ClientSession?) {
+    internal init(collection: MongoCollection<T>, options: DropCollectionOptions?) {
         self.collection = collection
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws {
         let command: Document = ["drop": self.collection.name]
-        let opts = try encodeOptions(options: options, session: self.session)
+        let opts = try encodeOptions(options: options, session: session)
 
         var reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -12,7 +12,7 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
         self.session = session
     }
 
-    internal func execute() throws {
+    internal func execute(using connection: Connection, session: ClientSession?) throws {
         let command: Document = ["drop": self.collection.name]
         let opts = try encodeOptions(options: options, session: self.session)
 

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -3,18 +3,16 @@ import mongoc
 /// An operation corresponding to a "drop" command on a MongoDatabase.
 internal struct DropDatabaseOperation: Operation {
     private let database: MongoDatabase
-    private let session: ClientSession?
     private let options: DropDatabaseOptions?
 
-    internal init(database: MongoDatabase, options: DropDatabaseOptions?, session: ClientSession?) {
+    internal init(database: MongoDatabase, options: DropDatabaseOptions?) {
         self.database = database
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws {
         let command: Document = ["dropDatabase": 1]
-        let opts = try encodeOptions(options: self.options, session: self.session)
+        let opts = try encodeOptions(options: self.options, session: session)
 
         var reply = Document()
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -12,7 +12,7 @@ internal struct DropDatabaseOperation: Operation {
         self.session = session
     }
 
-    internal func execute() throws {
+    internal func execute(using connection: Connection, session: ClientSession?) throws {
         let command: Document = ["dropDatabase": 1]
         let opts = try encodeOptions(options: self.options, session: self.session)
 

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -14,23 +14,18 @@ public struct DropIndexOptions: Encodable {
 /// An operation corresponding to a "dropIndexes" command.
 internal struct DropIndexesOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
-    private let session: ClientSession?
     private let index: BSONValue
     private let options: DropIndexOptions?
 
-    internal init(collection: MongoCollection<T>,
-                  index: BSONValue,
-                  options: DropIndexOptions?,
-                  session: ClientSession?) {
+    internal init(collection: MongoCollection<T>, index: BSONValue, options: DropIndexOptions?) {
         self.collection = collection
         self.index = index
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> Document {
         let command: Document = ["dropIndexes": self.collection.name, "index": self.index]
-        let opts = try encodeOptions(options: self.options, session: self.session)
+        let opts = try encodeOptions(options: self.options, session: session)
         var reply = Document()
         var error = bson_error_t()
         let success = withMutableBSONPointer(to: &reply) { replyPtr in

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -28,7 +28,7 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
         self.session = session
     }
 
-    internal func execute() throws -> Document {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> Document {
         let command: Document = ["dropIndexes": self.collection.name, "index": self.index]
         let opts = try encodeOptions(options: self.options, session: self.session)
         var reply = Document()

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -122,25 +122,22 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
     private let filter: Document
     private let update: Document?
     private let options: FindAndModifyOptionsConvertible?
-    private let session: ClientSession?
 
     internal init(collection: MongoCollection<T>,
                   filter: Document,
                   update: Document?,
-                  options: FindAndModifyOptionsConvertible?,
-                  session: ClientSession?) {
+                  options: FindAndModifyOptionsConvertible?) {
         self.collection = collection
         self.filter = filter
         self.update = update
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> T? {
         // we always need to send *something*, as findAndModify requires one of "remove"
         // or "update" to be set.
         let opts = try self.options?.asFindAndModifyOptions() ?? FindAndModifyOptions()
-        if let session = self.session { try opts.setSession(session) }
+        if let session = session { try opts.setSession(session) }
         if let update = self.update { try opts.setUpdate(update) }
 
         var reply = Document()

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -136,7 +136,7 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
         self.session = session
     }
 
-    internal func execute() throws -> T? {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> T? {
         // we always need to send *something*, as findAndModify requires one of "remove"
         // or "update" to be set.
         let opts = try self.options?.asFindAndModifyOptions() ?? FindAndModifyOptions()

--- a/Sources/MongoSwift/Operations/NextOperation.swift
+++ b/Sources/MongoSwift/Operations/NextOperation.swift
@@ -8,12 +8,15 @@ internal struct NextOperation<T: Codable>: Operation {
         self.cursor = cursor
     }
 
-    internal func execute() throws -> T? {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> T? {
+        // NOTE: this method does not actually use the `connection` parameter passed in. for the moment, it is only
+        // here so that `NextOperation` conforms to `Operation`. if we eventually rewrite MongoCursor to no longer
+        // wrap a mongoc cursor then we will use the connection here.
         guard let cursor = self.cursor._cursor else {
             throw UserError.logicError(message: "Tried to iterate a closed cursor.")
         }
 
-        if let session = self.cursor._session, !session.active {
+        if let session = session, !session.active {
             throw ClientSession.SessionInactiveError
         }
 

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -23,7 +23,7 @@ internal struct DefaultOperationExecutor: OperationExecutor {
                                         session: ClientSession?) throws -> T.OperationResult {
         // TODO SWIFT-374: if session is non-nil, use its underlying Connection
         return try client.connectionPool.withConnection { conn in
-            try operation.execute(using: conn, session: nil)
+            try operation.execute(using: conn, session: session)
         }
     }
 }

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -3,8 +3,29 @@
 internal protocol Operation {
     /// The result type this operation returns.
     associatedtype OperationResult
-    /// Executes this operation and returns its corresponding result type.
-    func execute() throws -> OperationResult
+    /// Executes this operation using the provided connection and optional session, and returns its corresponding
+    /// result type.
+    func execute(using connection: Connection, session: ClientSession?) throws -> OperationResult
+}
+
+/// A protocol for types that can be used to execute `Operation`s.
+internal protocol OperationExecutor {
+    /// Executes an operation using the provided client and optionally provided session.
+    func execute<T: Operation>(_ operation: T,
+                               client: MongoClient,
+                               session: ClientSession?) throws -> T.OperationResult
+}
+
+/// Default executor type used by `MongoClient`s.
+internal struct DefaultOperationExecutor: OperationExecutor {
+    internal func execute<T: Operation>(_ operation: T,
+                                        client: MongoClient,
+                                        session: ClientSession?) throws -> T.OperationResult {
+        // TODO SWIFT-374: if session is non-nil, use its underlying Connection
+        return try client.connectionPool.withConnection { conn in
+            try operation.execute(using: conn, session: nil)
+        }
+    }
 }
 
 /// Internal function for generating an options `Document` for passing to libmongoc.

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -42,7 +42,7 @@ internal struct RunCommandOperation: Operation {
         self.session = session
     }
 
-    internal func execute() throws -> Document {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> Document {
         let rp = self.options?.readPreference?._readPreference
         let opts = try encodeOptions(options: self.options, session: self.session)
         var reply = Document()

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -33,18 +33,16 @@ internal struct RunCommandOperation: Operation {
     private let database: MongoDatabase
     private let command: Document
     private let options: RunCommandOptions?
-    private let session: ClientSession?
 
-    internal init(database: MongoDatabase, command: Document, options: RunCommandOptions?, session: ClientSession?) {
+    internal init(database: MongoDatabase, command: Document, options: RunCommandOptions?) {
         self.database = database
         self.command = command
         self.options = options
-        self.session = session
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> Document {
         let rp = self.options?.readPreference?._readPreference
-        let opts = try encodeOptions(options: self.options, session: self.session)
+        let opts = try encodeOptions(options: self.options, session: session)
         var reply = Document()
         var error = bson_error_t()
         let success = withMutableBSONPointer(to: &reply) { replyPtr in


### PR DESCRIPTION
This PR:
- Introduces the `OperationExecutor` protocol and a `DefaultOperationExecutor` type. `MongoClient` stores an executor which is used for executing all operations that rely on the client. 
- Updates the `Operation` protocol so that `execute` now takes in a `Connection` and `ClientSession` with which to execute an `Operation`. 
- Updates all `Operation` types to conform to the protocol 
    - At the moment, they all ignore the passed-in `Connection`. In the next PR they will start using those to construct the short-lived DB and client pointers.
    - The operations no longer need to store their `ClientSession`s since they get passed into `execute`.