### PR TITLE
SWIFT-599 add helper for reading in JSON files

### DIFF
--- a/Tests/MongoSwiftTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftTests/CommandMonitoringTests.swift
@@ -15,21 +15,15 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
             return
         }
 
-        let decoder = BSONDecoder()
         let client = try SyncMongoClient.makeTestClient(options: ClientOptions(commandMonitoring: true))
 
-        let cmPath = MongoSwiftTestCase.specsPath + "/command-monitoring/tests"
-        let testFiles = try FileManager.default.contentsOfDirectory(atPath: cmPath).filter { $0.hasSuffix(".json") }
-        for filename in testFiles {
+        let tests = try retrieveSpecTestFiles(specName: "command-monitoring", asType: CMTestFile.self)
+        for (filename, testFile) in tests {
             // read in the file data and parse into a struct
             let name = filename.components(separatedBy: ".")[0]
 
             // remove this if/when bulkwrite is supported
             if name.lowercased().contains("bulkwrite") { continue }
-
-            let testFilePath = URL(fileURLWithPath: "\(cmPath)/\(filename)")
-            let asDocument = try Document(fromJSONFile: testFilePath)
-            let testFile = try decoder.decode(CMTestFile.self, from: asDocument)
 
             print("-----------------------")
             print("Executing tests for file \(name)...\n")

--- a/Tests/MongoSwiftTests/CrudTests.swift
+++ b/Tests/MongoSwiftTests/CrudTests.swift
@@ -50,7 +50,7 @@ final class CrudTests: MongoSwiftTestCase {
     }
 
     // Run all the tests at the /read path
-    func testReads() throws {        
+    func testReads() throws {
         try doTests(forSubdirectory: "read")
     }
 

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -47,17 +47,12 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
             return
         }
 
-        let specsPath = MongoSwiftTestCase.specsPath + "/initial-dns-seedlist-discovery/tests"
-        let testFiles = try FileManager.default.contentsOfDirectory(atPath: specsPath).filter { $0.hasSuffix(".json") }
-        for filename in testFiles {
+        let tests = try retrieveSpecTestFiles(specName: "initial-dns-seedlist-discovery", asType: DNSSeedlistTestCase.self)
+        for (filename, testCase) in tests {
             // TODO SWIFT-593: run these tests
             guard !["encoded-userinfo-and-db.json", "uri-with-auth.json"].contains(filename) else {
                 continue
             }
-
-            let testFilePath = URL(fileURLWithPath: "\(specsPath)/\(filename)")
-            let testDocument = try Document(fromJSONFile: testFilePath)
-            let testCase = try BSONDecoder().decode(DNSSeedlistTestCase.self, from: testDocument)
 
             // listen for TopologyDescriptionChanged events and continually record the latest description we've seen.
             let center = NotificationCenter.default

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -47,7 +47,8 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
             return
         }
 
-        let tests = try retrieveSpecTestFiles(specName: "initial-dns-seedlist-discovery", asType: DNSSeedlistTestCase.self)
+        let tests = try retrieveSpecTestFiles(specName: "initial-dns-seedlist-discovery",
+                                              asType: DNSSeedlistTestCase.self)
         for (filename, testCase) in tests {
             // TODO SWIFT-593: run these tests
             guard !["encoded-userinfo-and-db.json", "uri-with-auth.json"].contains(filename) else {

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -527,7 +527,7 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     }
 
     func testConnectionStrings() throws {
-        let testFiles = try retrieveSpecTestFiles(specName: "read-write-concern", 
+        let testFiles = try retrieveSpecTestFiles(specName: "read-write-concern",
                                                   subdirectory: "connection-string",
                                                   asType: Document.self)
         for (_, asDocument) in testFiles {
@@ -564,9 +564,9 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
     func testDocuments() throws {
         let encoder = BSONEncoder()
-        let testFiles = try retrieveSpecTestFiles(specName: "read-write-concern", 
-                                          subdirectory: "document",
-                                          asType: Document.self)
+        let testFiles = try retrieveSpecTestFiles(specName: "read-write-concern",
+                                                  subdirectory: "document",
+                                                  asType: Document.self)
 
         for (_, asDocument) in testFiles {
             let tests: [Document] = try asDocument.get("tests")

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -527,11 +527,10 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
     }
 
     func testConnectionStrings() throws {
-        let csPath = "\(MongoSwiftTestCase.specsPath)/read-write-concern/tests/connection-string"
-        let testFiles = try FileManager.default.contentsOfDirectory(atPath: csPath).filter { $0.hasSuffix(".json") }
-        for filename in testFiles {
-            let testFilePath = URL(fileURLWithPath: "\(csPath)/\(filename)")
-            let asDocument = try Document(fromJSONFile: testFilePath)
+        let testFiles = try retrieveSpecTestFiles(specName: "read-write-concern", 
+                                                  subdirectory: "connection-string",
+                                                  asType: Document.self)
+        for (_, asDocument) in testFiles {
             let tests: [Document] = try asDocument.get("tests")
             for test in tests {
                 let description: String = try test.get("description")
@@ -565,11 +564,11 @@ final class ReadWriteConcernTests: MongoSwiftTestCase {
 
     func testDocuments() throws {
         let encoder = BSONEncoder()
-        let docsPath = "\(MongoSwiftTestCase.specsPath)/read-write-concern/tests/document"
-        let testFiles = try FileManager.default.contentsOfDirectory(atPath: docsPath).filter { $0.hasSuffix(".json") }
-        for filename in testFiles {
-            let testFilePath = URL(fileURLWithPath: "\(docsPath)/\(filename)")
-            let asDocument = try Document(fromJSONFile: testFilePath)
+        let testFiles = try retrieveSpecTestFiles(specName: "read-write-concern", 
+                                          subdirectory: "document",
+                                          asType: Document.self)
+
+        for (_, asDocument) in testFiles {
             let tests: [Document] = try asDocument.get("tests")
             for test in tests {
                 let valid: Bool = try test.get("valid")

--- a/Tests/MongoSwiftTests/SpecTestRunner/SpecTestUtils.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/SpecTestUtils.swift
@@ -28,9 +28,9 @@ extension Document {
 
 /// Given a spec folder name (e.g. "crud") and optionally a subdirectory name for a folder (e.g. "read") retrieves an
 /// array of [(filename, file decoded to type T)].
-internal func retrieveSpecTestFiles<T: Decodable>(specName: String, 
-                                                subdirectory: String? = nil,
-                                                asType: T.Type) throws -> [(String, T)] {
+internal func retrieveSpecTestFiles<T: Decodable>(specName: String,
+                                                  subdirectory: String? = nil,
+                                                  asType: T.Type) throws -> [(String, T)] {
     var path = "\(MongoSwiftTestCase.specsPath)/\(specName)/tests"
     if let sd = subdirectory {
         path += "/\(sd)"

--- a/Tests/MongoSwiftTests/SpecTestRunner/SpecTestUtils.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/SpecTestUtils.swift
@@ -1,0 +1,73 @@
+import Foundation
+@testable import MongoSwift
+import XCTest
+
+extension MongoSwiftTestCase {
+    /// Gets the path of the directory containing spec files, depending on whether
+    /// we're running from XCode or the command line
+    static var specsPath: String {
+        // if we can access the "/Tests" directory, assume we're running from command line
+        if FileManager.default.fileExists(atPath: "./Tests") {
+            return "./Tests/Specs"
+        }
+        // otherwise we're in Xcode, get the bundle's resource path
+        guard let path = Bundle(for: self).resourcePath else {
+            XCTFail("Missing resource path")
+            return ""
+        }
+        return path
+    }
+}
+
+extension Document {
+    init(fromJSONFile file: URL) throws {
+        let jsonString = try String(contentsOf: file, encoding: .utf8)
+        try self.init(fromJSON: jsonString)
+    }
+}
+
+/// Given a spec folder name (e.g. "crud") and optionally a subdirectory name for a folder (e.g. "read") retrieves an
+/// array of [(filename, file decoded to type T)].
+internal func retrieveSpecTestFiles<T: Decodable>(specName: String, 
+                                                subdirectory: String? = nil,
+                                                asType: T.Type) throws -> [(String, T)] {
+    var path = "\(MongoSwiftTestCase.specsPath)/\(specName)/tests"
+    if let sd = subdirectory {
+        path += "/\(sd)"
+    }
+    let res = try FileManager.default
+                .contentsOfDirectory(atPath: path)
+                .filter { $0.hasSuffix(".json") }
+                .map { ($0, URL(fileURLWithPath: "\(path)/\($0)")) }
+                .map { ($0.0, try Document(fromJSONFile: $0.1)) }
+                .map { ($0.0, try BSONDecoder().decode(T.self, from: $0.1)) }
+    if res.count == 0 {
+        fatalError("count 0")
+    }
+    return res
+}
+
+/// Given two documents, returns a copy of the input document with all keys that *don't*
+/// exist in `standard` removed, and with all matching keys put in the same order they
+/// appear in `standard`.
+internal func rearrangeDoc(_ input: Document, toLookLike standard: Document) -> Document {
+    var output = Document()
+    for (k, v) in standard {
+        // if it's a document, recursively rearrange to look like corresponding sub-document
+        if let sDoc = v as? Document, let iDoc = input[k] as? Document {
+            output[k] = rearrangeDoc(iDoc, toLookLike: sDoc)
+
+        // if it's an array, recursively rearrange to look like corresponding sub-array
+        } else if let sArr = v as? [Document], let iArr = input[k] as? [Document] {
+            var newArr = [Document]()
+            for (i, el) in iArr.enumerated() {
+                newArr.append(rearrangeDoc(el, toLookLike: sArr[i]))
+            }
+            output[k] = newArr
+        // just copy the value over as is
+        } else {
+            output[k] = input[k]
+        }
+    }
+    return output
+}

--- a/Tests/MongoSwiftTests/SpecTestRunner/SpecTestUtils.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/SpecTestUtils.swift
@@ -35,16 +35,12 @@ internal func retrieveSpecTestFiles<T: Decodable>(specName: String,
     if let sd = subdirectory {
         path += "/\(sd)"
     }
-    let res = try FileManager.default
+    return try FileManager.default
                 .contentsOfDirectory(atPath: path)
                 .filter { $0.hasSuffix(".json") }
                 .map { ($0, URL(fileURLWithPath: "\(path)/\($0)")) }
                 .map { ($0.0, try Document(fromJSONFile: $0.1)) }
                 .map { ($0.0, try BSONDecoder().decode(T.self, from: $0.1)) }
-    if res.count == 0 {
-        fatalError("count 0")
-    }
-    return res
 }
 
 /// Given two documents, returns a copy of the input document with all keys that *don't*


### PR DESCRIPTION
 I did this in the process of implementing the auth tests rather than copy-pasting the code another time... putting up in a separate PR to cut down on noise in the auth one.
I also created a new `SpecTestUtils.swift` file where this lives along with some other helpers that are only relevant in the context of spec tests.