### PR TITLE
SWIFT-660 Use reference counting to check in Connections

### DIFF
--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -99,8 +99,8 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
             return nil
         }
         do {
-            let operation = NextOperation(target: .changeStream(self), using: connection)
-            guard let out = try client.executeOperation(operation, session: session) else {
+            let operation = NextOperation(target: .changeStream(self))
+            guard let out = try client.executeOperation(operation, using: connection, session: session) else {
                 self.error = self.getChangeStreamError()
                 if self.error != nil {
                     self.close()
@@ -162,17 +162,17 @@ public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
         }
 
         if let err = self.getChangeStreamError() {
+            self.close()
             throw err
         }
     }
 
     /// Cleans up internal state.
     private func close() {
-        guard case let .open(changeStream, connection, client, session) = self.state else {
+        guard case let .open(changeStream, _, _, _) = self.state else {
             return
         }
         mongoc_change_stream_destroy(changeStream)
-        releaseConnection(connection: connection, client: client, session: session)
         self.state = .closed
     }
 

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -476,12 +476,10 @@ public class MongoClient {
         session: ClientSession? = nil,
         withEventType _: EventType.Type
     ) throws -> ChangeStream<EventType> {
-        let connection = try resolveConnection(client: self, session: session)
         let operation = try WatchOperation<Document, EventType>(
             target: .client(self),
             pipeline: pipeline,
-            options: options,
-            stealing: connection
+            options: options
         )
         return try self.executeOperation(operation, session: session)
     }
@@ -489,9 +487,10 @@ public class MongoClient {
     /// Executes an `Operation` using this `MongoClient` and an optionally provided session.
     internal func executeOperation<T: Operation>(
         _ operation: T,
+        using connection: Connection? = nil,
         session: ClientSession? = nil
     ) throws -> T.OperationResult {
-        return try self.operationExecutor.execute(operation, client: self, session: session)
+        return try self.operationExecutor.execute(operation, using: connection, client: self, session: session)
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+ChangeStreams.swift
+++ b/Sources/MongoSwift/MongoCollection+ChangeStreams.swift
@@ -102,12 +102,10 @@ extension MongoCollection {
         session: ClientSession? = nil,
         withEventType _: EventType.Type
     ) throws -> ChangeStream<EventType> {
-        let connection = try resolveConnection(client: self._client, session: session)
         let operation = try WatchOperation<CollectionType, EventType>(
             target: .collection(self),
             pipeline: pipeline,
-            options: options,
-            stealing: connection
+            options: options
         )
         return try self._client.executeOperation(operation, session: session)
     }

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -421,12 +421,10 @@ public struct MongoDatabase {
         session: ClientSession? = nil,
         withEventType _: EventType.Type
     ) throws -> ChangeStream<EventType> {
-        let connection = try resolveConnection(client: self._client, session: session)
         let operation = try WatchOperation<Document, EventType>(
             target: .database(self),
             pipeline: pipeline,
-            options: options,
-            stealing: connection
+            options: options
         )
         return try self._client.executeOperation(operation, session: session)
     }

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -229,7 +229,7 @@ private func parseMongocError(_ error: bson_error_t, reply: Document?) -> MongoE
     case (MONGOC_ERROR_STREAM, _), (MONGOC_ERROR_SERVER_SELECTION, MONGOC_ERROR_SERVER_SELECTION_FAILURE):
         return RuntimeError.connectionError(message: message, errorLabels: errorLabels)
     case (MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR):
-        return UserError.logicError(message: message)
+        return UserError.invalidArgumentError(message: message)
     case (MONGOC_ERROR_CURSOR, MONGOC_ERROR_CHANGE_STREAM_NO_RESUME_TOKEN):
         return UserError.logicError(message: message)
     case (MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION):

--- a/Sources/MongoSwift/Operations/NextOperation.swift
+++ b/Sources/MongoSwift/Operations/NextOperation.swift
@@ -12,11 +12,9 @@ internal enum NextOperationTarget<T: Codable> {
 /// An operation corresponding to a `next` call on a `NextOperationTarget`.
 internal struct NextOperation<T: Codable>: Operation {
     private let target: NextOperationTarget<T>
-    internal let connectionStrategy: ConnectionStrategy
 
-    internal init(target: NextOperationTarget<T>, using connection: Connection) {
+    internal init(target: NextOperationTarget<T>) {
         self.target = target
-        self.connectionStrategy = .bound(to: connection)
     }
 
     // swiftlint:disable:next cyclomatic_complexity

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -3,28 +3,10 @@
 internal protocol Operation {
     /// The result type this operation returns.
     associatedtype OperationResult
-    /// Indicates how this operation interacts with `Connection`s.
-    var connectionStrategy: ConnectionStrategy { get }
 
     /// Executes this operation using the provided connection and optional session, and returns its corresponding
     /// result type.
     func execute(using connection: Connection, session: ClientSession?) throws -> OperationResult
-}
-
-extension Operation {
-    /// This is the behavior of most operations, so default to this.
-    internal var connectionStrategy: ConnectionStrategy { return .unbound }
-}
-
-/// Uses to indicate how an `Operation` type uses `Connection`s passed to its execute method.
-internal enum ConnectionStrategy {
-    /// This operation is already bound to the provided connection based on the context it was created in. This
-    /// connection must be used to execute it. This applies to e.g. `NextOperation` where the operation must use its
-    /// parent cursor's source connection rather than an arbitrary one from the pool.
-    case bound(to: Connection)
-    /// This operation will use the connection provided to its execute method to execute itself. It will not save it or
-    /// pass it off for later usage. This applies to the majority of operations.
-    case unbound
 }
 
 /// A protocol for types that can be used to execute `Operation`s.
@@ -32,6 +14,7 @@ internal protocol OperationExecutor {
     /// Executes an operation using the provided client and optionally provided session.
     func execute<T: Operation>(
         _ operation: T,
+        using connection: Connection?,
         client: MongoClient,
         session: ClientSession?
     ) throws -> T.OperationResult
@@ -41,24 +24,16 @@ internal protocol OperationExecutor {
 internal struct DefaultOperationExecutor: OperationExecutor {
     internal func execute<T: Operation>(
         _ operation: T,
+        using connection: Connection?,
         client: MongoClient,
         session: ClientSession?
     ) throws -> T.OperationResult {
-        switch operation.connectionStrategy {
-        case let .bound(conn):
-            // pass in the connection this operation is already bound to
-            return try operation.execute(using: conn, session: session)
-        case .unbound:
-            // if a session was provided, use its underlying connection
-            if let session = session {
-                let conn = try session.getConnection(forUseWith: client)
-                return try operation.execute(using: conn, session: session)
-            }
-            // otherwise use a new connection from the pool
-            return try client.connectionPool.withConnection { conn in
-                try operation.execute(using: conn, session: nil)
-            }
-        }
+        // select a connection in following order of priority:
+        // 1. connection specifically provided for use with this operation
+        // 2. if a session was provided, use its underlying connection
+        // 3. a new connection from the pool
+        let connection = try connection ?? resolveConnection(client: client, session: session)
+        return try operation.execute(using: connection, session: session)
     }
 }
 
@@ -67,14 +42,6 @@ internal struct DefaultOperationExecutor: OperationExecutor {
 /// passing it to `returnConnection` along with the same client and session that were passed into this method.
 internal func resolveConnection(client: MongoClient, session: ClientSession?) throws -> Connection {
     return try session?.getConnection(forUseWith: client) ?? client.connectionPool.checkOut()
-}
-
-/// Handles releasing a connection that was returned by `resolveConnection`. Must be called with the same client and
-/// session that were passed to `resolveConnection`.
-internal func releaseConnection(connection: Connection, client: MongoClient, session: ClientSession?) {
-    if session == nil {
-        client.connectionPool.checkIn(connection)
-    }
 }
 
 /// Internal function for generating an options `Document` for passing to libmongoc.

--- a/Sources/MongoSwift/Operations/WatchOperation.swift
+++ b/Sources/MongoSwift/Operations/WatchOperation.swift
@@ -17,18 +17,15 @@ internal struct WatchOperation<CollectionType: Codable, ChangeStreamType: Codabl
     private let target: ChangeStreamTarget<CollectionType>
     private let pipeline: BSON
     private let options: ChangeStreamOptions?
-    internal let connectionStrategy: ConnectionStrategy
 
     internal init(
         target: ChangeStreamTarget<CollectionType>,
         pipeline: [Document],
-        options: ChangeStreamOptions?,
-        stealing connection: Connection
+        options: ChangeStreamOptions?
     ) throws {
         self.target = target
         self.pipeline = .array(pipeline.map { .document($0) })
         self.options = options
-        self.connectionStrategy = .bound(to: connection)
     }
 
     internal func execute(


### PR DESCRIPTION
This PR does the following:
- Make `Connection` a class, which automatically checks the `mongoc_client_t` back into the pool upon `deinit`
    - This enables us to remove `releaseConnection` and just ensure that any place we were calling it we now drop our reference to the `Connection` being released
- Add the override option to pass a particular `Connection` into `OperationExecutor.execute`, and use this for executing `NextOperation`s
- Remove `ConnectionStrategy`, as the combination of the previous bullet point plus the ability to simply "steal" a `Connection` via maintaining a reference to it makes the strategies obsolete
- I've also updated the `MongoCursor` init to look more like the one for `ChangeStream` and no longer take in a closure that constructs a `mongoc_cursor_t`. Once `find`, `aggregate`, and `startSession` are operationized in upcoming PRs, this will make it so the only place we ever check out a `Connection` is directly within the executor. 