### PR TITLE
Introduce base classes for client and sessions

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -481,7 +481,7 @@ private func postNotification<T: MongoEvent>(
     guard let context = contextFunc(event) else {
         fatalError("Missing context for \(type)")
     }
-    let client = Unmanaged<SyncMongoClient>.fromOpaque(context).takeUnretainedValue()
+    let client = Unmanaged<MongoClient>.fromOpaque(context).takeUnretainedValue()
     let notification = Notification(name: type.eventName, userInfo: ["event": eventStruct])
     client.notificationCenter.post(notification)
 }
@@ -518,7 +518,7 @@ extension Notification.Name {
 /// An extension of `ConnectionPool` to add monitoring capability for commands and server discovery and monitoring.
 extension ConnectionPool {
     /// Internal function to install monitoring callbacks for this pool.
-    internal func initializeMonitoring(commandMonitoring: Bool, serverMonitoring: Bool, client: SyncMongoClient) {
+    internal func initializeMonitoring(commandMonitoring: Bool, serverMonitoring: Bool, client: MongoClient) {
         guard let callbacks = mongoc_apm_callbacks_new() else {
             fatalError("failed to initialize new mongoc_apm_callbacks_t")
         }
@@ -542,8 +542,8 @@ extension ConnectionPool {
             mongoc_apm_set_server_heartbeat_failed_cb(callbacks, serverHeartbeatFailed)
         }
 
-        // we can pass the SyncMongoClient as unretained because the callbacks are stored on clientHandle, so if the
-        // callback is being executed, this pool and therefore its parent `SyncMongoClient` must still be valid.
+        // we can pass the MongoClient as unretained because the callbacks are stored on clientHandle, so if the
+        // callback is being executed, this pool and therefore its parent `MongoClient` must still be valid.
         switch self.mode {
         case let .single(clientHandle):
             mongoc_client_set_apm_callbacks(clientHandle, callbacks, Unmanaged.passUnretained(client).toOpaque())

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -32,7 +32,8 @@ public class SyncChangeStream<T: Codable>: Sequence, IteratorProtocol {
         /// Indicates that the change stream is still open. Stores a pointer to the `mongoc_change_stream_t`, along
         /// with the source connection, client, and possibly session to ensure they are kept alive as long
         /// as the change stream is.
-        case open(changeStream: OpaquePointer,
+        case open(
+            changeStream: OpaquePointer,
             connection: Connection,
             client: SyncMongoClient,
             session: ClientSession?

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -32,11 +32,10 @@ public class SyncChangeStream<T: Codable>: Sequence, IteratorProtocol {
         /// Indicates that the change stream is still open. Stores a pointer to the `mongoc_change_stream_t`, along
         /// with the source connection, client, and possibly session to ensure they are kept alive as long
         /// as the change stream is.
-        case open(
-            changeStream: OpaquePointer,
+        case open(changeStream: OpaquePointer,
             connection: Connection,
             client: SyncMongoClient,
-            session: SyncClientSession?
+            session: ClientSession?
         )
         case closed
     }
@@ -148,7 +147,7 @@ public class SyncChangeStream<T: Codable>: Sequence, IteratorProtocol {
         stealing changeStream: OpaquePointer,
         connection: Connection,
         client: SyncMongoClient,
-        session: SyncClientSession?,
+        session: ClientSession?,
         decoder: BSONDecoder,
         options: ChangeStreamOptions?
     ) throws {

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -97,7 +97,7 @@ public class ClientSession {
     public let options: ClientSessionOptions?
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    private init(client: MongoClient, options: ClientSessionOptions?) throws {
+    fileprivate init(client: MongoClient, options: ClientSessionOptions?) throws {
         self._client = client
         self.options = options
         let connection = try client.connectionPool.checkOut()

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -97,6 +97,7 @@ public class ClientSession {
     public let options: ClientSessionOptions?
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
+    // swiftformat:disable:next redundantFileprivate
     fileprivate init(client: MongoClient, options: ClientSessionOptions?) throws {
         self._client = client
         self.options = options

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -97,7 +97,7 @@ public class ClientSession {
     public let options: ClientSessionOptions?
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    fileprivate init(client: MongoClient, options: ClientSessionOptions?) throws {
+    private init(client: MongoClient, options: ClientSessionOptions?) throws {
         self._client = client
         self.options = options
         let connection = try client.connectionPool.checkOut()

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -31,7 +31,7 @@ private func withSessionOpts<T>(
 
 /// A base class for `SyncClientSession` and `AsyncClientSession`.
 public class ClientSession {
-    internal let _client: MongoClient
+    private let _client: MongoClient
 
     /// Error thrown when an inactive session is used.
     internal static let SessionInactiveError = UserError.logicError(message: "Tried to use an inactive session")
@@ -203,6 +203,8 @@ public class ClientSession {
  *   - https://docs.mongodb.com/manual/core/causal-consistency-read-write-concerns/
  */
 public final class SyncClientSession: ClientSession {
+    // we store this in addition to the private `MongoClient` stored in the base class so that we can expose a sync
+    // client in the public API rather than the base type.
     /// The client used to start this session.
     public let client: SyncMongoClient
 

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -29,7 +29,37 @@ private func withSessionOpts<T>(
     return try body(opts)
 }
 
-/// A base class for `SyncClientSession` and `AsyncClientSession`.
+/**
+ * A MongoDB client session for use with clients, databases, and sessions.
+ * This class represents a logical session used for ordering sequential operations.
+ *
+ * This class serves as a base class for both `SyncClientSession` and `AsyncClientSession`. The only difference between
+ * the synchronous and asynchronous variants is that `AsyncClientSession` must be ended manually by calling `end`.
+ *
+ * To create a client session, use `startSession` or `withSession` on a `SyncMongoClient` or `AsyncMongoClient`.
+ *
+ * If `causalConsistency` is not set to `false` when starting a session, read and write operations that use the session
+ * will be provided causal consistency guarantees depending on the read and write concerns used. Using "majority"
+ * read and write concerns will provide the full set of guarantees. See
+ * https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#sessions for more details.
+ *
+ * e.g.
+ *   ```
+ *   let opts = CollectionOptions(readConcern: ReadConcern(.majority), writeConcern: try WriteConcern(w: .majority))
+ *   let collection = database.collection("mycoll", options: opts)
+ *   try client.withSession { session in
+ *       try collection.insertOne(["x": 1], session: session)
+ *       try collection.find(["x": 1], session: session)
+ *   }
+ *   ```
+ *
+ * To disable causal consistency, set `causalConsistency` to `false` in the `ClientSessionOptions` passed in to either
+ * `withSession` or `startSession`.
+ *
+ * - SeeAlso:
+ *   - https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#sessions
+ *   - https://docs.mongodb.com/manual/core/causal-consistency-read-write-concerns/
+ */
 public class ClientSession {
     private let _client: MongoClient
 
@@ -182,7 +212,7 @@ public class ClientSession {
  *
  * If `causalConsistency` is not set to `false` when starting a session, read and write operations that use the session
  * will be provided causal consistency guarantees depending on the read and write concerns used. Using "majority"
- * read and write preferences will provide the full set of guarantees. See
+ * read and write concerns will provide the full set of guarantees. See
  * https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#sessions for more details.
  *
  * e.g.

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -30,7 +30,7 @@ private func withSessionOpts<T>(
 }
 
 /**
- * A MongoDB client session for use with clients, databases, and sessions.
+ * A MongoDB client session.
  * This class represents a logical session used for ordering sequential operations.
  *
  * This class serves as a base class for both `SyncClientSession` and `AsyncClientSession`. The only difference between

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -202,7 +202,7 @@ public class MongoClient {
     public let writeConcern: WriteConcern?
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    fileprivate init(_ connectionString: String, options: ClientOptions?) throws {
+    private init(_ connectionString: String, options: ClientOptions?) throws {
         // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
         initializeMongoc()
 
@@ -236,7 +236,7 @@ public class MongoClient {
     }
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    fileprivate init(stealing pointer: OpaquePointer) {
+    private init(stealing pointer: OpaquePointer) {
         self.connectionPool = ConnectionPool(stealing: pointer)
         self.encoder = BSONEncoder()
         self.decoder = BSONDecoder()
@@ -273,7 +273,10 @@ public class SyncMongoClient: MongoClient {
      *   - A `UserError.invalidArgumentError` if the connection string specifies the use of TLS but libmongoc was not
      *     built with TLS support.
      */
-    override public init(_ connectionString: String = "mongodb://localhost:27017", options: ClientOptions? = nil) throws {
+    override public init(
+        _ connectionString: String = "mongodb://localhost:27017",
+        options: ClientOptions? = nil
+    ) throws {
         try super.init(connectionString, options: options)
     }
 

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -202,7 +202,8 @@ public class MongoClient {
     public let writeConcern: WriteConcern?
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    fileprivate init(_ connectionString: String, options: ClientOptions?) throws {
+    // swiftformat:disable:next redundantFilePrivate
+    private init(_ connectionString: String, options: ClientOptions?) throws {
         // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
         initializeMongoc()
 
@@ -236,6 +237,7 @@ public class MongoClient {
     }
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
+    // swiftformat:disable:next redundantFileprivate
     fileprivate init(stealing pointer: OpaquePointer) {
         self.connectionPool = ConnectionPool(stealing: pointer)
         self.encoder = BSONEncoder()

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -248,9 +248,10 @@ public class SyncMongoClient: MongoClient {
     private let operationExecutor: SyncOperationExecutor = DefaultSyncOperationExecutor()
 
     /**
-     * Create a new client connection to a MongoDB server. For options that included in both the connection string URI
-     * and the ClientOptions struct, the final value is set in descending order of priority: the value specified in
-     * ClientOptions (if non-nil), the value specified in the URI, or the default value if both are unset.
+     * Create a new client for use with the MongoDB deployment specified by the connection string. For options that are
+     * included in both the connection string and the `ClientOptions` struct, the final value is set in descending
+     * order of priority: the value specified in `ClientOptions` (if non-nil), the value specified in the URI, or the
+     * default value if both are unset.
      *
      * - Parameters:
      *   - connectionString: the connection string to connect to.

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -201,7 +201,8 @@ public class MongoClient {
     /// The write concern set on this client, or nil if one is not set.
     public let writeConcern: WriteConcern?
 
-    internal init(_ connectionString: String, options: ClientOptions?) throws {
+    /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
+    fileprivate init(_ connectionString: String, options: ClientOptions?) throws {
         // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
         initializeMongoc()
 
@@ -234,7 +235,8 @@ public class MongoClient {
         )
     }
 
-    internal init(stealing pointer: OpaquePointer) {
+    /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
+    fileprivate init(stealing pointer: OpaquePointer) {
         self.connectionPool = ConnectionPool(stealing: pointer)
         self.encoder = BSONEncoder()
         self.decoder = BSONDecoder()

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -530,7 +530,7 @@ public class SyncMongoClient: MongoClient {
     /// Executes an `Operation` using this `SyncMongoClient` and an optionally provided session.
     internal func executeOperation<T: Operation>(
         _ operation: T,
-        session: SyncClientSession? = nil
+        session: ClientSession? = nil
     ) throws -> T.OperationResult {
         return try self.operationExecutor.execute(operation, client: self, session: session)
     }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -202,7 +202,7 @@ public class MongoClient {
     public let writeConcern: WriteConcern?
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    private init(_ connectionString: String, options: ClientOptions?) throws {
+    fileprivate init(_ connectionString: String, options: ClientOptions?) throws {
         // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
         initializeMongoc()
 
@@ -236,7 +236,7 @@ public class MongoClient {
     }
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    private init(stealing pointer: OpaquePointer) {
+    fileprivate init(stealing pointer: OpaquePointer) {
         self.connectionPool = ConnectionPool(stealing: pointer)
         self.encoder = BSONEncoder()
         self.decoder = BSONDecoder()

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -202,8 +202,8 @@ public class MongoClient {
     public let writeConcern: WriteConcern?
 
     /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    // swiftformat:disable:next redundantFilePrivate
-    private init(_ connectionString: String, options: ClientOptions?) throws {
+    // swiftformat:disable:next redundantFileprivate
+    fileprivate init(_ connectionString: String, options: ClientOptions?) throws {
         // Initialize mongoc. Repeated calls have no effect so this is safe to do every time.
         initializeMongoc()
 

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -235,18 +235,6 @@ public class MongoClient {
             client: self
         )
     }
-
-    /// This type is not meant to be instantiated directly. Should only be instantiated via subclasses.
-    // swiftformat:disable:next redundantFileprivate
-    fileprivate init(stealing pointer: OpaquePointer) {
-        self.connectionPool = ConnectionPool(stealing: pointer)
-        self.encoder = BSONEncoder()
-        self.decoder = BSONDecoder()
-        self.readConcern = nil
-        self.readPreference = ReadPreference()
-        self.writeConcern = nil
-        self.notificationCenter = NotificationCenter.default
-    }
 }
 
 extension MongoClient: Equatable {
@@ -280,22 +268,6 @@ public class SyncMongoClient: MongoClient {
         options: ClientOptions? = nil
     ) throws {
         try super.init(connectionString, options: options)
-    }
-
-    /**
-     * :nodoc:
-     * Create a new client from an existing `mongoc_client_t`. The new client will destroy the `mongoc_client_t` upon
-     * deinitialization.
-     * Do not use this initializer unless you know what you are doing. You *must* call libmongoc_init *before* using
-     * this initializer for the first time.
-     *
-     * If this client was derived from a pool, ensure that the error api version was set to 2 on the pool.
-     *
-     * - Parameters:
-     *   - pointer: the `mongoc_client_t` to store and use internally
-     */
-    override public init(stealing pointer: OpaquePointer) {
-        super.init(stealing: pointer)
     }
 
     /**

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -188,7 +188,7 @@ internal struct BulkWriteOperation<T: Codable>: Operation {
      *   - `ServerError.commandError` if an error occurs that prevents the operation from executing.
      *   - `ServerError.bulkWriteError` if an error occurs while performing the writes.
      */
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> BulkWriteResult? {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> BulkWriteResult? {
         var reply = Document()
         var error = bson_error_t()
         let opts = try encodeOptions(options: options, session: session)

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -8,7 +8,7 @@ public class SyncMongoCursor<T: Codable>: Sequence, IteratorProtocol {
     internal enum State {
         /// Indicates that the cursor is still open. Stores a pointer to the `mongoc_cursor_t`, along with the source
         /// connection, client, and possibly session to ensure they are kept alive as long as the cursor is.
-        case open(cursor: OpaquePointer, connection: Connection, client: SyncMongoClient, session: SyncClientSession?)
+        case open(cursor: OpaquePointer, connection: Connection, client: SyncMongoClient, session: ClientSession?)
         case closed
     }
 
@@ -58,7 +58,7 @@ public class SyncMongoCursor<T: Codable>: Sequence, IteratorProtocol {
     internal init(
         client: SyncMongoClient,
         decoder: BSONDecoder,
-        session: SyncClientSession?,
+        session: ClientSession?,
         cursorType: CursorType? = nil,
         initializer: (Connection) -> OpaquePointer
     ) throws {

--- a/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
+++ b/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
@@ -61,7 +61,7 @@ internal struct CountDocumentsOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> Int {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> Int {
         let opts = try encodeOptions(options: options, session: session)
         let rp = self.options?.readPreference?._readPreference
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -121,7 +121,7 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> SyncMongoCollection<T> {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> SyncMongoCollection<T> {
         let opts = try encodeOptions(options: self.options, session: session)
         var error = bson_error_t()
 

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -27,7 +27,7 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> [String] {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> [String] {
         var indexData = [BSON]()
         for index in self.models {
             var indexDoc = try self.collection.encoder.encode(index)

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -48,7 +48,7 @@ internal struct DistinctOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> [BSON] {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> [BSON] {
         let command: Document = [
             "distinct": .string(self.collection.name),
             "key": .string(self.fieldName),

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -10,7 +10,7 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws {
+    internal func execute(using connection: Connection, session: ClientSession?) throws {
         let command: Document = ["drop": .string(self.collection.name)]
         let opts = try encodeOptions(options: options, session: session)
 

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -10,7 +10,7 @@ internal struct DropDatabaseOperation: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws {
+    internal func execute(using connection: Connection, session: ClientSession?) throws {
         let command: Document = ["dropDatabase": 1]
         let opts = try encodeOptions(options: self.options, session: session)
 

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -27,7 +27,7 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> Document {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> Document {
         let command: Document = ["dropIndexes": .string(self.collection.name), "index": self.index]
         let opts = try encodeOptions(options: self.options, session: session)
         var reply = Document()

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -39,7 +39,7 @@ internal struct EstimatedDocumentCountOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> Int {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> Int {
         let opts = try encodeOptions(options: options, session: session)
         let rp = self.options?.readPreference?._readPreference
         var error = bson_error_t()

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -110,7 +110,7 @@ internal class FindAndModifyOptions {
         }
     }
 
-    fileprivate func setSession(_ session: SyncClientSession?) throws {
+    fileprivate func setSession(_ session: ClientSession?) throws {
         guard let session = session else {
             return
         }
@@ -142,7 +142,7 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> T? {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> T? {
         // we always need to send *something*, as findAndModify requires one of "remove"
         // or "update" to be set.
         let opts = try self.options?.asFindAndModifyOptions() ?? FindAndModifyOptions()

--- a/Sources/MongoSwift/Operations/ListCollectionsOperation.swift
+++ b/Sources/MongoSwift/Operations/ListCollectionsOperation.swift
@@ -105,7 +105,7 @@ internal struct ListCollectionsOperation: Operation {
         self.options = options
     }
 
-    internal func execute(using _: Connection, session: SyncClientSession?) throws -> ListCollectionsResults {
+    internal func execute(using _: Connection, session: ClientSession?) throws -> ListCollectionsResults {
         var opts = try encodeOptions(options: self.options, session: session) ?? Document()
         opts["nameOnly"] = .bool(self.nameOnly)
         if let filterDoc = self.filter {

--- a/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
@@ -41,7 +41,7 @@ internal struct ListDatabasesOperation: Operation {
         self.nameOnly = nameOnly
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> ListDatabasesResults {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> ListDatabasesResults {
         // spec requires that this command be run against the primary.
         let readPref = ReadPreference(.primary)
         var cmd: Document = ["listDatabases": 1]

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -8,10 +8,7 @@ internal struct ListIndexesOperation<T: Codable>: Operation {
         self.collection = collection
     }
 
-    internal func execute(
-        using _: Connection,
-        session: SyncClientSession?
-    ) throws -> SyncMongoCursor<IndexModel> {
+    internal func execute(using _: Connection, session: ClientSession?) throws -> SyncMongoCursor<IndexModel> {
         let opts = try encodeOptions(options: nil as Document?, session: session)
 
         return try SyncMongoCursor(

--- a/Sources/MongoSwift/Operations/NextOperation.swift
+++ b/Sources/MongoSwift/Operations/NextOperation.swift
@@ -20,13 +20,13 @@ internal struct NextOperation<T: Codable>: Operation {
     }
 
     // swiftlint:disable:next cyclomatic_complexity
-    internal func execute(using _: Connection, session: SyncClientSession?) throws -> T? {
+    internal func execute(using _: Connection, session: ClientSession?) throws -> T? {
         // NOTE: this method does not actually use the `connection` parameter passed in. for the moment, it is only
         // here so that `NextOperation` conforms to `Operation`. if we eventually rewrite our cursors to no longer
         // wrap a mongoc cursor then we will use the connection here.
 
         if let session = session, !session.active {
-            throw SyncClientSession.SessionInactiveError
+            throw ClientSession.SessionInactiveError
         }
 
         let out = UnsafeMutablePointer<BSONPointer?>.allocate(capacity: 1)

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -8,7 +8,7 @@ internal protocol Operation {
 
     /// Executes this operation using the provided connection and optional session, and returns its corresponding
     /// result type.
-    func execute(using connection: Connection, session: SyncClientSession?) throws -> OperationResult
+    func execute(using connection: Connection, session: ClientSession?) throws -> OperationResult
 }
 
 extension Operation {
@@ -33,7 +33,7 @@ internal protocol SyncOperationExecutor {
     func execute<T: Operation>(
         _ operation: T,
         client: SyncMongoClient,
-        session: SyncClientSession?
+        session: ClientSession?
     ) throws -> T.OperationResult
 }
 
@@ -42,7 +42,7 @@ internal struct DefaultSyncOperationExecutor: SyncOperationExecutor {
     internal func execute<T: Operation>(
         _ operation: T,
         client: SyncMongoClient,
-        session: SyncClientSession?
+        session: ClientSession?
     ) throws -> T.OperationResult {
         switch operation.connectionStrategy {
         case let .bound(conn):
@@ -65,20 +65,20 @@ internal struct DefaultSyncOperationExecutor: SyncOperationExecutor {
 /// Given a client and optionally a session associated which are to be associated with an operation, returns a
 /// connection for the operation to use. After the connection is no longer in use, it should be returned by
 /// passing it to `returnConnection` along with the same client and session that were passed into this method.
-internal func resolveConnection(client: SyncMongoClient, session: SyncClientSession?) throws -> Connection {
+internal func resolveConnection(client: MongoClient, session: ClientSession?) throws -> Connection {
     return try session?.getConnection(forUseWith: client) ?? client.connectionPool.checkOut()
 }
 
 /// Handles releasing a connection that was returned by `resolveConnection`. Must be called with the same client and
 /// session that were passed to `resolveConnection`.
-internal func releaseConnection(connection: Connection, client: SyncMongoClient, session: SyncClientSession?) {
+internal func releaseConnection(connection: Connection, client: MongoClient, session: ClientSession?) {
     if session == nil {
         client.connectionPool.checkIn(connection)
     }
 }
 
 /// Internal function for generating an options `Document` for passing to libmongoc.
-internal func encodeOptions<T: Encodable>(options: T?, session: SyncClientSession?) throws -> Document? {
+internal func encodeOptions<T: Encodable>(options: T?, session: ClientSession?) throws -> Document? {
     guard options != nil || session != nil else {
         return nil
     }

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -42,7 +42,7 @@ internal struct RunCommandOperation: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: SyncClientSession?) throws -> Document {
+    internal func execute(using connection: Connection, session: ClientSession?) throws -> Document {
         let rp = self.options?.readPreference?._readPreference
         let opts = try encodeOptions(options: self.options, session: session)
         var reply = Document()

--- a/Sources/MongoSwift/Operations/WatchOperation.swift
+++ b/Sources/MongoSwift/Operations/WatchOperation.swift
@@ -33,7 +33,7 @@ internal struct WatchOperation<CollectionType: Codable, ChangeStreamType: Codabl
 
     internal func execute(
         using connection: Connection,
-        session: SyncClientSession?
+        session: ClientSession?
     ) throws -> SyncChangeStream<ChangeStreamType> {
         let pipeline: Document = ["pipeline": self.pipeline]
         let opts = try encodeOptions(options: self.options, session: session)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -157,7 +157,6 @@ extension Document_SequenceTests {
 extension MongoClientTests {
     static var allTests = [
         ("testListDatabases", testListDatabases),
-        ("testOpaqueInitialization", testOpaqueInitialization),
         ("testFailedClientInitialization", testFailedClientInitialization),
         ("testServerVersion", testServerVersion),
         ("testCodingStrategies", testCodingStrategies),

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -50,31 +50,6 @@ final class MongoClientTests: MongoSwiftTestCase {
         }
     }
 
-    func testOpaqueInitialization() throws {
-        if MongoSwiftTestCase.ssl {
-            print("Skipping test, bypasses SSL setup")
-            return
-        }
-        let connectionString = MongoSwiftTestCase.connStr
-        var error = bson_error_t()
-        guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {
-            throw extractMongoError(error: error)
-        }
-
-        guard let client_t = mongoc_client_new_from_uri(uri) else {
-            throw UserError.invalidArgumentError(message: "libmongoc not built with TLS support.")
-        }
-
-        let client = SyncMongoClient(stealing: client_t)
-        let db = client.db(type(of: self).testDatabase)
-        let coll = db.collection(self.getCollectionName())
-        let insertResult = try coll.insertOne(["test": 42])
-        let findResult = try coll.find(["_id": insertResult!.insertedId])
-        let docs = Array(findResult)
-        expect(docs[0]["test"]).to(equal(42))
-        try db.drop()
-    }
-
     func testFailedClientInitialization() {
         // check that we fail gracefully with an error if passing in an invalid URI
         expect(try SyncMongoClient("abcd")).to(throwError(UserError.invalidArgumentError(message: "")))


### PR DESCRIPTION
This PR introduces base classes for clients and sessions and updates the synchronous implementations to inherit from them. It also updates the operation layer to use these base classes rather than the sync variants.