### PR TITLE
Disable zstd when building libmongoc on evergreen

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -21,7 +21,7 @@ LIBMONGOC_VERSION="r1.15"
 # install libmongoc
 git clone --depth 1 -b "${LIBMONGOC_VERSION}" https://github.com/mongodb/mongo-c-driver "${BUILD_DIR}"
 cd "${BUILD_DIR}"
-$CMAKE -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_DIR}"
+$CMAKE -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_DIR}" -DENABLE_ZSTD=OFF
 make -j8 install
 cd "${PROJECT_DIRECTORY}"
 


### PR DESCRIPTION
fixes evergreen MacOS tasks. sample patch: https://evergreen.mongodb.com/version/5deea33561837d7951a09851