### PR TITLE
SWIFT-174 Implement DB enumeration spec

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -247,7 +247,7 @@ public class MongoClient {
         let operation = ListDatabasesOperation(client: self,
                                                options: ListDatabasesOptions(filter: filter, nameOnly: nil),
                                                session: session)
-        guard case let .specs(result) = try operation.execute() else {
+        guard case let .specs(result) = try self.executeOperation(operation) else {
             throw RuntimeError.internalError(message: "Invalid result")
         }
         return result
@@ -283,7 +283,7 @@ public class MongoClient {
         let operation = ListDatabasesOperation(client: self,
                                                options: ListDatabasesOptions(filter: filter, nameOnly: true),
                                                session: session)
-        guard case let .names(result) = try operation.execute() else {
+        guard case let .names(result) = try self.executeOperation(operation) else {
             throw RuntimeError.internalError(message: "Invalid result")
         }
         return result

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -245,7 +245,8 @@ public class MongoClient {
     public func listDatabases(_ filter: Document? = nil,
                               session: ClientSession? = nil) throws -> [DatabaseSpecification] {
         let operation = ListDatabasesOperation(client: self,
-                                               options: ListDatabasesOptions(filter: filter, nameOnly: nil),
+                                               filter: filter,
+                                               nameOnly: nil,
                                                session: session)
         guard case let .specs(result) = try self.executeOperation(operation) else {
             throw RuntimeError.internalError(message: "Invalid result")
@@ -281,7 +282,8 @@ public class MongoClient {
      */
     public func listDatabaseNames(_ filter: Document? = nil, session: ClientSession? = nil) throws -> [String] {
         let operation = ListDatabasesOperation(client: self,
-                                               options: ListDatabasesOptions(filter: filter, nameOnly: true),
+                                               filter: filter,
+                                               nameOnly: true,
                                                session: session)
         guard case let .names(result) = try self.executeOperation(operation) else {
             throw RuntimeError.internalError(message: "Invalid result")

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -236,9 +236,10 @@ public class MongoClient {
      * - Returns: A `MongoCursor` over `Document`s describing the databases matching provided criteria
      *
      * - Throws:
-     *   - `UserError.invalidArgumentError` if the options passed are an invalid combination.
      *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error is encountered while encoding the options to BSON.
+     *
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/listDatabases/
      */
     public func listDatabases(_ filter: Document? = nil,
                               session: ClientSession? = nil) throws -> ListDatabasesResult {

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -242,9 +242,9 @@ public class MongoClient {
      * - SeeAlso: https://docs.mongodb.com/manual/reference/command/listDatabases/
      */
     public func listDatabases(_ filter: Document? = nil,
-                              session: ClientSession? = nil) throws -> ListDatabasesResult {
+                              session: ClientSession? = nil) throws -> [DatabaseSpecification] {
         let operation = ListDatabasesOperation(client: self, filter: filter, options: nil, session: session)
-        guard case let .full(result) = try operation.execute() else {
+        guard case let .specs(result) = try operation.execute() else {
             throw RuntimeError.internalError(message: "Invalid result")
         }
         return result

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -231,7 +231,8 @@ public class MongoClient {
      * Run the `listDatabases` command.
      *
      * - Parameters:
-     *   - filter: Optional `Document` specifying a filter that the listed databases must pass.
+     *   - filter: Optional `Document` specifying a filter that the listed databases must pass. This filter can be based
+     *     on the "name", "sizeOnDisk", "empty", or "shards" fields of the output.
      *
      * - Returns: A `MongoCursor` over `Document`s describing the databases matching provided criteria
      *
@@ -243,7 +244,9 @@ public class MongoClient {
      */
     public func listDatabases(_ filter: Document? = nil,
                               session: ClientSession? = nil) throws -> [DatabaseSpecification] {
-        let operation = ListDatabasesOperation(client: self, filter: filter, options: nil, session: session)
+        let operation = ListDatabasesOperation(client: self,
+                                               options: ListDatabasesOptions(filter: filter, nameOnly: nil),
+                                               session: session)
         guard case let .specs(result) = try operation.execute() else {
             throw RuntimeError.internalError(message: "Invalid result")
         }
@@ -254,7 +257,7 @@ public class MongoClient {
      * Get a list of `MongoDatabase`s.
      *
      * - Parameters:
-     *   - filter: Optional `Document` specifying a filter that the listed databases must pass.
+     *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
      *
      * - Returns: An Array of `MongoDatabase`s that match the provided filter.
      *
@@ -269,7 +272,7 @@ public class MongoClient {
      * Get a list of names of databases.
      *
      * - Parameters:
-     *   - filter: Optional `Document` specifying a filter that the listed databases must pass.
+     *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
      *
      * - Returns: An Array of `MongoDatabase`s that match the provided filter.
      *
@@ -278,8 +281,7 @@ public class MongoClient {
      */
     public func listDatabaseNames(_ filter: Document? = nil, session: ClientSession? = nil) throws -> [String] {
         let operation = ListDatabasesOperation(client: self,
-                                               filter: filter,
-                                               options: ListDatabasesOptions(nameOnly: true),
+                                               options: ListDatabasesOptions(filter: filter, nameOnly: true),
                                                session: session)
         guard case let .names(result) = try operation.execute() else {
             throw RuntimeError.internalError(message: "Invalid result")

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -68,7 +68,7 @@ internal struct DistinctOperation<T: Codable>: Operation {
 
         guard let values = try reply.getValue(for: "values") as? [BSONValue] else {
             throw RuntimeError.internalError(message:
-                "expected server reply \(reply) to contain an array of distinct values")
+                                             "expected server reply \(reply) to contain an array of distinct values")
         }
 
         return values

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -68,7 +68,7 @@ internal struct DistinctOperation<T: Codable>: Operation {
 
         guard let values = try reply.getValue(for: "values") as? [BSONValue] else {
             throw RuntimeError.internalError(message:
-                                             "expected server reply \(reply) to contain an array of distinct values")
+                "expected server reply \(reply) to contain an array of distinct values")
         }
 
         return values

--- a/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
@@ -43,7 +43,7 @@ internal enum ListDatabasesResults {
     case names([String])
 }
 
-/// An operation corresponding to a "distinct" command on a collection.
+/// An operation corresponding to a "listDatabases" command on a collection.
 internal struct ListDatabasesOperation {
     private let filter: Document?
     private let session: ClientSession?

--- a/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
@@ -43,7 +43,7 @@ internal enum ListDatabasesResults {
 }
 
 /// An operation corresponding to a "listDatabases" command on a collection.
-internal struct ListDatabasesOperation {
+internal struct ListDatabasesOperation: Operation {
     private let session: ClientSession?
     private let client: MongoClient
     private let options: ListDatabasesOptions?
@@ -56,7 +56,7 @@ internal struct ListDatabasesOperation {
         self.session = session
     }
 
-    internal func execute() throws -> ListDatabasesResults {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> ListDatabasesResults {
         // spec requires that this command be run against the primary.
         let readPref = ReadPreference(.primary)
         let cmd: Document = ["listDatabases": 1]

--- a/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
@@ -1,5 +1,18 @@
 import mongoc
 
+/// Options to use when listing available databases.
+public struct ListDatabasesOptions: Encodable {
+    /// Optionally indicate whether only names should be returned.
+    /// This is internal and only used for implementation purposes. Users should use `listDatabaseNames` if they want
+    /// only names.
+    internal var nameOnly: Bool?
+
+    /// Convenience constructor for basic construction
+    public init(nameOnly: Bool? = nil) {
+        self.nameOnly = nameOnly
+    }
+}
+
 /// A struct modeling a response to the `listDatabases` command.
 public struct ListDatabasesResult: Codable {
     /// The list of database information returned.
@@ -21,40 +34,65 @@ public struct DatabaseSpecification: Codable {
     public let empty: Bool
 }
 
+/// Internal intermediate result of a ListDatabases command.
+internal enum ListDatabasesResults {
+    /// Includes the names and sizes.
+    case full(ListDatabasesResult)
+
+    /// Only includes the names.
+    case names([String])
+}
+
 /// An operation corresponding to a "distinct" command on a collection.
 internal struct ListDatabasesOperation {
     private let filter: Document?
     private let session: ClientSession?
     private let client: MongoClient
+    private let options: ListDatabasesOptions?
 
     internal init(client: MongoClient,
                   filter: Document?,
+                  options: ListDatabasesOptions?,
                   session: ClientSession?) {
+        self.client = client
         self.filter = filter
+        self.options = options
         self.session = session
     }
 
-    internal func execute() throws -> ListDatabasesResult {
+    internal func execute() throws -> ListDatabasesResults {
         let cmd: Document = ["listDatabases": 1]
-        var opts: Document?
+        var opts = try self.client.encoder.encode(self.options)
         if let filter = self.filter {
+            if opts == nil {
+                opts = Document()
+            }
             opts = ["filter": filter] as Document
         }
+        opts = try encodeOptions(options: opts, session: self.session)
         var reply = Document()
         var error = bson_error_t()
 
-        try withMutableBSONPointer(to: &reply) { replyPtr in
-            guard mongoc_client_read_command_with_opts(self.client._client,
-                                                       "admin",
-                                                       cmd._bson,
-                                                       nil,
-                                                       opts?._bson,
-                                                       replyPtr,
-                                                       &error) else {
-                throw extractMongoError(error: error, reply: reply)
-            }
+        let success = withMutableBSONPointer(to: &reply) { replyPtr in
+            mongoc_client_read_command_with_opts(self.client._client,
+                                                 "admin",
+                                                 cmd._bson,
+                                                 nil,
+                                                 opts?._bson,
+                                                 replyPtr,
+                                                 &error)
         }
 
-        return self.client.decoder.decode(ListDatabasesResult.self, from: reply)
+        guard success else {
+            throw extractMongoError(error: error, reply: reply)
+        }
+
+        if self.options?.nameOnly ?? false {
+            guard let databases = reply["databases"] as? [Document] else {
+                throw RuntimeError.internalError(message: "Invalid server response: \(reply)")
+            }
+            return .names(databases.map { $0["name"] as? String ?? "" })
+        }
+        return .full(try self.client.decoder.decode(ListDatabasesResult.self, from: reply))
     }
 }

--- a/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
@@ -1,0 +1,60 @@
+import mongoc
+
+/// A struct modeling a response to the `listDatabases` command.
+public struct ListDatabasesResult: Codable {
+    /// The list of database information returned.
+    public let databases: [DatabaseSpecification]
+
+    /// The total size in bytes of all the matching databases.
+    public let totalSize: Int64
+}
+
+/// A struct modeling the information returned from the `listDatabases` command about a single database.
+public struct DatabaseSpecification: Codable {
+    /// The name of the database.
+    public let name: String
+
+    /// The amount of disk space consumed by this database.
+    public let sizeOnDisk: Int
+
+    /// Whether or not this database is empty.
+    public let empty: Bool
+}
+
+/// An operation corresponding to a "distinct" command on a collection.
+internal struct ListDatabasesOperation {
+    private let filter: Document?
+    private let session: ClientSession?
+    private let client: MongoClient
+
+    internal init(client: MongoClient,
+                  filter: Document?,
+                  session: ClientSession?) {
+        self.filter = filter
+        self.session = session
+    }
+
+    internal func execute() throws -> ListDatabasesResult {
+        let cmd: Document = ["listDatabases": 1]
+        var opts: Document?
+        if let filter = self.filter {
+            opts = ["filter": filter] as Document
+        }
+        var reply = Document()
+        var error = bson_error_t()
+
+        try withMutableBSONPointer(to: &reply) { replyPtr in
+            guard mongoc_client_read_command_with_opts(self.client._client,
+                                                       "admin",
+                                                       cmd._bson,
+                                                       nil,
+                                                       opts?._bson,
+                                                       replyPtr,
+                                                       &error) else {
+                throw extractMongoError(error: error, reply: reply)
+            }
+        }
+
+        return self.client.decoder.decode(ListDatabasesResult.self, from: reply)
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -40,7 +40,6 @@ extension ClientSessionTests {
 
 extension CodecTests {
     static var allTests = [
-        ("testEncodeListDatabasesOptions", testEncodeListDatabasesOptions),
         ("testStructs", testStructs),
         ("testOptionals", testOptionals),
         ("testEncodingNonBSONNumbers", testEncodingNonBSONNumbers),

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -66,7 +66,8 @@ final class ClientSessionTests: MongoSwiftTestCase {
     // list of operatoins on MongoClient that take in a session
     let clientSessionOps: [ClientSessionOp] = [
         (name: "listDatabases", { _ = try $0.listDatabases(session: $1) }),
-        (name: "listMongoDatabases", { _ = try $0.listMongoDatabases(session: $1) })
+        (name: "listMongoDatabases", { _ = try $0.listMongoDatabases(session: $1) }),
+        (name: "listDatabaseNames", { _ = try $0.listDatabaseNames(session: $1) })
     ]
 
     // iterate over all the different session op types, passing in the provided client/db/collection as needed.

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -65,7 +65,8 @@ final class ClientSessionTests: MongoSwiftTestCase {
 
     // list of operatoins on MongoClient that take in a session
     let clientSessionOps: [ClientSessionOp] = [
-        (name: "listDatabases", { _ = try $0.listDatabases(session: $1).nextOrError() })
+        (name: "listDatabases", { _ = try $0.listDatabases(session: $1) }),
+        (name: "listMongoDatabases", { _ = try $0.listMongoDatabases(session: $1) })
     ]
 
     // iterate over all the different session op types, passing in the provided client/db/collection as needed.
@@ -296,7 +297,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
 
         try client.withSession { session in
             expect(session.clusterTime).to(beNil())
-            _ = try client.listDatabases(session: session).next()
+            _ = try client.listDatabases(session: session)
             expect(session.clusterTime).toNot(beNil())
         }
 

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -11,8 +11,8 @@ final class CodecTests: MongoSwiftTestCase {
             DecodingError.Context(codingPath: [], debugDescription: "dummy error"))
 
     func testEncodeListDatabasesOptions() throws {
-        let options = ListDatabasesOptions(filter: ["x": 1], nameOnly: true)
-        let expected: Document = ["filter": ["x": 1] as Document, "nameOnly": true]
+        let options = ListDatabasesOptions(filter: ["a": 10], nameOnly: true)
+        let expected: Document = ["filter": ["a": 10] as Document, "nameOnly": true]
         expect(try BSONEncoder().encode(options)).to(equal(expected))
     }
 

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -10,12 +10,6 @@ final class CodecTests: MongoSwiftTestCase {
     static let dataCorruptedErr = DecodingError.dataCorrupted(
             DecodingError.Context(codingPath: [], debugDescription: "dummy error"))
 
-    func testEncodeListDatabasesOptions() throws {
-        let options = ListDatabasesOptions(filter: ["a": 10], nameOnly: true)
-        let expected: Document = ["filter": ["a": 10] as Document, "nameOnly": true]
-        expect(try BSONEncoder().encode(options)).to(equal(expected))
-    }
-
     struct TestClass: Encodable {
         let val1 = "a"
         let val2 = 0

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -11,8 +11,8 @@ final class CodecTests: MongoSwiftTestCase {
             DecodingError.Context(codingPath: [], debugDescription: "dummy error"))
 
     func testEncodeListDatabasesOptions() throws {
-        let options = ListDatabasesOptions(nameOnly: true)
-        let expected: Document = ["nameOnly": true]
+        let options = ListDatabasesOptions(filter: ["x": 1], nameOnly: true)
+        let expected: Document = ["filter": ["x": 1] as Document, "nameOnly": true]
         expect(try BSONEncoder().encode(options)).to(equal(expected))
     }
 

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -11,8 +11,8 @@ final class CodecTests: MongoSwiftTestCase {
             DecodingError.Context(codingPath: [], debugDescription: "dummy error"))
 
     func testEncodeListDatabasesOptions() throws {
-        let options = ListDatabasesOptions(filter: ["a": 10], nameOnly: true)
-        let expected: Document = ["filter": ["a": 10] as Document, "nameOnly": true]
+        let options = ListDatabasesOptions(nameOnly: true)
+        let expected: Document = ["nameOnly": true]
         expect(try BSONEncoder().encode(options)).to(equal(expected))
     }
 

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -22,8 +22,8 @@ final class MongoClientTests: MongoSwiftTestCase {
         try client.db("db3").collection("c").insertOne(["a": 1])
 
         let dbInfo = try client.listDatabases()
-        expect(dbInfo.databases.map { $0.name }).to(contain(databases))
-        expect(Set(dbInfo.databases.map { $0.name }).count).to(equal(dbInfo.databases.count))
+        expect(dbInfo.map { $0.name }).to(contain(databases))
+        expect(Set(dbInfo.map { $0.name }).count).to(equal(dbInfo.count))
 
         let dbNames = try client.listDatabaseNames()
         expect(dbNames).to(contain(databases))

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -8,7 +8,7 @@ final class MongoClientTests: MongoSwiftTestCase {
     func testListDatabases() throws {
         let client = try MongoClient()
         let databases = try client.listDatabases(options: ListDatabasesOptions(nameOnly: true))
-        expect((Array(databases) as [Document]).count).to(beGreaterThan(0))
+        expect(databases.count).to(beGreaterThan(0))
     }
 
     func testOpaqueInitialization() throws {

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -31,7 +31,7 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         expect(try db.listCollections(options: opts)).to(beEmpty())
 
         expect(try db.drop()).toNot(throwError())
-        let names = try client.listDatabases(options: ListDatabasesOptions(nameOnly: true)).map { $0.name }
+        let names = try client.listDatabaseNames()
         expect(names).toNot(contain([type(of: self).testDatabase]))
 
         expect(db.name).to(equal(type(of: self).testDatabase))

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -31,8 +31,7 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         expect(try db.listCollections(options: opts)).to(beEmpty())
 
         expect(try db.drop()).toNot(throwError())
-        let dbs = try client.listDatabases(options: ListDatabasesOptions(nameOnly: true))
-        let names = (Array(dbs) as [Document]).map { $0["name"] as? String ?? "" }
+        let names = try client.listDatabases(options: ListDatabasesOptions(nameOnly: true)).map { $0.name }
         expect(names).toNot(contain([type(of: self).testDatabase]))
 
         expect(db.name).to(equal(type(of: self).testDatabase))


### PR DESCRIPTION
[SWIFT-174](https://jira.mongodb.org/browse/SWIFT-174)

This PR implements the full DB enumeration spec. As part of this change, there are now 3 methods on `MongoClient` in our public API for listing databases:
- `listDatabases -> [DatabaseSpecification]`
- `listDatabaseNames -> [String]`
- `listMongoDatabases -> [MongoDatabase]`

There were two different paths we could've chosen here:
- Implement _just_ `listDatabases` and provide an options struct for specifying `nameOnly`
- implement both `listDatabases` and `listDatabaseNames` and omit the options structs.

I opted to go with the latter for a couple reasons:
- Other drivers (e.g. Java, Go, even libmongoc) do
- It allows us to define the fields of `DatabaseSpecification` as non-optionals
- it seems more ergonomic. I imagine most users would be filtering it down to just names anyways

I also implemented the `listMongoDatabases` method for similar reasons, but I think the distinction is less important. 

Another thing worth mentioning: I moved filter out of the options struct to be a top level argument, since it felt more in line with our `find` wrapper. Other drivers do this as well.

I didn't include the `totalSize` part of the command result because the spec explicitly calls out including it as not super valuable. I kind of lean towards `listDatabases` returning a `ListDatabasesResult` that includes that within it, but I don't hold this opinion strongly enough to go against the spec though.

Anyways, these decisions were a little opinionated, so let me know what you guys think.