### PR TITLE
SWIFT-608 Implement index enumeration spec

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -364,6 +364,11 @@ extension MongoCollection {
     public func listIndexNames(session: ClientSession? = nil) throws -> [String] {
         let operation = ListIndexesOperation(collection: self)
         let models = try self._client.executeOperation(operation, session: session)
-        return models.map { $0.options?.name ?? $0.defaultName }
+        return try models.map { model in
+            guard let name = model.options?.name else {
+                throw RuntimeError.internalError(message: "Server response missing a 'name' field")
+            }
+            return name
+        }
     }
 }

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -21,13 +21,13 @@ public struct IndexModel: Codable {
 
     // Encode own data as well as nested options data
     private enum CodingKeys: String, CodingKey {
-        case key, name
+        case key
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(keys, forKey: .key)
-        try container.encode(self.options?.name ?? self.defaultName, forKey: .name)
+        try self.options?.encode(to: encoder)
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -5,24 +5,12 @@ public struct IndexModel: Codable {
     /// Contains the required keys for the index.
     public let keys: Document
 
-    /// Contains the name of the index.
-    public let name: String?
-
-    /// Contains the version of the index that lives on the server.
-    public let v: Int?
-
-    /// Contains the namespace of the index.
-    public let ns: String?
-
     /// Contains the options for the index.
     public let options: IndexOptions?
 
     /// Convenience initializer providing a default `options` value
-    public init(keys: Document, name: String? = nil, v: Int? = nil, ns: String? = nil, options: IndexOptions? = nil) {
+    public init(keys: Document, options: IndexOptions? = nil) {
         self.keys = keys
-        self.name = name
-        self.v = v
-        self.ns = ns
         self.options = options
     }
 
@@ -33,28 +21,18 @@ public struct IndexModel: Codable {
 
     // Encode own data as well as nested options data
     private enum CodingKeys: String, CodingKey {
-        case key, name, v, ns, options
-    }
-
-    // Encode nested options data
-    private enum OptionsKeys: String, CodingKey {
-        case background, expireAfterSeconds, sparse, storageEngine, unique, indexVersion = "v",
-            defaultLanguage = "default_language", languageOverride = "language_override", textIndexVersion, weights,
-            sphereIndexVersion = "2dsphereIndexVersion", bits, max, min, bucketSize, partialFilterExpression, collation
+        case key, name
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(keys, forKey: .key)
-        try container.encode(self.name ?? self.options?.name ?? self.defaultName, forKey: .name)
+        try container.encode(self.options?.name ?? self.defaultName, forKey: .name)
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         self.keys = try values.decode(Document.self, forKey: .key)
-        self.name = try values.decode(String.self, forKey: .name)
-        self.v = try values.decode(Int.self, forKey: .v)
-        self.ns = try values.decode(String.self, forKey: .ns)
         self.options = try IndexOptions(from: decoder)
     }
 }
@@ -89,7 +67,7 @@ public struct IndexOptions: Codable {
     public var unique: Bool?
 
     /// Optionally specifies the index version number, either 0 or 1.
-    public var indexVersion: Int32?
+    public var version: Int32?
 
     /// Optionally specifies the default language for text indexes. Is 'english' if none is provided.
     public var defaultLanguage: String?
@@ -128,6 +106,9 @@ public struct IndexOptions: Codable {
     /// is sent and the default collation of the collection server-side is used.
     public var collation: Document?
 
+    /// Optionally specifies the namespace of the index.
+    public var ns: String?
+
     /// Convenience initializer allowing any/all parameters to be omitted.
     public init(background: Bool? = nil,
                 expireAfterSeconds: Int32? = nil,
@@ -135,7 +116,7 @@ public struct IndexOptions: Codable {
                 sparse: Bool? = nil,
                 storageEngine: Document? = nil,
                 unique: Bool? = nil,
-                indexVersion: Int32? = nil,
+                version: Int32? = nil,
                 defaultLanguage: String? = nil,
                 languageOverride: String? = nil,
                 textIndexVersion: Int32? = nil,
@@ -146,14 +127,15 @@ public struct IndexOptions: Codable {
                 min: Double? = nil,
                 bucketSize: Int32? = nil,
                 partialFilterExpression: Document? = nil,
-                collation: Document? = nil) {
+                collation: Document? = nil,
+                ns: String? = nil) {
         self.background = background
         self.expireAfterSeconds = expireAfterSeconds
         self.name = name
         self.sparse = sparse
         self.storageEngine = storageEngine
         self.unique = unique
-        self.indexVersion = indexVersion
+        self.version = version
         self.defaultLanguage = defaultLanguage
         self.languageOverride = languageOverride
         self.textIndexVersion = textIndexVersion
@@ -165,13 +147,15 @@ public struct IndexOptions: Codable {
         self.bucketSize = bucketSize
         self.partialFilterExpression = partialFilterExpression
         self.collation = collation
+        self.ns = ns
     }
 
-    // Encode everything besides the name, as we will handle that when encoding the `IndexModel`
+    // The `name` key is encoded in `IndexModel` but needed here for decoding
     private enum CodingKeys: String, CodingKey {
-        case background, expireAfterSeconds, sparse, storageEngine, unique, indexVersion = "v",
+        case background, expireAfterSeconds, name, sparse, storageEngine, unique, version = "v",
             defaultLanguage = "default_language", languageOverride = "language_override", textIndexVersion, weights,
-            sphereIndexVersion = "2dsphereIndexVersion", bits, max, min, bucketSize, partialFilterExpression, collation
+            sphereIndexVersion = "2dsphereIndexVersion", bits, max, min, bucketSize, partialFilterExpression,
+            collation, ns
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -1,33 +1,67 @@
 import mongoc
 
+// /// A struct representing an index on a `MongoCollection`.
+// public struct IndexModel: Codable {
+//     /// Contains the required keys for the index.
+//     public let keys: Document
+
+//     /// Contains the options for the index.
+//     public let options: IndexOptions?
+
+//     // /// Contains the version of the index.
+//     // public let v: Int32?
+
+//     // /// Contains the default name of the index.
+//     // public let name: String?
+
+//     // /// Contains the namespace of the index.
+//     // public let ns: String?
+
+//     /// Convenience initializer providing a default `options`, `v`, `name` and `ns` value.
+//     // public init(keys: Document,
+//     //             options: IndexOptions? = nil,
+//     //             v: Int32? = nil,
+//     //             name: String? = nil,
+//     //             ns: String? = nil) {
+//     public init(keys: Document, options: IndexOptions? = nil) {
+//         self.keys = keys
+//         self.options = options
+//         // self.v = v
+//         // self.name = name
+//         // self.ns = ns
+//     }
+
+//     /// Gets the default name for this index.
+//     internal var defaultName: String {
+//         return self.keys.map { k, v in "\(k)_\(v)" }.joined(separator: "_")
+//     }
+
+//     // Encode own data as well as nested options data.
+//     private enum CodingKeys: String, CodingKey {
+//         case key, options
+//         // case keys, options, name, v, ns
+//     }
+
+//     public func encode(to encoder: Encoder) throws {
+//         var container = encoder.container(keyedBy: CodingKeys.self)
+//         try container.encode(keys, forKey: .key)
+//         // try container.encode(keys, forKey: .keys)
+//         try container.encode(self.options?.name ?? self.defaultName, forKey: .name)
+//     }
+
+
 /// A struct representing an index on a `MongoCollection`.
-public struct IndexModel: Codable {
+public struct IndexModel: Encodable {
     /// Contains the required keys for the index.
     public let keys: Document
 
     /// Contains the options for the index.
     public let options: IndexOptions?
 
-    /// Contains the version of the index.
-    public let v: Int32?
-
-    /// Contains the default name of the index.
-    public let name: String?
-
-    /// Contains the namespace of the index.
-    public let ns: String?
-
-    /// Convenience initializer providing a default `options`, `v`, `name` and `ns` value.
-    public init(keys: Document,
-                options: IndexOptions? = nil,
-                v: Int32? = nil,
-                name: String? = nil,
-                ns: String? = nil) {
+    /// Convenience initializer providing a default `options` value
+    public init(keys: Document, options: IndexOptions? = nil) {
         self.keys = keys
         self.options = options
-        self.v = v
-        self.name = name
-        self.ns = ns
     }
 
     /// Gets the default name for this index.
@@ -35,27 +69,30 @@ public struct IndexModel: Codable {
         return self.keys.map { k, v in "\(k)_\(v)" }.joined(separator: "_")
     }
 
-    // Encode own data as well as nested options data.
+    // Encode own data as well as nested options data
     private enum CodingKeys: String, CodingKey {
-        case keys, options, name, v, ns
+        case key, name
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(keys, forKey: .keys)
+        try container.encode(keys, forKey: .key)
         try container.encode(self.options?.name ?? self.defaultName, forKey: .name)
     }
-
-    /// Initializer to conform to Decodable protocol.
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        keys = try values.decode(Document.self, forKey: .keys)
-        options = try values.decode(IndexOptions.self, forKey: .options)
-        name = try values.decode(String.self, forKey: .name)
-        v = try values.decode(Int32.self, forKey: .v)
-        ns = try values.decode(String.self, forKey: .ns)
-    }
 }
+
+
+
+    // /// Initializer to conform to Decodable protocol.
+    // public init(from decoder: Decoder) throws {
+    //     let values = try decoder.container(keyedBy: CodingKeys.self)
+    //     keys = try values.decode(Document.self, forKey: .keys)
+    //     options = try values.decode(IndexOptions.self, forKey: .options)
+    //     name = try values.decode(String.self, forKey: .name)
+    //     v = try values.decode(Int32.self, forKey: .v)
+    //     ns = try values.decode(String.self, forKey: .ns)
+    // }
+// }
 
 /// Options to use when creating an index for a collection.
 public struct IndexOptions: Codable {

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -145,7 +145,6 @@ public struct IndexOptions: Codable {
         self.collation = collation
     }
 
-    // The `name` key is encoded in `IndexModel` but needed here for decoding
     private enum CodingKeys: String, CodingKey {
         case background, expireAfterSeconds, name, sparse, storageEngine, unique, version = "v",
             defaultLanguage = "default_language", languageOverride = "language_override", textIndexVersion, weights,

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -51,7 +51,6 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
         guard success else {
             throw extractMongoError(error: error, reply: reply)
         }
-
         return self.models.map { $0.options?.name ?? $0.defaultName }
     }
 }

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -31,8 +31,8 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
         var indexData = [Document]()
         for index in self.models {
             var indexDoc = try self.collection.encoder.encode(index)
-            if let opts = try self.collection.encoder.encode(index.options) {
-                try indexDoc.merge(opts)
+            if indexDoc["name"] == nil {
+                indexDoc["name"] = index.defaultName
             }
             indexData.append(indexDoc)
         }

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -30,13 +30,6 @@ internal struct ListIndexesOperation<T: Codable>: Operation {
                 return indexes
             }
         }
-        let toPrint: MongoCursor<Document> = try MongoCursor(client: self.collection._client,
-                                                                decoder: self.collection.decoder,
-                                                                session: session,
-                                                                initializer: initializer)
-        print("here is the original document:")
-        toPrint.map { print($0) }
-
         if self.nameOnly {
             let cursor: MongoCursor<Document> = try MongoCursor(client: self.collection._client,
                                                                 decoder: self.collection.decoder,

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -1,6 +1,6 @@
 import mongoc
 
-/// An operation corresponding to a listIndex command on a collection.
+/// An operation corresponding to a listIndexes command on a collection.
 internal struct ListIndexesOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
 
@@ -9,7 +9,7 @@ internal struct ListIndexesOperation<T: Codable>: Operation {
     }
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> MongoCursor<IndexModel> {
-        let opts = try encodeOptions(options: Document(), session: session)
+        let opts = try encodeOptions(options: nil as Document?, session: session)
 
         return try MongoCursor(client: self.collection._client,
                                decoder: self.collection.decoder,

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -35,7 +35,12 @@ internal struct ListIndexesOperation<T: Codable>: Operation {
                                                                 decoder: self.collection.decoder,
                                                                 session: session,
                                                                 initializer: initializer)
-            return .names(cursor.map { $0["name"] as? String ?? "" })
+            return try .names(cursor.map {
+                guard let name = $0["name"] as? String else {
+                    throw RuntimeError.internalError(message: "Invalid server response: collection has no name")
+                }
+                return name
+            })
         }
         let cursor: MongoCursor<IndexModel> = try MongoCursor(client: self.collection._client,
                                                               decoder: self.collection.decoder,

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -1,0 +1,47 @@
+import mongoc
+
+/// Internal intermediate result of a ListIndexes command.
+internal enum ListIndexesResults {
+    /// Includes the name, namespace, version, keys, and options of each index.
+    case specs(MongoCursor<IndexModel>)
+
+    /// Only includes the names.
+    case names([String])
+}
+
+/// An operation corresponding to a listIndex command on a collection.
+internal struct ListIndexesOperation: Operation {
+    private let collection: MongoCollection<Document>
+    private let nameOnly: Bool?
+
+    internal init(collection: MongoCollection<Document>, nameOnly: Bool?) {
+        self.collection = collection
+        self.nameOnly = nameOnly
+    }
+
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> ListIndexesResults {
+        let opts = try encodeOptions(options: Document(), session: session)
+
+        let initializer = { (conn: Connection) -> OpaquePointer in
+            self.collection.withMongocCollection(from: conn) { collPtr in
+                guard let indexes = mongoc_collection_find_indexes_with_opts(collPtr, opts?._bson) else {
+                    fatalError(failedToRetrieveCursorMessage)
+                }
+                return indexes
+            }
+        }
+
+        if self.nameOnly ?? false {
+            let cursor: MongoCursor<Document> = try MongoCursor(client: self.collection._client, 
+                                                                decoder: self.collection.decoder,
+                                                                session: session,
+                                                                initializer: initializer)
+            return .names(cursor.map { $0["name"] as? String ?? "" })
+        }
+        let cursor: MongoCursor<IndexModel> = try MongoCursor<Document>(client: self.collection_client,
+                                                                        decoder: self.collection.decoder,
+                                                                        session: session,
+                                                                        initializer: initializer)
+        return .specs(cursor)
+    }
+}

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -37,7 +37,7 @@ internal struct ListIndexesOperation<T: Codable>: Operation {
                                                                 initializer: initializer)
             return try .names(cursor.map {
                 guard let name = $0["name"] as? String else {
-                    throw RuntimeError.internalError(message: "Invalid server response: collection has no name")
+                    throw RuntimeError.internalError(message: "Invalid server response: index has no name")
                 }
                 return name
             })

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -10,11 +10,11 @@ internal enum ListIndexesResults {
 }
 
 /// An operation corresponding to a listIndex command on a collection.
-internal struct ListIndexesOperation: Operation {
-    private let collection: MongoCollection<Document>
+internal struct ListIndexesOperation<T: Codable>: Operation {
+    private let collection: MongoCollection<T>
     private let nameOnly: Bool?
 
-    internal init(collection: MongoCollection<Document>, nameOnly: Bool?) {
+    internal init(collection: MongoCollection<T>, nameOnly: Bool?) {
         self.collection = collection
         self.nameOnly = nameOnly
     }
@@ -32,16 +32,16 @@ internal struct ListIndexesOperation: Operation {
         }
 
         if self.nameOnly ?? false {
-            let cursor: MongoCursor<Document> = try MongoCursor(client: self.collection._client, 
+            let cursor: MongoCursor<Document> = try MongoCursor(client: self.collection._client,
                                                                 decoder: self.collection.decoder,
                                                                 session: session,
                                                                 initializer: initializer)
             return .names(cursor.map { $0["name"] as? String ?? "" })
         }
-        let cursor: MongoCursor<IndexModel> = try MongoCursor<Document>(client: self.collection_client,
-                                                                        decoder: self.collection.decoder,
-                                                                        session: session,
-                                                                        initializer: initializer)
+        let cursor: MongoCursor<IndexModel> = try MongoCursor(client: self.collection._client,
+                                                              decoder: self.collection.decoder,
+                                                              session: session,
+                                                              initializer: initializer)
         return .specs(cursor)
     }
 }

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -12,9 +12,9 @@ internal enum ListIndexesResults {
 /// An operation corresponding to a listIndex command on a collection.
 internal struct ListIndexesOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
-    private let nameOnly: Bool?
+    private let nameOnly: Bool
 
-    internal init(collection: MongoCollection<T>, nameOnly: Bool?) {
+    internal init(collection: MongoCollection<T>, nameOnly: Bool) {
         self.collection = collection
         self.nameOnly = nameOnly
     }
@@ -30,8 +30,14 @@ internal struct ListIndexesOperation<T: Codable>: Operation {
                 return indexes
             }
         }
+        let toPrint: MongoCursor<Document> = try MongoCursor(client: self.collection._client,
+                                                                decoder: self.collection.decoder,
+                                                                session: session,
+                                                                initializer: initializer)
+        print("here is the original document:")
+        toPrint.map { print($0) }
 
-        if self.nameOnly ?? false {
+        if self.nameOnly {
             let cursor: MongoCursor<Document> = try MongoCursor(client: self.collection._client,
                                                                 decoder: self.collection.decoder,
                                                                 session: session,

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -1,28 +1,19 @@
 import mongoc
 
-/// Internal intermediate result of a ListIndexes command.
-internal enum ListIndexesResults {
-    /// Includes the name, namespace, version, keys, and options of each index.
-    case specs(MongoCursor<IndexModel>)
-
-    /// Only includes the names.
-    case names([String])
-}
-
 /// An operation corresponding to a listIndex command on a collection.
 internal struct ListIndexesOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
-    private let nameOnly: Bool
 
-    internal init(collection: MongoCollection<T>, nameOnly: Bool) {
+    internal init(collection: MongoCollection<T>) {
         self.collection = collection
-        self.nameOnly = nameOnly
     }
 
-    internal func execute(using connection: Connection, session: ClientSession?) throws -> ListIndexesResults {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> MongoCursor<IndexModel> {
         let opts = try encodeOptions(options: Document(), session: session)
 
-        let initializer = { (conn: Connection) -> OpaquePointer in
+        return try MongoCursor(client: self.collection._client,
+                               decoder: self.collection.decoder,
+                               session: session) { conn in
             self.collection.withMongocCollection(from: conn) { collPtr in
                 guard let indexes = mongoc_collection_find_indexes_with_opts(collPtr, opts?._bson) else {
                     fatalError(failedToRetrieveCursorMessage)
@@ -30,22 +21,5 @@ internal struct ListIndexesOperation<T: Codable>: Operation {
                 return indexes
             }
         }
-        if self.nameOnly {
-            let cursor: MongoCursor<Document> = try MongoCursor(client: self.collection._client,
-                                                                decoder: self.collection.decoder,
-                                                                session: session,
-                                                                initializer: initializer)
-            return try .names(cursor.map {
-                guard let name = $0["name"] as? String else {
-                    throw RuntimeError.internalError(message: "Invalid server response: index has no name")
-                }
-                return name
-            })
-        }
-        let cursor: MongoCursor<IndexModel> = try MongoCursor(client: self.collection._client,
-                                                              decoder: self.collection.decoder,
-                                                              session: session,
-                                                              initializer: initializer)
-        return .specs(cursor)
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 
@@ -205,7 +205,7 @@ extension MongoCollection_IndexTests {
         ("testDropIndexByModel", testDropIndexByModel),
         ("testDropIndexByKeys", testDropIndexByKeys),
         ("testDropAllIndexes", testDropAllIndexes),
-        ("testListIndexes", testListIndexes),
+        ("testListIndexNames", testListIndexNames),
         ("testCreateDropIndexByModelWithMaxTimeMS", testCreateDropIndexByModelWithMaxTimeMS),
     ]
 }

--- a/Tests/MongoSwiftTests/CodecTests.swift
+++ b/Tests/MongoSwiftTests/CodecTests.swift
@@ -878,7 +878,7 @@ final class CodecTests: MongoSwiftTestCase {
                 sparse: false,
                 storageEngine: ["a": 1],
                 unique: true,
-                indexVersion: 123,
+                version: 123,
                 defaultLanguage: "english",
                 languageOverride: "asdf",
                 textIndexVersion: 123,
@@ -905,6 +905,7 @@ final class CodecTests: MongoSwiftTestCase {
             "bits",
             "max",
             "min",
+            "name",
             "bucketSize",
             "partialFilterExpression",
             "collation"

--- a/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
@@ -79,9 +79,13 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             return
         }
 
-        // guard _client.serverVersion() < ServerVersion("4.3.0") else {
-        //     print("Skipping test, fails with latest server version because of missing ns field")
-        // }
+        let sv = try _client?.serverVersion() ?? ServerVersion("8000")
+        guard try sv < ServerVersion("4.3.0") else {
+            print("Skipping test, fails with latest server version because of missing ns field")
+            return
+        }
+
+        let nsString = MongoSwiftTestCase.isMacOS ? "test.MongoCollection_IndexTests_testIndexOptions" : "test.MongoCollection_IndexTests.testIndexOptions"
 
         let options = IndexOptions(
             background: true,
@@ -100,15 +104,13 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             min: 0,
             bucketSize: 10,
             collation: ["locale": "fr"],
-            ns: "test.MongoCollection_IndexTests_testIndexOptions"
+            ns: nsString
         )
 
         let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)
         expect(try self.coll.createIndex(model)).to(equal("testOptions"))
 
-        let ttlOptions = IndexOptions(expireAfterSeconds: 100,
-                                      name: "ttl",
-                                      ns: "test.MongoCollection_IndexTests_testIndexOptions")
+        let ttlOptions = IndexOptions(expireAfterSeconds: 100, name: "ttl", ns: nsString)
         let ttlModel = IndexModel(keys: ["cat": 1], options: ttlOptions)
         expect(try self.coll.createIndex(ttlModel)).to(equal("ttl"))
 
@@ -117,9 +119,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         expect(indexOptions).to(haveCount(3))
 
         // _id index
-        expect(indexOptions[0]).to(equal(IndexOptions(name: "_id_",
-                                                      version: 2,
-                                                      ns: "test.MongoCollection_IndexTests_testIndexOptions")))
+        expect(indexOptions[0]).to(equal(IndexOptions(name: "_id_", version: 2, ns: nsString)))
 
         // testOptions index
         var expectedTestOptions = options

--- a/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
@@ -95,16 +95,12 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             max: 30,
             min: 0,
             bucketSize: 10,
-            collation: ["locale": "fr"],
-            ns: "test.MongoCollection_IndexTests_testIndexOptions"
-        )
+            collation: ["locale": "fr"])
 
         let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)
         expect(try self.coll.createIndex(model)).to(equal("testOptions"))
 
-        let ttlOptions = IndexOptions(expireAfterSeconds: 100,
-                                      name: "ttl",
-                                      ns: "test.MongoCollection_IndexTests_testIndexOptions")
+        let ttlOptions = IndexOptions(expireAfterSeconds: 100, name: "ttl")
         let ttlModel = IndexModel(keys: ["cat": 1], options: ttlOptions)
         expect(try self.coll.createIndex(ttlModel)).to(equal("ttl"))
 
@@ -113,9 +109,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         expect(indexOptions).to(haveCount(3))
 
         // _id index
-        expect(indexOptions[0]).to(equal(IndexOptions(name: "_id_",
-                                                      version: 2,
-                                                      ns: "test.MongoCollection_IndexTests_testIndexOptions")))
+        expect(indexOptions[0]).to(equal(IndexOptions(name: "_id_", version: 2)))
 
         // testOptions index
         var expectedTestOptions = options

--- a/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
@@ -65,202 +65,210 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
     func testCreateIndexFromModel() throws {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
-        let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
-        expect(indexes.next()).to(beNil())
+        var indexes = try Array(coll.listIndexes()) as [IndexModel]
+        indexes.sort { $0.defaultName < $1.defaultName }
+
+        print("HERE")
+        indexes.map { print($0.defaultName) }
+        print("DONE")
+
+        expect(indexes).to(haveCount(2))
+        expect(indexes[0].name).to(equal("_id_"))
+        expect(indexes[1].name).to(equal("cat_1"))
+        // expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
+        // expect(indexes.next()).to(beNil())
     }
 
-    func testIndexOptions() throws {
-        // TODO SWIFT-539: unskip
-        if MongoSwiftTestCase.ssl && MongoSwiftTestCase.isMacOS {
-            print("Skipping test, fails with SSL, see CDRIVER-3318")
-            return
-        }
+    // func testIndexOptions() throws {
+    //     // TODO SWIFT-539: unskip
+    //     if MongoSwiftTestCase.ssl && MongoSwiftTestCase.isMacOS {
+    //         print("Skipping test, fails with SSL, see CDRIVER-3318")
+    //         return
+    //     }
 
-        let options = IndexOptions(
-            background: true,
-            name: "testOptions",
-            sparse: false,
-            storageEngine: ["wiredTiger": ["configString": "access_pattern_hint=random"] as Document],
-            unique: true,
-            indexVersion: 2,
-            defaultLanguage: "english",
-            languageOverride: "cat",
-            textIndexVersion: 2,
-            weights: ["cat": 0.5, "_id": 0.5],
-            sphereIndexVersion: 2,
-            bits: 32,
-            max: 30,
-            min: 0,
-            bucketSize: 10,
-            collation: ["locale": "fr"]
-        )
+    //     let options = IndexOptions(
+    //         background: true,
+    //         name: "testOptions",
+    //         sparse: false,
+    //         storageEngine: ["wiredTiger": ["configString": "access_pattern_hint=random"] as Document],
+    //         unique: true,
+    //         indexVersion: 2,
+    //         defaultLanguage: "english",
+    //         languageOverride: "cat",
+    //         textIndexVersion: 2,
+    //         weights: ["cat": 0.5, "_id": 0.5],
+    //         sphereIndexVersion: 2,
+    //         bits: 32,
+    //         max: 30,
+    //         min: 0,
+    //         bucketSize: 10,
+    //         collation: ["locale": "fr"]
+    //     )
 
-        let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)
-        expect(try self.coll.createIndex(model)).to(equal("testOptions"))
+    //     let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)
+    //     expect(try self.coll.createIndex(model)).to(equal("testOptions"))
 
-        let ttlOptions = IndexOptions(expireAfterSeconds: 100, name: "ttl")
-        let ttlModel = IndexModel(keys: ["cat": 1], options: ttlOptions)
-        expect(try self.coll.createIndex(ttlModel)).to(equal("ttl"))
+    //     let ttlOptions = IndexOptions(expireAfterSeconds: 100, name: "ttl")
+    //     let ttlModel = IndexModel(keys: ["cat": 1], options: ttlOptions)
+    //     expect(try self.coll.createIndex(ttlModel)).to(equal("ttl"))
 
-        var indexes: [IndexOptions] = try self.coll.listIndexes().map { indexDoc in
-            var decoded = try BSONDecoder().decode(IndexOptions.self, from: indexDoc)
-            // name is not one of the CodingKeys for IndexOptions so manually pull
-            // it out of the doc and set it on the options.
-            decoded.name = indexDoc.name as? String
-            return decoded
-        }
+    //     var indexes: [IndexOptions] = try self.coll.listIndexes().map { indexDoc in
+    //         var decoded = try BSONDecoder().decode(IndexOptions.self, from: indexDoc)
+    //         // name is not one of the CodingKeys for IndexOptions so manually pull
+    //         // it out of the doc and set it on the options.
+    //         decoded.name = indexDoc.name as? String
+    //         return decoded
+    //     }
 
-        indexes.sort { $0.name! < $1.name! }
-        expect(indexes).to(haveCount(3))
+    //     indexes.sort { $0.name! < $1.name! }
+    //     expect(indexes).to(haveCount(3))
 
-        // _id index
-        expect(indexes[0]).to(equal(IndexOptions(name: "_id_", indexVersion: 2)))
+    //     // _id index
+    //     expect(indexes[0]).to(equal(IndexOptions(name: "_id_", indexVersion: 2)))
 
-        // testOptions index
-        var expectedTestOptions = options
-        expectedTestOptions.name = "testOptions"
-        expect(indexes[1]).to(equal(expectedTestOptions))
+    //     // testOptions index
+    //     var expectedTestOptions = options
+    //     expectedTestOptions.name = "testOptions"
+    //     expect(indexes[1]).to(equal(expectedTestOptions))
 
-        // ttl index
-        var expectedTtlOptions = ttlOptions
-        expectedTtlOptions.indexVersion = 2
-        expect(indexes[2]).to(equal(expectedTtlOptions))
-    }
+    //     // ttl index
+    //     var expectedTtlOptions = ttlOptions
+    //     expectedTtlOptions.indexVersion = 2
+    //     expect(indexes[2]).to(equal(expectedTtlOptions))
+    // }
 
-    func testCreateIndexesFromModels() throws {
-        let model1 = IndexModel(keys: ["cat": 1])
-        let model2 = IndexModel(keys: ["cat": -1])
-        expect( try self.coll.createIndexes([model1, model2]) ).to(equal(["cat_1", "cat_-1"]))
-        let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
-        expect(indexes.next()?["name"]).to(bsonEqual("cat_-1"))
-        expect(indexes.next()).to(beNil())
-    }
+    // func testCreateIndexesFromModels() throws {
+    //     let model1 = IndexModel(keys: ["cat": 1])
+    //     let model2 = IndexModel(keys: ["cat": -1])
+    //     expect( try self.coll.createIndexes([model1, model2]) ).to(equal(["cat_1", "cat_-1"]))
+    //     let indexes = try coll.listIndexes()
+    //     expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+    //     expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
+    //     expect(indexes.next()?["name"]).to(bsonEqual("cat_-1"))
+    //     expect(indexes.next()).to(beNil())
+    // }
 
-    func testCreateIndexFromKeys() throws {
-        expect(try self.coll.createIndex(["cat": 1])).to(equal("cat_1"))
+    // func testCreateIndexFromKeys() throws {
+    //     expect(try self.coll.createIndex(["cat": 1])).to(equal("cat_1"))
 
-        let indexOptions = IndexOptions(name: "blah", unique: true)
-        let model = IndexModel(keys: ["cat": -1], options: indexOptions)
-        expect(try self.coll.createIndex(model)).to(equal("blah"))
+    //     let indexOptions = IndexOptions(name: "blah", unique: true)
+    //     let model = IndexModel(keys: ["cat": -1], options: indexOptions)
+    //     expect(try self.coll.createIndex(model)).to(equal("blah"))
 
-        let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
+    //     let indexes = try coll.listIndexes()
+    //     expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+    //     expect(indexes.next()?["name"]).to(bsonEqual("cat_1"))
 
-        let thirdIndex = indexes.next()
-        expect(thirdIndex?["name"]).to(bsonEqual("blah"))
-        expect(thirdIndex?["unique"]).to(bsonEqual(true))
+    //     let thirdIndex = indexes.next()
+    //     expect(thirdIndex?["name"]).to(bsonEqual("blah"))
+    //     expect(thirdIndex?["unique"]).to(bsonEqual(true))
 
-        expect(indexes.next()).to(beNil())
-    }
+    //     expect(indexes.next()).to(beNil())
+    // }
 
-    func testDropIndexByName() throws {
-        let model = IndexModel(keys: ["cat": 1])
-        expect(try self.coll.createIndex(model)).to(equal("cat_1"))
-        expect(try self.coll.dropIndex("cat_1")).toNot(throwError())
+    // func testDropIndexByName() throws {
+    //     let model = IndexModel(keys: ["cat": 1])
+    //     expect(try self.coll.createIndex(model)).to(equal("cat_1"))
+    //     expect(try self.coll.dropIndex("cat_1")).toNot(throwError())
 
-        // now there should only be _id_ left
-        let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()).to(beNil())
-    }
+    //     // now there should only be _id_ left
+    //     let indexes = try coll.listIndexes()
+    //     expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+    //     expect(indexes.next()).to(beNil())
+    // }
 
-    func testDropIndexByModel() throws {
-        let model = IndexModel(keys: ["cat": 1])
-        expect(try self.coll.createIndex(model)).to(equal("cat_1"))
+    // func testDropIndexByModel() throws {
+    //     let model = IndexModel(keys: ["cat": 1])
+    //     expect(try self.coll.createIndex(model)).to(equal("cat_1"))
 
-        let res = try self.coll.dropIndex(model)
-        expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
+    //     let res = try self.coll.dropIndex(model)
+    //     expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
-        // now there should only be _id_ left
-        let indexes = try coll.listIndexes()
-        expect(indexes).toNot(beNil())
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()).to(beNil())
-    }
+    //     // now there should only be _id_ left
+    //     let indexes = try coll.listIndexes()
+    //     expect(indexes).toNot(beNil())
+    //     expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+    //     expect(indexes.next()).to(beNil())
+    // }
 
-    func testDropIndexByKeys() throws {
-        let model = IndexModel(keys: ["cat": 1])
-        expect(try self.coll.createIndex(model)).to(equal("cat_1"))
+    // func testDropIndexByKeys() throws {
+    //     let model = IndexModel(keys: ["cat": 1])
+    //     expect(try self.coll.createIndex(model)).to(equal("cat_1"))
 
-        let res = try self.coll.dropIndex(["cat": 1])
-        expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
+    //     let res = try self.coll.dropIndex(["cat": 1])
+    //     expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
-        // now there should only be _id_ left
-        let indexes = try coll.listIndexes()
-        expect(indexes).toNot(beNil())
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()).to(beNil())
-    }
+    //     // now there should only be _id_ left
+    //     let indexes = try coll.listIndexes()
+    //     expect(indexes).toNot(beNil())
+    //     expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+    //     expect(indexes.next()).to(beNil())
+    // }
 
-    func testDropAllIndexes() throws {
-        let model = IndexModel(keys: ["cat": 1])
-        expect(try self.coll.createIndex(model)).to(equal("cat_1"))
+    // func testDropAllIndexes() throws {
+    //     let model = IndexModel(keys: ["cat": 1])
+    //     expect(try self.coll.createIndex(model)).to(equal("cat_1"))
 
-        let res = try self.coll.dropIndexes()
-        expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
+    //     let res = try self.coll.dropIndexes()
+    //     expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
-        // now there should only be _id_ left
-        let indexes = try coll.listIndexes()
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()).to(beNil())
-    }
+    //     // now there should only be _id_ left
+    //     let indexes = try coll.listIndexes()
+    //     expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+    //     expect(indexes.next()).to(beNil())
+    // }
 
-    func testListIndexes() throws {
-        let indexes = try self.coll.listIndexes()
-        // New collection, so expect just the _id_ index to exist.
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()).to(beNil())
-    }
+    // func testListIndexes() throws {
+    //     let indexes = try self.coll.listIndexes()
+    //     // New collection, so expect just the _id_ index to exist.
+    //     expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+    //     expect(indexes.next()).to(beNil())
+    // }
 
-    func testCreateDropIndexByModelWithMaxTimeMS() throws {
-        let center = NotificationCenter.default
-        let maxTimeMS: Int64 = 1000
+    // func testCreateDropIndexByModelWithMaxTimeMS() throws {
+    //     let center = NotificationCenter.default
+    //     let maxTimeMS: Int64 = 1000
 
-        let client = try MongoClient.makeTestClient(options: ClientOptions(commandMonitoring: true))
-        let db = client.db(type(of: self).testDatabase)
+    //     let client = try MongoClient.makeTestClient(options: ClientOptions(commandMonitoring: true))
+    //     let db = client.db(type(of: self).testDatabase)
 
-        let collection = db.collection("collection")
-        try collection.insertOne(["test": "blahblah"])
+    //     let collection = db.collection("collection")
+    //     try collection.insertOne(["test": "blahblah"])
 
-        var receivedEvents = [CommandStartedEvent]()
-        let observer = center.addObserver(forName: nil, object: nil, queue: nil) { notif in
-            guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
-                return
-            }
-            receivedEvents.append(event)
-        }
+    //     var receivedEvents = [CommandStartedEvent]()
+    //     let observer = center.addObserver(forName: nil, object: nil, queue: nil) { notif in
+    //         guard let event = notif.userInfo?["event"] as? CommandStartedEvent else {
+    //             return
+    //         }
+    //         receivedEvents.append(event)
+    //     }
 
-        defer { center.removeObserver(observer) }
+    //     defer { center.removeObserver(observer) }
 
-        let model = IndexModel(keys: ["cat": 1])
-        let wc = try WriteConcern(w: .number(1))
-        let createIndexOpts = CreateIndexOptions(writeConcern: wc, maxTimeMS: maxTimeMS)
-        expect( try collection.createIndex(model, options: createIndexOpts)).to(equal("cat_1"))
+    //     let model = IndexModel(keys: ["cat": 1])
+    //     let wc = try WriteConcern(w: .number(1))
+    //     let createIndexOpts = CreateIndexOptions(writeConcern: wc, maxTimeMS: maxTimeMS)
+    //     expect( try collection.createIndex(model, options: createIndexOpts)).to(equal("cat_1"))
 
-        let dropIndexOpts = DropIndexOptions(writeConcern: wc, maxTimeMS: maxTimeMS)
-        let res = try collection.dropIndex(model, options: dropIndexOpts)
-        expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
+    //     let dropIndexOpts = DropIndexOptions(writeConcern: wc, maxTimeMS: maxTimeMS)
+    //     let res = try collection.dropIndex(model, options: dropIndexOpts)
+    //     expect((res["ok"] as? BSONNumber)?.doubleValue).to(bsonEqual(1.0))
 
-        // now there should only be _id_ left
-        let indexes = try coll.listIndexes()
-        expect(indexes).toNot(beNil())
-        expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
-        expect(indexes.next()).to(beNil())
+    //     // now there should only be _id_ left
+    //     let indexes = try coll.listIndexes()
+    //     expect(indexes).toNot(beNil())
+    //     expect(indexes.next()?["name"]).to(bsonEqual("_id_"))
+    //     expect(indexes.next()).to(beNil())
 
-        // test that maxTimeMS is an accepted option for createIndex and dropIndex
-        expect(receivedEvents.count).to(equal(2))
-        expect(receivedEvents[0].command["createIndexes"]).toNot(beNil())
-        expect(receivedEvents[0].command["maxTimeMS"]).toNot(beNil())
-        expect(receivedEvents[0].command["maxTimeMS"]).to(bsonEqual(maxTimeMS))
-        expect(receivedEvents[1].command["dropIndexes"]).toNot(beNil())
-        expect(receivedEvents[1].command["maxTimeMS"]).toNot(beNil())
-        expect(receivedEvents[1].command["maxTimeMS"]).to(bsonEqual(maxTimeMS))
-    }
+    //     // test that maxTimeMS is an accepted option for createIndex and dropIndex
+    //     expect(receivedEvents.count).to(equal(2))
+    //     expect(receivedEvents[0].command["createIndexes"]).toNot(beNil())
+    //     expect(receivedEvents[0].command["maxTimeMS"]).toNot(beNil())
+    //     expect(receivedEvents[0].command["maxTimeMS"]).to(bsonEqual(maxTimeMS))
+    //     expect(receivedEvents[1].command["dropIndexes"]).toNot(beNil())
+    //     expect(receivedEvents[1].command["maxTimeMS"]).toNot(beNil())
+    //     expect(receivedEvents[1].command["maxTimeMS"]).to(bsonEqual(maxTimeMS))
+    // }
 }
 
 extension IndexOptions: Equatable {

--- a/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
@@ -66,7 +66,6 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
         let indexes = try coll.listIndexes()
-        // indexes.map { print($0) }
         expect(indexes.next()?.options?.name).to(equal("_id_"))
         expect(indexes.next()?.options?.name).to(equal("cat_1"))
         expect(indexes.next()).to(beNil())

--- a/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
@@ -286,8 +286,7 @@ extension IndexOptions: Equatable {
             lhs.min == rhs.min &&
             lhs.bucketSize == rhs.bucketSize &&
             lhs.partialFilterExpression == rhs.partialFilterExpression &&
-            lhs.collation?["locale"] as? String == rhs.collation?["locale"] as? String &&
-            lhs.ns == rhs.ns
+            lhs.collation?["locale"] as? String == rhs.collation?["locale"] as? String
             // ^ server adds a bunch of extra fields and a version number
             // to collations. rather than deal with those, just verify the
             // locale matches.

--- a/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
@@ -79,15 +79,6 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             return
         }
 
-        let sv = try _client?.serverVersion() ?? ServerVersion("8000")
-        guard try sv < ServerVersion("4.3.0") else {
-            print("Skipping test, fails with latest server version because of missing ns field")
-            return
-        }
-
-        let nsString = MongoSwiftTestCase.isMacOS ? "test.MongoCollection_IndexTests_testIndexOptions" :
-                                                    "test.MongoCollection_IndexTests.testIndexOptions"
-
         let options = IndexOptions(
             background: true,
             name: "testOptions",
@@ -104,14 +95,13 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             max: 30,
             min: 0,
             bucketSize: 10,
-            collation: ["locale": "fr"],
-            ns: nsString
+            collation: ["locale": "fr"]
         )
 
         let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)
         expect(try self.coll.createIndex(model)).to(equal("testOptions"))
 
-        let ttlOptions = IndexOptions(expireAfterSeconds: 100, name: "ttl", ns: nsString)
+        let ttlOptions = IndexOptions(expireAfterSeconds: 100, name: "ttl")
         let ttlModel = IndexModel(keys: ["cat": 1], options: ttlOptions)
         expect(try self.coll.createIndex(ttlModel)).to(equal("ttl"))
 
@@ -120,7 +110,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         expect(indexOptions).to(haveCount(3))
 
         // _id index
-        expect(indexOptions[0]).to(equal(IndexOptions(name: "_id_", version: 2, ns: nsString)))
+        expect(indexOptions[0]).to(equal(IndexOptions(name: "_id_", version: 2)))
 
         // testOptions index
         var expectedTestOptions = options
@@ -291,8 +281,7 @@ extension IndexOptions: Equatable {
             lhs.min == rhs.min &&
             lhs.bucketSize == rhs.bucketSize &&
             lhs.partialFilterExpression == rhs.partialFilterExpression &&
-            lhs.collation?["locale"] as? String == rhs.collation?["locale"] as? String &&
-            lhs.ns == rhs.ns
+            lhs.collation?["locale"] as? String == rhs.collation?["locale"] as? String
             // ^ server adds a bunch of extra fields and a version number
             // to collations. rather than deal with those, just verify the
             // locale matches.

--- a/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
@@ -85,7 +85,8 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             return
         }
 
-        let nsString = MongoSwiftTestCase.isMacOS ? "test.MongoCollection_IndexTests_testIndexOptions" : "test.MongoCollection_IndexTests.testIndexOptions"
+        let nsString = MongoSwiftTestCase.isMacOS ? "test.MongoCollection_IndexTests_testIndexOptions" :
+                                                    "test.MongoCollection_IndexTests.testIndexOptions"
 
         let options = IndexOptions(
             background: true,

--- a/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftTests/MongoCollection+IndexTests.swift
@@ -79,6 +79,10 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             return
         }
 
+        // guard _client.serverVersion() < ServerVersion("4.3.0") else {
+        //     print("Skipping test, fails with latest server version because of missing ns field")
+        // }
+
         let options = IndexOptions(
             background: true,
             name: "testOptions",
@@ -95,12 +99,16 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             max: 30,
             min: 0,
             bucketSize: 10,
-            collation: ["locale": "fr"])
+            collation: ["locale": "fr"],
+            ns: "test.MongoCollection_IndexTests_testIndexOptions"
+        )
 
         let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)
         expect(try self.coll.createIndex(model)).to(equal("testOptions"))
 
-        let ttlOptions = IndexOptions(expireAfterSeconds: 100, name: "ttl")
+        let ttlOptions = IndexOptions(expireAfterSeconds: 100,
+                                      name: "ttl",
+                                      ns: "test.MongoCollection_IndexTests_testIndexOptions")
         let ttlModel = IndexModel(keys: ["cat": 1], options: ttlOptions)
         expect(try self.coll.createIndex(ttlModel)).to(equal("ttl"))
 
@@ -109,7 +117,9 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         expect(indexOptions).to(haveCount(3))
 
         // _id index
-        expect(indexOptions[0]).to(equal(IndexOptions(name: "_id_", version: 2)))
+        expect(indexOptions[0]).to(equal(IndexOptions(name: "_id_",
+                                                      version: 2,
+                                                      ns: "test.MongoCollection_IndexTests_testIndexOptions")))
 
         // testOptions index
         var expectedTestOptions = options
@@ -280,7 +290,8 @@ extension IndexOptions: Equatable {
             lhs.min == rhs.min &&
             lhs.bucketSize == rhs.bucketSize &&
             lhs.partialFilterExpression == rhs.partialFilterExpression &&
-            lhs.collation?["locale"] as? String == rhs.collation?["locale"] as? String
+            lhs.collation?["locale"] as? String == rhs.collation?["locale"] as? String &&
+            lhs.ns == rhs.ns
             // ^ server adds a bunch of extra fields and a version number
             // to collations. rather than deal with those, just verify the
             // locale matches.


### PR DESCRIPTION
Implement the index enumeration spec using listIndexes and listIndexNames. Note that some aspects of the spec weren't followed for the following reasons:
-  Naming of the fields `v`, `key`, `default_language`, and `language_override`, as they conflict with the existing index management spec (https://github.com/mongodb/specifications/blob/master/source/index-management.rst#standard-api) . Instead used `version`, `keys`, `defaultLanguage`, and `languageOverride` for the respective fields.
-  Naming of the field `2dsphereIndexVersion` because of Swift constraints on naming variables with numbers.
- Optional `ns` field - the latest version of the server has omitted this field, so `testIndexOptions` couldn't depend on and test the presence of the field.

JIRA ticket: https://jira.mongodb.org/browse/SWIFT-608

Evergreen: https://evergreen.mongodb.com/version/5d769864e3c33168706697cb