### PR TITLE
SWIFT-535 Add APM assertions to change stream spec test runner

### DIFF
--- a/Tests/MongoSwiftTests/SpecTestRunner/Match.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/Match.swift
@@ -7,18 +7,23 @@ import Nimble
 /// https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
 internal protocol Matchable {
     /// Returns whether this MATCHES the expected value according to the function defined in the spec.
+    /// This assumes `expected` is NOT a placeholder value (i.e. 42/"42"). Use `matches` if `expected` may be a
+    /// placeholder.
     /// https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
-    func matches(expected: Any) -> Bool
+    func contentMatches(expected: Any) -> Bool
 }
 // swiftlint:enable line_length
 
+extension Matchable {
+    /// Returns whether this MATCHES the expected value according to the function defined in the spec.
+    internal func matches(expected: Any) -> Bool {
+        return isPlaceholder(expected) || self.contentMatches(expected: expected)
+    }
+}
+
 /// Extension that adds MATCHES functionality to `Array`.
 extension Array: Matchable {
-    internal func matches(expected: Any) -> Bool {
-        guard !isPlaceholder(expected) else {
-            return true
-        }
-
+    internal func contentMatches(expected: Any) -> Bool {
         guard let expected = expected as? [Any], expected.count <= self.count else {
             return false
         }
@@ -42,7 +47,7 @@ extension Array: Matchable {
 
 /// Extension that adds MATCHES functionality to `Document`.
 extension Document: Matchable {
-    internal func matches(expected: Any) -> Bool {
+    internal func contentMatches(expected: Any) -> Bool {
         guard !isPlaceholder(expected) else {
             return true
         }

--- a/Tests/MongoSwiftTests/SpecTestRunner/Match.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/Match.swift
@@ -2,11 +2,15 @@ import Foundation
 import MongoSwift
 import Nimble
 
+// swiftlint:disable line_length
 /// Protocol that allows a type to assert it matches a given value according to the specs' MATCHES function.
-/// See: https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
+/// https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
 internal protocol Matchable {
+    /// Returns whether this MATCHES the expected value according to the function defined in the spec.
+    /// https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
     func matches(expected: Any) -> Bool
 }
+// swiftlint:enable line_length
 
 /// Extension that adds MATCHES functionality to `Array`.
 extension Array: Matchable {
@@ -66,9 +70,11 @@ extension BSONValue {
     }
 }
 
+// swiftlint:disable line_length
 /// A Nimble matcher for the MATCHES function defined in the spec.
-/// See: https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
+/// https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
 internal func match(_ expectedValue: Any?) -> Predicate<Matchable> {
+    // switlint:enable line_length
     return Predicate.define("match <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
         switch (expectedValue, actualValue) {

--- a/Tests/MongoSwiftTests/SpecTestRunner/Match.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/Match.swift
@@ -74,7 +74,7 @@ extension BSONValue {
 /// A Nimble matcher for the MATCHES function defined in the spec.
 /// https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
 internal func match(_ expectedValue: Any?) -> Predicate<Matchable> {
-    // switlint:enable line_length
+    // swiftlint:enable line_length
     return Predicate.define("match <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
         switch (expectedValue, actualValue) {

--- a/Tests/MongoSwiftTests/SpecTestRunner/Match.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/Match.swift
@@ -1,0 +1,89 @@
+import Foundation
+import MongoSwift
+import Nimble
+
+/// Protocol that allows a type to assert it matches a given value according to the specs' MATCHES function.
+/// See: https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
+internal protocol Matchable {
+    func matches(expected: Any) -> Bool
+}
+
+/// Extension that adds MATCHES functionality to `Array`.
+extension Array: Matchable {
+    internal func matches(expected: Any) -> Bool {
+        guard !isPlaceholder(expected) else {
+            return true
+        }
+
+        guard let expected = expected as? [Any], expected.count <= self.count else {
+            return false
+        }
+
+        for (aV, eV) in zip(self, expected) {
+            if let matchable = aV as? Matchable {
+                guard matchable.matches(expected: eV) else {
+                    return false
+                }
+            } else if let actualBSON = aV as? BSONValue, let expectedBSON = eV as? BSONValue {
+                guard actualBSON.bsonMatches(expected: expectedBSON) else {
+                    return false
+                }
+            } else {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+/// Extension that adds MATCHES functionality to `Document`.
+extension Document: Matchable {
+    internal func matches(expected: Any) -> Bool {
+        guard !isPlaceholder(expected) else {
+            return true
+        }
+
+        guard let expected = expected as? Document else {
+            return false
+        }
+
+        for (eK, eV) in expected {
+            guard let aV = self[eK], aV.bsonMatches(expected: eV) else {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+/// Extension that adds MATCHES functionality to `BSONValue`.
+extension BSONValue {
+    internal func bsonMatches(expected: BSONValue) -> Bool {
+        if let matchable = self as? Matchable {
+            return matchable.matches(expected: expected)
+        }
+        return isPlaceholder(expected) || self.bsonEquals(expected)
+    }
+}
+
+/// A Nimble matcher for the MATCHES function defined in the spec.
+/// See: https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests#spec-test-match-function
+internal func match(_ expectedValue: Any?) -> Predicate<Matchable> {
+    return Predicate.define("match <\(stringify(expectedValue))>") { actualExpression, msg in
+        let actualValue = try actualExpression.evaluate()
+        switch (expectedValue, actualValue) {
+        case (nil, _?):
+            return PredicateResult(status: .fail, message: msg.appendedBeNilHint())
+        case (nil, nil), (_, nil):
+            return PredicateResult(status: .fail, message: msg)
+        case let (expected?, actual?):
+            let matches = actual.matches(expected: expected)
+            return PredicateResult(bool: matches, message: msg)
+        }
+    }
+}
+
+/// Determines if an expected value is considered a wildcard for the purposes of the MATCHES function.
+internal func isPlaceholder(_ expected: Any) -> Bool {
+    return (expected as? BSONNumber)?.intValue == 42 || expected as? String == "42"
+}

--- a/Tests/MongoSwiftTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/SpecTest.swift
@@ -33,11 +33,7 @@ internal struct TestCommandStartedEvent: Decodable, Matchable {
         self.databaseName = try eventContainer.decode(String.self, forKey: .databaseName)
     }
 
-    internal func matches(expected: Any) -> Bool {
-        guard !isPlaceholder(expected) else {
-            return true
-        }
-
+    internal func contentMatches(expected: Any) -> Bool {
         guard let expected = expected as? TestCommandStartedEvent else {
             return false
         }


### PR DESCRIPTION
This PR adds APM assertions to the change streams spec test runner. Most of the code changes actually revolve around adding support for the [MATCHES](https://github.com/mongodb/specifications/tree/master/source/change-streams/tests#spec-test-match-function) function to the runner, though.

For now, I only added logic for command started events since they're the only types of events expected here and in the other spec tests. The command monitoring tests _do_ expect other types of events, but those tests have a bunch of specific logic that I didn't think was appropriate to bring into our generic runner framework. Also, the command monitoring tests are already written, so it would just be making more work for ourselves to modify them to use a more generic system.