### PR TITLE
SWIFT-374 MongoDatabase and MongoCollection no longer wrap libmongoc types

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -258,10 +258,11 @@ public class MongoClient {
     public func listDatabases(options: ListDatabasesOptions? = nil,
                               session: ClientSession? = nil) throws -> MongoCursor<Document> {
         let opts = try encodeOptions(options: options, session: session)
-        guard let cursor = mongoc_client_find_databases_with_opts(self._client, opts?._bson) else {
+        let conn = try self.connectionPool.checkOut()
+        guard let cursor = mongoc_client_find_databases_with_opts(conn.clientHandle, opts?._bson) else {
             fatalError("Couldn't get cursor from the server")
         }
-        return try MongoCursor(from: cursor, client: self, decoder: self.decoder, session: session)
+        return try MongoCursor(from: cursor, client: self, connection: conn, decoder: self.decoder, session: session)
     }
 
     /**

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -260,7 +260,7 @@ public class MongoClient {
         let opts = try encodeOptions(options: options, session: session)
         let conn = try self.connectionPool.checkOut()
         guard let cursor = mongoc_client_find_databases_with_opts(conn.clientHandle, opts?._bson) else {
-            fatalError("Couldn't get cursor from the server")
+            fatalError(failedToRetrieveCursorMessage)
         }
         return try MongoCursor(from: cursor, client: self, connection: conn, decoder: self.decoder, session: session)
     }

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -335,7 +335,7 @@ extension MongoCollection {
         let conn = try self._client.connectionPool.checkOut()
         let cursor: OpaquePointer = self.withMongocCollection(from: conn) { collPtr in
             guard let cursor = mongoc_collection_find_indexes_with_opts(collPtr, opts?._bson) else {
-                fatalError("Couldn't get cursor from the server")
+                fatalError(failedToRetrieveCursorMessage)
             }
             return cursor
         }

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -63,7 +63,7 @@ extension MongoCollection {
             guard let cursor = mongoc_collection_aggregate(collPtr,
                                                            MONGOC_QUERY_NONE,
                                                            pipeline._bson,
-                                                           opts?._bson, 
+                                                           opts?._bson,
                                                            rp) else {
                 fatalError("Couldn't get cursor from the server")
             }

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -25,7 +25,7 @@ extension MongoCollection {
         let conn = try self._client.connectionPool.checkOut()
         let cursor: OpaquePointer = self.withMongocCollection(from: conn) { collPtr in
             guard let cursor = mongoc_collection_find_with_opts(collPtr, filter._bson, opts?._bson, rp) else {
-                fatalError("Couldn't get cursor from the server")
+                fatalError(failedToRetrieveCursorMessage)
             }
             return cursor
         }
@@ -65,7 +65,7 @@ extension MongoCollection {
                                                            pipeline._bson,
                                                            opts?._bson,
                                                            rp) else {
-                fatalError("Couldn't get cursor from the server")
+                fatalError(failedToRetrieveCursorMessage)
             }
             return cursor
         }

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -22,10 +22,19 @@ extension MongoCollection {
         let opts = try encodeOptions(options: options, session: session)
         let rp = options?.readPreference?._readPreference
 
-        guard let cursor = mongoc_collection_find_with_opts(self._collection, filter._bson, opts?._bson, rp) else {
-            fatalError("Couldn't get cursor from the server")
+        let conn = try self._client.connectionPool.checkOut()
+        let cursor: OpaquePointer = self.withMongocCollection(from: conn) { collPtr in
+            guard let cursor = mongoc_collection_find_with_opts(collPtr, filter._bson, opts?._bson, rp) else {
+                fatalError("Couldn't get cursor from the server")
+            }
+            return cursor
         }
-        return try MongoCursor(from: cursor, client: self._client, decoder: self.decoder, session: session)
+
+        return try MongoCursor(from: cursor,
+                               client: self._client,
+                               connection: conn,
+                               decoder: self.decoder,
+                               session: session)
     }
 
     /**
@@ -49,11 +58,23 @@ extension MongoCollection {
         let rp = options?.readPreference?._readPreference
         let pipeline: Document = ["pipeline": pipeline]
 
-        guard let cursor = mongoc_collection_aggregate(
-            self._collection, MONGOC_QUERY_NONE, pipeline._bson, opts?._bson, rp) else {
-            fatalError("Couldn't get cursor from the server")
+        let conn = try self._client.connectionPool.checkOut()
+        let cursor: OpaquePointer = self.withMongocCollection(from: conn) { collPtr in
+            guard let cursor = mongoc_collection_aggregate(collPtr,
+                                                           MONGOC_QUERY_NONE,
+                                                           pipeline._bson,
+                                                           opts?._bson, 
+                                                           rp) else {
+                fatalError("Couldn't get cursor from the server")
+            }
+            return cursor
         }
-        return try MongoCursor(from: cursor, client: self._client, decoder: self.decoder, session: session)
+
+        return try MongoCursor(from: cursor,
+                               client: self._client,
+                               connection: conn,
+                               decoder: self.decoder,
+                               session: session)
     }
 
     // TODO SWIFT-133: mark this method deprecated https://jira.mongodb.org/browse/SWIFT-133

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -12,7 +12,7 @@ public struct DropCollectionOptions: Codable {
 }
 
 /// A MongoDB collection.
-public struct MongoCollection<T: Codable> {
+public class MongoCollection<T: Codable> {
     /// The client which this collection was derived from.
     internal let _client: MongoClient
 
@@ -60,8 +60,23 @@ public struct MongoCollection<T: Codable> {
     internal init(name: String, database: MongoDatabase, options: CollectionOptions?) {
         self.namespace = MongoNamespace(db: database.name, collection: name)
         self._client = database._client
-        self.readConcern = options?.readConcern ?? database.readConcern ?? database._client.readConcern
-        self.writeConcern = options?.writeConcern ?? database.writeConcern ?? database._client.writeConcern
+
+        // for both read concern and write concern, we look for a read concern in the following order:
+        // 1. options provided for this collection
+        // 2. value for this `MongoCollection`'s parent `MongoDatabase`
+        // if we found a non-nil value, we check if it's the empty/server default or not, and store it if not.
+        if let rc = options?.readConcern ?? database.readConcern, !rc.isDefault {
+            self.readConcern = rc
+        } else {
+            self.readConcern = nil
+        }
+
+        if let wc = options?.writeConcern ?? database.writeConcern, !wc.isDefault {
+            self.writeConcern = wc
+        } else {
+            self.writeConcern = nil
+        }
+
         self.readPreference = options?.readPreference ?? database.readPreference
         self.encoder = BSONEncoder(copies: database.encoder, options: options)
         self.decoder = BSONDecoder(copies: database.decoder, options: options)
@@ -84,7 +99,7 @@ public struct MongoCollection<T: Codable> {
     /// Uses the provided `Connection` to get a pointer to a `mongoc_collection_t` corresponding to this
     /// `MongoCollection`, and uses it to execute the given closure. The `mongoc_collection_t` is only valid for the
     /// body of the closure. The caller is *not responsible* for cleaning up the `mongoc_collection_t`.
-    internal func withMongocCollection<T>(from connection: Connection, 
+    internal func withMongocCollection<T>(from connection: Connection,
                                           body: (OpaquePointer) throws -> T) rethrows -> T {
         guard let collection = mongoc_client_get_collection(connection.clientHandle,
                                                             self.namespace.db,
@@ -93,13 +108,26 @@ public struct MongoCollection<T: Codable> {
         }
         defer { mongoc_collection_destroy(collection) }
 
-        self.readConcern?.withMongocReadConcern { rcPtr in
-            mongoc_collection_set_read_concern(collection, rcPtr)
+        // `collection` will automatically inherit read concern, write concern, and read preference from the parent
+        // client. If this `MongoCollection`'s value for any of those settings is different than the parent, we need to
+        // explicitly set it here.
+
+        if self.readConcern != self._client.readConcern {
+            // a nil value for self.readConcern corresponds to the empty read concern.
+            (self.readConcern ?? ReadConcern()).withMongocReadConcern { rcPtr in
+                mongoc_collection_set_read_concern(collection, rcPtr)
+            }
         }
-        self.writeConcern?.withMongocWriteConcern { wcPtr in
-            mongoc_collection_set_write_concern(collection, wcPtr)
+
+        if self.writeConcern != self._client.writeConcern {
+            // a nil value for self.writeConcern corresponds to the empty write concern.
+            (self.writeConcern ?? WriteConcern()).withMongocWriteConcern { wcPtr in
+                mongoc_collection_set_write_concern(collection, wcPtr)
+            }
         }
+
         if self.readPreference != self._client.readPreference {
+            // there is no concept of an empty read preference so we will always have a value here.
             mongoc_collection_set_read_prefs(collection, self.readPreference._readPreference)
         }
 

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -111,12 +111,6 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
     public func next() -> T? {
         do {
             let operation = NextOperation(cursor: self)
-            // TODO SWIFT-374: we temporarily use a fake connection here. eventually MongoCursor will store its source
-            // connection and we can pass that in here instead (though the execute method still won't use it.)
-            // we want to pass in a specific connection and call execute() ourselves rather than using an operation
-            // executor as that would require checking out a separate, unused connection for every single next() call.
-            // the force unwrap is safe as this bitPattern is always valid.
-            // swiftlint:disable:next force_unwrapping
             let out = try operation.execute(using: self._connection, session: self._session)
             self.swiftError = nil
             return out

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -236,7 +236,7 @@ public class MongoDatabase {
         let conn = try self._client.connectionPool.checkOut()
         let collections: OpaquePointer = self.withMongocDatabase(from: conn) { dbPtr in
             guard let collections = mongoc_database_find_collections_with_opts(dbPtr, opts?._bson) else {
-                fatalError("Couldn't get cursor from the server")
+                fatalError(failedToRetrieveCursorMessage)
             }
             return collections
         }

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -72,9 +72,12 @@ public struct DropDatabaseOptions: Codable {
 }
 
 /// A MongoDB Database.
-public class MongoDatabase {
-    internal var _database: OpaquePointer?
-    internal var _client: MongoClient
+public struct MongoDatabase {
+    /// The client which this database was derived from.
+    internal let _client: MongoClient
+
+    /// The namespace for this database.
+    private let namespace: MongoNamespace
 
     /// Encoder used by this database for BSON conversions. This encoder's options are inherited by collections derived
     /// from this database.
@@ -84,60 +87,26 @@ public class MongoDatabase {
     public let decoder: BSONDecoder
 
     /// The name of this database.
-    public var name: String {
-        return String(cString: mongoc_database_get_name(self._database))
-    }
+    public var name: String { return namespace.db }
 
     /// The `ReadConcern` set on this database, or `nil` if one is not set.
-    public var readConcern: ReadConcern? {
-        // per libmongoc docs, we don't need to handle freeing this ourselves
-        let rc = ReadConcern(from: mongoc_database_get_read_concern(self._database))
-        return rc.isDefault ? nil : rc
-    }
+    public let readConcern: ReadConcern?
 
     /// The `ReadPreference` set on this database
-    public var readPreference: ReadPreference {
-        return ReadPreference(from: mongoc_database_get_read_prefs(self._database))
-    }
+    public let readPreference: ReadPreference
 
     /// The `WriteConcern` set on this database, or `nil` if one is not set.
-    public var writeConcern: WriteConcern? {
-        // per libmongoc docs, we don't need to handle freeing this ourselves
-        let wc = WriteConcern(from: mongoc_database_get_write_concern(self._database))
-        return wc.isDefault ? nil : wc
-    }
+    public let writeConcern: WriteConcern?
 
     /// Initializes a new `MongoDatabase` instance, not meant to be instantiated directly.
     internal init(name: String, client: MongoClient, options: DatabaseOptions?) {
-        guard let db = mongoc_client_get_database(client._client, name) else {
-            fatalError("Couldn't get database '\(name)'")
-        }
-
-        options?.readConcern?.withMongocReadConcern { tmpReadConcernPtr in
-            mongoc_database_set_read_concern(db, tmpReadConcernPtr)
-        }
-
-        if let rp = options?.readPreference {
-            mongoc_database_set_read_prefs(db, rp._readPreference)
-        }
-
-        options?.writeConcern?.withMongocWriteConcern { tmpWriteConcernPtr in
-            mongoc_database_set_write_concern(db, tmpWriteConcernPtr)
-        }
-
-        self._database = db
+        self.namespace = MongoNamespace(db: name, collection: nil)
         self._client = client
+        self.readConcern = options?.readConcern ?? client.readConcern
+        self.writeConcern = options?.writeConcern ?? client.writeConcern
+        self.readPreference = options?.readPreference ?? client.readPreference
         self.encoder = BSONEncoder(copies: client.encoder, options: options)
         self.decoder = BSONDecoder(copies: client.decoder, options: options)
-    }
-
-    /// Cleans up internal state.
-    deinit {
-        guard let database = self._database else {
-            return
-        }
-        mongoc_database_destroy(database)
-        self._database = nil
     }
 
     /**
@@ -247,12 +216,19 @@ public class MongoDatabase {
     public func listCollections(options: ListCollectionsOptions? = nil,
                                 session: ClientSession? = nil) throws -> MongoCursor<Document> {
         let opts = try encodeOptions(options: options, session: session)
-
-        guard let collections = mongoc_database_find_collections_with_opts(self._database, opts?._bson) else {
-            fatalError("Couldn't get cursor from the server")
+        let conn = try self._client.connectionPool.checkOut()
+        let collections: OpaquePointer = self.withMongocDatabase(from: conn) { dbPtr in
+            guard let collections = mongoc_database_find_collections_with_opts(dbPtr, opts?._bson) else {
+                fatalError("Couldn't get cursor from the server")
+            }
+            return collections
         }
 
-        return try MongoCursor(from: collections, client: self._client, decoder: self.decoder, session: session)
+        return try MongoCursor(from: collections,
+                               client: self._client,
+                               connection: conn,
+                               decoder: self.decoder,
+                               session: session)
     }
 
     /**
@@ -277,5 +253,27 @@ public class MongoDatabase {
                            session: ClientSession? = nil) throws -> Document {
         let operation = RunCommandOperation(database: self, command: command, options: options)
         return try self._client.executeOperation(operation, session: session)
+    }
+
+    /// Uses the provided `Connection` to get a pointer to a `mongoc_database_t` corresponding to this `MongoDatabase`,
+    /// and uses it to execute the given closure. The `mongoc_database_t` is only valid for the body of the closure.
+    /// The caller is *not responsible* for cleaning up the `mongoc_database_t`.
+    internal func withMongocDatabase<T>(from connection: Connection, body: (OpaquePointer) throws -> T) rethrows -> T {
+        guard let db = mongoc_client_get_database(connection.clientHandle, self.name) else {
+            fatalError("Couldn't get database '\(self.name)'")
+        }
+        defer { mongoc_database_destroy(db) }
+
+        self.readConcern?.withMongocReadConcern { rcPtr in
+            mongoc_database_set_read_concern(db, rcPtr)
+        }
+        self.writeConcern?.withMongocWriteConcern { wcPtr in
+            mongoc_database_set_write_concern(db, wcPtr)
+        }
+        if self.readPreference != self._client.readPreference {
+            mongoc_database_set_read_prefs(db, self.readPreference._readPreference)
+        }
+
+        return try body(db)
     }
 }

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -369,3 +369,5 @@ internal func wrongIterTypeError(_ iter: DocumentIterator, expected type: BSONVa
     return UserError.logicError(message: "Tried to retreive a \(type) from an iterator whose next type " +
             "is \(iter.currentType) for key \(iter.currentKey)")
 }
+
+internal let failedToRetrieveCursorMessage = "Couldn't get cursor from the server"

--- a/Sources/MongoSwift/MongoNamespace.swift
+++ b/Sources/MongoSwift/MongoNamespace.swift
@@ -1,0 +1,14 @@
+/// Represents a MongoDB namespace for a database or collection.
+internal struct MongoNamespace {
+    internal let db: String
+    internal let collection: String?
+}
+
+extension MongoNamespace: CustomStringConvertible {
+    internal var description: String {
+        guard let collection = self.collection else {
+            return self.db
+        }
+        return "\(self.db).\(collection)"
+    }
+}

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -40,8 +40,9 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            mongoc_collection_write_command_with_opts(
-                self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
+            self.collection.withMongocCollection(from: connection) { collPtr in
+                mongoc_collection_write_command_with_opts(collPtr, command._bson, opts?._bson, replyPtr, &error)
+            }
         }
         guard success else {
             throw extractMongoError(error: error, reply: reply)

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -17,8 +17,9 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            mongoc_collection_write_command_with_opts(
-                    self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
+            self.collection.withMongocCollection(from: connection) { collPtr in
+                mongoc_collection_write_command_with_opts(collPtr, command._bson, opts?._bson, replyPtr, &error)
+            }
         }
         guard success else {
             throw extractMongoError(error: error, reply: reply)

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -17,8 +17,9 @@ internal struct DropDatabaseOperation: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            mongoc_database_write_command_with_opts(
-                    self.database._database, command._bson, opts?._bson, replyPtr, &error)
+            self.database.withMongocDatabase(from: connection) { dbPtr in
+                mongoc_database_write_command_with_opts(dbPtr, command._bson, opts?._bson, replyPtr, &error)
+            }
         }
         guard success else {
             throw extractMongoError(error: error, reply: reply)

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -29,8 +29,9 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            mongoc_collection_write_command_with_opts(
-                self.collection._collection, command._bson, opts?._bson, replyPtr, &error)
+            self.collection.withMongocCollection(from: connection) { collPtr in
+                mongoc_collection_write_command_with_opts(collPtr, command._bson, opts?._bson, replyPtr, &error)
+            }
         }
         guard success else {
             throw extractMongoError(error: error, reply: reply)

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -143,11 +143,13 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            mongoc_collection_find_and_modify_with_opts(self.collection._collection,
-                                                        self.filter._bson,
-                                                        opts._options,
-                                                        replyPtr,
-                                                        &error)
+            self.collection.withMongocCollection(from: connection) { collPtr in
+                mongoc_collection_find_and_modify_with_opts(collPtr,
+                                                            self.filter._bson,
+                                                            opts._options,
+                                                            replyPtr,
+                                                            &error)
+            }
         }
         guard success else {
             throw extractMongoError(error: error, reply: reply)

--- a/Sources/MongoSwift/Operations/NextOperation.swift
+++ b/Sources/MongoSwift/Operations/NextOperation.swift
@@ -12,9 +12,6 @@ internal struct NextOperation<T: Codable>: Operation {
         // NOTE: this method does not actually use the `connection` parameter passed in. for the moment, it is only
         // here so that `NextOperation` conforms to `Operation`. if we eventually rewrite MongoCursor to no longer
         // wrap a mongoc cursor then we will use the connection here.
-        guard let cursor = self.cursor._cursor else {
-            throw UserError.logicError(message: "Tried to iterate a closed cursor.")
-        }
 
         if let session = session, !session.active {
             throw ClientSession.SessionInactiveError
@@ -25,7 +22,7 @@ internal struct NextOperation<T: Codable>: Operation {
             out.deinitialize(count: 1)
             out.deallocate()
         }
-        guard mongoc_cursor_next(cursor, out) else {
+        guard mongoc_cursor_next(cursor._cursor, out) else {
             return nil
         }
 

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -46,8 +46,9 @@ internal struct RunCommandOperation: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            mongoc_database_command_with_opts(
-                self.database._database, self.command._bson, rp, opts?._bson, replyPtr, &error)
+            self.database.withMongocDatabase(from: connection) { dbPtr in
+                mongoc_database_command_with_opts(dbPtr, self.command._bson, rp, opts?._bson, replyPtr, &error)
+            }
         }
         guard success else {
             throw extractMongoError(error: error, reply: reply)

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -1,3 +1,4 @@
+import mongoc
 @testable import MongoSwift
 import Nimble
 import XCTest
@@ -70,213 +71,330 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
                 .to(throwError(UserError.invalidArgumentError(message: "")))
     }
 
+    /// Checks that a `MongoClient` as well as the underlying mongoc clients have the expected read concern.
+    func checkClientReadConcern(_ client: MongoClient,
+                                _ expected: ReadConcern,
+                                _ description: String) throws {
+        if expected.isDefault {
+            expect(client.readConcern).to(beNil(), description: description)
+        } else {
+            expect(client.readConcern).to(equal(expected), description: description)
+        }
+
+        try client.connectionPool.withConnection { conn in
+            let connRC = ReadConcern(from: mongoc_client_get_read_concern(conn.clientHandle))
+            expect(connRC).to(equal(expected), description: description)
+        }
+    }
+
+    /// Checks that a `MongoClient` as well as the underlying mongoc clients have the expected write concern.
+    func checkClientWriteConcern(_ client: MongoClient,
+                                 _ expected: WriteConcern,
+                                 _ description: String) throws {
+        if expected.isDefault {
+            expect(client.writeConcern).to(beNil(), description: description)
+        } else {
+            expect(client.writeConcern).to(equal(expected), description: description)
+        }
+
+        try client.connectionPool.withConnection { conn in
+            let connWC = WriteConcern(from: mongoc_client_get_write_concern(conn.clientHandle))
+            expect(connWC).to(equal(expected), description: description)
+        }
+    }
+
+    /// Checks that a `MongoDatabase`, as well as the temporarily constructed pointers to equivalent mongoc databases,
+    /// have the expected read concern.
+    func checkDatabaseReadConcern(_ db: MongoDatabase,
+                                  _ expected: ReadConcern,
+                                  _ description: String) throws {
+        if expected.isDefault {
+            expect(db.readConcern).to(beNil(), description: description)
+        } else {
+            expect(db.readConcern).to(equal(expected), description: description)
+        }
+
+        try db._client.connectionPool.withConnection { conn in
+            db.withMongocDatabase(from: conn) { dbPtr in
+                let dbRC = ReadConcern(from: mongoc_database_get_read_concern(dbPtr))
+                expect(dbRC).to(equal(expected), description: description)
+            }
+        }
+    }
+
+    /// Checks that a `MongoDatabase`, as well as the temporarily constructed pointers to equivalent mongoc databases,
+    /// have the expected write concern.
+    func checkDatabaseWriteConcern(_ db: MongoDatabase,
+                                   _ expected: WriteConcern,
+                                   _ description: String) throws {
+        if expected.isDefault {
+            expect(db.writeConcern).to(beNil(), description: description)
+        } else {
+            expect(db.writeConcern).to(equal(expected), description: description)
+        }
+
+        try db._client.connectionPool.withConnection { conn in
+            db.withMongocDatabase(from: conn) { dbPtr in
+                let dbWC = WriteConcern(from: mongoc_database_get_write_concern(dbPtr))
+                expect(dbWC).to(equal(expected), description: description)
+            }
+        }
+    }
+
+    /// Checks that a `MongoCollection`, as well as the temporarily constructed pointers to equivalent mongoc
+    /// collections, have the expected read concern.
+    func checkCollectionReadConcern<T: Codable>(_ coll: MongoCollection<T>,
+                                                _ expected: ReadConcern,
+                                                _ description: String) throws {
+        if expected.isDefault {
+            expect(coll.readConcern).to(beNil(), description: description)
+        } else {
+            expect(coll.readConcern).to(equal(expected), description: description)
+        }
+
+        try coll._client.connectionPool.withConnection { conn in
+            coll.withMongocCollection(from: conn) { collPtr in
+                let collRC = ReadConcern(from: mongoc_collection_get_read_concern(collPtr))
+                expect(collRC).to(equal(expected), description: description)
+            }
+        }
+    }
+
+    /// Checks that a `MongoCollection`, as well as the temporarily constructed pointers to equivalent mongoc
+    /// collections, have the expected write concern.
+    func checkCollectionWriteConcern<T: Codable>(_ coll: MongoCollection<T>,
+                                                 _ expected: WriteConcern,
+                                                 _ description: String) throws {
+        if expected.isDefault {
+            expect(coll.writeConcern).to(beNil(), description: description)
+        } else {
+            expect(coll.writeConcern).to(equal(expected), description: description)
+        }
+
+        try coll._client.connectionPool.withConnection { conn in
+            coll.withMongocCollection(from: conn) { collPtr in
+                let collWC = WriteConcern(from: mongoc_collection_get_write_concern(collPtr))
+                expect(collWC).to(equal(expected), description: description)
+            }
+        }
+    }
+
     func testClientReadConcern() throws {
+        let empty = ReadConcern()
         let majority = ReadConcern(.majority)
+        let majorityString = ReadConcern("majority")
+        let local = ReadConcern(.local)
 
         // test behavior of a client with initialized with no RC
         do {
             let client = try MongoClient()
-            // expect the readConcern property to exist with a nil level
-            expect(client.readConcern).to(beNil())
+            let clientDesc = "client created with no RC provided"
+            // expect the client to have empty/server default read concern
+            try checkClientReadConcern(client, empty, clientDesc)
 
             // expect that a DB created from this client inherits its unset RC
             let db1 = client.db(type(of: self).testDatabase)
-            expect(db1.readConcern).to(beNil())
+            try checkDatabaseReadConcern(db1, empty, "db created with no RC provided from \(clientDesc)")
 
             // expect that a DB created from this client can override the client's unset RC
             let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
-            expect(db2.readConcern?.level).to(equal(.majority))
+            try checkDatabaseReadConcern(db2, majority, "db created with majority RC from \(clientDesc)")
         }
 
         // test behavior of a client initialized with local RC
         do {
-            let client = try MongoClient(options: ClientOptions(readConcern: ReadConcern(.local)))
+            let client = try MongoClient(options: ClientOptions(readConcern: local))
+            let clientDesc = "client created with local RC"
             // although local is default, if it is explicitly provided it should be set
-            expect(client.readConcern?.level).to(equal(.local))
+            try checkClientReadConcern(client, local, clientDesc)
 
             // expect that a DB created from this client inherits its local RC
             let db1 = client.db(type(of: self).testDatabase)
-            expect(db1.readConcern?.level).to(equal(.local))
+            try checkDatabaseReadConcern(db1, local, "db created with no RC provided from \(clientDesc)")
 
             // expect that a DB created from this client can override the client's local RC
             let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majority))
-            expect(db2.readConcern?.level).to(equal(.majority))
+            try checkDatabaseReadConcern(db2, majority, "db created with majority RC from \(clientDesc)")
 
             // test with string init
-            let majorityString = ReadConcern("majority")
             let db3 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: majorityString))
-            expect(db3.readConcern?.level).to(equal(.majority))
+            try checkDatabaseReadConcern(db3, majority, "db created with majority string RC from \(clientDesc)")
 
             // test with unknown level
-            let db4 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: ReadConcern("blah")))
-            expect(db4.readConcern?.level).to(equal(.other(level: "blah")))
+            let unknown = ReadConcern("blah")
+            let db4 = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: unknown))
+            try checkDatabaseReadConcern(db4, unknown, "db created with unknown RC from \(clientDesc)")
         }
 
         // test behavior of a client initialized with majority RC
         do {
             var client = try MongoClient(options: ClientOptions(readConcern: majority))
-            expect(client.readConcern?.level).to(equal(.majority))
+            let clientDesc = "client created with majority RC"
+            try checkClientReadConcern(client, majority, clientDesc)
 
             // test with string init
-            client = try MongoClient(options: ClientOptions(readConcern: ReadConcern("majority")))
-            expect(client.readConcern?.level).to(equal(.majority))
+            client = try MongoClient(options: ClientOptions(readConcern: majorityString))
+            try checkClientReadConcern(client, majority, "\(clientDesc) string")
 
             // expect that a DB created from this client can override the client's majority RC with an unset one
-            let db = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: ReadConcern()))
-            expect(db.readConcern).to(beNil())
+            let db = client.db(type(of: self).testDatabase, options: DatabaseOptions(readConcern: empty))
+            try checkDatabaseReadConcern(db, empty, "db created with empty RC from \(clientDesc) string")
         }
     }
 
     func testClientWriteConcern() throws {
-        let w1 = WriteConcern.W.number(1)
-        let w2 = WriteConcern.W.number(2)
-        let wc2 = try WriteConcern(w: w2)
+        let w1 = try WriteConcern(w: .number(1))
+        let w2 = try WriteConcern(w: .number(2))
+        let empty = WriteConcern()
 
         // test behavior of a client with initialized with no WC
         do {
-            let client1 = try MongoClient()
+            let client = try MongoClient()
+            let clientDesc = "client created with no WC provided"
             // expect the readConcern property to exist and be default
-            expect(client1.writeConcern).to(beNil())
+            try checkClientWriteConcern(client, empty, clientDesc)
 
             // expect that a DB created from this client inherits its default WC
-            let db1 = client1.db(type(of: self).testDatabase)
-            expect(db1.writeConcern).to(beNil())
+            let db1 = client.db(type(of: self).testDatabase)
+            try checkDatabaseWriteConcern(db1, empty, "db created with no WC provided from \(clientDesc)")
 
             // expect that a DB created from this client can override the client's default WC
-            let db2 = client1.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc2))
-            expect(db2.writeConcern?.w).to(equal(w2))
+            let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: w2))
+            try checkDatabaseWriteConcern(db2, w2, "db created with w:2 from \(clientDesc)")
         }
 
         // test behavior of a client with w: 1
         do {
-            let client2 = try MongoClient(options: ClientOptions(writeConcern: WriteConcern(w: .number(1))))
+            let client = try MongoClient(options: ClientOptions(writeConcern: w1))
+            let clientDesc = "client created with w:1"
             // although w:1 is default, if it is explicitly provided it should be set
-            expect(client2.writeConcern?.w).to(equal(w1))
+            try checkClientWriteConcern(client, w1, clientDesc)
 
             // expect that a DB created from this client inherits its WC
-            let db3 = client2.db(type(of: self).testDatabase)
-            expect(db3.writeConcern?.w).to(equal(w1))
+            let db1 = client.db(type(of: self).testDatabase)
+            try checkDatabaseWriteConcern(db1, w1, "db created with no WC provided from \(clientDesc)")
 
             // expect that a DB created from this client can override the client's WC
-            let db4 = client2.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc2))
-            expect(db4.writeConcern?.w).to(equal(w2))
+            let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: w2))
+            try checkDatabaseWriteConcern(db2, w2, "db created with w:2 from \(clientDesc)")
         }
 
         // test behavior of a client with w: 2
         do {
-            let client3 = try MongoClient(options: ClientOptions(writeConcern: wc2))
-            expect(client3.writeConcern?.w).to(equal(w2))
+            let client = try MongoClient(options: ClientOptions(writeConcern: w2))
+            let clientDesc = "client created with w:2"
+            try checkClientWriteConcern(client, w2, clientDesc)
 
             // expect that a DB created from this client can override the client's WC with an unset one
-            let db5 = client3.db(
+            let db = client.db(
                     type(of: self).testDatabase,
-                    options: DatabaseOptions(writeConcern: WriteConcern()))
-            expect(db5.writeConcern).to(beNil())
+                    options: DatabaseOptions(writeConcern: empty))
+            try checkDatabaseWriteConcern(db, empty, "db created with empty WC from \(clientDesc)")
         }
     }
 
     func testDatabaseReadConcern() throws {
         let client = try MongoClient()
+        let empty = ReadConcern()
+        let local = ReadConcern(.local)
+        let localString = ReadConcern("local")
+        let unknown = ReadConcern("blah")
+        let majority = ReadConcern(.majority)
 
         let db1 = client.db(type(of: self).testDatabase)
         defer { try? db1.drop() }
 
+        let dbDesc = "db created with no RC provided"
+
         let coll1Name = self.getCollectionName(suffix: "1")
         // expect that a collection created from a DB with unset RC also has unset RC
         var coll1 = try db1.createCollection(coll1Name)
-        expect(coll1.readConcern).to(beNil())
+        try checkCollectionReadConcern(coll1, empty, "collection created with no RC provided from \(dbDesc)")
 
         // expect that a collection retrieved from a DB with unset RC also has unset RC
         coll1 = db1.collection(coll1Name)
-        expect(coll1.readConcern).to(beNil())
+        try checkCollectionReadConcern(coll1, empty, "collection retrieved with no RC provided from \(dbDesc)")
 
         // expect that a collection retrieved from a DB with unset RC can override the DB's RC
-        var coll2 = db1.collection(
-                self.getCollectionName(suffix: "2"),
-                options: CollectionOptions(readConcern: ReadConcern(.local))
-        )
-        expect(coll2.readConcern?.level).to(equal(.local))
+        let coll2 = db1.collection(self.getCollectionName(suffix: "2"), options: CollectionOptions(readConcern: local))
+        try checkCollectionReadConcern(coll2, local, "collection retrieved with local RC from \(dbDesc)")
 
         // test with string init
         var coll3 = db1.collection(
                 self.getCollectionName(suffix: "3"),
-                options: CollectionOptions(readConcern: ReadConcern("local"))
+                options: CollectionOptions(readConcern: localString)
         )
-        expect(coll3.readConcern?.level).to(equal(.local))
+        try checkCollectionReadConcern(coll3, local, "collection created with local RC string from \(dbDesc)")
 
         // test with unknown level
-        coll3 = db1.collection(
-                self.getCollectionName(suffix: "3"),
-                options: CollectionOptions(readConcern: ReadConcern("blah"))
-        )
-        expect(coll3.readConcern?.level).to(equal(.other(level: "blah")))
+        coll3 = db1.collection(self.getCollectionName(suffix: "3"), options: CollectionOptions(readConcern: unknown))
+        try checkCollectionReadConcern(coll3, unknown, "collection retrieved with unknown RC level from \(dbDesc)")
 
         try db1.drop()
 
         let db2 = client.db(
                 type(of: self).testDatabase,
-                options: DatabaseOptions(readConcern: ReadConcern(.local)))
+                options: DatabaseOptions(readConcern: local))
         defer { try? db2.drop() }
 
         let coll4Name = self.getCollectionName(suffix: "4")
         // expect that a collection created from a DB with local RC also has local RC
         var coll4 = try db2.createCollection(coll4Name)
-        expect(coll4.readConcern?.level).to(equal(.local))
+        try checkCollectionReadConcern(coll4, local, "collection created with no RC provided from \(dbDesc)")
 
         // expect that a collection retrieved from a DB with local RC also has local RC
         coll4 = db2.collection(coll4Name)
-        expect(coll4.readConcern?.level).to(equal(.local))
+        try checkCollectionReadConcern(coll4, local, "collection retrieved with no RC provided from \(dbDesc)")
 
         // expect that a collection retrieved from a DB with local RC can override the DB's RC
         let coll5 = db2.collection(
                 self.getCollectionName(suffix: "5"),
-                options: CollectionOptions(readConcern: ReadConcern(.majority))
+                options: CollectionOptions(readConcern: majority)
         )
-        expect(coll5.readConcern?.level).to(equal(.majority))
+        try checkCollectionReadConcern(coll5, majority, "collection retrieved with majority RC from \(dbDesc)")
     }
 
     func testDatabaseWriteConcern() throws {
         let client = try MongoClient()
 
+        let empty = WriteConcern()
+        let w1 = try WriteConcern(w: .number(1))
+        let w2 = try WriteConcern(w: .number(2))
+
         let db1 = client.db(type(of: self).testDatabase)
         defer { try? db1.drop() }
 
+        var dbDesc = "db created with no WC provided"
+
         // expect that a collection created from a DB with default WC also has default WC
         var coll1 = try db1.createCollection(self.getCollectionName(suffix: "1"))
-        expect(coll1.writeConcern).to(beNil())
+        try checkCollectionWriteConcern(coll1, empty, "collection created with no WC provided from \(dbDesc)")
 
         // expect that a collection retrieved from a DB with default WC also has default WC
         coll1 = db1.collection(coll1.name)
-        expect(coll1.writeConcern).to(beNil())
-
-        let wc1 = try WriteConcern(w: .number(1))
-        let wc2 = try WriteConcern(w: .number(2))
+        try checkCollectionWriteConcern(coll1, empty, "collection retrieved with no WC provided from \(dbDesc)")
 
         // expect that a collection retrieved from a DB with default WC can override the DB's WC
-        var coll2 = db1.collection(
-                self.getCollectionName(suffix: "2"),
-                options: CollectionOptions(writeConcern: wc1)
-        )
-        expect(coll2.writeConcern?.w).to(equal(wc1.w))
+        var coll2 = db1.collection(self.getCollectionName(suffix: "2"), options: CollectionOptions(writeConcern: w1))
+        try checkCollectionWriteConcern(coll2, w1, "collection retrieved with w:1 from \(dbDesc)")
 
         try db1.drop()
 
-        let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: wc1))
+        let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: w1))
         defer { try? db2.drop() }
+        dbDesc = "db created with w:1"
 
         // expect that a collection created from a DB with w:1 also has w:1
         var coll3 = try db2.createCollection(self.getCollectionName(suffix: "3"))
-        expect(coll3.writeConcern?.w).to(equal(wc1.w))
+        try checkCollectionWriteConcern(coll3, w1, "collection created with no WC provided from \(dbDesc)")
 
         // expect that a collection retrieved from a DB with w:1 also has w:1
         coll3 = db2.collection(coll3.name)
-        expect(coll3.writeConcern?.w).to(equal(wc1.w))
+        try checkCollectionWriteConcern(coll3, w1, "collection retrieved with no WC provided from \(dbDesc)")
 
         // expect that a collection retrieved from a DB with w:1 can override the DB's WC
-        let coll4 = db2.collection(
-                self.getCollectionName(suffix: "4"),
-                options: CollectionOptions(writeConcern: wc2))
-        expect(coll4.writeConcern?.w).to(equal(wc2.w))
+        let coll4 = db2.collection(self.getCollectionName(suffix: "4"), options: CollectionOptions(writeConcern: w2))
+        try checkCollectionWriteConcern(coll4, w2, "collection retrieved with w:2 from \(dbDesc)")
     }
 
     func testOperationReadConcerns() throws {


### PR DESCRIPTION
Apologies for the size of this, it got bigger than expected as I ended up doing a lot of refactoring in the read concern and write concern tests.

Changes:
- Added `MongoNamespace` type which DBs and collections use to track their namespaces.
- MongoDatabase and MongoCollection no longer wrap their corresponding mongoc types. They now have helper methods to create the mongoc types as needed.
- All operations now use the connections passed into `execute` to call those helpers and get the temp pointers.
- Methods returning `MongoCursor`s now check out `Connection`s and use them to call mongoc methods. The connection is then handed off to the `MongoCursor`, which will return it to the pool upon deinitialization.
    - As part of the work to store a connection in the cursor, I ended up getting rid of the manual `close` method on `MongoCursor`. I considered switching to the approach we discussed before with an enum wrapping the values we need to nil out but ultimately this seemed simpler.

Once the new read preference tests in #296 get merged in I will augment those tests with similar checks for the read preference set on the temporary pointers.