### PR TITLE
SWIFT-427 Remove autoIndexId option from collection creation

### DIFF
--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -2,8 +2,6 @@ import mongoc
 
 /// Options to use when executing a `createCollection` command on a `MongoDatabase`.
 public struct CreateCollectionOptions: Codable, CodingStrategyProvider {
-    /// Whether or not this collection will automatically generate an index on _id.
-    public var autoIndexId: Bool?
 
     /// Indicates whether this will be a capped collection.
     public var capped: Bool?
@@ -65,13 +63,12 @@ public struct CreateCollectionOptions: Codable, CodingStrategyProvider {
     public var writeConcern: WriteConcern?
 
     private enum CodingKeys: String, CodingKey {
-        case capped, autoIndexId, size, max, storageEngine, validator, validationLevel, validationAction,
+        case capped, size, max, storageEngine, validator, validationLevel, validationAction,
             indexOptionDefaults, viewOn, pipeline, collation, writeConcern
     }
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(
-        autoIndexId: Bool? = nil,
         capped: Bool? = nil,
         collation: Document? = nil,
         dataCodingStrategy: DataCodingStrategy? = nil,
@@ -88,7 +85,6 @@ public struct CreateCollectionOptions: Codable, CodingStrategyProvider {
         viewOn: String? = nil,
         writeConcern: WriteConcern? = nil
     ) {
-        self.autoIndexId = autoIndexId
         self.capped = capped
         self.collation = collation
         self.dataCodingStrategy = dataCodingStrategy

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -2,7 +2,6 @@ import mongoc
 
 /// Options to use when executing a `createCollection` command on a `MongoDatabase`.
 public struct CreateCollectionOptions: Codable, CodingStrategyProvider {
-
     /// Indicates whether this will be a capped collection.
     public var capped: Bool?
 

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -93,7 +93,6 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
 
         // test non-view options
         let fooOptions = CreateCollectionOptions(
-            autoIndexId: true,
             capped: true,
             collation: ["locale": "fr"],
             indexOptionDefaults: indexOpts,
@@ -149,8 +148,8 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
         let db = client.db(type(of: self).testDatabase)
         try db.drop()
 
-        let cappedOptions = CreateCollectionOptions(autoIndexId: true, capped: true, max: 1000, size: 10240)
-        let uncappedOptions = CreateCollectionOptions(autoIndexId: true, capped: false)
+        let cappedOptions = CreateCollectionOptions(capped: true, max: 1000, size: 10240)
+        let uncappedOptions = CreateCollectionOptions(capped: false)
 
         _ = try db.createCollection("capped", options: cappedOptions)
         _ = try db.createCollection("uncapped", options: uncappedOptions)
@@ -196,7 +195,6 @@ extension CreateCollectionOptions: Equatable {
     // and is not a property of the collection.
     public static func == (lhs: CreateCollectionOptions, rhs: CreateCollectionOptions) -> Bool {
         return rhs.capped == lhs.capped &&
-            rhs.autoIndexId == lhs.autoIndexId &&
             lhs.size == rhs.size &&
             lhs.max == rhs.max &&
             lhs.storageEngine == rhs.storageEngine &&


### PR DESCRIPTION
Removed `autoIndexId` option from collection creation, as it has been deprecated since MongoDB 3.2.