### PR TITLE
SWIFT-662, SWIFT-652: Decompose operations, and check cursor errors after iterating

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -383,11 +383,16 @@ extension MongoCollection {
     public func listIndexNames(session: ClientSession? = nil) throws -> [String] {
         let operation = ListIndexesOperation(collection: self)
         let models = try self._client.executeOperation(operation, session: session)
-        return try models.map { model in
+        let names: [String] = try models.map { model in
             guard let name = model.options?.name else {
                 throw RuntimeError.internalError(message: "Server response missing a 'name' field")
             }
             return name
         }
+        // ensure no cursor error occurred
+        if let error = models.error {
+            throw error
+        }
+        return names
     }
 }

--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -99,15 +99,15 @@ internal struct AggregateOperation<CollectionType: Codable>: Operation {
             return result
         }
 
-        // since mongoc_collection_aggregate doesn't do any I/O, set cacheFirstDocument = true so that we will send the
-        // aggregate command to the server immediately.
+        // since mongoc_collection_aggregate doesn't do any I/O, use forceIO to ensure this operation fails if we
+        // can not successfully get a cursor from the server.
         return try MongoCursor(
             stealing: result,
             connection: connection,
             client: self.collection._client,
             decoder: self.collection.decoder,
             session: session,
-            cacheFirstDocument: true
+            forceIO: true
         )
     }
 }

--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -104,7 +104,8 @@ internal struct AggregateOperation<CollectionType: Codable>: Operation {
             connection: connection,
             client: self.collection._client,
             decoder: self.collection.decoder,
-            session: session
+            session: session,
+            cacheFirstDocument: true
         )
     }
 }

--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -99,6 +99,8 @@ internal struct AggregateOperation<CollectionType: Codable>: Operation {
             return result
         }
 
+        // since mongoc_collection_aggregate doesn't do any I/O, set cacheFirstDocument = true so that we will send the
+        // aggregate command to the server immediately.
         return try MongoCursor(
             stealing: result,
             connection: connection,

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -222,7 +222,8 @@ internal struct FindOperation<CollectionType: Codable>: Operation {
             client: self.collection._client,
             decoder: self.collection.decoder,
             session: session,
-            cursorType: self.options?.cursorType
+            cursorType: self.options?.cursorType,
+            cacheFirstDocument: true
         )
     }
 }

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -216,8 +216,8 @@ internal struct FindOperation<CollectionType: Codable>: Operation {
             return result
         }
 
-        // since mongoc_collection_find_with_opts doesn't do any I/O, set cacheFirstDocument = true so that we will
-        // send the find command to the server immediately.
+        // since mongoc_collection_find_with_opts doesn't do any I/O, use forceIO to ensure this operation fails if we
+        // can not successfully get a cursor from the server.
         return try MongoCursor(
             stealing: result,
             connection: connection,
@@ -225,7 +225,7 @@ internal struct FindOperation<CollectionType: Codable>: Operation {
             decoder: self.collection.decoder,
             session: session,
             cursorType: self.options?.cursorType,
-            cacheFirstDocument: true
+            forceIO: true
         )
     }
 }

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -216,6 +216,8 @@ internal struct FindOperation<CollectionType: Codable>: Operation {
             return result
         }
 
+        // since mongoc_collection_find_with_opts doesn't do any I/O, set cacheFirstDocument = true so that we will
+        // send the find command to the server immediately.
         return try MongoCursor(
             stealing: result,
             connection: connection,


### PR DESCRIPTION
The only operation that appears to create other operations from within it right now is `ListCollectionsOperation`.
I've updated that to directly use the new `getNextDocumentFromMongocCursor` method instead of iterating the cursor and generating new ops.

This did make me realize a problem with always caching the first document though: for situations like this, there is no way to retrieve the cached one without calling `next()`. So I added a parameter `cacheFirstDocument` to the `MongoCursor` init which defaults to false.

I also audited the driver for places we iterate cursors and only found the one in `ListCollectionsOperation` plus one in `listIndexNames` so I have fixed both of those.

I noticed that `listIndexNames` is doing a lot of unnecessary decoding work so I have opened [SWIFT-677](https://jira.mongodb.org/browse/SWIFT-677) about optimizing that.