### PR TITLE
SWIFT-632 Drop Swift 4.2 support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -379,14 +379,14 @@ axes:
   - id: swift-version
     display_name: "Swift"
     values:
-      - id: "4.2"
-        display_name: "Swift 4.2"
-        variables:
-           SWIFT_VERSION: "4.2.4"
       - id: "5.0"
         display_name: "Swift 5.0"
         variables:
-           SWIFT_VERSION: "5.0"
+           SWIFT_VERSION: "5.0.3"
+      - id: "5.1"
+        display_name: "Swift 5.1"
+        variables:
+           SWIFT_VERSION: "5.1"
 
   - id: ssl
     display_name: SSL

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -383,6 +383,7 @@ axes:
         display_name: "Swift 5.0"
         variables:
            SWIFT_VERSION: "5.0.3"
+      # TODO SWIFT-634: uncomment this
       # - id: "5.1"
       #   display_name: "Swift 5.1"
       #   variables:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -383,10 +383,10 @@ axes:
         display_name: "Swift 5.0"
         variables:
            SWIFT_VERSION: "5.0.3"
-      - id: "5.1"
-        display_name: "Swift 5.1"
-        variables:
-           SWIFT_VERSION: "5.1"
+      # - id: "5.1"
+      #   display_name: "Swift 5.1"
+      #   variables:
+      #      SWIFT_VERSION: "5.1"
 
   - id: ssl
     display_name: SSL

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -3,7 +3,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 # variables
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
-SWIFT_VERSION=${SWIFT_VERSION:-5.1}
+SWIFT_VERSION=${SWIFT_VERSION:-5.0}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 EXTRA_FLAGS="-Xlinker -rpath -Xlinker ${INSTALL_DIR}/lib"

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -3,7 +3,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 # variables
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
-SWIFT_VERSION=${SWIFT_VERSION:-4.2}
+SWIFT_VERSION=${SWIFT_VERSION:-5.1}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 EXTRA_FLAGS="-Xlinker -rpath -Xlinker ${INSTALL_DIR}/lib"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -5,7 +5,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # variables
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
 MONGODB_URI=${MONGODB_URI:-"NO_URI_PROVIDED"}
-SWIFT_VERSION=${SWIFT_VERSION:-4.2}
+SWIFT_VERSION=${SWIFT_VERSION:-5.1}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 TOPOLOGY=${TOPOLOGY:-single}
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -5,7 +5,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # variables
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
 MONGODB_URI=${MONGODB_URI:-"NO_URI_PROVIDED"}
-SWIFT_VERSION=${SWIFT_VERSION:-5.1}
+SWIFT_VERSION=${SWIFT_VERSION:-5.0}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 TOPOLOGY=${TOPOLOGY:-single}
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,22 +21,8 @@ jobs:
 
     - stage: tests
       os: osx
-      osx_image: xcode10.1
-      env: SWIFT_VERSION=4.2.4
-
-    - stage: tests
-      os: osx
-      osx_image: xcode10.2
-      env: SWIFT_VERSION=4.2.4
-
-    - stage: tests
-      os: osx
       osx_image: xcode10.2
       env: SWIFT_VERSION=5.0
-
-    - stage: tests
-      os: linux
-      env: SWIFT_VERSION=4.2.4
 
     - stage: tests
       os: linux
@@ -45,7 +31,7 @@ jobs:
     - stage: post-tests
       name: code coverage
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       script: make coverage
       after_success: bash <(curl -s https://codecov.io/bash)
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "repositoryURL": "https://github.com/Quick/Nimble",
         "state": {
           "branch": null,
           "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
           "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/mongodb/swift-bson", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/mongodb/swift-mongoc", .upToNextMajor(from: "2.0.0")),
-        .package(url: "https://github.com/Quick/Nimble", .exact("8.0.2"))
+        .package(url: "https://github.com/Quick/Nimble.git", .exact("8.0.2"))
     ],
     targets: [
         .target(name: "MongoSwift", dependencies: ["mongoc", "bson"]),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 let package = Package(
     name: "MongoSwift",
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/mongodb/swift-bson", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/mongodb/swift-mongoc", .upToNextMajor(from: "2.0.0")),
-        .package(url: "https://github.com/Quick/Nimble.git", .exact("8.0.2"))
+        .package(url: "https://github.com/Quick/Nimble", .exact("8.0.2"))
     ],
     targets: [
         .target(name: "MongoSwift", dependencies: ["mongoc", "bson"]),

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ The official [MongoDB](https://www.mongodb.com/) driver for Swift.
 - [Documentation](#documentation)
 - [Bugs/Feature Requests](#bugs--feature-requests)
 - [Installation](#installation)
-    - [macOS and Linux](#macos-and-linux)
-      - [Step 1: Install the MongoDB C Driver](#step-1-install-the-mongodb-c-driver)
-      - [Step 2: Install MongoSwift](#step-2-install-mongoswift)
-    - [iOS, tvOS, and watchOS](#ios-tvos-and-watchos)
+    - [Step 1: Install the MongoDB C Driver](#step-1-install-the-mongodb-c-driver)
+    - [Step 2: Install MongoSwift](#step-2-install-mongoswift)
 - [Example Usage](#example-usage)
     - [Connect to MongoDB and Create a Collection](#connect-to-mongodb-and-create-a-collection)
     - [Create and Insert a Document](#create-and-insert-a-document)
@@ -35,13 +33,11 @@ Bug reports in JIRA for all driver projects (i.e. NODE, PYTHON, CSHARP, JAVA) an
 Core Server (i.e. SERVER) project are **public**.
 
 ## Installation
-`MongoSwift` works with Swift 5.0+.
+`MongoSwift` works with Swift 5.0+ on MacOS and Linux.
 
-### macOS and Linux
+Installation is supported via [Swift Package Manager](https://swift.org/package-manager/).
 
-Installation on macOS and Linux is supported via [Swift Package Manager](https://swift.org/package-manager/).
-
-#### Step 1: Install the MongoDB C Driver
+### Step 1: Install the MongoDB C Driver
 The driver wraps the MongoDB C driver, and using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. **The minimum required version of the C Driver is 1.15.1**.
 
 *On a Mac*, you can install both components at once using [Homebrew](https://brew.sh/):
@@ -51,13 +47,13 @@ The driver wraps the MongoDB C driver, and using it requires having the C driver
 
 See example installation from source on Ubuntu in [Docker](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/Docker).
 
-#### Step 2: Install MongoSwift
+### Step 2: Install MongoSwift
 *Please follow the instructions in the previous section on installing the MongoDB C Driver before proceeding.*
 
 Add MongoSwift to your dependencies in `Package.swift`:
 
 ```swift
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
@@ -72,27 +68,6 @@ let package = Package(
 ```
 
 Then run `swift build` to download, compile, and link all your dependencies.
-
-## iOS, tvOS, and watchOS
-Installation is supported via [CocoaPods](https://cocoapods.org/).
-
-The pod includes as a dependency an embedded version of the MongoDB C Driver, meant for use on these OSes.
-
-**Note**: the embedded driver currently does not support SSL. See [#141](https://github.com/mongodb/mongo-swift-driver/issues/141) and [CDRIVER-2850](https://jira.mongodb.org/browse/CDRIVER-2850) for more information.
-
-Add `MongoSwift` to your Podfile as follows:
-
-
-```ruby
-platform :ios, '11.0'
-use_frameworks!
-
-target 'MyApp' do
-    pod 'MongoSwift', '~> VERSION.STRING.HERE'
-end
-```
-
-Then run `pod install` to install your project's dependencies.
 
 ## Example Usage
 
@@ -164,8 +139,8 @@ Note that `Document` conforms to `Collection`, so useful methods from
 all available. However, runtime guarantees are not yet met for many of these
 methods.
 
-### Usage With Kitura and Vapor
-The `Examples/` directory contains sample projects that use the driver with [Kitura](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/Kitura) and [Vapor](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/Vapor).
+### Usage With Kitura, Vapor, and Perfect
+The `Examples/` directory contains sample projects that use the driver with [Kitura](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/Kitura), [Vapor](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/Vapor), and [Perfect](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/Perfect).
 
 ## Development Instructions
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Bug reports in JIRA for all driver projects (i.e. NODE, PYTHON, CSHARP, JAVA) an
 Core Server (i.e. SERVER) project are **public**.
 
 ## Installation
-`MongoSwift` works with Swift 4.2+.
+`MongoSwift` works with Swift 5.0+.
 
 ### macOS and Linux
 

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -769,7 +769,7 @@ private class MutableDictionary: BSONValue {
 
     subscript(key: String) -> BSONValue? {
         get {
-            guard let index = keys.index(of: key) else {
+            guard let index = keys.firstIndex(of: key) else {
                 return nil
             }
             return values[index]
@@ -779,7 +779,7 @@ private class MutableDictionary: BSONValue {
                 keys.append(key)
                 values.append(newValue)
             } else {
-                guard let index = keys.index(of: key) else {
+                guard let index = keys.firstIndex(of: key) else {
                     return
                 }
                 values.remove(at: index)

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -1377,14 +1377,15 @@ internal func getDecodingError<T: BSONValue>(type: T.Type, decoder: Decoder) -> 
 
 extension Data {
     /// Gets access to the start of the data buffer in the form of an UnsafeMutablePointer<CChar>. Useful for calling C
-    /// API methods that expect a location for a string. **You must only call this method on Data instances with 
+    /// API methods that expect a location for a string. **You must only call this method on Data instances with
     /// count > 0 so that the base address will exist.**
     /// Based on https://mjtsai.com/blog/2019/03/27/swift-5-released/
     fileprivate mutating func withUnsafeMutableCStringPointer<T>(body: (UnsafeMutablePointer<CChar>) throws -> T)
                                                                                                     rethrows -> T {
         return try self.withUnsafeMutableBytes { (rawPtr: UnsafeMutableRawBufferPointer) in
             let bufferPtr = rawPtr.bindMemory(to: CChar.self)
-            // swiftlint:disable:next force_unwrapping - baseAddress is non-nil as long as Data's count > 0.
+            // baseAddress is non-nil as long as Data's count > 0.
+            // swiftlint:disable:next force_unwrapping
             let bytesPtr = bufferPtr.baseAddress!
             return try body(bytesPtr)
         }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -365,14 +365,12 @@ extension Document {
      * - SeeAlso: http://bsonspec.org/
      */
     public init(fromBSON bson: Data) throws {
-        let data: MutableBSONPointer = try bson.withUnsafeBytePointer { bytes in
+        self._storage = DocumentStorage(stealing: try bson.withUnsafeBytePointer { bytes in
             guard let data = bson_new_from_data(bytes, bson.count) else {
                 throw UserError.invalidArgumentError(message: "Invalid BSON data")
             }
             return data
-        }
-
-        self._storage = DocumentStorage(stealing: data)
+        })
     }
 
     /// Returns a `Boolean` indicating whether this `Document` contains the provided key.
@@ -561,7 +559,7 @@ extension Document: Hashable {
 
 extension Data {
     /// Gets access to the start of the data buffer in the form of an UnsafePointer<UInt8>?. Useful for calling C API
-    /// ethods that expect the location of an uint8_t. The pointer provided to `body` will be null if the `Data` has
+    /// methods that expect the location of an uint8_t. The pointer provided to `body` will be null if the `Data` has
     /// count == 0.
     /// Based on https://mjtsai.com/blog/2019/03/27/swift-5-released/
     fileprivate func withUnsafeBytePointer<T>(body: (UnsafePointer<UInt8>?) throws -> T) rethrows -> T {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -121,6 +121,7 @@ extension DocumentTests {
         ("testDateDecodingStrategies", testDateDecodingStrategies),
         ("testDataCodingStrategies", testDataCodingStrategies),
         ("testIntegerRetrieval", testIntegerRetrieval),
+        ("testInvalidBSON", testInvalidBSON),
     ]
 }
 

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -261,7 +261,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
     func testRawBSON() throws {
         let doc = try Document(fromJSON: "{\"a\" : [{\"$numberInt\": \"10\"}]}")
-        let fromRawBSON = Document(fromBSON: doc.rawBSON)
+        let fromRawBSON = try Document(fromBSON: doc.rawBSON)
         expect(doc).to(equal(fromRawBSON))
     }
 
@@ -282,7 +282,7 @@ final class DocumentTests: MongoSwiftTestCase {
         let int32min_sub1 = Int64(Int32.min) - Int64(1)
         let int32max_add1 = Int64(Int32.max) + Int64(1)
 
-        var doc: Document = [
+        let doc: Document = [
             "int32min": Int(Int32.min),
             "int32max": Int(Int32.max),
             "int32min-1": Int(int32min_sub1),
@@ -358,7 +358,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
                 // for cB input:
                 // native_to_bson( bson_to_native(cB) ) = cB
-                let docFromCB = Document(fromBSON: cBData)
+                let docFromCB = try Document(fromBSON: cBData)
                 expect(docFromCB.rawBSON).to(equal(cBData))
 
                 // test round tripping through documents
@@ -388,7 +388,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
                 // native_to_relaxed_extended_json( bson_to_native(cB) ) = rEJ (if rEJ exists)
                 if let rEJ = validCase["relaxed_extjson"] as? String {
-                     expect(Document(fromBSON: cBData).extendedJSON).to(cleanEqual(rEJ))
+                     expect(try Document(fromBSON: cBData).extendedJSON).to(cleanEqual(rEJ))
                 }
 
                 // for cEJ input:
@@ -408,11 +408,11 @@ final class DocumentTests: MongoSwiftTestCase {
                     }
 
                     // bson_to_canonical_extended_json(dB) = cEJ
-                    expect(Document(fromBSON: dBData).canonicalExtendedJSON).to(cleanEqual(cEJ))
+                    expect(try Document(fromBSON: dBData).canonicalExtendedJSON).to(cleanEqual(cEJ))
 
                     // bson_to_relaxed_extended_json(dB) = rEJ (if rEJ exists)
                     if let rEJ = validCase["relaxed_extjson"] as? String {
-                        expect(Document(fromBSON: dBData).extendedJSON).to(cleanEqual(rEJ))
+                        expect(try Document(fromBSON: dBData).extendedJSON).to(cleanEqual(rEJ))
                     }
                 }
 
@@ -688,7 +688,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
     func testDocumentDictionarySimilarity() throws {
         var doc: Document = ["hello": "world", "swift": 4.2, "null": BSONNull(), "remove_me": "please"]
-        var dict: [String: BSONValue] = ["hello": "world", "swift": 4.2, "null": BSONNull(), "remove_me": "please"]
+        let dict: [String: BSONValue] = ["hello": "world", "swift": 4.2, "null": BSONNull(), "remove_me": "please"]
 
         expect(doc["hello"]).to(bsonEqual(dict["hello"]))
         expect(doc["swift"]).to(bsonEqual(dict["swift"]))
@@ -770,7 +770,7 @@ final class DocumentTests: MongoSwiftTestCase {
 
         decoder.uuidDecodingStrategy = .binary
         let uuidt = uuid.uuid
-        let bytes = Data(bytes: [
+        let bytes = Data([
             uuidt.0, uuidt.1, uuidt.2, uuidt.3,
             uuidt.4, uuidt.5, uuidt.6, uuidt.7,
             uuidt.8, uuidt.9, uuidt.10, uuidt.11,

--- a/Tests/MongoSwiftTests/DocumentTests.swift
+++ b/Tests/MongoSwiftTests/DocumentTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-@testable import MongoSwift
 import mongoc
+@testable import MongoSwift
 import Nimble
 import XCTest
 
@@ -1016,7 +1016,7 @@ final class DocumentTests: MongoSwiftTestCase {
             Data(count: 0), // too short
             Data(count: 4), // too short
             Data(hexString: "0100000000")!, // incorrectly sized
-            Data(hexString: "0500000001")!, // correctly sized, but doesn't end with null byte
+            Data(hexString: "0500000001")! // correctly sized, but doesn't end with null byte
         ]
 
         for data in invalidData {

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -147,8 +147,8 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         let cappedOptions = CreateCollectionOptions(autoIndexId: true, capped: true, max: 1000, size: 10240)
         let uncappedOptions = CreateCollectionOptions(autoIndexId: true, capped: false)
 
-        try db.createCollection("capped", options: cappedOptions)
-        try db.createCollection("uncapped", options: uncappedOptions)
+        _ = try db.createCollection("capped", options: cappedOptions)
+        _ = try db.createCollection("uncapped", options: uncappedOptions)
         try db.collection("capped").insertOne(["a": 1])
         try db.collection("uncapped").insertOne(["b": 2])
 


### PR DESCRIPTION
Drops support for Swift 4.2 and fixes various deprecation warnings that surfaced now that we are no longer using the Swift 5 compiler in 4.2 compatibility mode.