### PR TITLE
SWIFT-667, SWIFT-342 hodgepodge of small test changes

### DIFF
--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -194,31 +194,6 @@ extension Document {
         return try iter.safeCurrentValue()
     }
 
-    /**
-     * Allows retrieving and strongly typing a value at the same time. This means you can avoid
-     * having to cast and unwrap values from the `Document` when you know what type they will be.
-     * For example:
-     * ```
-     *  let d: Document = ["x": 1]
-     *  let x: Int = try d.get("x")
-     *  ```
-     *
-     *  - Parameters:
-     *      - key: The key under which the value you are looking up is stored
-     *      - `T`: Any type conforming to the `BSONValue` protocol
-     *  - Returns: The value stored under key, as type `T`
-     *  - Throws:
-     *    - `RuntimeError.internalError` if the value cannot be cast to type `T` or is not in the `Document`, or an
-     *      unexpected error occurs while decoding the `BSONValue`.
-     *
-     */
-    internal func get<T: BSONValue>(_ key: String) throws -> T {
-        guard let value = try self.getValue(for: key)?.bsonValue as? T else {
-            throw RuntimeError.internalError(message: "Could not cast value for key \(key) to type \(T.self)")
-        }
-        return value
-    }
-
     /// Appends the key/value pairs from the provided `doc` to this `Document`.
     /// Note: This function does not check for or clean away duplicate keys.
     internal mutating func merge(_ doc: Document) throws {

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -41,7 +41,6 @@ extension MongoCollection {
      *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
-
     public func findOne(
         _ filter: Document = [:],
         options: FindOneOptions? = nil,

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -220,18 +220,6 @@ public struct TopologyDescription {
         case sharded = "Sharded"
         /// A topology whose type is not yet known.
         case unknown = "Unknown"
-
-        /// Internal initializer used for translating evergreen config and spec test topologies to a `TopologyType`
-        internal init(from str: String) {
-            switch str {
-            case "sharded", "sharded_cluster":
-                self = .sharded
-            case "replicaset", "replica_set":
-                self = .replicaSetWithPrimary
-            default:
-                self = .single
-            }
-        }
     }
 
     /// The type of this topology.

--- a/Sources/MongoSwiftSync/ChangeStream.swift
+++ b/Sources/MongoSwiftSync/ChangeStream.swift
@@ -3,6 +3,9 @@ import MongoSwift
 /// A MongoDB change stream.
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
 public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
+    /// A `ResumeToken` associated with the most recent event seen by the change stream.
+    public var resumeToken: ResumeToken?{ fatalError("unimplemented") }
+    
     /// The error that occurred while iterating the change stream, if one exists. This should be used to check
     /// for errors after `next()` returns `nil`.
     public var error: Error? { fatalError("unimplemented") }

--- a/Sources/MongoSwiftSync/ChangeStream.swift
+++ b/Sources/MongoSwiftSync/ChangeStream.swift
@@ -4,8 +4,8 @@ import MongoSwift
 /// - SeeAlso: https://docs.mongodb.com/manual/changeStreams/
 public class ChangeStream<T: Codable>: Sequence, IteratorProtocol {
     /// A `ResumeToken` associated with the most recent event seen by the change stream.
-    public var resumeToken: ResumeToken?{ fatalError("unimplemented") }
-    
+    public var resumeToken: ResumeToken? { fatalError("unimplemented") }
+
     /// The error that occurred while iterating the change stream, if one exists. This should be used to check
     /// for errors after `next()` returns `nil`.
     public var error: Error? { fatalError("unimplemented") }

--- a/Sources/MongoSwiftSync/Exports.stencil
+++ b/Sources/MongoSwiftSync/Exports.stencil
@@ -12,3 +12,7 @@
 {% for protocol in types.protocols|public %}
 @_exported import protocol MongoSwift.{{ protocol.name }}
 {% endfor %}
+
+// Manually add typealiases
+@_exported import typealias MongoSwift.InsertManyOptions
+@_exported import typealias MongoSwift.ServerErrorCode

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -110,3 +110,7 @@
 @_exported import protocol MongoSwift.MongoCommandEvent
 @_exported import protocol MongoSwift.MongoError
 @_exported import protocol MongoSwift.MongoEvent
+
+// Manually add typealiases
+@_exported import typealias MongoSwift.InsertManyOptions
+@_exported import typealias MongoSwift.ServerErrorCode

--- a/Sources/MongoSwiftSync/MongoCollection+Read.swift
+++ b/Sources/MongoSwiftSync/MongoCollection+Read.swift
@@ -39,7 +39,6 @@ extension MongoCollection {
      *   - `UserError.logicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options to BSON.
      */
-
     public func findOne(
         _ filter: Document = [:],
         options: FindOneOptions? = nil,

--- a/Sources/MongoSwiftSync/MongoCollection+Read.swift
+++ b/Sources/MongoSwiftSync/MongoCollection+Read.swift
@@ -25,6 +25,30 @@ extension MongoCollection {
     }
 
     /**
+     * Finds a single document in this collection that matches the provided filter.
+     *
+     * - Parameters:
+     *   - filter: A `Document` that should match the query
+     *   - options: Optional `FindOneOptions` to use when executing the command
+     *   - session: Optional `ClientSession` to use when executing this command
+     *
+     * - Returns:  the resulting `Document`, or nil if there is no match
+     *
+     * - Throws:
+     *   - `UserError.invalidArgumentError` if the options passed are an invalid combination.
+     *   - `UserError.logicError` if the provided session is inactive.
+     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     */
+
+    public func findOne(
+        _ filter: Document = [:],
+        options: FindOneOptions? = nil,
+        session: ClientSession? = nil
+    ) throws -> T? {
+        fatalError("unimplemented")
+    }
+
+    /**
      * Runs an aggregation framework pipeline against this collection.
      *
      * - Parameters:

--- a/Tests/MongoSwiftTests/AuthTests.swift
+++ b/Tests/MongoSwiftTests/AuthTests.swift
@@ -3,7 +3,6 @@ import mongoc
 @testable import MongoSwift
 import Nimble
 import TestsCommon
-import XCTest
 
 /// An extension adding accessors for a number of options that may be set on a `ConnectionString`.
 extension ConnectionString {

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -2,7 +2,6 @@ import Foundation
 @testable import MongoSwift
 import Nimble
 import TestsCommon
-import XCTest
 
 final class ClientSessionTests: MongoSwiftTestCase {
     override func tearDown() {

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import mongoc
 @testable import MongoSwift
 import Nimble
 import TestsCommon

--- a/Tests/MongoSwiftTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftTests/MongoCursorTests.swift
@@ -2,7 +2,6 @@ import Foundation
 @testable import MongoSwift
 import Nimble
 import TestsCommon
-import XCTest
 
 private let doc1: Document = ["_id": 1, "x": 1]
 private let doc2: Document = ["_id": 2, "x": 2]

--- a/Tests/MongoSwiftTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftTests/MongoDatabaseTests.swift
@@ -1,7 +1,7 @@
+import Foundation
 @testable import MongoSwift
 import Nimble
 import TestsCommon
-import XCTest
 
 final class MongoDatabaseTests: MongoSwiftTestCase {
     override func setUp() {

--- a/Tests/MongoSwiftTests/MongoError+Equatable.swift
+++ b/Tests/MongoSwiftTests/MongoError+Equatable.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import MongoSwift
+import MongoSwift
 
 extension RuntimeError: Equatable {
     public static func == (lhs: RuntimeError, rhs: RuntimeError) -> Bool {

--- a/Tests/MongoSwiftTests/OptionsTests.swift
+++ b/Tests/MongoSwiftTests/OptionsTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import MongoSwift
+import MongoSwift
 import Nimble
 import TestsCommon
 

--- a/Tests/MongoSwiftTests/OptionsTests.swift
+++ b/Tests/MongoSwiftTests/OptionsTests.swift
@@ -2,7 +2,6 @@ import Foundation
 @testable import MongoSwift
 import Nimble
 import TestsCommon
-import XCTest
 
 final class OptionsTests: MongoSwiftTestCase {
     let allOptionsStructs: [Any] = [

--- a/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernTests.swift
@@ -2,7 +2,6 @@ import mongoc
 @testable import MongoSwift
 import Nimble
 import TestsCommon
-import XCTest
 
 extension WriteConcern {
     /// Initialize a new `WriteConcern` from a `Document`. We can't

--- a/Tests/MongoSwiftTests/RetryableReadsTests.swift
+++ b/Tests/MongoSwiftTests/RetryableReadsTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import MongoSwift
 import Nimble
 import TestsCommon
-import XCTest
 
 /// Struct representing a single test within a spec test JSON file.
 private struct RetryableReadsTest: SpecTest {

--- a/Tests/MongoSwiftTests/RetryableWritesTests.swift
+++ b/Tests/MongoSwiftTests/RetryableWritesTests.swift
@@ -1,8 +1,7 @@
 import Foundation
-@testable import MongoSwift
+import MongoSwift
 import Nimble
 import TestsCommon
-import XCTest
 
 /// Struct representing a single test within a retryable-writes spec test JSON file.
 private struct RetryableWritesTest: Decodable {


### PR DESCRIPTION
This contains a lot of small and I think non-controversial changes I've identified we should make as part of or as a precursor to splitting up the tests.

in particular:
- moving a couple of methods that are only used in tests and are defined internally in `MongoSwift` into `TestsCommon`
- Adding a couple missing components of the sync API
- removing various unused imports to make it easier to see which files can be moved to the sync test suite with no changes