### PR TITLE
SWIFT-364, SWIFT-395, SWIFT-609, SWIFT-600 Bump mongoc version to 1.15.1

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -13,7 +13,7 @@ export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
 export PATH=/opt/cmake/bin:${SWIFTENV_ROOT}/bin:$PATH
 
 # should be set by EVG eventuallty
-LIBMONGOC_VERSION="r1.14"
+LIBMONGOC_VERSION="r1.15"
 
 # find cmake and set the path to it in $CMAKE
 . $EVG_DIR/find-cmake.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 env:
   global:
     - MONGODB_VERSION=3.6.5
-    - LIBMONGOC_VERSION=r1.13
+    - LIBMONGOC_VERSION=r1.15
     - LIBMONGOC_CACHE_DIR=${HOME}/libmongoc-${LIBMONGOC_VERSION}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Core Server (i.e. SERVER) project are **public**.
 Installation on macOS and Linux is supported via [Swift Package Manager](https://swift.org/package-manager/).
 
 #### Step 1: Install the MongoDB C Driver
-The driver wraps the MongoDB C driver, and using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. **The minimum required version of the C Driver is 1.13.0**.
+The driver wraps the MongoDB C driver, and using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. **The minimum required version of the C Driver is 1.15.1**.
 
 *On a Mac*, you can install both components at once using [Homebrew](https://brew.sh/):
 `brew install mongo-c-driver`.

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -52,11 +52,9 @@ extension Double: Overwritable {
 
 extension Decimal128: Overwritable {
     internal func writeToCurrentPosition(of iter: DocumentIterator) throws {
-        withUnsafePointer(to: self.decimal128) { ptr in
-            // bson_iter_overwrite_decimal128 takes in a (non-const) *decimal_128_t, so we need to pass in a mutable
-            // pointer. no mutation of self.decimal128 should occur, however. (CDRIVER-3069)
+        withUnsafePointer(to: self.decimal128) { decPtr in
             iter.withMutableBSONIterPointer { iterPtr in
-                bson_iter_overwrite_decimal128(iterPtr, UnsafeMutablePointer<bson_decimal128_t>(mutating: ptr))
+                bson_iter_overwrite_decimal128(iterPtr, decPtr)
             }
         }
     }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -3,6 +3,10 @@ import mongoc
 
 /// Options to use when creating a `MongoClient`.
 public struct ClientOptions: CodingStrategyProvider, Decodable {
+    /// Determines whether the client should retry supported read operations.
+    /// TODO SWIFT-587 make this public.
+    internal var retryReads: Bool?
+
     /// Determines whether the client should retry supported write operations.
     public var retryWrites: Bool?
 

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -130,7 +130,7 @@ public struct WriteConcern: Codable {
             self.w = .number(number)
         }
 
-        let wtimeout = Int64(mongoc_write_concern_get_wtimeout(writeConcern))
+        let wtimeout = mongoc_write_concern_get_wtimeout_int64(writeConcern)
         if wtimeout != 0 {
             self.wtimeoutMS = wtimeout
         } else {
@@ -142,16 +142,6 @@ public struct WriteConcern: Codable {
         case w, journal = "j", wtimeoutMS = "wtimeout"
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encodeIfPresent(self.w, forKey: .w)
-        if let wtimeout = self.wtimeoutMS {
-            // TODO: Casting wtimeout to Int32 is the only reason this encode method is needed.
-            // Remove this encode method once SWIFT-395 gets fixed.
-            try container.encode(Int32(truncatingIfNeeded: wtimeout), forKey: .wtimeoutMS)
-        }
-        try container.encodeIfPresent(self.journal, forKey: .journal)
-    }
     /**
      *  Creates a new `mongoc_write_concern_t` based on this `WriteConcern` and passes it to the provided closure.
      *  The pointer is only valid within the body of the closure and will be freed after the body completes.
@@ -173,7 +163,7 @@ public struct WriteConcern: Codable {
             }
         }
         if let wtimeoutMS = self.wtimeoutMS {
-            mongoc_write_concern_set_wtimeout(writeConcern, Int32(truncatingIfNeeded: wtimeoutMS))
+            mongoc_write_concern_set_wtimeout_int64(writeConcern, wtimeoutMS)
         }
         return try body(writeConcern)
     }

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -527,7 +527,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
         // the next set of assertions relies on the presence of the NonResumableChangeStreamError label, which was
         // introduced in 4.1.1 via SERVER-40446.
-        guard MongoClient.makeTestClient().serverVersion >= ServerVersion(major: 4, minor: 1, patch: 1) else {
+        guard try MongoClient.makeTestClient().serverVersion() >= ServerVersion(major: 4, minor: 1, patch: 1) else {
             return
         }
 

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -521,14 +521,13 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         }
         expect(killedAggs.count).to(equal(1))
 
-        // TODO SWIFT-609: enable this portion of the test.
-        // let nonResumableLabel = FailPoint.failCommand(failCommands: ["getMore"], mode: .times(1), errorCode: 280)
-        //  try nonResumableLabel.enable()
-        // defer { nonResumableLabel.disable() }
-        // let labelAggs = try captureCommandEvents(eventTypes: [.commandStarted], commandNames: ["aggregate"]) {
-        //    expect(try $0.watch().nextOrError()).to(throwError())
-        // }
-        // expect(labelAggs.count).to(equal(1))
+        let nonResumableLabel = FailPoint.failCommand(failCommands: ["getMore"], mode: .times(1), errorCode: 280)
+         try nonResumableLabel.enable()
+        defer { nonResumableLabel.disable() }
+        let labelAggs = try captureCommandEvents(eventTypes: [.commandStarted], commandNames: ["aggregate"]) {
+           expect(try $0.watch().nextOrError()).to(throwError())
+        }
+        expect(labelAggs.count).to(equal(1))
     }
 
     /**

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -600,10 +600,9 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
                             expect(try encoder.encode(wc)).to(beNil())
                         } else {
                             if let wtimeoutMS = expected["wtimeout"] as? BSONNumber {
-                                // TODO: This should use int64Value instead once SWIFT-395 is completed
-                                expected["wtimeout"] = wtimeoutMS.int32Value!
+                                expected["wtimeout"] = wtimeoutMS.int64Value!
                             }
-                            expect(try encoder.encode(wc)).to(equal(expected))
+                            expect(try encoder.encode(wc)).to(sortedEqual(expected))
                         }
                     } else {
                         expect(try WriteConcern(wcToUse)).to(throwError(UserError.invalidArgumentError(message: "")))


### PR DESCRIPTION
Bumps min libmongoc version to 1.15.1 ([SWIFT-364](https://jira.mongodb.org/browse/SWIFT-600)) and fixes various new errors introduced by the version bump and switch to having retryable reads on by default.

Also implements a bunch of quick fixes we had depending on that:
* [SWIFT-369](https://jira.mongodb.org/browse/SWIFT-369) `wtimeoutMS` is truncated if set to a value > `Int32.max`
* [SWIFT-609](https://jira.mongodb.org/browse/SWIFT-609) Enable change stream prose test that verifies no resume is attempted for specific error labels
* [SWIFT-600](https://jira.mongodb.org/browse/SWIFT-600) `Decimal128.writeToCurrentPosition` should pass a non-mutable pointer to `bson_iter_overwrite_decimal128`
 