### PR TITLE
SWIFT-176 Add watch methods to MongoClient, MongoDatabase, and MongoCollection

### DIFF
--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -17,25 +17,25 @@ public struct ChangeStreamToken: Codable {
 /// A MongoDB ChangeStream.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
 public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
-    // A `ChangeStreamToken` used for manually resuming a change stream.
+    /// A `ChangeStreamToken` used for manually resuming a change stream.
     public private(set) var resumeToken: ChangeStreamToken
 
-    // A `MongoClient` stored to make sure the source client stays valid until the change stream is destroyed.
+    /// A `MongoClient` stored to make sure the source client stays valid until the change stream is destroyed.
     private let client: MongoClient
 
-    // A `Connection` stored to make sure the client connection stays valid until the change stream is destroyed.
+    /// A `Connection` stored to make sure the client connection stays valid until the change stream is destroyed.
     private let connection: Connection
 
-    // A `ClientSession` stored to make sure the session stays valid until the change stream is destroyed.
+    /// A `ClientSession` stored to make sure the session stays valid until the change stream is destroyed.
     private let session: ClientSession?
 
-    // A reference to the `mongoc_change_stream_t` pointer.
+    /// A reference to the `mongoc_change_stream_t` pointer.
     private let changeStream: OpaquePointer
 
-    // Decoder for decoding documents into type `T`.
+    /// Decoder for decoding documents into type `T`.
     private let decoder: BSONDecoder
 
-    // Used for storing Swift errors.
+    /// Used for storing Swift errors.
     private var swiftError: Error?
 
     /// The error that occurred while iterating the change stream, if one exists. This should be used to check

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -14,6 +14,12 @@ public struct ChangeStreamToken: Codable {
     }
 }
 
+extension ChangeStreamToken: Equatable {
+    public static func == (lhs: ChangeStreamToken, rhs: ChangeStreamToken) -> Bool {
+        return lhs.resumeToken == rhs.resumeToken
+    }
+}
+
 /// A MongoDB ChangeStream.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
 public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -137,19 +137,15 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
                 client: MongoClient,
                 session: ClientSession? = nil,
                 decoder: BSONDecoder) throws {
-      self.changeStream = changeStream
-      self.session = session
-      self.client = client
-      self.decoder = decoder
-      self.resumeToken = ChangeStreamToken(resumeToken: [])
+    self.changeStream = changeStream
+    self.session = session
+    self.client = client
+    self.decoder = decoder
+    self.resumeToken = ChangeStreamToken(resumeToken: [])
 
     if let err = self.error {
       throw err
     }
-  }
-
-  func foobar() {
-    fgdf
   }
 
   /// Cleans up internal state.

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -2,7 +2,7 @@ import mongoc
 /// A token used for manually resuming a change stream. Pass this to the `resumeAfter` field of
 /// `ChangeStreamOptions` to resume or start a change stream where a previous one left off.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
-public struct ChangeStreamToken: Codable {
+public struct ChangeStreamToken: Codable, Equatable {
     private let resumeToken: Document
 
     internal init(resumeToken: Document) {
@@ -11,12 +11,6 @@ public struct ChangeStreamToken: Codable {
 
     public init(from decoder: Decoder) throws {
         self.resumeToken = try Document(from: decoder)
-    }
-}
-
-extension ChangeStreamToken: Equatable {
-    public static func == (lhs: ChangeStreamToken, rhs: ChangeStreamToken) -> Bool {
-        return lhs.resumeToken == rhs.resumeToken
     }
 }
 

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -93,8 +93,6 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     // we have to copy because libmongoc owns the pointer.
     let doc = Document(copying: pointee)
 
-    print(doc)
-
     // Update the resumeToken with the `_id` field from the document.
     if let resumeToken = doc["_id"] as? Document {
         self.resumeToken = ChangeStreamToken(resumeToken: resumeToken)

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -1,6 +1,8 @@
 import mongoc
 
-/// A `ChangeStreamToken` used for wrapping the resume token.
+/// A token used for manually resuming a change stream. Pass this to the `resumeAfter` or `startAfter` fields of
+/// `ChangeStreamOptions` to resume or start a change stream where a previous one left off.
+/// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
 public struct ChangeStreamToken: Codable {
     private let resumeToken: Document
 
@@ -16,7 +18,7 @@ public struct ChangeStreamToken: Codable {
 /// A MongoDB ChangeStream.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
 public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
-  /// The cached resume token.
+  /// A `ChangeStreamToken` used to manually resume a change stream.
   public private(set) var resumeToken: ChangeStreamToken
 
   /// A `MongoClient` stored to make sure the source client stays valid
@@ -33,9 +35,8 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
   /// Used for storing Swift errors.
   private var swiftError: Error?
 
-  /// The error that occurred while iterating the ChangeStream cursor,
-  /// if one exists. This should be used to check for errors after
-  /// `next()` returns `nil`.
+  /// The error that occurred while iterating the ChangeStream cursor, if one exists.
+  /// This should be used to check for errors after `next()` returns `nil`.
   public var error: Error? {
     if let err = self.swiftError {
         return err
@@ -68,26 +69,25 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
   /// Decoder for decoding documents into type `T`.
   internal let decoder: BSONDecoder
 
-  /// Returns the next `T` in the change stream or nil if there is no next value.
-  /// Will block for a maximum of `maxAwaitTimeMS` milliseconds as specified in the
-  /// `ChangeStreamOptions`, or for the server default timeout if omitted.
+  /// Returns the next `T` in the change stream or nil if there is no next value. Will block for a maximum of
+  /// `maxAwaitTimeMS` milliseconds as specified in the `ChangeStreamOptions`, or for the server default timeout
+  /// if omitted.
   public func next() -> T? {
     let cursor = self.changeStream
     // Allocate space for a reference to a BSON pointer.
     let out = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+    defer {
+        out.deinitialize(count: 1)
+        out.deallocate()
+    }
 
     // Check that there’s another document in the stream.
     guard mongoc_change_stream_next(cursor, out) else {
       return nil
     }
 
-    defer {
-        out.deinitialize(count: 1)
-        out.deallocate()
-    }
-
     guard let pointee = out.pointee else {
-        fatalError("mongoc_change_stream_next returned true, but document is nil")
+        fatalError("Could not advance the change stream.")
     }
 
     // we have to copy because libmongoc owns the pointer.
@@ -102,30 +102,25 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     }
 
     do {
-      return try decoder.decode(T.self, from: doc)
+        return try decoder.decode(T.self, from: doc)
     } catch {
-      self.swiftError = error
+        self.swiftError = error
     }
 
     return nil
   }
 
   /**
-   * Returns the next `T` in this change stream or
-   * `nil`, or throws an error if one occurs -- compared to `next()`,
-   * which returns `nil` and requires manually checking for an error
-   * afterward.
-   * Will block for a maximum of `maxAwaitTimeMS` milliseconds as specified in the
-   * `ChangeStreamOptions`, or for the server default timeout if omitted.
-   * - Returns: the next `T` in this change stream,
-   *            or `nil` if at the end of the change stream cursor.
+   * Returns the next `T` in this change stream or `nil`, or throws an error if one occurs -- compared to `next()`,
+   * whichreturns `nil` and requires manually checking for an error afterward. Will block for a maximum of
+   * `maxAwaitTimeMS` milliseconds as specified in the `ChangeStreamOptions`, or for the server default timeout if
+   * omitted.
+   * - Returns: the next `T` in this change stream, or `nil` if at the end of the change stream cursor.
    * - Throws:
-   *   - `ServerError.commandError` if an error occurs on the
-   *     server while iterating the change stream cursor.
-   *   - `UserError.logicError` if this function is called and the
-   *     session associated with this change stream is inactive.
-   *   - `DecodingError` if an error occurs decoding the server's
-   *     response.
+   *   - `ServerError.commandError` if an error occurs on the server while iterating the change stream cursor.
+   *   - `UserError.logicError` if this function is called and the session associated with this change stream is
+   *     inactive.
+   *   - `DecodingError` if an error occurs decoding the server's response.
    */
   public func nextOrError() throws -> T? {
     if let next = self.next() {
@@ -141,10 +136,8 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
   /**
    * Initializes a `ChangeStream`.
    * - Throws:
-   *   - `ServerError.commandError` if an error occurred on the
-   *     server when creating the `mongoc_change_stream_t`.
-   *   - `UserError.invalidArgumentError` if the `mongoc_change_stream_t`
-   *     was created with invalid options.
+   *   - `ServerError.commandError` if an error occurred on the server when creating the `mongoc_change_stream_t`.
+   *   - `UserError.invalidArgumentError` if the `mongoc_change_stream_t` was created with invalid options.
    */
   internal init(stealing changeStream: OpaquePointer,
                 client: MongoClient,
@@ -163,12 +156,12 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
 
   /// Cleans up internal state.
   deinit {
-     guard let cursor = self.changeStream else {
-          return
-      }
-      mongoc_change_stream_destroy(changeStream)
-      self.changeStream = nil
-      self.session = nil
-      self.client = nil
+    guard let cursor = self.changeStream else {
+        return
+    }
+    mongoc_change_stream_destroy(changeStream)
+    self.changeStream = nil
+    self.session = nil
+    self.client = nil
   }
 }

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -110,7 +110,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
 
   /**
    * Returns the next `T` in this change stream or `nil`, or throws an error if one occurs -- compared to `next()`,
-   * whichreturns `nil` and requires manually checking for an error afterward. Will block for a maximum of
+   * which returns `nil` and requires manually checking for an error afterward. Will block for a maximum of
    * `maxAwaitTimeMS` milliseconds as specified in the `ChangeStreamOptions`, or for the server default timeout if
    * omitted.
    * - Returns: the next `T` in this change stream, or `nil` if at the end of the change stream cursor.

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -92,7 +92,6 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
 
     // we have to copy because libmongoc owns the pointer.
     let doc = Document(copying: pointee)
-    print(doc)
 
     // Update the resumeToken with the `_id` field from the document.
     if let resumeToken = doc["_id"] as? Document {

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -93,6 +93,8 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     // we have to copy because libmongoc owns the pointer.
     let doc = Document(copying: pointee)
 
+    print(doc)
+
     // Update the resumeToken with the `_id` field from the document.
     if let resumeToken = doc["_id"] as? Document {
         self.resumeToken = ChangeStreamToken(resumeToken: resumeToken)

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -21,6 +21,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     public private(set) var resumeToken: ChangeStreamToken
 
     /// A `MongoClient` stored to make sure the source client stays valid until the change stream is destroyed.
+    // TODO: SWIFT-374: remove this property.
     private let client: MongoClient
 
     /// A `Connection` stored to make sure the client connection stays valid until the change stream is destroyed.

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -1,6 +1,6 @@
 import mongoc
 
-/// A `ChangeStreamToken` that wraps `resumeToken`.
+/// A `ChangeStreamToken` used for wrapping the resume token.
 public struct ChangeStreamToken: Codable {
     private let resumeToken: Document
 

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -70,7 +70,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
 
   /// Returns the next `T` in the change stream or nil if there is no next value.
   /// Will block for a maximum of `maxAwaitTimeMS` milliseconds as specified in the
-  /// `ChangeStreamOptions`, or the server default timeout if omitted.
+  /// `ChangeStreamOptions`, or for the server default timeout if omitted.
   public func next() -> T? {
     let cursor = self.changeStream
     // Allocate space for a reference to a BSON pointer.
@@ -116,16 +116,16 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
    * which returns `nil` and requires manually checking for an error
    * afterward.
    * Will block for a maximum of `maxAwaitTimeMS` milliseconds as specified in the
-   * `ChangeStreamOptions`, or the server default timeout if omitted.
+   * `ChangeStreamOptions`, or for the server default timeout if omitted.
    * - Returns: the next `T` in this change stream,
    *            or `nil` if at the end of the change stream cursor.
    * - Throws:
    *   - `ServerError.commandError` if an error occurs on the
-   * 	   server while iterating the change stream cursor.
+   *     server while iterating the change stream cursor.
    *   - `UserError.logicError` if this function is called and the
    *     session associated with this change stream is inactive.
    *   - `DecodingError` if an error occurs decoding the server's
-   * 	   response.
+   *     response.
    */
   public func nextOrError() throws -> T? {
     if let next = self.next() {

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -78,7 +78,6 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
         out.deallocate()
     }
 
-    // Check that there’s another document in the stream.
     guard mongoc_change_stream_next(self.changeStream, out) else {
       return nil
     }

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -1,155 +1,155 @@
 import mongoc
-/// A token used for manually resuming a change stream. Pass this to the `resumeAfter` or `startAfter` fields of
+/// A token used for manually resuming a change stream. Pass this to the `resumeAfter` field of
 /// `ChangeStreamOptions` to resume or start a change stream where a previous one left off.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
 public struct ChangeStreamToken: Codable {
     private let resumeToken: Document
 
     internal init(resumeToken: Document) {
-      self.resumeToken = resumeToken
+        self.resumeToken = resumeToken
     }
 
     public init(from decoder: Decoder) throws {
-      self.resumeToken = try Document(from: decoder)
+        self.resumeToken = try Document(from: decoder)
     }
 }
 
 /// A MongoDB ChangeStream.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
 public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
-  /// A `ChangeStreamToken` used for manually resuming a change stream.
-  public private(set) var resumeToken: ChangeStreamToken
+    /// A `ChangeStreamToken` used for manually resuming a change stream.
+    public private(set) var resumeToken: ChangeStreamToken
 
-  /// A `MongoClient` stored to make sure the source client stays valid until the change stream is destroyed.
-  private let client: MongoClient
+    /// A `MongoClient` stored to make sure the source client stays valid until the change stream is destroyed.
+    private let client: MongoClient
 
-  /// A `ClientSession` stored to make sure the session stays valid until the change stream is destroyed.
-  private let session: ClientSession?
+    /// A `ClientSession` stored to make sure the session stays valid until the change stream is destroyed.
+    private let session: ClientSession?
 
-  /// A reference to the `mongoc_change_stream_t` pointer.
-  private let changeStream: OpaquePointer
+    /// A reference to the `mongoc_change_stream_t` pointer.
+    private let changeStream: OpaquePointer
 
-  /// Used for storing Swift errors.
-  private var swiftError: Error?
+    /// Decoder for decoding documents into type `T`.
+    private let decoder: BSONDecoder
 
-  /// The error that occurred while iterating the change stream, if one exists. This should be used to check
-  /// for errors after `next()` returns `nil`.
-  public var error: Error? {
-    if let err = self.swiftError {
-        return err
+    /// Used for storing Swift errors.
+    private var swiftError: Error?
+
+    /// The error that occurred while iterating the change stream, if one exists. This should be used to check
+    /// for errors after `next()` returns `nil`.
+    public var error: Error? {
+        if let err = self.swiftError {
+            return err
+        }
+
+        var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+        defer {
+            replyPtr.deinitialize(count: 1)
+            replyPtr.deallocate()
+        }
+
+        var error = bson_error_t()
+        guard mongoc_change_stream_error_document(self.changeStream, &error, replyPtr) else {
+            return nil
+        }
+
+        // If a reply is present, it implies the error occurred on the server. This *should* always be a commandError,
+        // but we will still parse the mongoc error to cover all cases.
+        if let docPtr = replyPtr.pointee {
+            // we have to copy because libmongoc owns the pointer.
+            let reply = Document(copying: docPtr)
+            return extractMongoError(error: error, reply: reply)
+        }
+
+        // Otherwise, the only feasible error is that the user tried to advance a dead change stream cursor,
+        // which is a logic error. We will still parse the mongoc error to cover all cases.
+        return extractMongoError(error: error)
     }
 
-    var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-    defer {
-        replyPtr.deinitialize(count: 1)
-        replyPtr.deallocate()
-    }
+    /// Returns the next `T` in the change stream or nil if there is no next value. Will block for a maximum of
+    /// `maxAwaitTimeMS` milliseconds as specified in the `ChangeStreamOptions`, or for the server default timeout
+    /// if omitted.
+    public func next() -> T? {
+        // Allocate space for a reference to a BSON pointer.
+        let out = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+        defer {
+            out.deinitialize(count: 1)
+            out.deallocate()
+        }
 
-    var error = bson_error_t()
-    guard mongoc_change_stream_error_document(self.changeStream, &error, replyPtr) else {
-        return nil
-    }
+        guard mongoc_change_stream_next(self.changeStream, out) else {
+            return nil
+        }
 
-    // If a reply is present, it implies the error occurred on the server. This *should* always be a commandError,
-    // but we will still parse the mongoc error to cover all cases.
-    if let docPtr = replyPtr.pointee {
+        guard let pointee = out.pointee else {
+            fatalError("The change stream was advanced, but the document is nil.")
+        }
+
         // we have to copy because libmongoc owns the pointer.
-        let reply = Document(copying: docPtr)
-        return extractMongoError(error: error, reply: reply)
-    }
+        let doc = Document(copying: pointee)
 
-    // Otherwise, the only feasible error is that the user tried to advance a dead change stream cursor,
-    // which is a logic error. We will still parse the mongoc error to cover all cases.
-    return extractMongoError(error: error)
-  }
+        // Update the resumeToken with the `_id` field from the document.
+        guard let resumeToken = doc["_id"] as? Document else {
+            self.swiftError = RuntimeError
+                            .internalError(message: "_id field is missing from the change stream document.")
+                return nil
+        }
+        self.resumeToken = ChangeStreamToken(resumeToken: resumeToken)
 
-  /// Decoder for decoding documents into type `T`.
-  internal let decoder: BSONDecoder
-
-  /// Returns the next `T` in the change stream or nil if there is no next value. Will block for a maximum of
-  /// `maxAwaitTimeMS` milliseconds as specified in the `ChangeStreamOptions`, or for the server default timeout
-  /// if omitted.
-  public func next() -> T? {
-    // Allocate space for a reference to a BSON pointer.
-    let out = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-    defer {
-        out.deinitialize(count: 1)
-        out.deallocate()
-    }
-
-    guard mongoc_change_stream_next(self.changeStream, out) else {
-      return nil
-    }
-
-    guard let pointee = out.pointee else {
-        fatalError("The change stream was advanced, but the document is nil.")
-    }
-
-    // we have to copy because libmongoc owns the pointer.
-    let doc = Document(copying: pointee)
-
-    // Update the resumeToken with the `_id` field from the document.
-    guard let resumeToken = doc["_id"] as? Document else {
-      self.swiftError = RuntimeError.internalError(message: "_id field is missing from the change stream document.")
+        do {
+            return try decoder.decode(T.self, from: doc)
+        } catch {
+            self.swiftError = error
+        }
         return nil
     }
-    self.resumeToken = ChangeStreamToken(resumeToken: resumeToken)
 
-    do {
-        return try decoder.decode(T.self, from: doc)
-    } catch {
-        self.swiftError = error
+    /**
+     * Returns the next `T` in this change stream or `nil`, or throws an error if one occurs -- compared to `next()`,
+     * which returns `nil` and requires manually checking for an error afterward. Will block for a maximum of
+     * `maxAwaitTimeMS` milliseconds as specified in the `ChangeStreamOptions`, or for the server default timeout if
+     * omitted.
+     * - Returns: the next `T` in this change stream, or `nil` if at the end of the change stream cursor.
+     * - Throws:
+     *   - `ServerError.commandError` if an error occurs on the server while iterating the change stream cursor.
+     *   - `UserError.logicError` if this function is called and the session associated with this change stream is
+     *     inactive.
+     *   - `DecodingError` if an error occurs decoding the server's response.
+     */
+    public func nextOrError() throws -> T? {
+        if let next = self.next() {
+            return next
+        }
+
+        if let error = self.error {
+            throw error
+        }
+        return nil
     }
 
-    return nil
-  }
+    /**
+     * Initializes a `ChangeStream`.
+     * - Throws:
+     *   - `ServerError.commandError` if an error occurred on the server when creating the `mongoc_change_stream_t`.
+     *   - `UserError.invalidArgumentError` if the `mongoc_change_stream_t` was created with invalid options.
+     */
+    internal init(stealing changeStream: OpaquePointer,
+                  client: MongoClient,
+                  session: ClientSession? = nil,
+                  decoder: BSONDecoder) throws {
+        self.changeStream = changeStream
+        self.session = session
+        self.client = client
+        self.decoder = decoder
+        self.resumeToken = ChangeStreamToken(resumeToken: [])
 
-  /**
-   * Returns the next `T` in this change stream or `nil`, or throws an error if one occurs -- compared to `next()`,
-   * whichreturns `nil` and requires manually checking for an error afterward. Will block for a maximum of
-   * `maxAwaitTimeMS` milliseconds as specified in the `ChangeStreamOptions`, or for the server default timeout if
-   * omitted.
-   * - Returns: the next `T` in this change stream, or `nil` if at the end of the change stream cursor.
-   * - Throws:
-   *   - `ServerError.commandError` if an error occurs on the server while iterating the change stream cursor.
-   *   - `UserError.logicError` if this function is called and the session associated with this change stream is
-   *     inactive.
-   *   - `DecodingError` if an error occurs decoding the server's response.
-   */
-  public func nextOrError() throws -> T? {
-    if let next = self.next() {
-      return next
+        if let err = self.error {
+            throw err
+        }
     }
 
-    if let error = self.error {
-      throw error
+    /// Cleans up internal state.
+    deinit {
+        mongoc_change_stream_destroy(self.changeStream)
     }
-    return nil
-  }
-
-  /**
-   * Initializes a `ChangeStream`.
-   * - Throws:
-   *   - `ServerError.commandError` if an error occurred on the server when creating the `mongoc_change_stream_t`.
-   *   - `UserError.invalidArgumentError` if the `mongoc_change_stream_t` was created with invalid options.
-   */
-  internal init(stealing changeStream: OpaquePointer,
-                client: MongoClient,
-                session: ClientSession? = nil,
-                decoder: BSONDecoder) throws {
-    self.changeStream = changeStream
-    self.session = session
-    self.client = client
-    self.decoder = decoder
-    self.resumeToken = ChangeStreamToken(resumeToken: [])
-
-    if let err = self.error {
-      throw err
-    }
-  }
-
-  /// Cleans up internal state.
-  deinit {
-    mongoc_change_stream_destroy(changeStream)
-  }
 }

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -143,9 +143,13 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
       self.decoder = decoder
       self.resumeToken = ChangeStreamToken(resumeToken: [])
 
-      if let err = self.error {
-        throw err
-      }
+    if let err = self.error {
+      throw err
+    }
+  }
+
+  func foobar() {
+    fgdf
   }
 
   /// Cleans up internal state.

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -61,8 +61,8 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
         return extractMongoError(error: error, reply: reply)
     }
 
-    // Otherwise, the only feasible error is that the user tried to advance a dead cursor, which is a logic error.
-    // We will still parse the mongoc error to cover all cases.
+    // Otherwise, the only feasible error is that the user tried to advance a dead change stream cursor,
+    // which is a logic error. We will still parse the mongoc error to cover all cases.
     return extractMongoError(error: error)
   }
 

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -21,7 +21,6 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     public private(set) var resumeToken: ChangeStreamToken
 
     /// A `MongoClient` stored to make sure the source client stays valid until the change stream is destroyed.
-    // TODO: SWIFT-374: remove this property.
     private let client: MongoClient
 
     /// A `Connection` stored to make sure the client connection stays valid until the change stream is destroyed.

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -7,7 +7,7 @@ public struct ChangeStreamToken: Codable {
     private let resumeToken: Document
 
     internal init(resumeToken: Document) {
-        self.resumeToken = resumeToken
+      self.resumeToken = resumeToken
     }
 
     public init(from decoder: Decoder) throws {
@@ -33,7 +33,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
   /// Used for storing Swift errors.
   private var swiftError: Error?
 
-  /// The error that occurred while iterating the ChangeStream cursor, if one exists. This should be used to check
+  /// The error that occurred while iterating the change stream, if one exists. This should be used to check
   /// for errors after `next()` returns `nil`.
   public var error: Error? {
     if let err = self.swiftError {
@@ -84,7 +84,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     }
 
     guard let pointee = out.pointee else {
-        fatalError("Could not advance the change stream.")
+        fatalError("The change stream was advanced, but the document is nil.")
     }
 
     // we have to copy because libmongoc owns the pointer.

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -2,7 +2,7 @@ import mongoc
 /// A token used for manually resuming a change stream. Pass this to the `resumeAfter` field of
 /// `ChangeStreamOptions` to resume or start a change stream where a previous one left off.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
-public struct ChangeStreamToken: Codable, Equatable {
+public struct ResumeToken: Codable, Equatable {
     private let resumeToken: Document
 
     internal init(resumeToken: Document) {
@@ -17,8 +17,8 @@ public struct ChangeStreamToken: Codable, Equatable {
 /// A MongoDB ChangeStream.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
 public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
-    /// A `ChangeStreamToken` used for manually resuming a change stream.
-    public private(set) var resumeToken: ChangeStreamToken
+    /// A `ResumeToken` used for manually resuming a change stream.
+    public private(set) var resumeToken: ResumeToken
 
     /// A `MongoClient` stored to make sure the source client stays valid until the change stream is destroyed.
     private let client: MongoClient
@@ -97,7 +97,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
                             .internalError(message: "_id field is missing from the change stream document.")
                 return nil
         }
-        self.resumeToken = ChangeStreamToken(resumeToken: resumeToken)
+        self.resumeToken = ResumeToken(resumeToken: resumeToken)
 
         do {
             return try decoder.decode(T.self, from: doc)
@@ -141,7 +141,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
                   connection: Connection,
                   session: ClientSession? = nil,
                   decoder: BSONDecoder) throws {
-        self.resumeToken = ChangeStreamToken(resumeToken: [])
+        self.resumeToken = ResumeToken(resumeToken: [])
         self.client = client
         self.connection = connection
         self.session = session

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -18,15 +18,13 @@ public struct ChangeStreamToken: Codable {
 /// A MongoDB ChangeStream.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
 public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
-  /// A `ChangeStreamToken` used to manually resume a change stream.
+  /// A `ChangeStreamToken` used for manually resuming a change stream.
   public private(set) var resumeToken: ChangeStreamToken
 
-  /// A `MongoClient` stored to make sure the source client stays valid
-  /// until the change stream is destroyed.
+  /// A `MongoClient` stored to make sure the source client stays valid until the change stream is destroyed.
   private var client: MongoClient?
 
-  /// A `ClientSession` stored to make sure the session stays valid
-  /// until the change stream is destroyed.
+  /// A `ClientSession` stored to make sure the session stays valid until the change stream is destroyed.
   private var session: ClientSession?
 
   /// A reference to the `mongoc_change_stream_t` pointer.
@@ -35,8 +33,8 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
   /// Used for storing Swift errors.
   private var swiftError: Error?
 
-  /// The error that occurred while iterating the ChangeStream cursor, if one exists.
-  /// This should be used to check for errors after `next()` returns `nil`.
+  /// The error that occurred while iterating the ChangeStream cursor, if one exists. This should be used to check
+  /// for errors after `next()` returns `nil`.
   public var error: Error? {
     if let err = self.swiftError {
         return err

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -130,7 +130,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     *   - `UserError.invalidArgumentError` if the `mongoc_change_stream_t`
     *      was created with invalid options.
     */
-  internal init<K: Codable>(stealing changeStream: OpaquePointer, client: MongoClient, session: ClientSession?, decoder: BSONDecoder, withType: K.Type) throws {
+  internal init(stealing changeStream: OpaquePointer, client: MongoClient, session: ClientSession?, decoder: BSONDecoder) throws {
     self.changeStream = changeStream
     self.session = session
     self.client = client

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -1,5 +1,4 @@
 import mongoc
-
 /// A token used for manually resuming a change stream. Pass this to the `resumeAfter` or `startAfter` fields of
 /// `ChangeStreamOptions` to resume or start a change stream where a previous one left off.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -61,8 +61,8 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
         return extractMongoError(error: error, reply: reply)
     }
 
-    // Otherwise, the only feasible error is that the user tried to advance a dead change stream cursor,
-    // which is a logic error. We will still parse the mongoc error to cover all cases.
+    // Otherwise, the only feasible error is that the user tried to advance a dead cursor, which is a logic error.
+    // We will still parse the mongoc error to cover all cases.
     return extractMongoError(error: error)
   }
 
@@ -159,7 +159,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     guard let cursor = self.changeStream else {
         return
     }
-    mongoc_change_stream_destroy(changeStream)
+    mongoc_cursor_destroy(changeStream)
     self.changeStream = nil
     self.session = nil
     self.client = nil

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -1,0 +1,151 @@
+import mongoc
+
+/// A MongoDB ChangeStream.
+/// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
+public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
+  /// The cached resume token.
+  public private(set) var resumeToken: ChangeStreamToken
+
+  /// A `MongoClient` stored to make sure the source client stays valid
+  /// until the change stream is destroyed.
+  private var client: MongoClient?
+
+  /// A  `ClientSession` stored to make sure the session stays valid
+  /// until the change stream is destroyed.
+  private var session: ClientSession?
+
+  /// A reference to the `mongoc_change_stream_t` pointer.
+  private var changeStream: OpaquePointer?
+
+  /// Used for storing Swift errors.
+  private var swiftError: Error?
+
+  /// The error that occurred while iterating the ChangeStream cursor,
+  /// if one exists. This should be used to check for errors after
+  /// `next()` returns `nil`.
+  public var error: Error? {
+    if let err = self.swiftError {
+        return err
+    }
+
+    var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+    defer {
+        replyPtr.deinitialize(count: 1)
+        replyPtr.deallocate()
+    }
+
+    var error = bson_error_t()
+    guard mongoc_cursor_error_document(self.changeStream, &error, replyPtr) else {
+        return nil
+    }
+
+    // If a reply is present, it implies the error occurred on the server. This *should* always be a commandError,
+    // but we will still parse the mongoc error to cover all cases.
+    if let docPtr = replyPtr.pointee {
+        // we have to copy because libmongoc owns the pointer.
+        let reply = Document(copying: docPtr)
+        return extractMongoError(error: error, reply: reply)
+    }
+
+    // Otherwise, the only feasible error is that the user tried to advance a dead cursor, which is a logic error.
+    // We will still parse the mongoc error to cover all cases.
+    return extractMongoError(error: error)
+  }
+
+  /// Decoder for decoding documents into type `T`.
+  internal let decoder: BSONDecoder
+
+  /// Returns the next `ChangeStreamDocument` in the change stream or nil
+  /// if there is no document.
+  public func next() -> T? {
+    let cursor = self.changeStream
+    // Allocate space for a reference to a BSON pointer.
+    let out = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+
+    // Check that there’s another document in the stream.
+    guard mongoc_change_stream_next(cursor, out) else {
+      return nil
+    }
+
+    defer {
+        out.deinitialize(count: 1)
+        out.deallocate()
+    }
+
+    guard let pointee = out.pointee else {
+        fatalError("mongoc_change_stream_next returned true, but document is nil")
+    }
+
+    // we have to copy because libmongoc owns the pointer.
+    let doc = Document(copying: pointee)
+
+    // Update the resumeToken with the `_id` field from the document.
+    if let resumeToken = doc["id"] as? Document {
+        self.resumeToken = ChangeStreamToken(resumeToken: resumeToken)
+    } else {
+        self.swiftError = RuntimeError.internalError(message: "_id field is missing from the change stream document.")
+        return nil
+    }
+
+    do {
+      return try decoder.decode(T.self, from: doc)
+    } catch {
+      self.swiftError = error
+    }
+
+    return nil
+  }
+
+  /**
+  * Returns the next `ChangeStreamDocument<T>` in this change stream or
+  * `nil`, or throws an error if one occurs -- compared to `next()`,
+  * which returns `nil` and requires manually checking for an error
+  * afterward.
+  * - Returns: the next `ChangeStreamDocument<T>` in this change stream,
+  *            or `nil` if at the end of the change stream cursor.
+  * - Throws:
+  *   - `ServerError.commandError` if an error occurs on the
+  * 	 server while iterating the cursor.
+  *   - `UserError.logicError` if this function is called and the
+  *      session associated with this change stream is inactive.
+  *   - `DecodingError` if an error occurs decoding the server's
+  * 	 response.
+  */
+  public func nextOrError() throws -> T? {
+    if let next = self.next() {
+      return next
+    }
+
+    if let error = self.error {
+      throw error
+    }
+    return nil
+  }
+
+  /**
+    * Initializes a `ChangeStream`.
+    * - Throws:
+    *   - `ServerError.commandError` if an error occurred on the
+    *      server when creating the `mongoc_change_stream_t`.
+    *   - `UserError.invalidArgumentError` if the `mongoc_change_stream_t`
+    *      was created with invalid options.
+    */
+  internal init<K: Codable>(stealing changeStream: OpaquePointer, client: MongoClient, session: ClientSession?, decoder: BSONDecoder, withType: K.Type) throws {
+    self.changeStream = changeStream
+    self.session = session
+    self.client = client
+    self.decoder = decoder
+    self.resumeToken = ChangeStreamToken(resumeToken: [])
+  }
+
+  /// Cleans up internal state.
+  deinit {
+     guard let cursor = self.changeStream else {
+          return
+      }
+      mongoc_cursor_destroy(changeStream)
+      self.changeStream = nil
+      self.session = nil
+      self.client = nil
+  }
+}

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -92,6 +92,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
 
     // we have to copy because libmongoc owns the pointer.
     let doc = Document(copying: pointee)
+    print(doc)
 
     // Update the resumeToken with the `_id` field from the document.
     if let resumeToken = doc["_id"] as? Document {
@@ -159,7 +160,7 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     guard let cursor = self.changeStream else {
         return
     }
-    mongoc_cursor_destroy(changeStream)
+    mongoc_change_stream_destroy(changeStream)
     self.changeStream = nil
     self.session = nil
     self.client = nil

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -44,7 +44,7 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
 
     /// An opaque token for use when resuming an interrupted change stream.
     /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
-    public let _id: ChangeStreamToken
+    public let _id: ResumeToken
 
     /// A document containing the database and collection names in which this change happened.
     public let ns: MongoNamespace

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,8 +1,8 @@
 /// An `UpdateDescription` containing fields that will be present in the change stream document
 /// for operations of type `update`.
 public struct UpdateDescription: Codable {
-   /// A document containing key:value pairs of names of the fields
-   /// that were changed, and the new value for those fields.
+   /// A document containing key:value pairs of names of the fields that were changed, and the new
+   /// value for those fields.
    public let updatedFields: Document
 
    /// An array of field names that were removed from the document.
@@ -46,8 +46,7 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
     public let _id: ChangeStreamToken
 
-    /// A document containing the database and collection names in
-    /// which this change happened.
+    /// A document containing the database and collection names in which this change happened.
     public let ns: MongoNamespace
 
     /**

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 /// An `UpdateDescription` containing fields that will be present in the change stream document
 /// for operations of type `update`.
 public struct UpdateDescription: Codable {
@@ -44,12 +45,43 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
 
     /// An opaque token for use when resuming an interrupted change stream.
     /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
+=======
+/// The response document type from a `ChangeStream`.
+public struct ChangeStreamDocument<T: Codable>: Codable {
+	public struct UpdateDescription: Codable {
+        /// A document containing key:value pairs of names of the fields
+        /// that were changed, and the new value for those fields.
+        public let updatedFields: Document
+
+        /// An array of field names that were removed from the document.
+        public let removedFields: [String]
+    }
+
+    /// An enum representing the type of operation for this change.
+     public enum OperationType: String, Codable {
+        case insert
+        case update
+        case replace
+        case delete
+        case invalidate
+        case drop
+        case dropDatabase
+        case rename
+     }
+
+    /// Describes the type of operation for this change.
+    public let operationType: OperationType
+
+    /// An opaque token for use when resuming an interrupted change
+    /// stream.
+>>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
     public let _id: ChangeStreamToken
 
     /// A document containing the database and collection names in
     /// which this change happened.
     public let ns: MongoNamespace
 
+<<<<<<< HEAD
     /**
      * Only present for options of type `insert’, `update’, `replace’ and `delete’. For unsharded collections this
      * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
@@ -72,6 +104,36 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     *
     * For operations of type `update’, this key will contain a copy of the full version of the document from some point
     * after the update occurred. If the document was deleted since the updated happened, it will be null.
+=======
+    /** Only present for options of type ‘insert’, ‘update’,
+      * ‘replace’ and ‘delete’.
+      *
+      * For unsharded collections this contains a single field, _id, with the
+      * value of the _id of the document updated. For sharded collections,
+      * this will contain all the components of the shard key in order,
+      * followed by the _id if the _id isn’t part of the shard key.
+      */
+    public let documentKey: Document?
+
+    /// An `UpdateDescription` containing updated and removed fields in
+    /// this operation. Only present for operations of type `update`.
+    public let updateDescription: UpdateDescription?
+
+   /**
+    * Always present for operations of type ‘insert’ and ‘replace’. Also
+    * present for operations of type ‘update’ if the user has specified
+    * ‘updateLookup’ in the ‘fullDocument’ arguments to the ‘$changeStream’
+    *  stage.
+    *
+    * For operations of type ‘insert’ and ‘replace’, this key will contain
+    * the document being inserted, or the new version of the document that is
+    * replacing the existing document, respectively.
+    *
+    * For operations of type ‘update’, this key will contain a copy of the
+    * full version of the document from some point after the update occurred.
+    * If the document was deleted since the updated happened, it will be
+    * null.
+>>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
     */
     public let fullDocument: T?
  }

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,0 +1,65 @@
+/// The response document type from a `ChangeStream`.
+public struct ChangeStreamDocument<T: Codable>: Codable {
+	public struct UpdateDescription: Codable {
+        /// A document containing key:value pairs of names of the fields
+        /// that were changed, and the new value for those fields.
+        public let updatedFields: Document
+
+        /// An array of field names that were removed from the document.
+        public let removedFields: [String]
+    }
+
+    /// An enum representing the type of operation for this change.
+     public enum OperationType: String, Codable {
+        case insert
+        case update
+        case replace
+        case delete
+        case invalidate
+        case drop
+        case dropDatabase
+        case rename
+     }
+
+    /// Describes the type of operation for this change.
+    public let operationType: OperationType
+
+    /// An opaque token for use when resuming an interrupted change
+    /// stream.
+    public let _id: ChangeStreamToken
+
+    /// A document containing the database and collection names in
+    /// which this change happened.
+    public let ns: MongoNamespace
+
+    /** Only present for options of type ‘insert’, ‘update’,
+      * ‘replace’ and ‘delete’.
+      *
+      * For unsharded collections this contains a single field, _id, with the
+      * value of the _id of the document updated. For sharded collections,
+      * this will contain all the components of the shard key in order,
+      * followed by the _id if the _id isn’t part of the shard key.
+      */
+    public let documentKey: Document?
+
+    /// An `UpdateDescription` containing updated and removed fields in
+    /// this operation. Only present for operations of type `update`.
+    public let updateDescription: UpdateDescription?
+
+   /**
+    * Always present for operations of type ‘insert’ and ‘replace’. Also
+    * present for operations of type ‘update’ if the user has specified
+    * ‘updateLookup’ in the ‘fullDocument’ arguments to the ‘$changeStream’
+    *  stage.
+    *
+    * For operations of type ‘insert’ and ‘replace’, this key will contain
+    * the document being inserted, or the new version of the document that is
+    * replacing the existing document, respectively.
+    *
+    * For operations of type ‘update’, this key will contain a copy of the
+    * full version of the document from some point after the update occurred.
+    * If the document was deleted since the updated happened, it will be
+    * null.
+    */
+    public let fullDocument: T?
+ }

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,9 +1,14 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 /// An `UpdateDescription` containing fields that will be present in the change stream document
 /// for operations of type `update`.
 =======
 >>>>>>> Add tests for ChangeStream and ChangeStream.next
+=======
+/// An `UpdateDescription` containing fields that will be present in
+/// the change stream document for operations of type `update`.
+>>>>>>> update docstrings
 public struct UpdateDescription: Codable {
    /// A document containing key:value pairs of names of the fields
    /// that were changed, and the new value for those fields.

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -50,11 +50,11 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     public let ns: MongoNamespace
 
     /**
-    * Only present for options of type `insert`, `update`, `replace` and `delete`. For unsharded collections this
-    * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
-    * will contain all the components of the shard key in order, followed by the _id if the _id isn’t part of the
-    * shard key.
-    */
+     * Only present for options of type `insert`, `update`, `replace` and `delete`. For unsharded collections this
+     * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
+     * will contain all the components of the shard key in order, followed by the _id if the _id isn’t part of the
+     * shard key.
+     */
     public let documentKey: Document?
 
     /// An `UpdateDescription` containing updated and removed fields in this operation. Only present for operations of
@@ -62,15 +62,15 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     public let updateDescription: UpdateDescription?
 
     /**
-    * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if
-    * the user has specified `.updateLookup` for the `fullDocument` option in the `ChangeStreamOptions` used to create
-    * the `ChangeStream` that emitted this document.
-    *
-    * For operations of type `insert’ and `replace’, this key will contain the document being inserted, or the new
-    * version of the document that is replacing the existing document, respectively.
-    *
-    * For operations of type `update’, this key will contain a copy of the full version of the document from some
-    * point after the update occurred. If the document was deleted since the updated happened, it will be nil.
-    */
+     * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if
+     * the user has specified `.updateLookup` for the `fullDocument` option in the `ChangeStreamOptions` used to create
+     * the `ChangeStream` that emitted this document.
+     *
+     * For operations of type `insert’ and `replace’, this key will contain the document being inserted, or the new
+     * version of the document that is replacing the existing document, respectively.
+     *
+     * For operations of type `update’, this key will contain a copy of the full version of the document from some
+     * point after the update occurred. If the document was deleted since the updated happened, it will be nil.
+     */
     public let fullDocument: T?
 }

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -70,13 +70,29 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
 
 /// An enum representing the type of operation for this change.
 public enum OperationType: String, Codable {
+   /// Specifies an operation of type `insert`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
    case insert
+   /// Specifies an operation of type `update`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#update-event
    case update
+   /// Specifies an operation of type `replace`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#replace-event
    case replace
+   /// Specifies an operation of type `delete`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#delete-event
    case delete
+   /// Specifies an operation of type `invalidate`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#change-event-invalidate
    case invalidate
+   /// Specifies an operation of type `drop`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#drop-event
    case drop
+   /// Specifies an operation of type `dropDatabase`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#dropdatabase-event
    case dropDatabase
+   /// Specifies an operation of type `rename`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#rename-event
    case rename
 }
 
@@ -85,9 +101,14 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     /// Describes the type of operation for this change.
     public let operationType: OperationType
 
+<<<<<<< HEAD
     /// An opaque token for use when resuming an interrupted change
     /// stream.
 >>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
+=======
+    /// An opaque token for use when resuming an interrupted change stream.
+    /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
+>>>>>>> Update docstrings
     public let _id: ChangeStreamToken
 
     /// A document containing the database and collection names in
@@ -95,11 +116,15 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     public let ns: MongoNamespace
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Update docstrings
     /**
      * Only present for options of type `insert’, `update’, `replace’ and `delete’. For unsharded collections this
      * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
      * will contain all the components of the shard key in order, followed by the _id if the _id isn’t part of the shard
      * key.
+<<<<<<< HEAD
      */
     public let documentKey: Document?
 
@@ -125,6 +150,8 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
      * value of the _id of the document updated. For sharded collections,
      * this will contain all the components of the shard key in order,
      * followed by the _id if the _id isn’t part of the shard key.
+=======
+>>>>>>> Update docstrings
      */
     public let documentKey: Document?
 
@@ -133,20 +160,23 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     public let updateDescription: UpdateDescription?
 
    /**
-    * Always present for operations of type ‘insert’ and ‘replace’. Also
-    * present for operations of type ‘update’ if the user has specified
-    * ‘updateLookup’ in the ‘fullDocument’ arguments to the ‘$changeStream’
-    *  stage.
+    * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if the
+    * user has specified `updateLookup` in the `fullDocument.updateLookup` in the `ChangeStreamOptions` used to create
+    * the `ChangeStream` that emitted this document.
     *
-    * For operations of type ‘insert’ and ‘replace’, this key will contain
-    * the document being inserted, or the new version of the document that is
-    * replacing the existing document, respectively.
+    * For operations of type `insert’ and `replace’, this key will contain the document being inserted, or the new
+    * version of the document that is replacing the existing document, respectively.
     *
+<<<<<<< HEAD
     * For operations of type ‘update’, this key will contain a copy of the
     * full version of the document from some point after the update occurred.
     * If the document was deleted since the updated happened, it will be
     * null.
 >>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
+=======
+    * For operations of type `update’, this key will contain a copy of the full version of the document from some point
+    * after the update occurred. If the document was deleted since the updated happened, it will be null.
+>>>>>>> Update docstrings
     */
     public let fullDocument: T?
  }

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,5 +1,5 @@
-/// An `UpdateDescription` containing fields that will be present in
-/// the change stream document for operations of type `update`.
+/// An `UpdateDescription` containing fields that will be present in the change stream document
+/// for operations of type `update`.
 public struct UpdateDescription: Codable {
    /// A document containing key:value pairs of names of the fields
    /// that were changed, and the new value for those fields.
@@ -9,7 +9,7 @@ public struct UpdateDescription: Codable {
    public let removedFields: [String]
 }
 
-/// An enum representing the type of operation for this change.
+/// An enum representing the type of operation for this change event.
 public enum OperationType: String, Codable {
    /// Specifies an operation of type `insert`.
    /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
@@ -58,8 +58,8 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
      */
     public let documentKey: Document?
 
-    /// An `UpdateDescription` containing updated and removed fields in
-    /// this operation. Only present for operations of type `update`.
+    /// An `UpdateDescription` containing updated and removed fields in this operation.
+    /// Only present for operations of type `update`.
     public let updateDescription: UpdateDescription?
 
    /**

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,10 +1,14 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 /// An `UpdateDescription` containing fields that will be present in the change stream document
 /// for operations of type `update`.
+=======
+>>>>>>> Add tests for ChangeStream and ChangeStream.next
 public struct UpdateDescription: Codable {
    /// A document containing key:value pairs of names of the fields
    /// that were changed, and the new value for those fields.
    public let updatedFields: Document
+<<<<<<< HEAD
 
    /// An array of field names that were removed from the document.
    public let removedFields: [String]
@@ -52,23 +56,27 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
         /// A document containing key:value pairs of names of the fields
         /// that were changed, and the new value for those fields.
         public let updatedFields: Document
+=======
+>>>>>>> Add tests for ChangeStream and ChangeStream.next
 
-        /// An array of field names that were removed from the document.
-        public let removedFields: [String]
-    }
+   /// An array of field names that were removed from the document.
+   public let removedFields: [String]
+}
 
-    /// An enum representing the type of operation for this change.
-     public enum OperationType: String, Codable {
-        case insert
-        case update
-        case replace
-        case delete
-        case invalidate
-        case drop
-        case dropDatabase
-        case rename
-     }
+/// An enum representing the type of operation for this change.
+public enum OperationType: String, Codable {
+   case insert
+   case update
+   case replace
+   case delete
+   case invalidate
+   case drop
+   case dropDatabase
+   case rename
+}
 
+/// The response document type from a `ChangeStream`.
+public struct ChangeStreamDocument<T: Codable>: Codable {
     /// Describes the type of operation for this change.
     public let operationType: OperationType
 
@@ -106,13 +114,13 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     * after the update occurred. If the document was deleted since the updated happened, it will be null.
 =======
     /** Only present for options of type ‘insert’, ‘update’,
-      * ‘replace’ and ‘delete’.
-      *
-      * For unsharded collections this contains a single field, _id, with the
-      * value of the _id of the document updated. For sharded collections,
-      * this will contain all the components of the shard key in order,
-      * followed by the _id if the _id isn’t part of the shard key.
-      */
+     * ‘replace’ and ‘delete’.
+     *
+     * For unsharded collections this contains a single field, _id, with the
+     * value of the _id of the document updated. For sharded collections,
+     * this will contain all the components of the shard key in order,
+     * followed by the _id if the _id isn’t part of the shard key.
+     */
     public let documentKey: Document?
 
     /// An `UpdateDescription` containing updated and removed fields in

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -11,13 +11,29 @@ public struct UpdateDescription: Codable {
 
 /// An enum representing the type of operation for this change.
 public enum OperationType: String, Codable {
+   /// Specifies an operation of type `insert`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
    case insert
+   /// Specifies an operation of type `update`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#update-event
    case update
+   /// Specifies an operation of type `replace`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#replace-event
    case replace
+   /// Specifies an operation of type `delete`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#delete-event
    case delete
+   /// Specifies an operation of type `invalidate`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#change-event-invalidate
    case invalidate
+   /// Specifies an operation of type `drop`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#drop-event
    case drop
+   /// Specifies an operation of type `dropDatabase`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#dropdatabase-event
    case dropDatabase
+   /// Specifies an operation of type `rename`.
+   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#rename-event
    case rename
 }
 
@@ -26,21 +42,19 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     /// Describes the type of operation for this change.
     public let operationType: OperationType
 
-    /// An opaque token for use when resuming an interrupted change
-    /// stream.
+    /// An opaque token for use when resuming an interrupted change stream.
+    /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
     public let _id: ChangeStreamToken
 
     /// A document containing the database and collection names in
     /// which this change happened.
     public let ns: MongoNamespace
 
-    /** Only present for options of type ‘insert’, ‘update’,
-     * ‘replace’ and ‘delete’.
-     *
-     * For unsharded collections this contains a single field, _id, with the
-     * value of the _id of the document updated. For sharded collections,
-     * this will contain all the components of the shard key in order,
-     * followed by the _id if the _id isn’t part of the shard key.
+    /**
+     * Only present for options of type `insert’, `update’, `replace’ and `delete’. For unsharded collections this
+     * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
+     * will contain all the components of the shard key in order, followed by the _id if the _id isn’t part of the shard
+     * key.
      */
     public let documentKey: Document?
 
@@ -49,19 +63,15 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     public let updateDescription: UpdateDescription?
 
    /**
-    * Always present for operations of type ‘insert’ and ‘replace’. Also
-    * present for operations of type ‘update’ if the user has specified
-    * ‘updateLookup’ in the ‘fullDocument’ arguments to the ‘$changeStream’
-    *  stage.
+    * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if the
+    * user has specified `updateLookup` in the `fullDocument.updateLookup` in the `ChangeStreamOptions` used to create
+    * the `ChangeStream` that emitted this document.
     *
-    * For operations of type ‘insert’ and ‘replace’, this key will contain
-    * the document being inserted, or the new version of the document that is
-    * replacing the existing document, respectively.
+    * For operations of type `insert’ and `replace’, this key will contain the document being inserted, or the new
+    * version of the document that is replacing the existing document, respectively.
     *
-    * For operations of type ‘update’, this key will contain a copy of the
-    * full version of the document from some point after the update occurred.
-    * If the document was deleted since the updated happened, it will be
-    * null.
+    * For operations of type `update’, this key will contain a copy of the full version of the document from some point
+    * after the update occurred. If the document was deleted since the updated happened, it will be null.
     */
     public let fullDocument: T?
  }

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -57,8 +57,8 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
      */
     public let documentKey: Document?
 
-    /// An `UpdateDescription` containing updated and removed fields in this operation.
-    /// Only present for operations of type `update`.
+    /// An `UpdateDescription` containing updated and removed fields in this operation. Only present for operations of
+    /// type`update`.
     public let updateDescription: UpdateDescription?
 
    /**

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,3 +1,5 @@
+/// An `UpdateDescription` containing fields that will be present in
+/// the change stream document for operations of type `update`.
 public struct UpdateDescription: Codable {
    /// A document containing key:value pairs of names of the fields
    /// that were changed, and the new value for those fields.

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,24 +1,9 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 /// An `UpdateDescription` containing fields that will be present in the change stream document
 /// for operations of type `update`.
-=======
->>>>>>> Add tests for ChangeStream and ChangeStream.next
-=======
-/// An `UpdateDescription` containing fields that will be present in
-/// the change stream document for operations of type `update`.
->>>>>>> update docstrings
-=======
-/// An `UpdateDescription` containing fields that will be present in the change stream document
-/// for operations of type `update`.
->>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
 public struct UpdateDescription: Codable {
    /// A document containing key:value pairs of names of the fields
    /// that were changed, and the new value for those fields.
    public let updatedFields: Document
-<<<<<<< HEAD
 
    /// An array of field names that were removed from the document.
    public let removedFields: [String]
@@ -59,77 +44,17 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
 
     /// An opaque token for use when resuming an interrupted change stream.
     /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
-=======
-/// The response document type from a `ChangeStream`.
-public struct ChangeStreamDocument<T: Codable>: Codable {
-	public struct UpdateDescription: Codable {
-        /// A document containing key:value pairs of names of the fields
-        /// that were changed, and the new value for those fields.
-        public let updatedFields: Document
-=======
->>>>>>> Add tests for ChangeStream and ChangeStream.next
-
-   /// An array of field names that were removed from the document.
-   public let removedFields: [String]
-}
-
-/// An enum representing the type of operation for this change event.
-public enum OperationType: String, Codable {
-   /// Specifies an operation of type `insert`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
-   case insert
-   /// Specifies an operation of type `update`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#update-event
-   case update
-   /// Specifies an operation of type `replace`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#replace-event
-   case replace
-   /// Specifies an operation of type `delete`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#delete-event
-   case delete
-   /// Specifies an operation of type `invalidate`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#change-event-invalidate
-   case invalidate
-   /// Specifies an operation of type `drop`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#drop-event
-   case drop
-   /// Specifies an operation of type `dropDatabase`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#dropdatabase-event
-   case dropDatabase
-   /// Specifies an operation of type `rename`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#rename-event
-   case rename
-}
-
-/// The response document type from a `ChangeStream`.
-public struct ChangeStreamDocument<T: Codable>: Codable {
-    /// Describes the type of operation for this change.
-    public let operationType: OperationType
-
-<<<<<<< HEAD
-    /// An opaque token for use when resuming an interrupted change
-    /// stream.
->>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
-=======
-    /// An opaque token for use when resuming an interrupted change stream.
-    /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
->>>>>>> Update docstrings
     public let _id: ChangeStreamToken
 
     /// A document containing the database and collection names in
     /// which this change happened.
     public let ns: MongoNamespace
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Update docstrings
     /**
      * Only present for options of type `insert’, `update’, `replace’ and `delete’. For unsharded collections this
      * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
      * will contain all the components of the shard key in order, followed by the _id if the _id isn’t part of the shard
      * key.
-<<<<<<< HEAD
      */
     public let documentKey: Document?
 
@@ -147,41 +72,6 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     *
     * For operations of type `update’, this key will contain a copy of the full version of the document from some point
     * after the update occurred. If the document was deleted since the updated happened, it will be null.
-=======
-    /** Only present for options of type ‘insert’, ‘update’,
-     * ‘replace’ and ‘delete’.
-     *
-     * For unsharded collections this contains a single field, _id, with the
-     * value of the _id of the document updated. For sharded collections,
-     * this will contain all the components of the shard key in order,
-     * followed by the _id if the _id isn’t part of the shard key.
-=======
->>>>>>> Update docstrings
-     */
-    public let documentKey: Document?
-
-    /// An `UpdateDescription` containing updated and removed fields in this operation.
-    /// Only present for operations of type `update`.
-    public let updateDescription: UpdateDescription?
-
-   /**
-    * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if the
-    * user has specified `updateLookup` in the `fullDocument.updateLookup` in the `ChangeStreamOptions` used to create
-    * the `ChangeStream` that emitted this document.
-    *
-    * For operations of type `insert’ and `replace’, this key will contain the document being inserted, or the new
-    * version of the document that is replacing the existing document, respectively.
-    *
-<<<<<<< HEAD
-    * For operations of type ‘update’, this key will contain a copy of the
-    * full version of the document from some point after the update occurred.
-    * If the document was deleted since the updated happened, it will be
-    * null.
->>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
-=======
-    * For operations of type `update’, this key will contain a copy of the full version of the document from some point
-    * after the update occurred. If the document was deleted since the updated happened, it will be null.
->>>>>>> Update docstrings
     */
     public let fullDocument: T?
  }

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,5 +1,5 @@
-/// An `UpdateDescription` containing fields that will be present in the change stream document
-/// for operations of type `update`.
+/// An `UpdateDescription` containing fields that will be present in the change stream document for
+/// operations of type `update`.
 public struct UpdateDescription: Codable {
    /// A document containing key:value pairs of names of the fields that were changed, and the new
    /// value for those fields.
@@ -50,7 +50,7 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     public let ns: MongoNamespace
 
     /**
-     * Only present for options of type `insert’, `update’, `replace’ and `delete’. For unsharded collections this
+     * Only present for options of type `insert`, `update`, `replace` and `delete`. For unsharded collections this
      * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
      * will contain all the components of the shard key in order, followed by the _id if the _id isn’t part of the shard
      * key.

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -15,25 +15,25 @@ public enum OperationType: String, Codable {
    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
    case insert
    /// Specifies an operation of type `update`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#update-event
+   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#update-event
    case update
    /// Specifies an operation of type `replace`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#replace-event
+   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#replace-event
    case replace
    /// Specifies an operation of type `delete`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#delete-event
+   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#delete-event
    case delete
    /// Specifies an operation of type `invalidate`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#change-event-invalidate
+   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#change-event-invalidate
    case invalidate
    /// Specifies an operation of type `drop`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#drop-event
+   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#drop-event
    case drop
    /// Specifies an operation of type `dropDatabase`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#dropdatabase-event
+   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#dropdatabase-event
    case dropDatabase
    /// Specifies an operation of type `rename`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#rename-event
+   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#rename-event
    case rename
 }
 
@@ -63,7 +63,7 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
 
    /**
     * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if the
-    * user has specified `updateLookup` in the `fullDocument.updateLookup` in the `ChangeStreamOptions` used to create
+    * user has specified `.updateLookup` for the `fullDocument` option in the `ChangeStreamOptions` used to create
     * the `ChangeStream` that emitted this document.
     *
     * For operations of type `insert’ and `replace’, this key will contain the document being inserted, or the new

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,40 +1,40 @@
 /// An `UpdateDescription` containing fields that will be present in the change stream document for
 /// operations of type `update`.
 public struct UpdateDescription: Codable {
-   /// A document containing key:value pairs of names of the fields that were changed, and the new
-   /// value for those fields.
-   public let updatedFields: Document
+    /// A document containing key:value pairs of names of the fields that were changed, and the new
+    /// value for those fields.
+    public let updatedFields: Document
 
-   /// An array of field names that were removed from the document.
-   public let removedFields: [String]
+    /// An array of field names that were removed from the document.
+    public let removedFields: [String]
 }
 
 /// An enum representing the type of operation for this change event.
 public enum OperationType: String, Codable {
-   /// Specifies an operation of type `insert`.
-   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
-   case insert
-   /// Specifies an operation of type `update`.
-   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#update-event
-   case update
-   /// Specifies an operation of type `replace`.
-   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#replace-event
-   case replace
-   /// Specifies an operation of type `delete`.
-   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#delete-event
-   case delete
-   /// Specifies an operation of type `invalidate`.
-   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#change-event-invalidate
-   case invalidate
-   /// Specifies an operation of type `drop`.
-   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#drop-event
-   case drop
-   /// Specifies an operation of type `dropDatabase`.
-   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#dropdatabase-event
-   case dropDatabase
-   /// Specifies an operation of type `rename`.
-   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#rename-event
-   case rename
+    /// Specifies an operation of type `insert`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
+    case insert
+    /// Specifies an operation of type `update`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#update-event
+    case update
+    /// Specifies an operation of type `replace`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#replace-event
+    case replace
+    /// Specifies an operation of type `delete`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#delete-event
+    case delete
+    /// Specifies an operation of type `invalidate`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#change-event-invalidate
+    case invalidate
+    /// Specifies an operation of type `drop`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#drop-event
+    case drop
+    /// Specifies an operation of type `dropDatabase`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#dropdatabase-event
+    case dropDatabase
+    /// Specifies an operation of type `rename`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#rename-event
+    case rename
 }
 
 /// The response document type from a `ChangeStream`.
@@ -50,27 +50,27 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     public let ns: MongoNamespace
 
     /**
-     * Only present for options of type `insert`, `update`, `replace` and `delete`. For unsharded collections this
-     * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
-     * will contain all the components of the shard key in order, followed by the _id if the _id isn’t part of the shard
-     * key.
-     */
+    * Only present for options of type `insert`, `update`, `replace` and `delete`. For unsharded collections this
+    * contains a single field, _id, with the value of the _id of the document updated. For sharded collections, this
+    * will contain all the components of the shard key in order, followed by the _id if the _id isn’t part of the
+    * shard key.
+    */
     public let documentKey: Document?
 
     /// An `UpdateDescription` containing updated and removed fields in this operation. Only present for operations of
     /// type`update`.
     public let updateDescription: UpdateDescription?
 
-   /**
-    * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if the
-    * user has specified `.updateLookup` for the `fullDocument` option in the `ChangeStreamOptions` used to create
+    /**
+    * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if
+    * the user has specified `.updateLookup` for the `fullDocument` option in the `ChangeStreamOptions` used to create
     * the `ChangeStream` that emitted this document.
     *
     * For operations of type `insert’ and `replace’, this key will contain the document being inserted, or the new
     * version of the document that is replacing the existing document, respectively.
     *
-    * For operations of type `update’, this key will contain a copy of the full version of the document from some point
-    * after the update occurred. If the document was deleted since the updated happened, it will be null.
+    * For operations of type `update’, this key will contain a copy of the full version of the document from some
+    * point after the update occurred. If the document was deleted since the updated happened, it will be nil.
     */
     public let fullDocument: T?
- }
+}

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,6 +1,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 /// An `UpdateDescription` containing fields that will be present in the change stream document
 /// for operations of type `update`.
 =======
@@ -9,6 +10,10 @@
 /// An `UpdateDescription` containing fields that will be present in
 /// the change stream document for operations of type `update`.
 >>>>>>> update docstrings
+=======
+/// An `UpdateDescription` containing fields that will be present in the change stream document
+/// for operations of type `update`.
+>>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
 public struct UpdateDescription: Codable {
    /// A document containing key:value pairs of names of the fields
    /// that were changed, and the new value for those fields.
@@ -68,7 +73,7 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
    public let removedFields: [String]
 }
 
-/// An enum representing the type of operation for this change.
+/// An enum representing the type of operation for this change event.
 public enum OperationType: String, Codable {
    /// Specifies an operation of type `insert`.
    /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
@@ -155,8 +160,8 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
      */
     public let documentKey: Document?
 
-    /// An `UpdateDescription` containing updated and removed fields in
-    /// this operation. Only present for operations of type `update`.
+    /// An `UpdateDescription` containing updated and removed fields in this operation.
+    /// Only present for operations of type `update`.
     public let updateDescription: UpdateDescription?
 
    /**

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -12,7 +12,7 @@ public struct UpdateDescription: Codable {
 /// An enum representing the type of operation for this change event.
 public enum OperationType: String, Codable {
    /// Specifies an operation of type `insert`.
-   /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
+   /// - SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#insert-event
    case insert
    /// Specifies an operation of type `update`.
    /// SeeAlso: https://docs.mongodb.com/manual/reference/change-events/index.html#update-event

--- a/Sources/MongoSwift/ChangeStreamDocument.swift
+++ b/Sources/MongoSwift/ChangeStreamDocument.swift
@@ -1,26 +1,26 @@
+public struct UpdateDescription: Codable {
+   /// A document containing key:value pairs of names of the fields
+   /// that were changed, and the new value for those fields.
+   public let updatedFields: Document
+
+   /// An array of field names that were removed from the document.
+   public let removedFields: [String]
+}
+
+/// An enum representing the type of operation for this change.
+public enum OperationType: String, Codable {
+   case insert
+   case update
+   case replace
+   case delete
+   case invalidate
+   case drop
+   case dropDatabase
+   case rename
+}
+
 /// The response document type from a `ChangeStream`.
 public struct ChangeStreamDocument<T: Codable>: Codable {
-	public struct UpdateDescription: Codable {
-        /// A document containing key:value pairs of names of the fields
-        /// that were changed, and the new value for those fields.
-        public let updatedFields: Document
-
-        /// An array of field names that were removed from the document.
-        public let removedFields: [String]
-    }
-
-    /// An enum representing the type of operation for this change.
-     public enum OperationType: String, Codable {
-        case insert
-        case update
-        case replace
-        case delete
-        case invalidate
-        case drop
-        case dropDatabase
-        case rename
-     }
-
     /// Describes the type of operation for this change.
     public let operationType: OperationType
 
@@ -33,13 +33,13 @@ public struct ChangeStreamDocument<T: Codable>: Codable {
     public let ns: MongoNamespace
 
     /** Only present for options of type ‘insert’, ‘update’,
-      * ‘replace’ and ‘delete’.
-      *
-      * For unsharded collections this contains a single field, _id, with the
-      * value of the _id of the document updated. For sharded collections,
-      * this will contain all the components of the shard key in order,
-      * followed by the _id if the _id isn’t part of the shard key.
-      */
+     * ‘replace’ and ‘delete’.
+     *
+     * For unsharded collections this contains a single field, _id, with the
+     * value of the _id of the document updated. For sharded collections,
+     * this will contain all the components of the shard key in order,
+     * followed by the _id if the _id isn’t part of the shard key.
+     */
     public let documentKey: Document?
 
     /// An `UpdateDescription` containing updated and removed fields in

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,7 +1,7 @@
 /// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
 public enum FullDocument: RawRepresentable, Codable {
-    /// The `fullDocument` field will contain a copy of the entire document that was changed from some time
-    /// after the change occurred. If the document was deleted since the updated happened, it will be null.
+    /// Specifies that the `fullDocument` field will contain a copy of the entire document that was changed from
+    /// some time after the change occurred. If the document was deleted since the updated happened, it will be null.
     case updateLookup
     /// For an unknown value. For forwards compatibility, no error will be thrown when an unknown value is provided.
     case other(String)
@@ -29,7 +29,7 @@ public enum FullDocument: RawRepresentable, Codable {
 public struct ChangeStreamOptions: Codable {
     /**
      * Indicates how the `fullDocument` field of a `ChangeStreamDocument` should be filled out by the server.
-     * By default (indicated by a nil value for this option), the fullDocument field in the change stream document
+     * By default (indicated by a nil value for this option), the `fullDocument` field in the change stream document
      * will always be present in the case of 'insert' and 'replace' operations (containing the document being inserted)
      * and will be nil for all other operations.
      */
@@ -46,7 +46,7 @@ public struct ChangeStreamOptions: Codable {
     public let resumeAfter: ChangeStreamToken?
 
     /// The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a
-    // change stream query. Uses the server default timeout when omitted.
+    /// change stream query. Uses the server default timeout when omitted.
     public let maxAwaitTimeMS: Int64?
 
     /// The number of documents to return per batch. The default is to not send a value.

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -62,7 +62,7 @@ public struct ChangeStreamOptions: Codable {
     /// - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
     public let startAfter: ChangeStreamToken?
 
-    /// Initializes a `ChangeStreamOption`.
+    /// Initializes a `ChangeStreamOptions`.
     public init(fullDocument: FullDocument? = nil,
                 resumeAfter: ChangeStreamToken? = nil,
                 maxAwaitTimeMS: Int64? = nil,

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,7 +1,7 @@
 /// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
 public enum FullDocument: RawRepresentable, Codable {
-    /// The change stream document will include both a delta describing the changes to the document,
-    /// as well as a copy of the entire document that was changed from some time after the change occurred.
+    /// The `fullDocument` field will contain a copy of the entire document that was changed from some time
+    /// after the change occurred. If the document was deleted since the updated happened, it will be null.
     case updateLookup
     /// For an unknown value. For forwards compatibility, no error will be thrown when an unknown value is provided.
     case other(String)
@@ -35,8 +35,14 @@ public struct ChangeStreamOptions: Codable {
      */
     public let fullDocument: FullDocument?
 
-    /// A `ChangeStreamToken` to manually specify the resumeToken which will be used to start a new change stream that
-    /// will return the first notification after this token.
+    /**
+     * A `ChangeStreamToken` that manually specifies the logical starting point for the new change stream.
+     * The change stream will attempt to resume notifications starting after the operation associated with
+     * the provided token.
+     * - Note: A change stream cannot be resumed after an invalidate event (e.g. a collection drop or rename).
+     *         Use the `startAfter` option in those cases instead.
+     * - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
+     */
     public let resumeAfter: ChangeStreamToken?
 
     /// The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a
@@ -56,10 +62,14 @@ public struct ChangeStreamOptions: Codable {
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
     public let startAtOperationTime: Timestamp?
 
-    /// A `ChangeStreamToken` similar to `resumeAfter` except `startAfter` will allow users to watch collections
-    /// that have been dropped and recreated or newly renamed collections without missing any notifications.
-    /// The server will report an error if `startAfter` and `resumeAfter` are both specified.
-    /// - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
+    /**
+     * Similar to `resumeAfter`, this option takes a `ChangeStreamToken` which will serve as the logical starting
+     * point for the new change stream. This option differs from `resumeAfter` in that it will allow a change stream
+     * to receive notifications even after an invalidate event (e.g. it will allow watching a collection that has
+     * been dropped and recreated).
+     * - Note: The server will report an error if `startAfter` and `resumeAfter` are both specified.
+     * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
+     */
     public let startAfter: ChangeStreamToken?
 
     /// Initializes a `ChangeStreamOptions`.

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -38,53 +38,49 @@ public struct ChangeStreamOptions: Codable {
     public let resumeAfter: Document?
 
     /**
-    * The maximum amount of time for the server to wait on new documents to
-    * satisfy a change stream query.
-    * This is the same field described in FindOptions in the CRUD spec.
-    * - SeeAlso:
-    https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#read
-    */
+     * The maximum amount of time in milliseconds for the server to wait on new
+     * documents to satisfy a change stream query. Uses the server default timeout
+     * when omitted.
+     */
     public let maxAwaitTimeMS: Int64?
 
     /**
-    * The number of documents to return per batch.
-    * This option is sent only if the caller explicitly provides a value. The
-    * default is to not send a value.
-    * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-    */
+     * The number of documents to return per batch.
+     * This option is sent only if the caller explicitly provides a value. The
+     * default is to not send a value.
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
+     */
     public let batchSize: Int32?
 
     /**
-    * Specifies a collation.
-    * This option is sent only if the caller explicitly provides a value. The
-    * default is to not send a value.
-    * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-    */
+     * Specifies a collation.
+     * This option is sent only if the caller explicitly provides a value. The
+     * default is to not send a value.
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
+     */
     public let collation: Document?
 
     /**
-    * The change stream will only provide changes that occurred at or after
-    * the specified timestamp. Any command run against the server will return
-    * an operation time that can be used here.
-    * - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
-    */
+     * The change stream will only provide changes that occurred at or after
+     * the specified timestamp. Any command run against the server will return
+     * an operation time that can be used here.
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
+     */
     public let startAtOperationTime: Timestamp?
 
     /**
-    * Similar to `resumeAfter`, this option takes a resume token and starts a
-    * new change stream returning the first notification after the token.
-    * This will allow users to watch collections that have been dropped and
-    * recreated or newly renamed collections without missing any
-    * notifications.
-    * The server will report an error if `startAfter` and `resumeAfter` are
-    * both specified.
-    * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
-    */
+     * Similar to `resumeAfter`, this option takes a resume token and starts a
+     * new change stream returning the first notification after the token.
+     * This will allow users to watch collections that have been dropped and
+     * recreated or newly renamed collections without missing any
+     * notifications.
+     * The server will report an error if `startAfter` and `resumeAfter` are
+     * both specified.
+     * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
+     */
     public let startAfter: Document?
 
-    /**
-    * Initializes a `ChangeStreamOption`.
-    */
+    /// Initializes a `ChangeStreamOption`.
     public init(fullDocument: FullDocument? = nil,
                 resumeAfter: Document? = nil,
                 maxAwaitTimeMS: Int64? = nil,

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,7 +1,16 @@
+<<<<<<< HEAD
 /// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
 public enum FullDocument: RawRepresentable, Codable {
     /// The change stream document will include both a delta describing the changes to the document,
     /// as well as a copy of the entire document that was changed from some time after the change occurred.
+=======
+/// Describes the modes for configuring the fullDocument field of a
+/// `ChangeStreamDocument`.
+public enum FullDocument: RawRepresentable, Codable {
+    /// The change stream document will include both a delta describing the
+    /// changes to the document, as well as a copy of the entire document that
+    /// was changed from some time after the change occurred.
+>>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
     case updateLookup
     /// For an unknown value. For forwards compatibility, no error will be
     /// thrown when an unknown value is provided.
@@ -28,6 +37,7 @@ public enum FullDocument: RawRepresentable, Codable {
 
 /// Options to use when creating a `ChangeStream`.
 public struct ChangeStreamOptions: Codable {
+<<<<<<< HEAD
     /**
      * Indicates how the `fullDocument` field of a `ChangeStreamDocument` should be filled out by the server.
      * By default (indicated by a nil value for this option), the fullDocument field in the change stream document
@@ -66,11 +76,74 @@ public struct ChangeStreamOptions: Codable {
     /// Initializes a `ChangeStreamOption`.
     public init(fullDocument: FullDocument? = nil,
                 resumeAfter: ChangeStreamToken? = nil,
+=======
+    /// Indicates the value of the mode on the `fullDocument` field of a
+    /// `ChangeStreamDocument`.
+    public let fullDocument: FullDocument?
+
+    /// Specifies the logical starting point for the new change stream.
+    public let resumeAfter: Document?
+
+    /**
+    * The maximum amount of time for the server to wait on new documents to
+    * satisfy a change stream query.
+    * This is the same field described in FindOptions in the CRUD spec.
+    * - SeeAlso:
+    https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#read
+    */
+    public let maxAwaitTimeMS: Int64?
+
+    /**
+    * The number of documents to return per batch.
+    * This option is sent only if the caller explicitly provides a value. The
+    * default is to not send a value.
+    * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
+    */
+    public let batchSize: Int32?
+
+    /**
+    * Specifies a collation.
+    * This option is sent only if the caller explicitly provides a value. The
+    * default is to not send a value.
+    * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
+    */
+    public let collation: Document?
+
+    /**
+    * The change stream will only provide changes that occurred at or after
+    * the specified timestamp. Any command run against the server will return
+    * an operation time that can be used here.
+    * - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
+    */
+    public let startAtOperationTime: Timestamp?
+
+    /**
+    * Similar to `resumeAfter`, this option takes a resume token and starts a
+    * new change stream returning the first notification after the token.
+    * This will allow users to watch collections that have been dropped and
+    * recreated or newly renamed collections without missing any
+    * notifications.
+    * The server will report an error if `startAfter` and `resumeAfter` are
+    * both specified.
+    * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
+    */
+    public let startAfter: Document?
+
+    /**
+    * Initializes a `ChangeStreamOption`.
+    */
+    public init(fullDocument: FullDocument? = nil,
+                resumeAfter: Document? = nil,
+>>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
                 maxAwaitTimeMS: Int64? = nil,
                 batchSize: Int32? = nil,
                 collation: Document? = nil,
                 startAtOperationTime: Timestamp? = nil,
+<<<<<<< HEAD
                 startAfter: ChangeStreamToken? = nil) {
+=======
+                startAfter: Document? = nil) {
+>>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
         self.fullDocument = fullDocument
         self.resumeAfter = resumeAfter
         self.maxAwaitTimeMS = maxAwaitTimeMS

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -3,8 +3,7 @@ public enum FullDocument: RawRepresentable, Codable {
     /// The change stream document will include both a delta describing the changes to the document,
     /// as well as a copy of the entire document that was changed from some time after the change occurred.
     case updateLookup
-    /// For an unknown value. For forwards compatibility, no error will be
-    /// thrown when an unknown value is provided.
+    /// For an unknown value. For forwards compatibility, no error will be thrown when an unknown value is provided.
     case other(String)
 
     public var rawValue: String {

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,0 +1,103 @@
+/// Describes the modes for configuring the fullDocument field of a
+/// `ChangeStreamDocument`.
+public enum FullDocument: RawRepresentable, Codable {
+    /// The change stream document will include both a delta describing the
+    /// changes to the document, as well as a copy of the entire document that
+    /// was changed from some time after the change occurred.
+    case updateLookup
+    /// For an unknown value. For forwards compatibility, no error will be
+    /// thrown when an unknown value is provided.
+    case other(String)
+
+    public var rawValue: String {
+        switch self {
+        case .updateLookup:
+            return "updateLookup"
+        case .other(let v):
+            return v
+        }
+    }
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "updateLookup":
+            self = .updateLookup
+        default:
+            self = .other(rawValue)
+        }
+    }
+}
+
+/// Options to use when creating a `ChangeStream`.
+public struct ChangeStreamOptions: Codable {
+    /// Indicates the value of the mode on the `fullDocument` field of a
+    /// `ChangeStreamDocument`.
+    public let fullDocument: FullDocument?
+
+    /// Specifies the logical starting point for the new change stream.
+    public let resumeAfter: Document?
+
+    /**
+    * The maximum amount of time for the server to wait on new documents to
+    * satisfy a change stream query.
+    * This is the same field described in FindOptions in the CRUD spec.
+    * - SeeAlso:
+    https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#read
+    */
+    public let maxAwaitTimeMS: Int64?
+
+    /**
+    * The number of documents to return per batch.
+    * This option is sent only if the caller explicitly provides a value. The
+    * default is to not send a value.
+    * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
+    */
+    public let batchSize: Int32?
+
+    /**
+    * Specifies a collation.
+    * This option is sent only if the caller explicitly provides a value. The
+    * default is to not send a value.
+    * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
+    */
+    public let collation: Document?
+
+    /**
+    * The change stream will only provide changes that occurred at or after
+    * the specified timestamp. Any command run against the server will return
+    * an operation time that can be used here.
+    * - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
+    */
+    public let startAtOperationTime: Timestamp?
+
+    /**
+    * Similar to `resumeAfter`, this option takes a resume token and starts a
+    * new change stream returning the first notification after the token.
+    * This will allow users to watch collections that have been dropped and
+    * recreated or newly renamed collections without missing any
+    * notifications.
+    * The server will report an error if `startAfter` and `resumeAfter` are
+    * both specified.
+    * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
+    */
+    public let startAfter: Document?
+
+    /**
+    * Initializes a `ChangeStreamOption`.
+    */
+    public init(fullDocument: FullDocument? = nil,
+                resumeAfter: Document? = nil,
+                maxAwaitTimeMS: Int64? = nil,
+                batchSize: Int32? = nil,
+                collation: Document? = nil,
+                startAtOperationTime: Timestamp? = nil,
+                startAfter: Document? = nil) {
+        self.fullDocument = fullDocument
+        self.resumeAfter = resumeAfter
+        self.maxAwaitTimeMS = maxAwaitTimeMS
+        self.batchSize = batchSize
+        self.collation = collation
+        self.startAtOperationTime = startAtOperationTime
+        self.startAfter = startAfter
+    }
+}

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,9 +1,7 @@
-/// Describes the modes for configuring the fullDocument field of a
-/// `ChangeStreamDocument`.
+/// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
 public enum FullDocument: RawRepresentable, Codable {
-    /// The change stream document will include both a delta describing the
-    /// changes to the document, as well as a copy of the entire document that
-    /// was changed from some time after the change occurred.
+    /// The change stream document will include both a delta describing the changes to the document,
+    /// as well as a copy of the entire document that was changed from some time after the change occurred.
     case updateLookup
     /// For an unknown value. For forwards compatibility, no error will be
     /// thrown when an unknown value is provided.
@@ -38,56 +36,41 @@ public struct ChangeStreamOptions: Codable {
      */
     public let fullDocument: FullDocument?
 
-    /// A `ChangeStreamToken` used to manually specify the logical starting point for the new change stream.
+    /// A `ChangeStreamToken` to manually specify the resumeToken which will be used to start a new change stream that
+    /// will return the first notification after this token.
     public let resumeAfter: ChangeStreamToken?
 
-    /// The maximum amount of time in milliseconds for the server to wait on new documents
-    // to satisfy a change stream query. Uses the server default timeout when omitted.
+    /// The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a
+    // change stream query. Uses the server default timeout when omitted.
     public let maxAwaitTimeMS: Int64?
 
-    /**
-     * The number of documents to return per batch. This option is sent only if the caller explicitly provides a value.
-     * The default is to not send a value.
-     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-     */
+    /// The number of documents to return per batch. The default is to not send a value.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
     public let batchSize: Int32?
 
-    /**
-     * Specifies a collation.
-     * This option is sent only if the caller explicitly provides a value. The
-     * default is to not send a value.
-     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-     */
+    /// Specifies a collation.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
     public let collation: Document?
 
-    /**
-     * The change stream will only provide changes that occurred at or after
-     * the specified timestamp. Any command run against the server will return
-     * an operation time that can be used here.
-     * - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
-     */
+    /// The change stream will only provide changes that occurred at or after the specified timestamp.
+    /// Any command run against the server will return an operation time that can be used here.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
     public let startAtOperationTime: Timestamp?
 
-    /**
-     * Similar to `resumeAfter`, this option takes a resume token and starts a new change stream returning the first
-     * notification after the token.
-     * This will allow users to watch collections that have been dropped and
-     * recreated or newly renamed collections without missing any
-     * notifications.
-     * The server will report an error if `startAfter` and `resumeAfter` are
-     * both specified.
-     * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
-     */
+    /// A `ChangeStreamToken` similar to `resumeAfter` except `startAfter` will allow users to watch collections
+    /// have been dropped and recreated or newly renamed collections without missing any notifications.
+    /// The server will report an error if `startAfter` and `resumeAfter` are both specified.
+    /// - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
     public let startAfter: ChangeStreamToken?
 
     /// Initializes a `ChangeStreamOption`.
     public init(fullDocument: FullDocument? = nil,
-                resumeAfter: Document? = nil,
+                resumeAfter: ChangeStreamToken? = nil,
                 maxAwaitTimeMS: Int64? = nil,
                 batchSize: Int32? = nil,
                 collation: Document? = nil,
                 startAtOperationTime: Timestamp? = nil,
-                startAfter: Document? = nil) {
+                startAfter: ChangeStreamToken? = nil) {
         self.fullDocument = fullDocument
         self.resumeAfter = resumeAfter
         self.maxAwaitTimeMS = maxAwaitTimeMS

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -37,13 +37,13 @@ public struct ChangeStreamOptions: Codable {
     public let fullDocument: FullDocument?
 
     /**
-     * A `ChangeStreamToken` that manually specifies the logical starting point for the new change stream.
+     * A `ResumeToken` that manually specifies the logical starting point for the new change stream.
      * The change stream will attempt to resume notifications starting after the operation associated with
      * the provided token.
      * - Note: A change stream cannot be resumed after an invalidate event (e.g. a collection drop or rename).
      * - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
      */
-    public let resumeAfter: ChangeStreamToken?
+    public let resumeAfter: ResumeToken?
 
     /// The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a
     /// change stream query. If omitted, the server will use its default timeout.
@@ -63,7 +63,7 @@ public struct ChangeStreamOptions: Codable {
     public let startAtOperationTime: Timestamp?
 
     /**
-     * Similar to `resumeAfter`, this option takes a `ChangeStreamToken` which will serve as the logical starting
+     * Similar to `resumeAfter`, this option takes a `ResumeToken` which will serve as the logical starting
      * point for the new change stream. This option differs from `resumeAfter` in that it will allow a change stream
      * to receive notifications even after an invalidate event (e.g. it will allow watching a collection that has
      * been dropped and recreated).
@@ -71,11 +71,11 @@ public struct ChangeStreamOptions: Codable {
      * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
      */
      // TODO: SWIFT-519 - Make this public when support is added for 4.2 change stream features.
-    internal let startAfter: ChangeStreamToken?
+    internal let startAfter: ResumeToken?
 
     /// Initializes a `ChangeStreamOptions`.
     public init(fullDocument: FullDocument? = nil,
-                resumeAfter: ChangeStreamToken? = nil,
+                resumeAfter: ResumeToken? = nil,
                 maxAwaitTimeMS: Int64? = nil,
                 batchSize: Int32? = nil,
                 collation: Document? = nil,

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,23 +1,7 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 /// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
 public enum FullDocument: RawRepresentable, Codable {
     /// The change stream document will include both a delta describing the changes to the document,
     /// as well as a copy of the entire document that was changed from some time after the change occurred.
-=======
-/// Describes the modes for configuring the fullDocument field of a
-/// `ChangeStreamDocument`.
-public enum FullDocument: RawRepresentable, Codable {
-    /// The change stream document will include both a delta describing the
-    /// changes to the document, as well as a copy of the entire document that
-    /// was changed from some time after the change occurred.
->>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
-=======
-/// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
-public enum FullDocument: RawRepresentable, Codable {
-    /// The change stream document will include both a delta describing the changes to the document,
-    /// as well as a copy of the entire document that was changed from some time after the change occurred.
->>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
     case updateLookup
     /// For an unknown value. For forwards compatibility, no error will be
     /// thrown when an unknown value is provided.
@@ -44,17 +28,11 @@ public enum FullDocument: RawRepresentable, Codable {
 
 /// Options to use when creating a `ChangeStream`.
 public struct ChangeStreamOptions: Codable {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Update docstrings
     /**
      * Indicates how the `fullDocument` field of a `ChangeStreamDocument` should be filled out by the server.
      * By default (indicated by a nil value for this option), the fullDocument field in the change stream document
      * will always be present in the case of 'insert' and 'replace' operations (containing the document being inserted)
      * and will be nil for all other operations.
-<<<<<<< HEAD
      */
     public let fullDocument: FullDocument?
 
@@ -88,70 +66,11 @@ public struct ChangeStreamOptions: Codable {
     /// Initializes a `ChangeStreamOption`.
     public init(fullDocument: FullDocument? = nil,
                 resumeAfter: ChangeStreamToken? = nil,
-=======
-    /// Indicates the value of the mode on the `fullDocument` field of a
-    /// `ChangeStreamDocument`.
-=======
-    /** Indicates how the `fullDocument` field of a `ChangeStreamDocument` should
-     * be filled out by the server.
-     * By default (indicated by a nil value for this option), the fullDocument field
-     * in the change stream document will always be present in the case of 'insert'
-     * and 'replace' operations (containing the document being inserted) and will be
-     * nil for all other operations.
-=======
->>>>>>> Update docstrings
-     */
->>>>>>> update docstrings
-    public let fullDocument: FullDocument?
-
-    /// A `ChangeStreamToken` to manually specify the resumeToken which will be used to start a new change stream that
-    /// will return the first notification after this token.
-    public let resumeAfter: ChangeStreamToken?
-
-    /// The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a
-    // change stream query. Uses the server default timeout when omitted.
-    public let maxAwaitTimeMS: Int64?
-
-    /// The number of documents to return per batch. The default is to not send a value.
-    /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-    public let batchSize: Int32?
-
-    /// Specifies a collation.
-    /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-    public let collation: Document?
-
-    /// The change stream will only provide changes that occurred at or after the specified timestamp.
-    /// Any command run against the server will return an operation time that can be used here.
-    /// - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
-    public let startAtOperationTime: Timestamp?
-
-    /// A `ChangeStreamToken` similar to `resumeAfter` except `startAfter` will allow users to watch collections
-    /// have been dropped and recreated or newly renamed collections without missing any notifications.
-    /// The server will report an error if `startAfter` and `resumeAfter` are both specified.
-    /// - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
-    public let startAfter: ChangeStreamToken?
-
-    /// Initializes a `ChangeStreamOption`.
-    public init(fullDocument: FullDocument? = nil,
-<<<<<<< HEAD
-                resumeAfter: Document? = nil,
->>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
-=======
-                resumeAfter: ChangeStreamToken? = nil,
->>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
                 maxAwaitTimeMS: Int64? = nil,
                 batchSize: Int32? = nil,
                 collation: Document? = nil,
                 startAtOperationTime: Timestamp? = nil,
-<<<<<<< HEAD
-<<<<<<< HEAD
                 startAfter: ChangeStreamToken? = nil) {
-=======
-                startAfter: Document? = nil) {
->>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
-=======
-                startAfter: ChangeStreamToken? = nil) {
->>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
         self.fullDocument = fullDocument
         self.resumeAfter = resumeAfter
         self.maxAwaitTimeMS = maxAwaitTimeMS

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,7 +1,8 @@
 /// Describes the modes for configuring the fullDocument field of a change stream document.
 public enum FullDocument: RawRepresentable, Codable {
-    /// Specifies that the `fullDocument` field will contain a copy of the entire document that was changed from
-    /// some time after the change occurred. If the document was deleted since the updated happened, it will be nil.
+    /// Specifies that the `fullDocument` field of an update event will contain a copy of the entire document that
+    /// was changed from some time after the change occurred. If the document was deleted since the updated happened,
+    /// it will be nil.
     case updateLookup
     /// For an unknown value. For forwards compatibility, no error will be thrown when an unknown value is provided.
     case other(String)
@@ -69,7 +70,7 @@ public struct ChangeStreamOptions: Codable {
      * - Note: The server will report an error if `startAfter` and `resumeAfter` are both specified.
      * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
      */
-     // TODO: Make this public when support is added for 4.2 change stream features.
+     // TODO: SWIFT-519 - Make this public when support is added for 4.2 change stream features.
     internal let startAfter: ChangeStreamToken?
 
     /// Initializes a `ChangeStreamOptions`.

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -58,7 +58,7 @@ public struct ChangeStreamOptions: Codable {
     public let startAtOperationTime: Timestamp?
 
     /// A `ChangeStreamToken` similar to `resumeAfter` except `startAfter` will allow users to watch collections
-    /// have been dropped and recreated or newly renamed collections without missing any notifications.
+    /// that have been dropped and recreated or newly renamed collections without missing any notifications.
     /// The server will report an error if `startAfter` and `resumeAfter` are both specified.
     /// - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
     public let startAfter: ChangeStreamToken?

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,4 +1,5 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 /// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
 public enum FullDocument: RawRepresentable, Codable {
     /// The change stream document will include both a delta describing the changes to the document,
@@ -11,6 +12,12 @@ public enum FullDocument: RawRepresentable, Codable {
     /// changes to the document, as well as a copy of the entire document that
     /// was changed from some time after the change occurred.
 >>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
+=======
+/// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
+public enum FullDocument: RawRepresentable, Codable {
+    /// The change stream document will include both a delta describing the changes to the document,
+    /// as well as a copy of the entire document that was changed from some time after the change occurred.
+>>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
     case updateLookup
     /// For an unknown value. For forwards compatibility, no error will be
     /// thrown when an unknown value is provided.
@@ -97,61 +104,54 @@ public struct ChangeStreamOptions: Codable {
 >>>>>>> update docstrings
     public let fullDocument: FullDocument?
 
-    /// A `ChangeStreamToken` used to manually specify the logical starting point for the new change stream.
+    /// A `ChangeStreamToken` to manually specify the resumeToken which will be used to start a new change stream that
+    /// will return the first notification after this token.
     public let resumeAfter: ChangeStreamToken?
 
-    /// The maximum amount of time in milliseconds for the server to wait on new documents
-    // to satisfy a change stream query. Uses the server default timeout when omitted.
+    /// The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a
+    // change stream query. Uses the server default timeout when omitted.
     public let maxAwaitTimeMS: Int64?
 
-    /**
-     * The number of documents to return per batch. This option is sent only if the caller explicitly provides a value.
-     * The default is to not send a value.
-     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-     */
+    /// The number of documents to return per batch. The default is to not send a value.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
     public let batchSize: Int32?
 
-    /**
-     * Specifies a collation.
-     * This option is sent only if the caller explicitly provides a value. The
-     * default is to not send a value.
-     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-     */
+    /// Specifies a collation.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
     public let collation: Document?
 
-    /**
-     * The change stream will only provide changes that occurred at or after
-     * the specified timestamp. Any command run against the server will return
-     * an operation time that can be used here.
-     * - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
-     */
+    /// The change stream will only provide changes that occurred at or after the specified timestamp.
+    /// Any command run against the server will return an operation time that can be used here.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
     public let startAtOperationTime: Timestamp?
 
-    /**
-     * Similar to `resumeAfter`, this option takes a resume token and starts a new change stream returning the first
-     * notification after the token.
-     * This will allow users to watch collections that have been dropped and
-     * recreated or newly renamed collections without missing any
-     * notifications.
-     * The server will report an error if `startAfter` and `resumeAfter` are
-     * both specified.
-     * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
-     */
+    /// A `ChangeStreamToken` similar to `resumeAfter` except `startAfter` will allow users to watch collections
+    /// have been dropped and recreated or newly renamed collections without missing any notifications.
+    /// The server will report an error if `startAfter` and `resumeAfter` are both specified.
+    /// - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
     public let startAfter: ChangeStreamToken?
 
     /// Initializes a `ChangeStreamOption`.
     public init(fullDocument: FullDocument? = nil,
+<<<<<<< HEAD
                 resumeAfter: Document? = nil,
 >>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
+=======
+                resumeAfter: ChangeStreamToken? = nil,
+>>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
                 maxAwaitTimeMS: Int64? = nil,
                 batchSize: Int32? = nil,
                 collation: Document? = nil,
                 startAtOperationTime: Timestamp? = nil,
 <<<<<<< HEAD
+<<<<<<< HEAD
                 startAfter: ChangeStreamToken? = nil) {
 =======
                 startAfter: Document? = nil) {
 >>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument
+=======
+                startAfter: ChangeStreamToken? = nil) {
+>>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
         self.fullDocument = fullDocument
         self.resumeAfter = resumeAfter
         self.maxAwaitTimeMS = maxAwaitTimeMS

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -30,18 +30,20 @@ public enum FullDocument: RawRepresentable, Codable {
 
 /// Options to use when creating a `ChangeStream`.
 public struct ChangeStreamOptions: Codable {
-    /// Indicates the value of the mode on the `fullDocument` field of a
-    /// `ChangeStreamDocument`.
+    /** Indicates how the `fullDocument` field of a `ChangeStreamDocument` should
+     * be filled out by the server.
+     * By default (indicated by a nil value for this option), the fullDocument field
+     * in the change stream document will always be present in the case of 'insert'
+     * and 'replace' operations (containing the document being inserted) and will be
+     * nil for all other operations.
+     */
     public let fullDocument: FullDocument?
 
     /// Specifies the logical starting point for the new change stream.
     public let resumeAfter: Document?
 
-    /**
-     * The maximum amount of time in milliseconds for the server to wait on new
-     * documents to satisfy a change stream query. Uses the server default timeout
-     * when omitted.
-     */
+    /// The maximum amount of time in milliseconds for the server to wait on new documents
+    // to satisfy a change stream query. Uses the server default timeout when omitted.
     public let maxAwaitTimeMS: Int64?
 
     /**

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -85,53 +85,49 @@ public struct ChangeStreamOptions: Codable {
     public let resumeAfter: Document?
 
     /**
-    * The maximum amount of time for the server to wait on new documents to
-    * satisfy a change stream query.
-    * This is the same field described in FindOptions in the CRUD spec.
-    * - SeeAlso:
-    https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#read
-    */
+     * The maximum amount of time in milliseconds for the server to wait on new
+     * documents to satisfy a change stream query. Uses the server default timeout
+     * when omitted.
+     */
     public let maxAwaitTimeMS: Int64?
 
     /**
-    * The number of documents to return per batch.
-    * This option is sent only if the caller explicitly provides a value. The
-    * default is to not send a value.
-    * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-    */
+     * The number of documents to return per batch.
+     * This option is sent only if the caller explicitly provides a value. The
+     * default is to not send a value.
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
+     */
     public let batchSize: Int32?
 
     /**
-    * Specifies a collation.
-    * This option is sent only if the caller explicitly provides a value. The
-    * default is to not send a value.
-    * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-    */
+     * Specifies a collation.
+     * This option is sent only if the caller explicitly provides a value. The
+     * default is to not send a value.
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
+     */
     public let collation: Document?
 
     /**
-    * The change stream will only provide changes that occurred at or after
-    * the specified timestamp. Any command run against the server will return
-    * an operation time that can be used here.
-    * - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
-    */
+     * The change stream will only provide changes that occurred at or after
+     * the specified timestamp. Any command run against the server will return
+     * an operation time that can be used here.
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/method/db.runCommand/
+     */
     public let startAtOperationTime: Timestamp?
 
     /**
-    * Similar to `resumeAfter`, this option takes a resume token and starts a
-    * new change stream returning the first notification after the token.
-    * This will allow users to watch collections that have been dropped and
-    * recreated or newly renamed collections without missing any
-    * notifications.
-    * The server will report an error if `startAfter` and `resumeAfter` are
-    * both specified.
-    * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
-    */
+     * Similar to `resumeAfter`, this option takes a resume token and starts a
+     * new change stream returning the first notification after the token.
+     * This will allow users to watch collections that have been dropped and
+     * recreated or newly renamed collections without missing any
+     * notifications.
+     * The server will report an error if `startAfter` and `resumeAfter` are
+     * both specified.
+     * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
+     */
     public let startAfter: Document?
 
-    /**
-    * Initializes a `ChangeStreamOption`.
-    */
+    /// Initializes a `ChangeStreamOption`.
     public init(fullDocument: FullDocument? = nil,
                 resumeAfter: Document? = nil,
 >>>>>>> first commit - Add ChangeStream, ChangeStreamOptions, ChangeStreamDocument

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -30,26 +30,24 @@ public enum FullDocument: RawRepresentable, Codable {
 
 /// Options to use when creating a `ChangeStream`.
 public struct ChangeStreamOptions: Codable {
-    /** Indicates how the `fullDocument` field of a `ChangeStreamDocument` should
-     * be filled out by the server.
-     * By default (indicated by a nil value for this option), the fullDocument field
-     * in the change stream document will always be present in the case of 'insert'
-     * and 'replace' operations (containing the document being inserted) and will be
-     * nil for all other operations.
+    /**
+     * Indicates how the `fullDocument` field of a `ChangeStreamDocument` should be filled out by the server.
+     * By default (indicated by a nil value for this option), the fullDocument field in the change stream document
+     * will always be present in the case of 'insert' and 'replace' operations (containing the document being inserted)
+     * and will be nil for all other operations.
      */
     public let fullDocument: FullDocument?
 
-    /// Specifies the logical starting point for the new change stream.
-    public let resumeAfter: Document?
+    /// A `ChangeStreamToken` used to manually specify the logical starting point for the new change stream.
+    public let resumeAfter: ChangeStreamToken?
 
     /// The maximum amount of time in milliseconds for the server to wait on new documents
     // to satisfy a change stream query. Uses the server default timeout when omitted.
     public let maxAwaitTimeMS: Int64?
 
     /**
-     * The number of documents to return per batch.
-     * This option is sent only if the caller explicitly provides a value. The
-     * default is to not send a value.
+     * The number of documents to return per batch. This option is sent only if the caller explicitly provides a value.
+     * The default is to not send a value.
      * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
      */
     public let batchSize: Int32?
@@ -71,8 +69,8 @@ public struct ChangeStreamOptions: Codable {
     public let startAtOperationTime: Timestamp?
 
     /**
-     * Similar to `resumeAfter`, this option takes a resume token and starts a
-     * new change stream returning the first notification after the token.
+     * Similar to `resumeAfter`, this option takes a resume token and starts a new change stream returning the first
+     * notification after the token.
      * This will allow users to watch collections that have been dropped and
      * recreated or newly renamed collections without missing any
      * notifications.
@@ -80,7 +78,7 @@ public struct ChangeStreamOptions: Codable {
      * both specified.
      * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
      */
-    public let startAfter: Document?
+    public let startAfter: ChangeStreamToken?
 
     /// Initializes a `ChangeStreamOption`.
     public init(fullDocument: FullDocument? = nil,

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -38,6 +38,7 @@ public enum FullDocument: RawRepresentable, Codable {
 /// Options to use when creating a `ChangeStream`.
 public struct ChangeStreamOptions: Codable {
 <<<<<<< HEAD
+<<<<<<< HEAD
     /**
      * Indicates how the `fullDocument` field of a `ChangeStreamDocument` should be filled out by the server.
      * By default (indicated by a nil value for this option), the fullDocument field in the change stream document
@@ -79,16 +80,22 @@ public struct ChangeStreamOptions: Codable {
 =======
     /// Indicates the value of the mode on the `fullDocument` field of a
     /// `ChangeStreamDocument`.
+=======
+    /** Indicates how the `fullDocument` field of a `ChangeStreamDocument` should
+     * be filled out by the server.
+     * By default (indicated by a nil value for this option), the fullDocument field
+     * in the change stream document will always be present in the case of 'insert'
+     * and 'replace' operations (containing the document being inserted) and will be
+     * nil for all other operations.
+     */
+>>>>>>> update docstrings
     public let fullDocument: FullDocument?
 
     /// Specifies the logical starting point for the new change stream.
     public let resumeAfter: Document?
 
-    /**
-     * The maximum amount of time in milliseconds for the server to wait on new
-     * documents to satisfy a change stream query. Uses the server default timeout
-     * when omitted.
-     */
+    /// The maximum amount of time in milliseconds for the server to wait on new documents
+    // to satisfy a change stream query. Uses the server default timeout when omitted.
     public let maxAwaitTimeMS: Int64?
 
     /**

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -39,11 +39,15 @@ public enum FullDocument: RawRepresentable, Codable {
 public struct ChangeStreamOptions: Codable {
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Update docstrings
     /**
      * Indicates how the `fullDocument` field of a `ChangeStreamDocument` should be filled out by the server.
      * By default (indicated by a nil value for this option), the fullDocument field in the change stream document
      * will always be present in the case of 'insert' and 'replace' operations (containing the document being inserted)
      * and will be nil for all other operations.
+<<<<<<< HEAD
      */
     public let fullDocument: FullDocument?
 
@@ -87,21 +91,22 @@ public struct ChangeStreamOptions: Codable {
      * in the change stream document will always be present in the case of 'insert'
      * and 'replace' operations (containing the document being inserted) and will be
      * nil for all other operations.
+=======
+>>>>>>> Update docstrings
      */
 >>>>>>> update docstrings
     public let fullDocument: FullDocument?
 
-    /// Specifies the logical starting point for the new change stream.
-    public let resumeAfter: Document?
+    /// A `ChangeStreamToken` used to manually specify the logical starting point for the new change stream.
+    public let resumeAfter: ChangeStreamToken?
 
     /// The maximum amount of time in milliseconds for the server to wait on new documents
     // to satisfy a change stream query. Uses the server default timeout when omitted.
     public let maxAwaitTimeMS: Int64?
 
     /**
-     * The number of documents to return per batch.
-     * This option is sent only if the caller explicitly provides a value. The
-     * default is to not send a value.
+     * The number of documents to return per batch. This option is sent only if the caller explicitly provides a value.
+     * The default is to not send a value.
      * - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
      */
     public let batchSize: Int32?
@@ -123,8 +128,8 @@ public struct ChangeStreamOptions: Codable {
     public let startAtOperationTime: Timestamp?
 
     /**
-     * Similar to `resumeAfter`, this option takes a resume token and starts a
-     * new change stream returning the first notification after the token.
+     * Similar to `resumeAfter`, this option takes a resume token and starts a new change stream returning the first
+     * notification after the token.
      * This will allow users to watch collections that have been dropped and
      * recreated or newly renamed collections without missing any
      * notifications.
@@ -132,7 +137,7 @@ public struct ChangeStreamOptions: Codable {
      * both specified.
      * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
      */
-    public let startAfter: Document?
+    public let startAfter: ChangeStreamToken?
 
     /// Initializes a `ChangeStreamOption`.
     public init(fullDocument: FullDocument? = nil,

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,7 +1,7 @@
-/// Describes the modes for configuring the fullDocument field of a `ChangeStreamDocument`.
+/// Describes the modes for configuring the fullDocument field of a change stream document.
 public enum FullDocument: RawRepresentable, Codable {
     /// Specifies that the `fullDocument` field will contain a copy of the entire document that was changed from
-    /// some time after the change occurred. If the document was deleted since the updated happened, it will be null.
+    /// some time after the change occurred. If the document was deleted since the updated happened, it will be nil.
     case updateLookup
     /// For an unknown value. For forwards compatibility, no error will be thrown when an unknown value is provided.
     case other(String)
@@ -28,7 +28,7 @@ public enum FullDocument: RawRepresentable, Codable {
 /// Options to use when creating a `ChangeStream`.
 public struct ChangeStreamOptions: Codable {
     /**
-     * Indicates how the `fullDocument` field of a `ChangeStreamDocument` should be filled out by the server.
+     * Indicates how the `fullDocument` field of a change stream document should be filled out by the server.
      * By default (indicated by a nil value for this option), the `fullDocument` field in the change stream document
      * will always be present in the case of 'insert' and 'replace' operations (containing the document being inserted)
      * and will be nil for all other operations.
@@ -40,16 +40,15 @@ public struct ChangeStreamOptions: Codable {
      * The change stream will attempt to resume notifications starting after the operation associated with
      * the provided token.
      * - Note: A change stream cannot be resumed after an invalidate event (e.g. a collection drop or rename).
-     *         Use the `startAfter` option in those cases instead.
      * - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream
      */
     public let resumeAfter: ChangeStreamToken?
 
     /// The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a
-    /// change stream query. Uses the server default timeout when omitted.
+    /// change stream query. If omitted, the server will use its default timeout.
     public let maxAwaitTimeMS: Int64?
 
-    /// The number of documents to return per batch. The default is to not send a value.
+    /// The number of documents to return per batch. If omitted, the server will use its default batch size.
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
     public let batchSize: Int32?
 
@@ -70,7 +69,8 @@ public struct ChangeStreamOptions: Codable {
      * - Note: The server will report an error if `startAfter` and `resumeAfter` are both specified.
      * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
      */
-    public let startAfter: ChangeStreamToken?
+     // TODO: Make this public when support is added for 4.2 change stream features.
+    internal let startAfter: ChangeStreamToken?
 
     /// Initializes a `ChangeStreamOptions`.
     public init(fullDocument: FullDocument? = nil,
@@ -78,14 +78,13 @@ public struct ChangeStreamOptions: Codable {
                 maxAwaitTimeMS: Int64? = nil,
                 batchSize: Int32? = nil,
                 collation: Document? = nil,
-                startAtOperationTime: Timestamp? = nil,
-                startAfter: ChangeStreamToken? = nil) {
+                startAtOperationTime: Timestamp? = nil) {
         self.fullDocument = fullDocument
         self.resumeAfter = resumeAfter
         self.maxAwaitTimeMS = maxAwaitTimeMS
         self.batchSize = batchSize
         self.collation = collation
         self.startAtOperationTime = startAtOperationTime
-        self.startAfter = startAfter
+        self.startAfter = nil
     }
 }

--- a/Sources/MongoSwift/ChangeStreamToken.swift
+++ b/Sources/MongoSwift/ChangeStreamToken.swift
@@ -1,0 +1,8 @@
+/// A wrapper for resumeToken.
+public struct ChangeStreamToken: Codable {
+    private let resumeToken: Document
+
+    public init(resumeToken: Document) {
+        self.resumeToken = resumeToken
+    }
+}

--- a/Sources/MongoSwift/ChangeStreamToken.swift
+++ b/Sources/MongoSwift/ChangeStreamToken.swift
@@ -1,8 +1,0 @@
-/// A wrapper for resumeToken.
-public struct ChangeStreamToken: Codable {
-    private let resumeToken: Document
-
-    public init(resumeToken: Document) {
-        self.resumeToken = resumeToken
-    }
-}

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -83,14 +83,14 @@ public class MongoCollection<T: Codable> {
     }
 
     /**
-    *   Drops this collection from its parent database.
-    * - Parameters:
-    *   - options: An optional `DropCollectionOptions` to use when executing this command
-    *   - session: An optional `ClientSession` to use when executing this command
-    *
-    * - Throws:
-    *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
-    */
+     *   Drops this collection from its parent database.
+     * - Parameters:
+     *   - options: An optional `DropCollectionOptions` to use when executing this command
+     *   - session: An optional `ClientSession` to use when executing this command
+     *
+     * - Throws:
+     *   - `ServerError.commandError` if an error occurs that prevents the command from executing.
+     */
     public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) throws {
         let operation = DropCollectionOperation(collection: self, options: options)
         return try self._client.executeOperation(operation, session: session)
@@ -135,8 +135,8 @@ public class MongoCollection<T: Codable> {
     }
 
     /**
-      * Starts a `ChangeStream` on a collection. By default, the type `CollectionType` is associated with the
-      * `fullDocument`field in `ChangeStreamsDocument`.
+     * Starts a `ChangeStream` on a collection. By default, the type `CollectionType` is associated with the
+     * `fullDocument`field in `ChangeStreamsDocument`.
      * - Parameters:
      *   - Pipeline: The pipeline of stages to append to an initial `ChangeStream` stage.
      *   - Options: An optional `ChangeStreamOptions` to use on the initial `ChangeStream` stage.
@@ -159,7 +159,6 @@ public class MongoCollection<T: Codable> {
     /**
      * Starts a `ChangeStream` on a collection. Associates the specified `Codable` type `T` with the `fullDocument`
      * field in the `ChangeStreamDocument`.
-     * `ChangeStreamDocument` in the returned `ChangeStream`.
      * - Parameters:
      *   - Pipeline: The pipeline of stages to append to an initial `ChangeStream` stage.
      *   - Options: An optional `ChangeStreamOptions` to use on the initial `ChangeStream` stage.

--- a/Sources/MongoSwift/MongoNamespace.swift
+++ b/Sources/MongoSwift/MongoNamespace.swift
@@ -1,9 +1,11 @@
 /// Represents a MongoDB namespace for a database or collection.
 public struct MongoNamespace: Codable {
+    /// The database name.
     public let db: String
+    /// The collection name if this is a collection's namespace, or nil otherwise.
     public let collection: String?
 
-    public enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case db, collection = "coll"
     }
 }

--- a/Sources/MongoSwift/MongoNamespace.swift
+++ b/Sources/MongoSwift/MongoNamespace.swift
@@ -1,11 +1,11 @@
 /// Represents a MongoDB namespace for a database or collection.
-internal struct MongoNamespace {
-    internal let db: String
-    internal let collection: String?
+public struct MongoNamespace: Codable {
+    public let db: String
+    public let collection: String?
 }
 
 extension MongoNamespace: CustomStringConvertible {
-    internal var description: String {
+    public var description: String {
         guard let collection = self.collection else {
             return self.db
         }

--- a/Sources/MongoSwift/MongoNamespace.swift
+++ b/Sources/MongoSwift/MongoNamespace.swift
@@ -2,6 +2,10 @@
 public struct MongoNamespace: Codable {
     public let db: String
     public let collection: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case db, collection = "coll"
+    }
 }
 
 extension MongoNamespace: CustomStringConvertible {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -18,7 +18,7 @@ extension BSONValueTests {
 
 extension ChangeStreamTest {
     static var allTests = [
-        ("testChangeStream", testChangeStream),
+        ("testChangeStreamOnAClient", testChangeStreamOnAClient),
         ("testChangeStreamOnADatabase", testChangeStreamOnADatabase),
         ("testChangeStreamOnACollection", testChangeStreamOnACollection),
     ]

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -16,6 +16,12 @@ extension BSONValueTests {
     ]
 }
 
+extension ChangeStream {
+    static var allTests = [
+        ("testChangeStream", testChangeStream),
+    ]
+}
+
 extension ClientSessionTests {
     static var allTests = [
         ("testSessionCleanup", testSessionCleanup),
@@ -236,6 +242,7 @@ extension SDAMTests {
 
 XCTMain([
     testCase(BSONValueTests.allTests),
+    testCase(ChangeStream.allTests),
     testCase(ClientSessionTests.allTests),
     testCase(CodecTests.allTests),
     testCase(CommandMonitoringTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -16,9 +16,11 @@ extension BSONValueTests {
     ]
 }
 
-extension ChangeStream {
+extension ChangeStreamTest {
     static var allTests = [
         ("testChangeStream", testChangeStream),
+        ("testChangeStreamOnADatabase", testChangeStreamOnADatabase),
+        ("testChangeStreamOnACollection", testChangeStreamOnACollection),
     ]
 }
 
@@ -242,7 +244,7 @@ extension SDAMTests {
 
 XCTMain([
     testCase(BSONValueTests.allTests),
-    testCase(ChangeStream.allTests),
+    testCase(ChangeStreamTest.allTests),
     testCase(ClientSessionTests.allTests),
     testCase(CodecTests.allTests),
     testCase(CommandMonitoringTests.allTests),

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -4,38 +4,57 @@ import Nimble
 import XCTest
 
 final class ChangeStreamTest: MongoSwiftTestCase {
-    func testChangeStream() throws {
+    func testChangeStreamOnAClient() throws {
         guard MongoSwiftTestCase.topologyType != .single else {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
 
         let client = try MongoClient()
-        let db = client.db(type(of: self).testDatabase)
-        defer { try? db.drop() }
-        let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
+        guard try client.serverVersion() >= ServerVersion(major: 4, minor: 0) else {
+            print("Skipping test case for server version \(try client.serverVersion())")
+            return
+        }
         let session = try client.startSession()
         let options = ChangeStreamOptions(fullDocument: .updateLookup)
-        let opts = try encodeOptions(options: options, session: session)
-        let pipeline: Document = []
-        let decoder = BSONDecoder()
-
+        let pipeline: [Document] = []
         let connection = try client.connectionPool.checkOut()
-        try coll.withMongocCollection(from: connection) { collPtr in
-            // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
-            let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
-            var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-            defer {
-                replyPtr.deinitialize(count: 1)
-                replyPtr.deallocate()
-            }
-            expect(try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                    client: client,
-                                                                    connection: connection,
-                                                                    session: session,
-                                                                    decoder: decoder))
-                                                                    .toNot(throwError())
-        }
+        let changeStream = try client.watch(pipeline, options: options, session: session)
+
+        let db1 = client.db("db1")
+        defer { try? db1.drop() }
+        let coll1 = db1.collection("coll1")
+        let coll2 = db1.collection("coll2")
+        try coll1.insertOne(["a": 1], session: session)
+        try coll2.insertOne(["x": 123], session: session)
+
+        let res1 = changeStream.next()
+        // test that the change stream contains a change document for the `insert` operation.
+        expect(res1).toNot(beNil())
+        expect(res1?.operationType).to(equal(.insert))
+        expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
+        // test that the resumeToken is updated
+        expect(changeStream.resumeToken).to(equal(res1?._id))
+
+        let res2 = changeStream.next()
+        // test that the change stream contains a document for changes on a different collection in the same database
+        expect(res2).toNot(beNil())
+        expect(res2?.operationType).to(equal(.insert))
+        expect(res2?.fullDocument?["x"]).to(bsonEqual(123))
+        // test that the resumeToken is updated
+        expect(changeStream.resumeToken).to(equal(res2?._id))
+
+        let db2 = client.db("db2")
+        defer { try? db1.drop() }
+        let coll3 = try db2.collection("coll3")
+        try coll3.insertOne(["y": 321], session: session)
+        let res4 = changeStream.next()
+        // test that the change stream contains a document for changes on a collection in a different database
+        expect(res4).toNot(beNil())
+        expect(res4?.operationType).to(equal(.insert))
+        expect(res4?.fullDocument?["y"]).to(bsonEqual(321))
+        // test that the resumeToken is updated
+        expect(changeStream.resumeToken).to(equal(res4?._id))
     }
 
     func testChangeStreamOnADatabase() throws {
@@ -45,58 +64,40 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         }
 
         let client = try MongoClient()
-
         guard try client.serverVersion() >= ServerVersion(major: 4, minor: 0) else {
             print("Skipping test case for server version \(try client.serverVersion())")
             return
         }
-
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
         let session = try client.startSession()
         let options = ChangeStreamOptions(fullDocument: .updateLookup)
-        let opts = try encodeOptions(options: options, session: session)
-        let pipeline: Document = []
+        let pipeline: [Document] = []
+        let changeStream = try db.watch(pipeline, options: options, session: session)
 
-        let connection = try client.connectionPool.checkOut()
-        try db.withMongocDatabase(from: connection) { dbPtr in
-            // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
-            let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
-            var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-            defer {
-                replyPtr.deinitialize(count: 1)
-                replyPtr.deallocate()
-            }
+        // expect the first iteration to be nil since no changes have been made to the database.
+        expect(changeStream.next()).to(beNil())
 
-            let decoder = BSONDecoder()
-            let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                                client: client,
-                                                                                connection: connection,
-                                                                                decoder: decoder)
-            // expect the first iteration to be nil since no changes have been made to the database.
-            expect(changeStream.next()).to(beNil())
+        let coll = db.collection(self.getCollectionName(suffix: "1"))
+        try coll.insertOne(["a": 1], session: session)
 
-            let coll = db.collection(self.getCollectionName(suffix: "1"))
-            try coll.insertOne(["a": 1], session: session)
+        // test that the change stream contains a change document for the `insert` operation.
+        let res1 = changeStream.next()
+        expect(res1).toNot(beNil())
+        expect(res1?.operationType).to(equal(.insert))
+        expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
 
-            // test that the change stream contains a change document for the `insert` operation.
-            let res1 = changeStream.next()
-            expect(res1).toNot(beNil())
-            expect(res1?.operationType).to(equal(.insert))
-            expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
+        // test that the resumeToken is updated
+        expect(changeStream.resumeToken).to(equal(res1?._id))
 
-            // test that the resumeToken is updated
-            expect(changeStream.resumeToken).to(equal(res1?._id))
+        // test that the change stream contains a change document for the `drop` operation.
+        try db.drop()
+        let res2 = changeStream.next()
+        expect(res2).toNot(beNil())
+        expect(res2?.operationType).to(equal(.drop))
 
-            // test that the change stream contains a change document for the `drop` operation.
-            try db.drop()
-            let res2 = changeStream.next()
-            expect(res2).toNot(beNil())
-            expect(res2?.operationType).to(equal(.drop))
-
-            // test that the resumeToken is updated
-            expect(changeStream.resumeToken).to(equal(res2?._id))
-        }
+        // test that the resumeToken is updated
+        expect(changeStream.resumeToken).to(equal(res2?._id))
     }
 
     func testChangeStreamOnACollection() throws {
@@ -110,57 +111,40 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
         let session = try client.startSession()
         let options = ChangeStreamOptions(fullDocument: .updateLookup)
-        let opts = try encodeOptions(options: options, session: session)
-        let pipeline: Document = []
+        let pipeline: [Document] = []
 
-        let connection = try client.connectionPool.checkOut()
-        try coll.withMongocCollection(from: connection) { collPtr in
-            // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
-            let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
-            var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-            defer {
-                replyPtr.deinitialize(count: 1)
-                replyPtr.deallocate()
-            }
+        let changeStream = try coll.watch(pipeline, options: options, session: session)
+        // expect the first iteration to be nil since no changes have been made to the database.
+        expect(changeStream.next()).to(beNil())
 
-            let decoder = BSONDecoder()
-            let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                                client: client,
-                                                                                connection: connection,
-                                                                                session: session,
-                                                                                decoder: decoder)
-            // expect the first iteration to be nil since no changes have been made to the collection.
-            expect(changeStream.next()).to(beNil())
+        // test that the change stream contains a change document for the `insert` operation.
+        try coll.insertOne(["x": 1], session: session)
+        let res1 = changeStream.next()
+        expect(res1).toNot(beNil())
+        expect(res1?.operationType).to(equal(.insert))
+        expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
 
-            // test that the change stream contains a change document for the `insert` operation.
-            try coll.insertOne(["x": 1], session: session)
-            let res1 = changeStream.next()
-            expect(res1).toNot(beNil())
-            expect(res1?.operationType).to(equal(.insert))
-            expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
+        // test that the resumeToken is updated
+        expect(changeStream.resumeToken).to(equal(res1?._id))
 
-            // test that the resumeToken is updated
-            expect(changeStream.resumeToken).to(equal(res1?._id))
+        try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
+        let res2 = changeStream.next()
 
-            try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
-            let res2 = changeStream.next()
+        // test that the change stream contains a change document for the `update` operation.
+        expect(res2).toNot(beNil())
+        expect(res2?.operationType).to(equal(.update))
+        expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
 
-            // test that the change stream contains a change document for the `update` operation.
-            expect(res2).toNot(beNil())
-            expect(res2?.operationType).to(equal(.update))
-            expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
+        // test that the resumeToken is updated
+        expect(changeStream.resumeToken).to(equal(res2?._id))
 
-            // test that the resumeToken is updated
-            expect(changeStream.resumeToken).to(equal(res2?._id))
+        // test that the change stream contains a change document for the `find` operation.
+        try coll.findOneAndDelete(["x": 2], session: session)
+        let res3 = changeStream.next()
+        expect(res3).toNot(beNil())
+        expect(res3?.operationType).to(equal(.delete))
 
-            // test that the change stream contains a change document for the `find` operation.
-            try coll.findOneAndDelete(["x": 2], session: session)
-            let res3 = changeStream.next()
-            expect(res3).toNot(beNil())
-            expect(res3?.operationType).to(equal(.delete))
-
-            // test that the resumeToken is updated
-            expect(changeStream.resumeToken).to(equal(res3?._id))
-        }
+        // test that the resumeToken is updated
+        expect(changeStream.resumeToken).to(equal(res3?._id))
     }
 }

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -4,8 +4,7 @@ import Nimble
 import XCTest
 
 final class ChangeStreamTest: MongoSwiftTestCase {
-    override func setUp() {
-        super.setUp()
+    func testChangeStream() throws {
         guard MongoSwiftTestCase.topologyType != .single else {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
@@ -47,7 +46,10 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
+<<<<<<< HEAD
 
+=======
+>>>>>>> Add topology check for change streams when not single
         let client = try MongoClient()
 
         if try client.serverVersion() < ServerVersion(major: 4, minor: 0) {

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -20,21 +20,21 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let pipeline: Document = []
         let decoder = BSONDecoder()
 
-        try client.connectionPool.withConnection { conn in
-            try coll.withMongocCollection(from: conn) { collPtr in
-                // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
-                let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
-                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-                defer {
-                    replyPtr.deinitialize(count: 1)
-                    replyPtr.deallocate()
-                }
-                expect(try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                        client: client,
-                                                                        session: session,
-                                                                        decoder: decoder))
-                                                                        .toNot(throwError())
+        let connection = try client.connectionPool.checkOut()
+        try coll.withMongocCollection(from: connection) { collPtr in
+            // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
+            let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
+            var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+            defer {
+                replyPtr.deinitialize(count: 1)
+                replyPtr.deallocate()
             }
+            expect(try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                    client: client,
+                                                                    connection: connection,
+                                                                    session: session,
+                                                                    decoder: decoder))
+                                                                    .toNot(throwError())
         }
     }
 
@@ -58,38 +58,38 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
-        try client.connectionPool.withConnection { conn in
-            try db.withMongocDatabase(from: conn) { dbPtr in
-                // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
-                let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
-                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-                defer {
-                    replyPtr.deinitialize(count: 1)
-                    replyPtr.deallocate()
-                }
-
-                let decoder = BSONDecoder()
-                let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                                    client: client,
-                                                                                    decoder: decoder)
-                // expect the first iteration to be nil since no changes have been made to the database.
-                expect(changeStream.next()).to(beNil())
-
-                let coll = db.collection(self.getCollectionName(suffix: "1"))
-                try coll.insertOne(["a": 1], session: session)
-
-                // test that the change stream contains a change document for the `insert` operation.
-                let res1 = changeStream.next()
-                expect(res1).toNot(beNil())
-                expect(res1?.operationType).to(equal(.insert))
-                expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
-
-                // test that the change stream contains a change document for the `drop` operation.
-                try db.drop()
-                let res2 = changeStream.next()
-                expect(res2).toNot(beNil())
-                expect(res2?.operationType).to(equal(.drop))
+        let connection = try client.connectionPool.checkOut()
+        try db.withMongocDatabase(from: connection) { dbPtr in
+            // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
+            let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
+            var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+            defer {
+                replyPtr.deinitialize(count: 1)
+                replyPtr.deallocate()
             }
+
+            let decoder = BSONDecoder()
+            let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                                client: client,
+                                                                                connection: connection,
+                                                                                decoder: decoder)
+            // expect the first iteration to be nil since no changes have been made to the database.
+            expect(changeStream.next()).to(beNil())
+
+            let coll = db.collection(self.getCollectionName(suffix: "1"))
+            try coll.insertOne(["a": 1], session: session)
+
+            // test that the change stream contains a change document for the `insert` operation.
+            let res1 = changeStream.next()
+            expect(res1).toNot(beNil())
+            expect(res1?.operationType).to(equal(.insert))
+            expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
+
+            // test that the change stream contains a change document for the `drop` operation.
+            try db.drop()
+            let res2 = changeStream.next()
+            expect(res2).toNot(beNil())
+            expect(res2?.operationType).to(equal(.drop))
         }
     }
 
@@ -107,45 +107,45 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
-        try client.connectionPool.withConnection { conn in
-            try coll.withMongocCollection(from: conn) { collPtr in
-                // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
-                let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
-                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-                defer {
-                    replyPtr.deinitialize(count: 1)
-                    replyPtr.deallocate()
-                }
-
-                let decoder = BSONDecoder()
-                let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                                    client: client,
-                                                                                    session: session,
-                                                                                    decoder: decoder)
-                // expect the first iteration to be nil since no changes have been made to the collection.
-                expect(changeStream.next()).to(beNil())
-
-                // test that the change stream contains a change document for the `insert` operation.
-                try coll.insertOne(["x": 1], session: session)
-                let res1 = changeStream.next()
-                expect(res1).toNot(beNil())
-                expect(res1?.operationType).to(equal(.insert))
-                expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
-
-                try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
-                let res2 = changeStream.next()
-
-                // test that the change stream contains a change document for the `update` operation.
-                expect(res2).toNot(beNil())
-                expect(res2?.operationType).to(equal(.update))
-                expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
-
-                // test that the change stream contains a change document for the `find` operation.
-                try coll.findOneAndDelete(["x": 2], session: session)
-                let res3 = changeStream.next()
-                expect(res3).toNot(beNil())
-                expect(res3?.operationType).to(equal(.delete))
+        let connection = try client.connectionPool.checkOut()
+        try coll.withMongocCollection(from: connection) { collPtr in
+            // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
+            let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
+            var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+            defer {
+                replyPtr.deinitialize(count: 1)
+                replyPtr.deallocate()
             }
+
+            let decoder = BSONDecoder()
+            let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                                client: client,
+                                                                                connection: connection,
+                                                                                session: session,
+                                                                                decoder: decoder)
+            // expect the first iteration to be nil since no changes have been made to the collection.
+            expect(changeStream.next()).to(beNil())
+
+            // test that the change stream contains a change document for the `insert` operation.
+            try coll.insertOne(["x": 1], session: session)
+            let res1 = changeStream.next()
+            expect(res1).toNot(beNil())
+            expect(res1?.operationType).to(equal(.insert))
+            expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
+
+            try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
+            let res2 = changeStream.next()
+
+            // test that the change stream contains a change document for the `update` operation.
+            expect(res2).toNot(beNil())
+            expect(res2?.operationType).to(equal(.update))
+            expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
+
+            // test that the change stream contains a change document for the `find` operation.
+            try coll.findOneAndDelete(["x": 2], session: session)
+            let res3 = changeStream.next()
+            expect(res3).toNot(beNil())
+            expect(res3?.operationType).to(equal(.delete))
         }
     }
 }

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -9,12 +9,6 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
-    }
-    func testChangeStream() throws {
-        guard MongoSwiftTestCase.topologyType != .single else {
-            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
-            return
-        }
 
         let decoder = BSONDecoder()
         let client = try MongoClient()
@@ -27,7 +21,7 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
-        let connection = try client.connectionPool.withConnection { conn in
+        try client.connectionPool.withConnection { conn in
             try db.withMongocDatabase(from: conn) { dbPtr in
                 // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
                 let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
@@ -45,116 +39,116 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         }
     }
 
-    func testChangeStreamOnADatabase() throws {
-        guard MongoSwiftTestCase.topologyType != .single else {
-            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
-            return
-        }
-        let client = try MongoClient()
+    // func testChangeStreamOnADatabase() throws {
+    //     guard MongoSwiftTestCase.topologyType != .single else {
+    //         print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+    //         return
+    //     }
+    //     let client = try MongoClient()
 
-        if try client.serverVersion() < ServerVersion(major: 4, minor: 0) {
-            print("Skipping test case for server version \(try client.serverVersion())")
-            return
-        }
+    //     if try client.serverVersion() < ServerVersion(major: 4, minor: 0) {
+    //         print("Skipping test case for server version \(try client.serverVersion())")
+    //         return
+    //     }
 
-        let db = client.db(type(of: self).testDatabase)
-        defer { try? db.drop() }
+    //     let db = client.db(type(of: self).testDatabase)
+    //     defer { try? db.drop() }
 
-        let options = ChangeStreamOptions(fullDocument: .updateLookup)
-        let session = try client.startSession()
-        let opts = try encodeOptions(options: options, session: session)
-        let pipeline: Document = []
+    //     let options = ChangeStreamOptions(fullDocument: .updateLookup)
+    //     let session = try client.startSession()
+    //     let opts = try encodeOptions(options: options, session: session)
+    //     let pipeline: Document = []
 
-        try client.connectionPool.withConnection { conn in
-            try db.withMongocDatabase(from: conn) { dbPtr in
-                // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
-                let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
-                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-                defer {
-                    replyPtr.deinitialize(count: 1)
-                    replyPtr.deallocate()
-                }
+    //     try client.connectionPool.withConnection { conn in
+    //         try db.withMongocDatabase(from: conn) { dbPtr in
+    //             // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
+    //             let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
+    //             var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+    //             defer {
+    //                 replyPtr.deinitialize(count: 1)
+    //                 replyPtr.deallocate()
+    //             }
 
-                let decoder = BSONDecoder()
-                let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                                    client: client,
-                                                                                    decoder: decoder)
-                // expect the first iteration to be nil since no changes have been made to the database.
-                expect(changeStream.next()).to(beNil())
+    //             let decoder = BSONDecoder()
+    //             let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+    //                                                                                 client: client,
+    //                                                                                 decoder: decoder)
+    //             // expect the first iteration to be nil since no changes have been made to the database.
+    //             expect(changeStream.next()).to(beNil())
 
-                let coll = try db.collection(self.getCollectionName(suffix: "1"))
-                try coll.insertOne(["a": 1], session: session)
+    //             let coll = try db.collection(self.getCollectionName(suffix: "1"))
+    //             try coll.insertOne(["a": 1], session: session)
 
-                // test that the change stream contains a change document for the `insert` operation.
-                let res1 = changeStream.next()
-                expect(res1).toNot(beNil())
-                expect(res1?.operationType).to(equal(.insert))
-                expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
+    //             // test that the change stream contains a change document for the `insert` operation.
+    //             let res1 = changeStream.next()
+    //             expect(res1).toNot(beNil())
+    //             expect(res1?.operationType).to(equal(.insert))
+    //             expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
 
-                // test that the change stream contains a change document for the `drop` operation.
-                try db.drop()
-                let res2 = changeStream.next()
-                expect(res2).toNot(beNil())
-                expect(res2?.operationType).to(equal(.drop))
-            }
-        }
-    }
+    //             // test that the change stream contains a change document for the `drop` operation.
+    //             try db.drop()
+    //             let res2 = changeStream.next()
+    //             expect(res2).toNot(beNil())
+    //             expect(res2?.operationType).to(equal(.drop))
+    //         }
+    //     }
+    // }
 
-    func testChangeStreamOnACollection() throws {
-        guard MongoSwiftTestCase.topologyType != .single else {
-            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
-            return
-        }
-        let client = try MongoClient()
+    // func testChangeStreamOnACollection() throws {
+    //     guard MongoSwiftTestCase.topologyType != .single else {
+    //         print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+    //         return
+    //     }
+    //     let client = try MongoClient()
 
-        let db = client.db(type(of: self).testDatabase)
-        defer { try? db.drop() }
+    //     let db = client.db(type(of: self).testDatabase)
+    //     defer { try? db.drop() }
 
-        // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
-        let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
-        let session = try client.startSession()
-        let options = ChangeStreamOptions(fullDocument: .updateLookup)
-        let opts = try encodeOptions(options: options, session: session)
-        let pipeline: Document = []
+    //     // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
+    //     let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
+    //     let session = try client.startSession()
+    //     let options = ChangeStreamOptions(fullDocument: .updateLookup)
+    //     let opts = try encodeOptions(options: options, session: session)
+    //     let pipeline: Document = []
 
-        try client.connectionPool.withConnection { conn in
-            try coll.withMongocCollection(from: conn) { collPtr in
-                let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
-                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-                defer {
-                    replyPtr.deinitialize(count: 1)
-                    replyPtr.deallocate()
-                }
+    //     try client.connectionPool.withConnection { conn in
+    //         try coll.withMongocCollection(from: conn) { collPtr in
+    //             let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
+    //             var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+    //             defer {
+    //                 replyPtr.deinitialize(count: 1)
+    //                 replyPtr.deallocate()
+    //             }
 
-                let decoder = BSONDecoder()
-                let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                                    client: client,
-                                                                                    session: session,
-                                                                                    decoder: decoder)
-                // expect the first iteration to be nil since no changes have been made to the collection.
-                expect(changeStream.next()).to(beNil())
+    //             let decoder = BSONDecoder()
+    //             let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+    //                                                                                 client: client,
+    //                                                                                 session: session,
+    //                                                                                 decoder: decoder)
+    //             // expect the first iteration to be nil since no changes have been made to the collection.
+    //             expect(changeStream.next()).to(beNil())
 
-                // test that the change stream contains a change document for the `insert` operation.
-                try coll.insertOne(["x": 1], session: session)
-                let res1 = changeStream.next()
-                expect(res1).toNot(beNil())
-                expect(res1?.operationType).to(equal(.insert))
-                expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
+    //             // test that the change stream contains a change document for the `insert` operation.
+    //             try coll.insertOne(["x": 1], session: session)
+    //             let res1 = changeStream.next()
+    //             expect(res1).toNot(beNil())
+    //             expect(res1?.operationType).to(equal(.insert))
+    //             expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
 
-                try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
-                let res2 = changeStream.next()
+    //             try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
+    //             let res2 = changeStream.next()
 
-                // test that the change stream contains a change document for the `update` operation.
-                expect(res2).toNot(beNil())
-                expect(res2?.operationType).to(equal(.update))
-                expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
+    //             // test that the change stream contains a change document for the `update` operation.
+    //             expect(res2).toNot(beNil())
+    //             expect(res2?.operationType).to(equal(.update))
+    //             expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
 
-                // test that the change stream contains a change document for the `find` operation.
-                try coll.findOneAndDelete(["x": 2], session: session)
-                let res3 = changeStream.next()
-                expect(res3).toNot(beNil())
-                expect(res3?.operationType).to(equal(.delete))
-            }
-        }
-    }
+    //             // test that the change stream contains a change document for the `find` operation.
+    //             try coll.findOneAndDelete(["x": 2], session: session)
+    //             let res3 = changeStream.next()
+    //             expect(res3).toNot(beNil())
+    //             expect(res3?.operationType).to(equal(.delete))
+    //         }
+    //     }
+    // }
 }

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -110,7 +110,7 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             replyPtr.deallocate()
         }
 
-        let decoder = BSONDecoder()
+       let decoder = BSONDecoder()
        let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
                                                                            client: client,
                                                                            session: session,
@@ -129,6 +129,7 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         // test that the change stream contains a change document for the `update` operation.
         expect(res2).toNot(beNil())
         expect(res2?.operationType).to(equal(.update))
+        print("res: ", res2)
 
         // test that the change stream contains a change document for the `find` operation.
         try coll.findOneAndDelete(["x": 2], session: session)

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -137,11 +137,7 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         // test that the change stream contains a change document for the `update` operation.
         expect(res2).toNot(beNil())
         expect(res2?.operationType).to(equal(.update))
-<<<<<<< HEAD
         expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
-=======
-        print("res: ", res2)
->>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
 
         // test that the change stream contains a change document for the `find` operation.
         try coll.findOneAndDelete(["x": 2], session: session)

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -9,6 +9,7 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
+
         let decoder = BSONDecoder()
         let client = try MongoClient()
 
@@ -20,6 +21,7 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
+        // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
         let changeStreamPtr: OpaquePointer = mongoc_database_watch(db._database, pipeline._bson, opts?._bson)
         var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
         defer {
@@ -38,7 +40,13 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
+
         let client = try MongoClient()
+
+        if try client.serverVersion() < ServerVersion(major: 4, minor: 0) {
+            print("Skipping test case for server version \(try client.serverVersion())")
+            return
+        }
 
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
@@ -48,6 +56,7 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
+        // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
         let changeStreamPtr: OpaquePointer = mongoc_database_watch(db._database, pipeline._bson, opts?._bson)
         var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
         defer {
@@ -87,6 +96,7 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
 
+        // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
         let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
         let session = try client.startSession()
         let options = ChangeStreamOptions()

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -85,11 +85,17 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             expect(res1?.operationType).to(equal(.insert))
             expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
 
+            // test that the resumeToken is updated
+            expect(changeStream.resumeToken).to(equal(res1?._id))
+
             // test that the change stream contains a change document for the `drop` operation.
             try db.drop()
             let res2 = changeStream.next()
             expect(res2).toNot(beNil())
             expect(res2?.operationType).to(equal(.drop))
+
+            // test that the resumeToken is updated
+            expect(changeStream.resumeToken).to(equal(res2?._id))
         }
     }
 
@@ -133,6 +139,9 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             expect(res1?.operationType).to(equal(.insert))
             expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
 
+            // test that the resumeToken is updated
+            expect(changeStream.resumeToken).to(equal(res1?._id))
+
             try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
             let res2 = changeStream.next()
 
@@ -141,11 +150,17 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             expect(res2?.operationType).to(equal(.update))
             expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
 
+            // test that the resumeToken is updated
+            expect(changeStream.resumeToken).to(equal(res2?._id))
+
             // test that the change stream contains a change document for the `find` operation.
             try coll.findOneAndDelete(["x": 2], session: session)
             let res3 = changeStream.next()
             expect(res3).toNot(beNil())
             expect(res3?.operationType).to(equal(.delete))
+
+            // test that the resumeToken is updated
+            expect(changeStream.resumeToken).to(equal(res3?._id))
         }
     }
 }

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -5,26 +5,113 @@ import XCTest
 
 final class ChangeStreamTest: MongoSwiftTestCase {
     func testChangeStream() throws {
-        let encoder = BSONEncoder()
+        let decoder = BSONDecoder()
         let client = try MongoClient()
+
+        let db = client.db(type(of: self).testDatabase)
+        defer { try? db.drop() }
+
         let session = try client.startSession()
-        let db = client.db("myDb")
-        let coll = db.collection("myColl")
         let options = ChangeStreamOptions()
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
-        let changeStreamPtr = mongoc_collection_watch(coll._collection, pipeline._bson, opts?._bson)
+        let changeStreamPtr: OpaquePointer = mongoc_database_watch(db._database, pipeline._bson, opts?._bson)
+        var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+        defer {
+            replyPtr.deinitialize(count: 1)
+            replyPtr.deallocate()
+        }
+        expect(try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                client: client,
+                                                                session: session,
+                                                                decoder: decoder))
+                                                                .toNot(throwError())
+    }
+
+    func testChangeStreamOnADatabase() throws {
+        let client = try MongoClient()
+
+        let db = client.db(type(of: self).testDatabase)
+        defer { try? db.drop() }
+
+        let options = ChangeStreamOptions()
+        let session = try client.startSession()
+        let opts = try encodeOptions(options: options, session: session)
+        let pipeline: Document = []
+
+        let changeStreamPtr: OpaquePointer = mongoc_database_watch(db._database, pipeline._bson, opts?._bson)
         var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
         defer {
             replyPtr.deinitialize(count: 1)
             replyPtr.deallocate()
         }
 
-        var error = bson_error_t()
-        mongoc_cursor_error_document(changeStreamPtr, &error, replyPtr)
-        print(extractMongoError(error: error))
         let decoder = BSONDecoder()
-        //expect(try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr!, client: client, session: session, decoder: decoder)).toNot(throwError())
+        let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                            client: client,
+                                                                            decoder: decoder)
+        // expect the first iteration to be nil since no changes have been made to the database.
+        expect(changeStream.next()).to(beNil())
+
+        let coll = try db.collection(self.getCollectionName(suffix: "1"))
+        try coll.insertOne(["a": 1], session: session)
+
+        // test that the change stream contains a change document for the `insert` operation.
+        let res1 = changeStream.next()
+        expect(res1).toNot(beNil())
+        expect(res1?.operationType).to(equal(.insert))
+
+        // test that the change stream contains a change document for the `drop` operation.
+        try db.drop()
+        let res2 = changeStream.next()
+        expect(res2).toNot(beNil())
+        expect(res2?.operationType).to(equal(.drop))
+    }
+
+    func testChangeStreamOnACollection() throws {
+        let client = try MongoClient()
+
+        let db = client.db(type(of: self).testDatabase)
+        defer { try? db.drop() }
+
+        let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
+        let session = try client.startSession()
+        let options = ChangeStreamOptions()
+        let opts = try encodeOptions(options: options, session: session)
+        let pipeline: Document = []
+
+        let changeStreamPtr: OpaquePointer = mongoc_collection_watch(coll._collection, pipeline._bson, opts?._bson)
+        var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+        defer {
+            replyPtr.deinitialize(count: 1)
+            replyPtr.deallocate()
+        }
+
+        let decoder = BSONDecoder()
+       let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                           client: client,
+                                                                           session: session,
+                                                                           decoder: decoder)
+       // expect the first iteration to be nil since no changes have been made to the collection.
+        expect(changeStream.next()).to(beNil())
+
+        // test that the change stream contains a change document for the `insert` operation.
+        try coll.insertOne(["x": 1], session: session)
+        let res1 = changeStream.next()
+        expect(res1).toNot(beNil())
+        expect(res1?.operationType).to(equal(.insert))
+
+        try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
+        let res2 = changeStream.next()
+        // test that the change stream contains a change document for the `update` operation.
+        expect(res2).toNot(beNil())
+        expect(res2?.operationType).to(equal(.update))
+
+        // test that the change stream contains a change document for the `find` operation.
+        try coll.findOneAndDelete(["x": 2], session: session)
+        let res3 = changeStream.next()
+        expect(res3).toNot(beNil())
+        expect(res3?.operationType).to(equal(.delete))
     }
 }

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -39,116 +39,116 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         }
     }
 
-    // func testChangeStreamOnADatabase() throws {
-    //     guard MongoSwiftTestCase.topologyType != .single else {
-    //         print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
-    //         return
-    //     }
-    //     let client = try MongoClient()
+    func testChangeStreamOnADatabase() throws {
+        guard MongoSwiftTestCase.topologyType != .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+        let client = try MongoClient()
 
-    //     if try client.serverVersion() < ServerVersion(major: 4, minor: 0) {
-    //         print("Skipping test case for server version \(try client.serverVersion())")
-    //         return
-    //     }
+        if try client.serverVersion() < ServerVersion(major: 4, minor: 0) {
+            print("Skipping test case for server version \(try client.serverVersion())")
+            return
+        }
 
-    //     let db = client.db(type(of: self).testDatabase)
-    //     defer { try? db.drop() }
+        let db = client.db(type(of: self).testDatabase)
+        defer { try? db.drop() }
 
-    //     let options = ChangeStreamOptions(fullDocument: .updateLookup)
-    //     let session = try client.startSession()
-    //     let opts = try encodeOptions(options: options, session: session)
-    //     let pipeline: Document = []
+        let options = ChangeStreamOptions(fullDocument: .updateLookup)
+        let session = try client.startSession()
+        let opts = try encodeOptions(options: options, session: session)
+        let pipeline: Document = []
 
-    //     try client.connectionPool.withConnection { conn in
-    //         try db.withMongocDatabase(from: conn) { dbPtr in
-    //             // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
-    //             let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
-    //             var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-    //             defer {
-    //                 replyPtr.deinitialize(count: 1)
-    //                 replyPtr.deallocate()
-    //             }
+        try client.connectionPool.withConnection { conn in
+            try db.withMongocDatabase(from: conn) { dbPtr in
+                // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
+                let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
+                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+                defer {
+                    replyPtr.deinitialize(count: 1)
+                    replyPtr.deallocate()
+                }
 
-    //             let decoder = BSONDecoder()
-    //             let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-    //                                                                                 client: client,
-    //                                                                                 decoder: decoder)
-    //             // expect the first iteration to be nil since no changes have been made to the database.
-    //             expect(changeStream.next()).to(beNil())
+                let decoder = BSONDecoder()
+                let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                                    client: client,
+                                                                                    decoder: decoder)
+                // expect the first iteration to be nil since no changes have been made to the database.
+                expect(changeStream.next()).to(beNil())
 
-    //             let coll = try db.collection(self.getCollectionName(suffix: "1"))
-    //             try coll.insertOne(["a": 1], session: session)
+                let coll = try db.collection(self.getCollectionName(suffix: "1"))
+                try coll.insertOne(["a": 1], session: session)
 
-    //             // test that the change stream contains a change document for the `insert` operation.
-    //             let res1 = changeStream.next()
-    //             expect(res1).toNot(beNil())
-    //             expect(res1?.operationType).to(equal(.insert))
-    //             expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
+                // test that the change stream contains a change document for the `insert` operation.
+                let res1 = changeStream.next()
+                expect(res1).toNot(beNil())
+                expect(res1?.operationType).to(equal(.insert))
+                expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
 
-    //             // test that the change stream contains a change document for the `drop` operation.
-    //             try db.drop()
-    //             let res2 = changeStream.next()
-    //             expect(res2).toNot(beNil())
-    //             expect(res2?.operationType).to(equal(.drop))
-    //         }
-    //     }
-    // }
+                // test that the change stream contains a change document for the `drop` operation.
+                try db.drop()
+                let res2 = changeStream.next()
+                expect(res2).toNot(beNil())
+                expect(res2?.operationType).to(equal(.drop))
+            }
+        }
+    }
 
-    // func testChangeStreamOnACollection() throws {
-    //     guard MongoSwiftTestCase.topologyType != .single else {
-    //         print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
-    //         return
-    //     }
-    //     let client = try MongoClient()
+    func testChangeStreamOnACollection() throws {
+        guard MongoSwiftTestCase.topologyType != .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+        let client = try MongoClient()
 
-    //     let db = client.db(type(of: self).testDatabase)
-    //     defer { try? db.drop() }
+        let db = client.db(type(of: self).testDatabase)
+        defer { try? db.drop() }
 
-    //     // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
-    //     let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
-    //     let session = try client.startSession()
-    //     let options = ChangeStreamOptions(fullDocument: .updateLookup)
-    //     let opts = try encodeOptions(options: options, session: session)
-    //     let pipeline: Document = []
+        // TODO: Use MongoCollection.watch() instead `mongoc_collection_watch` of once it gets added
+        let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
+        let session = try client.startSession()
+        let options = ChangeStreamOptions(fullDocument: .updateLookup)
+        let opts = try encodeOptions(options: options, session: session)
+        let pipeline: Document = []
 
-    //     try client.connectionPool.withConnection { conn in
-    //         try coll.withMongocCollection(from: conn) { collPtr in
-    //             let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
-    //             var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-    //             defer {
-    //                 replyPtr.deinitialize(count: 1)
-    //                 replyPtr.deallocate()
-    //             }
+        try client.connectionPool.withConnection { conn in
+            try coll.withMongocCollection(from: conn) { collPtr in
+                let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
+                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+                defer {
+                    replyPtr.deinitialize(count: 1)
+                    replyPtr.deallocate()
+                }
 
-    //             let decoder = BSONDecoder()
-    //             let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-    //                                                                                 client: client,
-    //                                                                                 session: session,
-    //                                                                                 decoder: decoder)
-    //             // expect the first iteration to be nil since no changes have been made to the collection.
-    //             expect(changeStream.next()).to(beNil())
+                let decoder = BSONDecoder()
+                let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                                    client: client,
+                                                                                    session: session,
+                                                                                    decoder: decoder)
+                // expect the first iteration to be nil since no changes have been made to the collection.
+                expect(changeStream.next()).to(beNil())
 
-    //             // test that the change stream contains a change document for the `insert` operation.
-    //             try coll.insertOne(["x": 1], session: session)
-    //             let res1 = changeStream.next()
-    //             expect(res1).toNot(beNil())
-    //             expect(res1?.operationType).to(equal(.insert))
-    //             expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
+                // test that the change stream contains a change document for the `insert` operation.
+                try coll.insertOne(["x": 1], session: session)
+                let res1 = changeStream.next()
+                expect(res1).toNot(beNil())
+                expect(res1?.operationType).to(equal(.insert))
+                expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
 
-    //             try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
-    //             let res2 = changeStream.next()
+                try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
+                let res2 = changeStream.next()
 
-    //             // test that the change stream contains a change document for the `update` operation.
-    //             expect(res2).toNot(beNil())
-    //             expect(res2?.operationType).to(equal(.update))
-    //             expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
+                // test that the change stream contains a change document for the `update` operation.
+                expect(res2).toNot(beNil())
+                expect(res2?.operationType).to(equal(.update))
+                expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
 
-    //             // test that the change stream contains a change document for the `find` operation.
-    //             try coll.findOneAndDelete(["x": 2], session: session)
-    //             let res3 = changeStream.next()
-    //             expect(res3).toNot(beNil())
-    //             expect(res3?.operationType).to(equal(.delete))
-    //         }
-    //     }
-    // }
+                // test that the change stream contains a change document for the `find` operation.
+                try coll.findOneAndDelete(["x": 2], session: session)
+                let res3 = changeStream.next()
+                expect(res3).toNot(beNil())
+                expect(res3?.operationType).to(equal(.delete))
+            }
+        }
+    }
 }

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -128,7 +128,6 @@ final class ChangeStreamTest: MongoSwiftTestCase {
 
         try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
         let res2 = changeStream.next()
-        //print("res: ", res2)
 
         // test that the change stream contains a change document for the `update` operation.
         expect(res2).toNot(beNil())

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -47,9 +47,13 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             return
         }
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 =======
 >>>>>>> Add topology check for change streams when not single
+=======
+
+>>>>>>> Skip tests for database.watch  when server is < 4.0
         let client = try MongoClient()
 
         if try client.serverVersion() < ServerVersion(major: 4, minor: 0) {

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -3,7 +3,7 @@ import mongoc
 import Nimble
 import XCTest
 
-final class ChangeStream: MongoSwiftTestCase {
+final class ChangeStreamTest: MongoSwiftTestCase {
     func testChangeStream() throws {
         let encoder = BSONEncoder()
         let client = try MongoClient()
@@ -15,7 +15,16 @@ final class ChangeStream: MongoSwiftTestCase {
         let pipeline: Document = []
 
         let changeStreamPtr = mongoc_collection_watch(coll._collection, pipeline._bson, opts?._bson)
+        var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+        defer {
+            replyPtr.deinitialize(count: 1)
+            replyPtr.deallocate()
+        }
+
+        var error = bson_error_t()
+        mongoc_cursor_error_document(changeStreamPtr, &error, replyPtr)
+        print(extractMongoError(error: error))
         let decoder = BSONDecoder()
-        expect(try ChangeStream(changeStreamPtr, client: client, session: session, decoder: decoder, withType: Document.self)).toNot(throwError())
+        //expect(try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr!, client: client, session: session, decoder: decoder)).toNot(throwError())
     }
 }

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -46,14 +46,6 @@ final class ChangeStreamTest: MongoSwiftTestCase {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-=======
->>>>>>> Add topology check for change streams when not single
-=======
-
->>>>>>> Skip tests for database.watch  when server is < 4.0
         let client = try MongoClient()
 
         if try client.serverVersion() < ServerVersion(major: 4, minor: 0) {
@@ -145,7 +137,11 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         // test that the change stream contains a change document for the `update` operation.
         expect(res2).toNot(beNil())
         expect(res2?.operationType).to(equal(.update))
+<<<<<<< HEAD
         expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
+=======
+        print("res: ", res2)
+>>>>>>> Update docstrings and use ChangeStreamToken for resumeAfter and startAfter
 
         // test that the change stream contains a change document for the `find` operation.
         try coll.findOneAndDelete(["x": 2], session: session)

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -4,6 +4,13 @@ import Nimble
 import XCTest
 
 final class ChangeStreamTest: MongoSwiftTestCase {
+    override func setUp() {
+        super.setUp()
+        guard MongoSwiftTestCase.topologyType != .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+    }
     func testChangeStream() throws {
         let decoder = BSONDecoder()
         let client = try MongoClient()

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -4,6 +4,13 @@ import Nimble
 import XCTest
 
 final class ChangeStreamTest: MongoSwiftTestCase {
+    override func setUp() {
+        super.setUp()
+        guard MongoSwiftTestCase.topologyType != .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+    }
     func testChangeStream() throws {
         guard MongoSwiftTestCase.topologyType != .single else {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -1,0 +1,21 @@
+import mongoc
+@testable import MongoSwift
+import Nimble
+import XCTest
+
+final class ChangeStream: MongoSwiftTestCase {
+    func testChangeStream() throws {
+        let encoder = BSONEncoder()
+        let client = try MongoClient()
+        let session = try client.startSession()
+        let db = client.db("myDb")
+        let coll = db.collection("myColl")
+        let options = ChangeStreamOptions()
+        let opts = try encodeOptions(options: options, session: session)
+        let pipeline: Document = []
+
+        let changeStreamPtr = mongoc_collection_watch(coll._collection, pipeline._bson, opts?._bson)
+        let decoder = BSONDecoder()
+        expect(try ChangeStream(changeStreamPtr, client: client, session: session, decoder: decoder, withType: Document.self)).toNot(throwError())
+    }
+}

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -4,14 +4,11 @@ import Nimble
 import XCTest
 
 final class ChangeStreamTest: MongoSwiftTestCase {
-    override func setUp() {
-        super.setUp()
+    func testChangeStream() throws {
         guard MongoSwiftTestCase.topologyType != .single else {
             print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
-    }
-    func testChangeStream() throws {
         let decoder = BSONDecoder()
         let client = try MongoClient()
 
@@ -37,6 +34,10 @@ final class ChangeStreamTest: MongoSwiftTestCase {
     }
 
     func testChangeStreamOnADatabase() throws {
+        guard MongoSwiftTestCase.topologyType != .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
         let client = try MongoClient()
 
         let db = client.db(type(of: self).testDatabase)
@@ -77,6 +78,10 @@ final class ChangeStreamTest: MongoSwiftTestCase {
     }
 
     func testChangeStreamOnACollection() throws {
+        guard MongoSwiftTestCase.topologyType != .single else {
+            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
         let client = try MongoClient()
 
         let db = client.db(type(of: self).testDatabase)

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -27,18 +27,22 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
-        // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
-        let changeStreamPtr: OpaquePointer = mongoc_database_watch(db._database, pipeline._bson, opts?._bson)
-        var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-        defer {
-            replyPtr.deinitialize(count: 1)
-            replyPtr.deallocate()
+        let connection = try client.connectionPool.withConnection { conn in
+            try db.withMongocDatabase(from: conn) { dbPtr in
+                // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
+                let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
+                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+                defer {
+                    replyPtr.deinitialize(count: 1)
+                    replyPtr.deallocate()
+                }
+                expect(try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                        client: client,
+                                                                        session: session,
+                                                                        decoder: decoder))
+                                                                        .toNot(throwError())
+            }
         }
-        expect(try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                client: client,
-                                                                session: session,
-                                                                decoder: decoder))
-                                                                .toNot(throwError())
     }
 
     func testChangeStreamOnADatabase() throws {
@@ -61,35 +65,39 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
-        // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
-        let changeStreamPtr: OpaquePointer = mongoc_database_watch(db._database, pipeline._bson, opts?._bson)
-        var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-        defer {
-            replyPtr.deinitialize(count: 1)
-            replyPtr.deallocate()
+        try client.connectionPool.withConnection { conn in
+            try db.withMongocDatabase(from: conn) { dbPtr in
+                // TODO: Use MongoDatabase.watch() instead `mongoc_database_watch` of once it gets added
+                let changeStreamPtr: OpaquePointer = mongoc_database_watch(dbPtr, pipeline._bson, opts?._bson)
+                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+                defer {
+                    replyPtr.deinitialize(count: 1)
+                    replyPtr.deallocate()
+                }
+
+                let decoder = BSONDecoder()
+                let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                                    client: client,
+                                                                                    decoder: decoder)
+                // expect the first iteration to be nil since no changes have been made to the database.
+                expect(changeStream.next()).to(beNil())
+
+                let coll = try db.collection(self.getCollectionName(suffix: "1"))
+                try coll.insertOne(["a": 1], session: session)
+
+                // test that the change stream contains a change document for the `insert` operation.
+                let res1 = changeStream.next()
+                expect(res1).toNot(beNil())
+                expect(res1?.operationType).to(equal(.insert))
+                expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
+
+                // test that the change stream contains a change document for the `drop` operation.
+                try db.drop()
+                let res2 = changeStream.next()
+                expect(res2).toNot(beNil())
+                expect(res2?.operationType).to(equal(.drop))
+            }
         }
-
-        let decoder = BSONDecoder()
-        let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                            client: client,
-                                                                            decoder: decoder)
-        // expect the first iteration to be nil since no changes have been made to the database.
-        expect(changeStream.next()).to(beNil())
-
-        let coll = try db.collection(self.getCollectionName(suffix: "1"))
-        try coll.insertOne(["a": 1], session: session)
-
-        // test that the change stream contains a change document for the `insert` operation.
-        let res1 = changeStream.next()
-        expect(res1).toNot(beNil())
-        expect(res1?.operationType).to(equal(.insert))
-        expect(res1?.fullDocument?["a"]).to(bsonEqual(1))
-
-        // test that the change stream contains a change document for the `drop` operation.
-        try db.drop()
-        let res2 = changeStream.next()
-        expect(res2).toNot(beNil())
-        expect(res2?.operationType).to(equal(.drop))
     }
 
     func testChangeStreamOnACollection() throws {
@@ -109,40 +117,44 @@ final class ChangeStreamTest: MongoSwiftTestCase {
         let opts = try encodeOptions(options: options, session: session)
         let pipeline: Document = []
 
-        let changeStreamPtr: OpaquePointer = mongoc_collection_watch(coll._collection, pipeline._bson, opts?._bson)
-        var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
-        defer {
-            replyPtr.deinitialize(count: 1)
-            replyPtr.deallocate()
+        try client.connectionPool.withConnection { conn in
+            try coll.withMongocCollection(from: conn) { collPtr in
+                let changeStreamPtr: OpaquePointer = mongoc_collection_watch(collPtr, pipeline._bson, opts?._bson)
+                var replyPtr = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
+                defer {
+                    replyPtr.deinitialize(count: 1)
+                    replyPtr.deallocate()
+                }
+
+                let decoder = BSONDecoder()
+                let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
+                                                                                    client: client,
+                                                                                    session: session,
+                                                                                    decoder: decoder)
+                // expect the first iteration to be nil since no changes have been made to the collection.
+                expect(changeStream.next()).to(beNil())
+
+                // test that the change stream contains a change document for the `insert` operation.
+                try coll.insertOne(["x": 1], session: session)
+                let res1 = changeStream.next()
+                expect(res1).toNot(beNil())
+                expect(res1?.operationType).to(equal(.insert))
+                expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
+
+                try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
+                let res2 = changeStream.next()
+
+                // test that the change stream contains a change document for the `update` operation.
+                expect(res2).toNot(beNil())
+                expect(res2?.operationType).to(equal(.update))
+                expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
+
+                // test that the change stream contains a change document for the `find` operation.
+                try coll.findOneAndDelete(["x": 2], session: session)
+                let res3 = changeStream.next()
+                expect(res3).toNot(beNil())
+                expect(res3?.operationType).to(equal(.delete))
+            }
         }
-
-       let decoder = BSONDecoder()
-       let changeStream = try ChangeStream<ChangeStreamDocument<Document>>(stealing: changeStreamPtr,
-                                                                           client: client,
-                                                                           session: session,
-                                                                           decoder: decoder)
-       // expect the first iteration to be nil since no changes have been made to the collection.
-        expect(changeStream.next()).to(beNil())
-
-        // test that the change stream contains a change document for the `insert` operation.
-        try coll.insertOne(["x": 1], session: session)
-        let res1 = changeStream.next()
-        expect(res1).toNot(beNil())
-        expect(res1?.operationType).to(equal(.insert))
-        expect(res1?.fullDocument?["x"]).to(bsonEqual(1))
-
-        try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2] as Document], session: session)
-        let res2 = changeStream.next()
-
-        // test that the change stream contains a change document for the `update` operation.
-        expect(res2).toNot(beNil())
-        expect(res2?.operationType).to(equal(.update))
-        expect(res2?.fullDocument?["x"]).to(bsonEqual(2))
-
-        // test that the change stream contains a change document for the `find` operation.
-        try coll.findOneAndDelete(["x": 2], session: session)
-        let res3 = changeStream.next()
-        expect(res3).toNot(beNil())
-        expect(res3?.operationType).to(equal(.delete))
     }
 }


### PR DESCRIPTION
This is the second PR for [ChangeStreams support](https://jira.mongodb.org/browse/SWIFT-176).
It adds:
* `MongoClient.watch`
* `MongoDatabase.watch`
* `MongoCollection.watch`

