### PR TITLE
SWIFT-471 Client-Level TLS/SSL Options

### DIFF
--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -36,7 +36,7 @@ internal class ConnectionPool {
     }
 
     /// Initializes the pool in pooled mode using the provided `ConnectionString`.
-    internal init(from connString: ConnectionString, withTLSConfig config: TLSConfig? = nil) throws {
+    internal init(from connString: ConnectionString, withOptions options: TLSOptions? = nil) throws {
         guard let pool = mongoc_client_pool_new(connString._uri) else {
             throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support")
         }
@@ -46,8 +46,8 @@ internal class ConnectionPool {
         }
 
         self.mode = .pooled(pool: pool)
-        if let config = config {
-            try self.setTLSConfig(config)
+        if let options = options {
+            try self.setTLSOptions(options)
         }
     }
 
@@ -101,10 +101,10 @@ internal class ConnectionPool {
     }
 
     /// Sets TLS/SSL options that the user passes in through the client level.
-    private func setTLSConfig(_ config: TLSConfig) throws {
-        let pemFileStr = config.pemFile?.absoluteString.asCString
-        let pemPassStr = config.pemPassword?.asCString
-        let caFileStr = config.caFile?.asCString
+    private func setTLSOptions(_ options: TLSOptions) throws {
+        let pemFileStr = options.pemFile?.absoluteString.asCString
+        let pemPassStr = options.pemPassword?.asCString
+        let caFileStr = options.caFile?.asCString
         defer {
             pemFileStr?.deallocate()
             pemPassStr?.deallocate()
@@ -121,10 +121,10 @@ internal class ConnectionPool {
         if let caFileStr = caFileStr {
             opts.ca_file = caFileStr
         }
-        if let weakCert = config.weakCertValidation {
+        if let weakCert = options.weakCertValidation {
             opts.weak_cert_validation = weakCert
         }
-        if let invalidHosts = config.allowInvalidHostnames {
+        if let invalidHosts = options.allowInvalidHostnames {
             opts.allow_invalid_hostname = invalidHosts
         }
         switch self.mode {

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -100,7 +100,8 @@ internal class ConnectionPool {
         return try body(connection)
     }
 
-    /// Sets TLS/SSL options that the user passes in through the client level.
+    // Sets TLS/SSL options that the user passes in through the client level. This must be called from
+    // the ConnectionPool init before the pool is used.
     private func setTLSOptions(_ options: TLSOptions) throws {
         let pemFileStr = options.pemFile?.absoluteString.asCString
         let pemPassStr = options.pemPassword?.asCString

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -36,7 +36,7 @@ internal class ConnectionPool {
     }
 
     /// Initializes the pool in pooled mode using the provided `ConnectionString`.
-    internal init(from connString: ConnectionString, withOptions options: TLSOptions? = nil) throws {
+    internal init(from connString: ConnectionString, options: TLSOptions? = nil) throws {
         guard let pool = mongoc_client_pool_new(connString._uri) else {
             throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support")
         }

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -102,7 +102,7 @@ internal class ConnectionPool {
 
     /// Sets TLS/SSL options that the user passes in through the client level.
     private func setTLSConfig(_ config: TLSConfig) throws {
-        let pemFileStr = config.pemFile?.asCString
+        let pemFileStr = config.pemFile?.absoluteString.asCString
         let pemPassStr = config.pemPassword?.asCString
         let caFileStr = config.caFile?.asCString
         defer {

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -10,37 +10,6 @@ internal struct Connection {
     }
 }
 
-/// Options used to configure TLS/SSL connections to the database.
-public struct TLSOptions {
-    /// Specifies the path to the client certificate key file.
-    public let pemFile: String?
-
-    /// Specifies the path to the client certificate key password.
-    public let pemPassword: String?
-
-    /// Specifies the path to the certificate authority file.
-    public let caFile: String?
-
-    /// Indicates whether invalid certificates are allowed. By default this is set to false.
-    public let weakCertValidation: Bool?
-
-    /// Indicates whether invalid hostnames are allowed. By default this is set to false.
-    public let allowInvalidHostnames: Bool?
-
-    /// Allows the user to specify TLS/SSL options.
-    public init(pemFile: String? = nil,
-                pemPassword: String? = nil,
-                caFile: String? = nil,
-                weakCertValidation: Bool? = nil,
-                allowInvalidHostnames: Bool? = nil) {
-        self.pemFile = pemFile
-        self.pemPassword = pemPassword
-        self.caFile = caFile
-        self.weakCertValidation = weakCertValidation
-        self.allowInvalidHostnames = allowInvalidHostnames
-    }
-}
-
 /// A pool of one or more connections.
 internal class ConnectionPool {
     /// Represents the mode of a `ConnectionPool`.
@@ -128,8 +97,8 @@ internal class ConnectionPool {
         return try body(connection)
     }
 
-    /// Allows the user to set TLS/SSL options at the client level.
-    public func setTLSOptions(options: TLSOptions) throws {
+    /// Sets TLS/SSL options that the user passes in at the client level.
+    internal func setTLSOptions(_ options: TLSOptions) throws {
         let pemFileStr = options.pemFile?.asCString
         let pemPassStr = options.pemPassword?.asCString
         let caFileStr = options.caFile?.asCString

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -104,7 +104,7 @@ internal class ConnectionPool {
     private func setTLSOptions(_ options: TLSOptions) throws {
         let pemFileStr = options.pemFile?.absoluteString.asCString
         let pemPassStr = options.pemPassword?.asCString
-        let caFileStr = options.caFile?.asCString
+        let caFileStr = options.caFile?.absoluteString.asCString
         defer {
             pemFileStr?.deallocate()
             pemPassStr?.deallocate()

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -138,9 +138,9 @@ public struct DatabaseOptions: CodingStrategyProvider {
 /// Options used to configure TLS/SSL connections to the database.
 public struct TLSConfig {
     /// Specifies the path to the client certificate key file.
-    public var pemFile: String?
+    public var pemFile: URL?
 
-    /// Specifies the path to the client certificate key password.
+    /// Specifies the client certificate key password.
     public var pemPassword: String?
 
     /// Specifies the path to the certificate authority file.
@@ -153,7 +153,7 @@ public struct TLSConfig {
     public var allowInvalidHostnames: Bool?
 
     /// Convenience initializer allowing any/all arguments to be omitted or optional.
-    public init(pemFile: String? = nil,
+    public init(pemFile: URL? = nil,
                 pemPassword: String? = nil,
                 caFile: String? = nil,
                 weakCertValidation: Bool? = nil,

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -138,19 +138,19 @@ public struct DatabaseOptions: CodingStrategyProvider {
 /// Options used to configure TLS/SSL connections to the database.
 public struct TLSConfig {
     /// Specifies the path to the client certificate key file.
-    public let pemFile: String?
+    public var pemFile: String?
 
     /// Specifies the path to the client certificate key password.
-    public let pemPassword: String?
+    public var pemPassword: String?
 
     /// Specifies the path to the certificate authority file.
-    public let caFile: String?
+    public var caFile: String?
 
     /// Indicates whether invalid certificates are allowed. By default this is set to false.
-    public let weakCertValidation: Bool?
+    public var weakCertValidation: Bool?
 
     /// Indicates whether invalid hostnames are allowed. By default this is set to false.
-    public let allowInvalidHostnames: Bool?
+    public var allowInvalidHostnames: Bool?
 
     /// Convenience initializer allowing any/all arguments to be omitted or optional.
     public init(pemFile: String? = nil,

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -144,7 +144,7 @@ public struct TLSOptions {
     public var pemPassword: String?
 
     /// Specifies the path to the certificate authority file.
-    public var caFile: String?
+    public var caFile: URL?
 
     /// Indicates whether invalid certificates are allowed. By default this is set to false.
     public var weakCertValidation: Bool?
@@ -155,7 +155,7 @@ public struct TLSOptions {
     /// Convenience initializer allowing any/all arguments to be omitted or optional.
     public init(pemFile: URL? = nil,
                 pemPassword: String? = nil,
-                caFile: String? = nil,
+                caFile: URL? = nil,
                 weakCertValidation: Bool? = nil,
                 allowInvalidHostnames: Bool? = nil) {
         self.pemFile = pemFile

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -59,6 +59,7 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
     /// databases or collections that derive from it.
     public var dataCodingStrategy: DataCodingStrategy? = nil
 
+    /// Specifies the TLS/SSL options to use for database connections.
     public var tlsOptions: TLSOptions? = nil
 
     // swiftlint:enable redundant_optional_initialization
@@ -216,7 +217,7 @@ public class MongoClient {
 
         var options = options ?? ClientOptions()
         let connString = try ConnectionString(connectionString, options: &options)
-        self.connectionPool = try ConnectionPool(from: connString, withOptions: options.tlsOptions)
+        self.connectionPool = try ConnectionPool(from: connString, options: options.tlsOptions)
 
         if let rc = options.readConcern, !rc.isDefault {
             self.readConcern = rc

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -59,7 +59,7 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
     /// databases or collections that derive from it.
     public var dataCodingStrategy: DataCodingStrategy? = nil
 
-    public var tlsConfig: TLSConfig? = nil
+    public var tlsOptions: TLSOptions? = nil
 
     // swiftlint:enable redundant_optional_initialization
 
@@ -78,7 +78,7 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
                 dateCodingStrategy: DateCodingStrategy? = nil,
                 uuidCodingStrategy: UUIDCodingStrategy? = nil,
                 dataCodingStrategy: DataCodingStrategy? = nil,
-                tlsConfig: TLSConfig? = nil) {
+                tlsOptions: TLSOptions? = nil) {
         self.retryWrites = retryWrites
         self.commandMonitoring = commandMonitoring
         self.serverMonitoring = serverMonitoring
@@ -89,7 +89,7 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
         self.dateCodingStrategy = dateCodingStrategy
         self.uuidCodingStrategy = uuidCodingStrategy
         self.dataCodingStrategy = dataCodingStrategy
-        self.tlsConfig = tlsConfig
+        self.tlsOptions = tlsOptions
     }
 }
 
@@ -136,7 +136,7 @@ public struct DatabaseOptions: CodingStrategyProvider {
 }
 
 /// Options used to configure TLS/SSL connections to the database.
-public struct TLSConfig {
+public struct TLSOptions {
     /// Specifies the path to the client certificate key file.
     public var pemFile: URL?
 
@@ -216,7 +216,7 @@ public class MongoClient {
 
         var options = options ?? ClientOptions()
         let connString = try ConnectionString(connectionString, options: &options)
-        self.connectionPool = try ConnectionPool(from: connString, withTLSConfig: options.tlsConfig)
+        self.connectionPool = try ConnectionPool(from: connString, withOptions: options.tlsOptions)
 
         if let rc = options.readConcern, !rc.isDefault {
             self.readConcern = rc

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -131,6 +131,37 @@ public struct DatabaseOptions: CodingStrategyProvider {
     }
 }
 
+/// Options used to configure TLS/SSL connections to the database.
+public struct TLSOptions {
+    /// Specifies the path to the client certificate key file.
+    public let pemFile: String?
+
+    /// Specifies the path to the client certificate key password.
+    public let pemPassword: String?
+
+    /// Specifies the path to the certificate authority file.
+    public let caFile: String?
+
+    /// Indicates whether invalid certificates are allowed. By default this is set to false.
+    public let weakCertValidation: Bool?
+
+    /// Indicates whether invalid hostnames are allowed. By default this is set to false.
+    public let allowInvalidHostnames: Bool?
+
+    /// Convenience initializer allowing any/all arguments to be omitted or optional.
+    public init(pemFile: String? = nil,
+                pemPassword: String? = nil,
+                caFile: String? = nil,
+                weakCertValidation: Bool? = nil,
+                allowInvalidHostnames: Bool? = nil) {
+        self.pemFile = pemFile
+        self.pemPassword = pemPassword
+        self.caFile = caFile
+        self.weakCertValidation = weakCertValidation
+        self.allowInvalidHostnames = allowInvalidHostnames
+    }
+}
+
 /// A MongoDB Client.
 public class MongoClient {
     internal let connectionPool: ConnectionPool
@@ -335,6 +366,10 @@ public class MongoClient {
      */
     public func db(_ name: String, options: DatabaseOptions? = nil) -> MongoDatabase {
         return MongoDatabase(name: name, client: self, options: options)
+    }
+
+    public func setTLSOptions(_ options: TLSOptions) throws {
+        try self.connectionPool.setTLSOptions(options)
     }
 
     /**

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -77,11 +77,12 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                 // TODO SWIFT-471: we should pass `allowInvalidHostnames` via the `ClientOptions` to `makeTestClient`.
                 // for now we just bypass the factory method to set this additional option since we only need it for
                 // these DNS tests and not for SSL tests in general.
-                let client = try MongoClient(testCase.uri, options: ClientOptions(serverMonitoring: true))
-                let opts = TLSOptions(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
-                                      caFile: MongoSwiftTestCase.sslCAFilePath,
-                                      allowInvalidHostnames: true)
-                try client.setTLSOptions(opts)
+                let config = TLSConfig(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
+                                       caFile: MongoSwiftTestCase.sslCAFilePath,
+                                       allowInvalidHostnames: true)
+                let client = try MongoClient(testCase.uri,
+                                             options: ClientOptions(serverMonitoring: true, tlsConfig: config))
+
                 // mongoc connects lazily so we need to send a command.
                 let db = client.db("test")
                 _ = try db.runCommand(["isMaster": 1])

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -81,7 +81,7 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                 let opts = TLSOptions(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
                                       caFile: MongoSwiftTestCase.sslCAFilePath,
                                       allowInvalidHostnames: true)
-                try client.connectionPool.setTLSOptions(options: opts)
+                try client.setTLSOptions(opts)
                 // mongoc connects lazily so we need to send a command.
                 let db = client.db("test")
                 _ = try db.runCommand(["isMaster": 1])

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -77,7 +77,7 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                 // TODO SWIFT-471: we should pass `allowInvalidHostnames` via the `ClientOptions` to `makeTestClient`.
                 // for now we just bypass the factory method to set this additional option since we only need it for
                 // these DNS tests and not for SSL tests in general.
-                let config = TLSConfig(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
+                let config = TLSConfig(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
                                        caFile: MongoSwiftTestCase.sslCAFilePath,
                                        allowInvalidHostnames: true)
                 let client = try MongoClient(testCase.uri,

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -77,11 +77,11 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                 // TODO SWIFT-471: we should pass `allowInvalidHostnames` via the `ClientOptions` to `makeTestClient`.
                 // for now we just bypass the factory method to set this additional option since we only need it for
                 // these DNS tests and not for SSL tests in general.
-                let config = TLSConfig(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
-                                       caFile: MongoSwiftTestCase.sslCAFilePath,
-                                       allowInvalidHostnames: true)
+                let opts = TLSOptions(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
+                                      caFile: MongoSwiftTestCase.sslCAFilePath,
+                                      allowInvalidHostnames: true)
                 let client = try MongoClient(testCase.uri,
-                                             options: ClientOptions(serverMonitoring: true, tlsConfig: config))
+                                             options: ClientOptions(serverMonitoring: true, tlsOptions: opts))
 
                 // mongoc connects lazily so we need to send a command.
                 let db = client.db("test")

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -74,9 +74,6 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
             // Enclose all of the potentially throwing code in `doTest`. Sometimes the expected errors come when
             // parsing the URI, and other times they are not until we try to send a command.
             func doTest() throws {
-                // TODO SWIFT-471: we should pass `allowInvalidHostnames` via the `ClientOptions` to `makeTestClient`.
-                // for now we just bypass the factory method to set this additional option since we only need it for
-                // these DNS tests and not for SSL tests in general.
                 let opts = TLSOptions(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
                                       caFile: MongoSwiftTestCase.sslCAFilePath,
                                       allowInvalidHostnames: true)

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -75,7 +75,7 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
             // parsing the URI, and other times they are not until we try to send a command.
             func doTest() throws {
                 let opts = TLSOptions(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
-                                      caFile: MongoSwiftTestCase.sslCAFilePath,
+                                      caFile: URL(string: MongoSwiftTestCase.sslCAFilePath ?? ""),
                                       allowInvalidHostnames: true)
                 let client = try MongoClient(testCase.uri,
                                              options: ClientOptions(serverMonitoring: true, tlsOptions: opts))

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -78,9 +78,10 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                 // for now we just bypass the factory method to set this additional option since we only need it for
                 // these DNS tests and not for SSL tests in general.
                 let client = try MongoClient(testCase.uri, options: ClientOptions(serverMonitoring: true))
-                try client.connectionPool.setSSLOpts(caFile: MongoSwiftTestCase.sslCAFilePath,
-                                                     pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
-                                                     allowInvalidHostnames: true)
+                let opts = TLSOptions(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
+                                      caFile: MongoSwiftTestCase.sslCAFilePath,
+                                      allowInvalidHostnames: true)
+                try client.connectionPool.setTLSOptions(options: opts)
                 // mongoc connects lazily so we need to send a command.
                 let db = client.db("test")
                 _ = try db.runCommand(["isMaster": 1])

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -183,7 +183,7 @@ extension MongoClient {
                                options: ClientOptions? = nil) throws -> MongoClient {
         var opts = options ?? ClientOptions()
         if MongoSwiftTestCase.ssl {
-            opts.tlsConfig = TLSConfig(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
+            opts.tlsConfig = TLSConfig(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
                                        caFile: MongoSwiftTestCase.sslCAFilePath)
         }
         return try MongoClient(uri, options: opts)
@@ -355,7 +355,7 @@ internal func captureCommandEvents(eventTypes: [Notification.Name]? = nil,
                                    f: (MongoClient) throws -> Void) throws -> [MongoCommandEvent] {
     var clientOpts = ClientOptions(commandMonitoring: true)
     if MongoSwiftTestCase.ssl {
-        let config = TLSConfig(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
+        let config = TLSConfig(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
                                caFile: MongoSwiftTestCase.sslCAFilePath)
         clientOpts.tlsConfig = config
     }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -115,12 +115,6 @@ class MongoSwiftTestCase: XCTestCase {
                                        collectionOptions: CreateCollectionOptions? = nil,
                                        f: (MongoClient, MongoDatabase, MongoCollection<Document>) throws -> T)
     throws -> T {
-        if MongoSwiftTestCase.ssl {
-            let config = TLSConfig(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
-                                   caFile: MongoSwiftTestCase.sslCAFilePath)
-            var clientOptions = clientOptions ?? ClientOptions()
-            clientOptions.tlsConfig = config
-        }
         let client = try MongoClient.makeTestClient(options: clientOptions)
 
         return try withTestNamespace(client: client, ns: ns, options: collectionOptions) { db, coll in
@@ -187,13 +181,12 @@ extension MongoClient {
 
     static func makeTestClient(_ uri: String = MongoSwiftTestCase.connStr,
                                options: ClientOptions? = nil) throws -> MongoClient {
-        let client = try MongoClient(uri, options: options)
-        // if MongoSwiftTestCase.ssl {
-        //     let options = TLSOptions(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
-        //                              caFile: MongoSwiftTestCase.sslCAFilePath)
-        //     try client.setTLSOptions(options)
-        // }
-        return client
+        var opts = options ?? ClientOptions()
+        if MongoSwiftTestCase.ssl {
+            opts.tlsConfig = TLSConfig(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
+                                       caFile: MongoSwiftTestCase.sslCAFilePath)
+        }
+        return try MongoClient(uri, options: opts)
     }
 
     internal func supportsFailCommand() -> Bool {

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -183,8 +183,9 @@ extension MongoClient {
                                options: ClientOptions? = nil) throws -> MongoClient {
         let client = try MongoClient(uri, options: options)
         if MongoSwiftTestCase.ssl {
-             try client.connectionPool.setSSLOpts(caFile: MongoSwiftTestCase.sslCAFilePath,
-                                                  pemFile: MongoSwiftTestCase.sslPEMKeyFilePath)
+            let options = TLSOptions(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
+                                     caFile: MongoSwiftTestCase.sslCAFilePath)
+            try client.connectionPool.setTLSOptions(options: options)
         }
         return client
     }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -354,11 +354,6 @@ internal func captureCommandEvents(eventTypes: [Notification.Name]? = nil,
                                    commandNames: [String]? = nil,
                                    f: (MongoClient) throws -> Void) throws -> [MongoCommandEvent] {
     var clientOpts = ClientOptions(commandMonitoring: true)
-    if MongoSwiftTestCase.ssl {
-        let opts = TLSOptions(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
-                              caFile: URL(string: MongoSwiftTestCase.sslCAFilePath ?? ""))
-        clientOpts.tlsOptions = opts
-    }
     let client = try MongoClient.makeTestClient(options: clientOpts)
     return try captureCommandEvents(from: client, eventTypes: eventTypes, commandNames: commandNames) {
         try f(client)

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -185,7 +185,7 @@ extension MongoClient {
         if MongoSwiftTestCase.ssl {
             let options = TLSOptions(pemFile: MongoSwiftTestCase.sslPEMKeyFilePath,
                                      caFile: MongoSwiftTestCase.sslCAFilePath)
-            try client.connectionPool.setTLSOptions(options: options)
+            try client.setTLSOptions(options)
         }
         return client
     }

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -184,7 +184,7 @@ extension MongoClient {
         var opts = options ?? ClientOptions()
         if MongoSwiftTestCase.ssl {
             opts.tlsOptions = TLSOptions(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
-                                         caFile: MongoSwiftTestCase.sslCAFilePath)
+                                         caFile: URL(string: MongoSwiftTestCase.sslCAFilePath ?? ""))
         }
         return try MongoClient(uri, options: opts)
     }
@@ -356,7 +356,7 @@ internal func captureCommandEvents(eventTypes: [Notification.Name]? = nil,
     var clientOpts = ClientOptions(commandMonitoring: true)
     if MongoSwiftTestCase.ssl {
         let opts = TLSOptions(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
-                              caFile: MongoSwiftTestCase.sslCAFilePath)
+                              caFile: URL(string: MongoSwiftTestCase.sslCAFilePath ?? ""))
         clientOpts.tlsOptions = opts
     }
     let client = try MongoClient.makeTestClient(options: clientOpts)

--- a/Tests/MongoSwiftTests/TestUtils.swift
+++ b/Tests/MongoSwiftTests/TestUtils.swift
@@ -183,8 +183,8 @@ extension MongoClient {
                                options: ClientOptions? = nil) throws -> MongoClient {
         var opts = options ?? ClientOptions()
         if MongoSwiftTestCase.ssl {
-            opts.tlsConfig = TLSConfig(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
-                                       caFile: MongoSwiftTestCase.sslCAFilePath)
+            opts.tlsOptions = TLSOptions(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
+                                         caFile: MongoSwiftTestCase.sslCAFilePath)
         }
         return try MongoClient(uri, options: opts)
     }
@@ -355,9 +355,9 @@ internal func captureCommandEvents(eventTypes: [Notification.Name]? = nil,
                                    f: (MongoClient) throws -> Void) throws -> [MongoCommandEvent] {
     var clientOpts = ClientOptions(commandMonitoring: true)
     if MongoSwiftTestCase.ssl {
-        let config = TLSConfig(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
-                               caFile: MongoSwiftTestCase.sslCAFilePath)
-        clientOpts.tlsConfig = config
+        let opts = TLSOptions(pemFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? ""),
+                              caFile: MongoSwiftTestCase.sslCAFilePath)
+        clientOpts.tlsOptions = opts
     }
     let client = try MongoClient.makeTestClient(options: clientOpts)
     return try captureCommandEvents(from: client, eventTypes: eventTypes, commandNames: commandNames) {


### PR DESCRIPTION
Adds the struct `TLSConfig` to the `ClientOptions` parameter passed into `MongoClient` that allows users to specify TLS/SSL options.

JIRA ticket: https://jira.mongodb.org/browse/SWIFT-471

Design doc: https://docs.google.com/document/d/1W4DhnurX_EOBB7z8K5Ar34gBjT0Cqv607q-PZmf35uk/edit?usp=sharing

Evergreen: https://evergreen.mongodb.com/version/5d926f8f1e2d171b7b4e919b