### PR TITLE
Remove findOne compilation warning in TestOperation

### DIFF
--- a/Tests/MongoSwiftTests/SpecTestRunner/TestOperation.swift
+++ b/Tests/MongoSwiftTests/SpecTestRunner/TestOperation.swift
@@ -160,7 +160,7 @@ struct AnyTestOperation: Decodable, TestOperation {
             self.op = ListCollectionNames()
         case "watch":
             self.op = Watch()
-        case "mapReduce", "download_by_name", "findOne", "download", "count":
+        case "mapReduce", "download_by_name", "download", "count":
             self.op = NotImplemented(name: opName)
         default:
             throw UserError.logicError(message: "unsupported op name \(opName)")


### PR DESCRIPTION
Removed extra case for findOne in TestOperation.swift, removing the compilation warning. 