### PR TITLE
SWIFT-517 Return Connection to pool as soon as MongoCursor is exhausted

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -22,8 +22,8 @@ extension MongoCollection {
                      session: ClientSession? = nil) throws -> MongoCursor<CollectionType> {
         let opts = try encodeOptions(options: options, session: session)
         let rp = options?.readPreference?._readPreference
-
-        return try MongoCursor(client: self._client, decoder: self.decoder, session: session) { conn in
+        let isTailable = [.tailable, .tailableAwait].contains(options?.cursorType)
+        return try MongoCursor(client: self._client, decoder: self.decoder, session: session, isTailable: isTailable) { conn in
             self.withMongocCollection(from: conn) { collPtr in
                 guard let cursor = mongoc_collection_find_with_opts(collPtr, filter._bson, opts?._bson, rp) else {
                     fatalError(failedToRetrieveCursorMessage)

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -22,11 +22,10 @@ extension MongoCollection {
                      session: ClientSession? = nil) throws -> MongoCursor<CollectionType> {
         let opts = try encodeOptions(options: options, session: session)
         let rp = options?.readPreference?._readPreference
-        let isTailable = [.tailable, .tailableAwait].contains(options?.cursorType)
         return try MongoCursor(client: self._client,
                                decoder: self.decoder,
                                session: session,
-                               isTailable: isTailable) { conn in
+                               cursorType: options?.cursorType) { conn in
             self.withMongocCollection(from: conn) { collPtr in
                 guard let cursor = mongoc_collection_find_with_opts(collPtr, filter._bson, opts?._bson, rp) else {
                     fatalError(failedToRetrieveCursorMessage)
@@ -289,6 +288,10 @@ public enum CursorType {
      * - SeeAlso: https://docs.mongodb.com/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
      */
     case tailableAwait
+
+    internal var isTailable: Bool {
+        return self != .nonTailable
+    }
 }
 
 /// Options to use when executing a `find` command on a `MongoCollection`.

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -23,7 +23,10 @@ extension MongoCollection {
         let opts = try encodeOptions(options: options, session: session)
         let rp = options?.readPreference?._readPreference
         let isTailable = [.tailable, .tailableAwait].contains(options?.cursorType)
-        return try MongoCursor(client: self._client, decoder: self.decoder, session: session, isTailable: isTailable) { conn in
+        return try MongoCursor(client: self._client,
+                               decoder: self.decoder,
+                               session: session,
+                               isTailable: isTailable) { conn in
             self.withMongocCollection(from: conn) { collPtr in
                 guard let cursor = mongoc_collection_find_with_opts(collPtr, filter._bson, opts?._bson, rp) else {
                     fatalError(failedToRetrieveCursorMessage)

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -144,8 +144,9 @@ public class MongoCursor<T: Codable>: Sequence, IteratorProtocol {
         return extractMongoError(error: error)
     }
 
-    /// Returns the next `Document` in this cursor, or nil. Once this function returns `nil`, the caller should use
-    /// the `.error` property to check for errors.
+    /// Returns the next `Document` in this cursor, or `nil`. After this function returns `nil`, the caller should use
+    /// the `.error` property to check for errors. For tailable cursors, users should also check `isAlive` after this
+    /// method returns `nil`, to determine if the cursor has the potential to return any more data in the future.
     public func next() -> T? {
         // We already closed the mongoc cursor, either because we reached the end or encountered an error.
         guard case let .open(cursor, conn, _, session) = self.state else {

--- a/Sources/MongoSwift/Operations/NextOperation.swift
+++ b/Sources/MongoSwift/Operations/NextOperation.swift
@@ -17,8 +17,10 @@ internal struct NextOperation<T: Codable>: Operation {
             throw ClientSession.SessionInactiveError
         }
 
+        // We already check this in `MongoCursor.next()` in order to extract the relevant connection and session,
+        // but error again here just in case.
         guard case let .open(cursorPtr, _, _, _) = cursor.state else {
-            return nil
+            throw ClosedCursorError
         }
 
         let out = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)

--- a/Sources/MongoSwift/Operations/NextOperation.swift
+++ b/Sources/MongoSwift/Operations/NextOperation.swift
@@ -17,12 +17,16 @@ internal struct NextOperation<T: Codable>: Operation {
             throw ClientSession.SessionInactiveError
         }
 
+        guard case let .open(cursorPtr, _, _, _) = cursor.state else {
+            return nil
+        }
+
         let out = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)
         defer {
             out.deinitialize(count: 1)
             out.deallocate()
         }
-        guard mongoc_cursor_next(cursor._cursor, out) else {
+        guard mongoc_cursor_next(cursorPtr, out) else {
             return nil
         }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -218,6 +218,13 @@ extension MongoCollection_IndexTests {
     ]
 }
 
+extension MongoCursorTests {
+    static var allTests = [
+        ("testNonTailableCursor", testNonTailableCursor),
+        ("testTailableCursor", testTailableCursor),
+    ]
+}
+
 extension MongoDatabaseTests {
     static var allTests = [
         ("testMongoDatabase", testMongoDatabase),
@@ -283,6 +290,7 @@ XCTMain([
     testCase(MongoCollectionTests.allTests),
     testCase(MongoCollection_BulkWriteTests.allTests),
     testCase(MongoCollection_IndexTests.allTests),
+    testCase(MongoCursorTests.allTests),
     testCase(MongoDatabaseTests.allTests),
     testCase(ReadPreferenceTests.allTests),
     testCase(ReadWriteConcernTests.allTests),

--- a/Tests/MongoSwiftTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftTests/MongoCursorTests.swift
@@ -46,9 +46,9 @@ final class MongoCursorTests: MongoSwiftTestCase {
             // run killCursors so next iteration fails on the server
             try db.runCommand(["killCursors": coll.name, "cursors": [cursor.id]])
             let expectedError2 = ServerError.commandError(code: 43,
-                                                         codeName: "CursorNotFound",
-                                                         message: "",
-                                                         errorLabels: nil)
+                                                          codeName: "CursorNotFound",
+                                                          message: "",
+                                                          errorLabels: nil)
             expect(try cursor.nextOrError()).to(throwError(expectedError2))
             // cursor should be closed now that it errored
             expect(cursor.isAlive).to(beFalse())

--- a/Tests/MongoSwiftTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftTests/MongoCursorTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+@testable import MongoSwift
+import Nimble
+import XCTest
+
+private let doc1: Document = ["_id": 1, "x": 1]
+private let doc2: Document = ["_id": 2, "x": 2]
+private let doc3: Document = ["_id": 3, "x": 3]
+private let logicError = UserError.logicError(message: "")
+
+final class MongoCursorTests: MongoSwiftTestCase {
+    func testNonTailableCursor() throws {
+        try self.withTestNamespace { _, db, coll in
+            // query empty collection
+            var cursor = try coll.find()
+            expect(try cursor.nextOrError()).toNot(throwError())
+            // cursor should immediately be closed as its empty
+            expect(cursor.isAlive).to(beFalse())
+            // iterating dead cursor should error
+            expect(try cursor.nextOrError()).to(throwError(logicError))
+
+            // insert and read out one document
+            try coll.insertOne(doc1)
+            cursor = try coll.find()
+            var results = Array(cursor)
+            expect(results).to(haveCount(1))
+            expect(results[0]).to(equal(doc1))
+            // cursor should be closed now that its exhausted
+            expect(cursor.isAlive).to(beFalse())
+            // iterating dead cursor should error
+            expect(try cursor.nextOrError()).to(throwError())
+
+            try coll.insertMany([doc2, doc3])
+            cursor = try coll.find()
+            results = Array(cursor)
+            expect(results).to(haveCount(3))
+            expect(results).to(equal([doc1, doc2, doc3]))
+            // cursor should be closed now that its exhausted
+            expect(cursor.isAlive).to(beFalse())
+            // iterating dead cursor should error
+            expect(try cursor.nextOrError()).to(throwError(logicError))
+
+            cursor = try coll.find(options: FindOptions(batchSize: 1))
+            expect(try cursor.nextOrError()).toNot(throwError())
+
+            // run killCursors so next iteration fails on the server
+            try db.runCommand(["killCursors": coll.name, "cursors": [cursor.id]])
+            let expectedError2 = ServerError.commandError(code: 43,
+                                                         codeName: "CursorNotFound",
+                                                         message: "",
+                                                         errorLabels: nil)
+            expect(try cursor.nextOrError()).to(throwError(expectedError2))
+            // cursor should be closed now that it errored
+            expect(cursor.isAlive).to(beFalse())
+        }
+    }
+
+    func testTailableCursor() throws {
+        let collOptions = CreateCollectionOptions(capped: true, max: 3, size: 1000)
+        try self.withTestNamespace(collectionOptions: collOptions) { _, _, coll in
+            let cursorOpts = FindOptions(cursorType: .tailable)
+
+            var cursor = try coll.find(options: cursorOpts)
+            expect(try cursor.nextOrError()).to(beNil())
+            // no documents matched initial query, so cursor is dead
+            expect(cursor.isAlive).to(beFalse())
+            // iterating iterating dead cursor should error
+            expect(try cursor.nextOrError()).to(throwError(logicError))
+
+            // insert a doc so something matches initial query
+            try coll.insertOne(doc1)
+            cursor = try coll.find(options: cursorOpts)
+
+            // for each doc we insert, check that it arrives in the cursor next,
+            // and that the cursor is still alive afterward
+            let checkNextResult: (Document) -> Void = { doc in
+                let results = Array(cursor)
+                expect(results).to(haveCount(1))
+                expect(results[0]).to(equal(doc))
+                expect(cursor.error).to(beNil())
+                expect(cursor.isAlive).to(beTrue())
+            }
+            checkNextResult(doc1)
+
+            try coll.insertOne(doc2)
+            checkNextResult(doc2)
+
+            try coll.insertOne(doc3)
+            checkNextResult(doc3)
+
+            // no more docs, but should still be alive
+            expect(try cursor.nextOrError()).to(beNil())
+            expect(cursor.isAlive).to(beTrue())
+
+            // insert 3 docs so the cursor loses track of its position
+            for i in 4..<7 {
+                try coll.insertOne(["_id": i, "x": i])
+            }
+
+            let expectedError = ServerError.commandError(code: 136,
+                                                         codeName: "CappedPositionLost",
+                                                         message: "",
+                                                         errorLabels: nil)
+            expect(try cursor.nextOrError()).to(throwError(expectedError))
+            // cursor should be closed now that it errored
+            expect(cursor.isAlive).to(beFalse())
+
+            // iterating dead cursor should error
+            expect(try cursor.nextOrError()).to(throwError(logicError))
+        }
+    }
+}


### PR DESCRIPTION
This PR implements [SWIFT-517](https://jira.mongodb.org/browse/SWIFT-517) and adds some tests around tailable and non-tailable cursor behavior.