### PR TITLE
SWIFT-644 Fix change stream tests  failing on latest with sharded clusters

### DIFF
--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -773,10 +773,10 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
-        let changeStream = try db.watch()
+        let changeStream = try db.watch(options: ChangeStreamOptions(maxAwaitTimeMS: 100))
 
         // expect the first iteration to be nil since no changes have been made to the database.
-        expect(try changeStream.nextWithTimeout()).to(beNil())
+        expect(try changeStream.nextOrError()).to(beNil())
 
         let coll = db.collection(self.getCollectionName(suffix: "1"))
         let doc1: Document = ["_id": 1, "a": 1]

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -190,7 +190,7 @@ internal struct ChangeStreamTest: Decodable {
 
             switch self.result {
             case .error:
-                _ = try changeStream.nextOrError()
+                _ = try changeStream.nextWithTimeout()
                 fail("\(self.description) failed: expected error but got none while iterating")
             case let .success(events):
                 var seenEvents: [Document] = []
@@ -305,8 +305,9 @@ final class ChangeStreamSpecTests: MongoSwiftTestCase, FailPointConfigured {
 
 /// Class for spec prose tests and other integration tests associated with change streams.
 final class ChangeStreamTests: MongoSwiftTestCase {
-    /// A short maxAwaitTimeMS setting used to speed up tests.
-    private static let MAX_AWAIT_TIME: Int64 = 100
+    /// How long in total a change stream should poll for an event or error before returning.
+    /// Used as a default value for `ChangeStream.nextWithTimeout`
+    public static let TIMEOUT: TimeInterval = 10
 
     /// Prose test 1 of change stream spec.
     /// "ChangeStream must continuously track the last seen resumeToken"
@@ -317,8 +318,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         }
 
         try withTestNamespace { _, _, coll in
-            let changeStream =
-                try coll.watch(options: ChangeStreamOptions(maxAwaitTimeMS: ChangeStreamTests.MAX_AWAIT_TIME))
+            let changeStream = try coll.watch()
             for x in 0..<5 {
                 try coll.insertOne(["x": BSON(x)])
             }
@@ -326,9 +326,11 @@ final class ChangeStreamTests: MongoSwiftTestCase {
             expect(changeStream.resumeToken).to(beNil())
 
             var lastSeen: ResumeToken?
-            for change in changeStream {
+            for _ in 0..<5 {
+                let change = try changeStream.nextWithTimeout()
+                expect(change).toNot(beNil())
                 expect(changeStream.resumeToken).toNot(beNil())
-                expect(changeStream.resumeToken).to(equal(change._id))
+                expect(changeStream.resumeToken).to(equal(change?._id))
                 if lastSeen != nil {
                     expect(changeStream.resumeToken).toNot(equal(lastSeen))
                 }
@@ -362,7 +364,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
                     message: "",
                     errorLabels: ["NonResumableChangeStreamError"]
                 )
-                expect(try changeStream.nextOrError()).to(throwError(expectedError))
+                expect(try changeStream.nextWithTimeout()).to(throwError(expectedError))
             } else {
                 expect(try changeStream.nextOrError()).to(throwError(UserError.logicError(message: "")))
             }
@@ -391,7 +393,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
                 let options = ChangeStreamOptions(
                     batchSize: 123,
                     fullDocument: .updateLookup,
-                    maxAwaitTimeMS: ChangeStreamTests.MAX_AWAIT_TIME
+                    maxAwaitTimeMS: 100
                 )
                 let changeStream = try coll.watch([["$match": ["fullDocument.x": 2]]], options: options)
                 for x in 0..<5 {
@@ -406,7 +408,6 @@ final class ChangeStreamTests: MongoSwiftTestCase {
                 while try changeStream.nextOrError() != nil {}
             }
         }
-
         expect(events.count).to(equal(2))
 
         let originalCommand = (events[0] as? CommandStartedEvent)!.command
@@ -561,7 +562,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         let events = try captureCommandEvents(commandNames: ["killCursors"]) { client in
             try withTestNamespace(client: client) { _, coll in
                 changeStream =
-                    try coll.watch(options: ChangeStreamOptions(maxAwaitTimeMS: ChangeStreamTests.MAX_AWAIT_TIME))
+                    try coll.watch(options: ChangeStreamOptions(maxAwaitTimeMS: 100))
                 _ = try changeStream!.nextOrError()
             }
         }
@@ -595,7 +596,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
                 eventTypes: [.commandSucceeded],
                 commandNames: ["aggregate"]
             ) {
-                let options = ChangeStreamOptions(batchSize: 1, maxAwaitTimeMS: ChangeStreamTests.MAX_AWAIT_TIME)
+                let options = ChangeStreamOptions(batchSize: 1)
                 changeStream = try collection.watch(options: options)
             }
 
@@ -603,7 +604,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
                 try collection.insertOne(["x": 1])
             }
 
-            expect(try changeStream?.nextOrError()).toNot(throwError())
+            expect(try changeStream?.nextWithTimeout()).toNot(throwError())
 
             // kill the underlying cursor to trigger a resume.
             let reply = (aggEvent[0] as! CommandSucceededEvent).reply["cursor"]!.documentValue!
@@ -617,7 +618,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
             // even if killCursors command fails, no error should be returned to the user.
             for _ in 0..<4 {
-                expect(changeStream?.next()).toNot(beNil())
+                expect(try changeStream?.nextWithTimeout()).toNot(beNil())
                 expect(changeStream?.error).to(beNil())
             }
         }
@@ -648,22 +649,20 @@ final class ChangeStreamTests: MongoSwiftTestCase {
                 return
             }
 
-            var options = ChangeStreamOptions(maxAwaitTimeMS: ChangeStreamTests.MAX_AWAIT_TIME)
-
-            let basicStream = try coll.watch(options: options)
-            _ = try basicStream.nextOrError()
+            let basicStream = try coll.watch()
+            _ = try basicStream.nextWithTimeout()
             expect(basicStream.resumeToken).to(beNil())
             try coll.insertOne(["x": 1])
             let firstToken = try basicStream.nextOrError()!._id
             expect(basicStream.resumeToken).to(equal(firstToken))
 
-            options.resumeAfter = firstToken
+            let options = ChangeStreamOptions(resumeAfter: firstToken)
             let resumeStream = try coll.watch(options: options)
             expect(resumeStream.resumeToken).to(equal(firstToken))
-            _ = try resumeStream.nextOrError()
+            _ = try resumeStream.nextWithTimeout()
             expect(resumeStream.resumeToken).to(equal(firstToken))
             try coll.insertOne(["x": 1])
-            let lastId = try resumeStream.nextOrError()?._id
+            let lastId = try resumeStream.nextWithTimeout()?._id
             expect(lastId).toNot(beNil())
             expect(resumeStream.resumeToken).to(equal(lastId))
         }
@@ -690,15 +689,14 @@ final class ChangeStreamTests: MongoSwiftTestCase {
                 return
             }
 
-            let changeStream =
-                try coll.watch(options: ChangeStreamOptions(maxAwaitTimeMS: ChangeStreamTests.MAX_AWAIT_TIME))
+            let changeStream = try coll.watch()
             for i in 0..<5 {
                 try coll.insertOne(["x": BSON(i)])
             }
             for _ in 0..<3 {
-                _ = try changeStream.nextOrError()
+                _ = try changeStream.nextWithTimeout()
             }
-            let lastId = try changeStream.nextOrError()?._id
+            let lastId = try changeStream.nextWithTimeout()?._id
             expect(lastId).toNot(beNil())
             expect(changeStream.resumeToken).to(equal(lastId))
         }
@@ -724,12 +722,13 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         defer { try? db1.drop() }
         let coll1 = db1.collection("coll1")
         let coll2 = db1.collection("coll2")
+
         let doc1: Document = ["_id": 1, "a": 1]
         let doc2: Document = ["_id": 2, "x": 123]
         try coll1.insertOne(doc1)
         try coll2.insertOne(doc2)
 
-        let change1 = changeStream.next()
+        let change1 = try changeStream.nextWithTimeout()
         expect(change1).toNot(beNil())
         expect(change1?.operationType).to(equal(.insert))
         expect(change1?.fullDocument).to(equal(doc1))
@@ -737,7 +736,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         expect(changeStream.resumeToken).to(equal(change1?._id))
 
         // test that a change exists for a different collection in the same database
-        let change2 = changeStream.next()
+        let change2 = try changeStream.nextWithTimeout()
         expect(change2).toNot(beNil())
         expect(change2?.operationType).to(equal(.insert))
         expect(change2?.fullDocument).to(equal(doc2))
@@ -748,9 +747,11 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         let db2 = client.db("db2")
         defer { try? db2.drop() }
         let coll = db2.collection("coll3")
+
         let doc3: Document = ["_id": 3, "y": 321]
         try coll.insertOne(doc3)
-        let change3 = changeStream.next()
+
+        let change3 = try changeStream.nextWithTimeout()
         expect(change3).toNot(beNil())
         expect(change3?.operationType).to(equal(.insert))
         expect(change3?.fullDocument).to(equal(doc3))
@@ -772,17 +773,17 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
-        let changeStream = try db.watch(options: ChangeStreamOptions(maxAwaitTimeMS: ChangeStreamTests.MAX_AWAIT_TIME))
+        let changeStream = try db.watch()
 
         // expect the first iteration to be nil since no changes have been made to the database.
-        expect(changeStream.next()).to(beNil())
+        expect(try changeStream.nextWithTimeout()).to(beNil())
 
         let coll = db.collection(self.getCollectionName(suffix: "1"))
         let doc1: Document = ["_id": 1, "a": 1]
         try coll.insertOne(doc1)
 
         // test that the change stream contains a change document for the `insert` operation
-        let change1 = changeStream.next()
+        let change1 = try changeStream.nextWithTimeout()
         expect(change1).toNot(beNil())
         expect(change1?.operationType).to(equal(.insert))
         expect(change1?.fullDocument).to(equal(doc1))
@@ -792,7 +793,7 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
         // expect the change stream to contain a change document for the `drop` operation
         try db.drop()
-        let change2 = changeStream.next()
+        let change2 = try changeStream.nextWithTimeout()
         expect(change2).toNot(beNil())
         expect(change2?.operationType).to(equal(.drop))
 
@@ -815,8 +816,9 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
         let doc: Document = ["_id": 1, "x": 1]
         try coll.insertOne(doc)
-        let change1 = changeStream.next()
+
         // expect the change stream to contain a change document for the `insert` operation
+        let change1 = try changeStream.nextWithTimeout()
         expect(change1).toNot(beNil())
         expect(change1?.operationType).to(equal(.insert))
         expect(change1?.fullDocument).to(equal(doc))
@@ -825,8 +827,9 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         expect(changeStream.resumeToken).to(equal(change1?._id))
 
         try coll.updateOne(filter: ["x": 1], update: ["$set": ["x": 2]])
-        let change2 = changeStream.next()
+
         // expect the change stream to contain a change document for the `update` operation
+        let change2 = try changeStream.nextWithTimeout()
         expect(change2).toNot(beNil())
         expect(change2?.operationType).to(equal(.update))
         expect(change2?.fullDocument).to(equal(["_id": 1, "x": 2]))
@@ -834,9 +837,10 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         // expect the resumeToken to be updated to the _id field of the most recently accessed document
         expect(changeStream.resumeToken).to(equal(change2?._id))
 
-        // expect the change stream contains a change document for the `find` operation
         try coll.findOneAndDelete(["x": 2])
-        let change3 = changeStream.next()
+
+        // expect the change stream contains a change document for the `find` operation
+        let change3 = try changeStream.nextWithTimeout()
         expect(change3).toNot(beNil())
         expect(change3?.operationType).to(equal(.delete))
 
@@ -854,20 +858,22 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
         let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
-        let options = ChangeStreamOptions(fullDocument: .updateLookup, maxAwaitTimeMS: ChangeStreamTests.MAX_AWAIT_TIME)
+
+        let options = ChangeStreamOptions(fullDocument: .updateLookup)
         let pipeline: [Document] = [["$match": ["fullDocument.a": 1]]]
         let changeStream = try coll.watch(pipeline, options: options)
 
         let doc1: Document = ["_id": 1, "a": 1]
         try coll.insertOne(doc1)
-        let change1 = changeStream.next()
+        let change1 = try changeStream.nextWithTimeout()
 
         expect(change1).toNot(beNil())
         expect(change1?.operationType).to(equal(.insert))
         expect(change1?.fullDocument).to(equal(doc1))
+
         // test that a change event does not exists for this insert since this field's been excluded by the pipeline.
         try coll.insertOne(["b": 2])
-        let change2 = changeStream.next()
+        let change2 = try changeStream.nextWithTimeout()
         expect(change2).to(beNil())
     }
 
@@ -881,18 +887,24 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         let db = client.db(type(of: self).testDatabase)
         defer { try? db.drop() }
         let coll = try db.createCollection(self.getCollectionName(suffix: "1"))
+
         let changeStream1 = try coll.watch()
+
         try coll.insertOne(["x": 1])
         try coll.insertOne(["y": 2])
-        _ = changeStream1.next()
+        _ = try changeStream1.nextWithTimeout()
         expect(changeStream1.error).to(beNil())
+
         // save the current resumeToken and use it as the resumeAfter in a new change stream
-        let resumeAfter = changeStream1.resumeToken
-        let changeStream2 = try coll.watch(options: ChangeStreamOptions(resumeAfter: resumeAfter))
+        let resumeToken = changeStream1.resumeToken
+        let options = ChangeStreamOptions(resumeAfter: resumeToken)
+        let changeStream2 = try coll.watch(options: options)
+
         // expect this change stream to have its resumeToken set to the resumeAfter
-        expect(changeStream2.resumeToken).to(equal(resumeAfter))
+        expect(changeStream2.resumeToken).to(equal(resumeToken))
+
         // expect this change stream to have more events after resuming
-        expect(changeStream2.next()).toNot(beNil())
+        expect(try changeStream2.nextWithTimeout()).toNot(beNil())
         expect(changeStream2.error).to(beNil())
     }
 
@@ -931,9 +943,11 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
         // test that the change stream works on a collection when using withEventType
         let collChangeStream = try coll.watch(withEventType: MyEventType.self)
+
         let doc: Document = ["_id": 1, "x": 1, "y": 2]
         try coll.insertOne(doc)
-        let collChange = collChangeStream.next()
+
+        let collChange = try collChangeStream.nextWithTimeout()
         expect(collChangeStream.error).to(beNil())
         expect(collChange).toNot(beNil())
         expect(collChange?.operation).to(equal("insert"))
@@ -947,16 +961,20 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         // test that the change stream works on client and database when using withEventType
         let clientChangeStream = try client.watch(withEventType: MyEventType.self)
         let dbChangeStream = try db.watch(withEventType: MyEventType.self)
+
         let expectedFullDocument = MyFullDocumentType(id: 2, x: 1, y: 2)
+
         try coll.insertOne(["_id": 2, "x": 1, "y": 2])
-        let clientChange = clientChangeStream.next()
-        let dbChange = dbChangeStream.next()
-        expect(clientChangeStream).toNot(beNil())
+
+        let clientChange = try clientChangeStream.nextWithTimeout()
         expect(clientChangeStream.error).to(beNil())
+        expect(clientChange).toNot(beNil())
         expect(clientChange?.operation).to(equal("insert"))
         expect(clientChange?.fullDocument).to(equal(expectedFullDocument))
-        expect(dbChangeStream).toNot(beNil())
+
+        let dbChange = try dbChangeStream.nextWithTimeout()
         expect(dbChangeStream.error).to(beNil())
+        expect(dbChange).toNot(beNil())
         expect(dbChange?.operation).to(equal("insert"))
         expect(dbChange?.fullDocument).to(equal(expectedFullDocument))
     }
@@ -978,7 +996,8 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         // test that the change stream works on a collection when using withFullDocumentType
         let collChangeStream = try coll.watch(withFullDocumentType: MyFullDocumentType.self)
         try coll.insertOne(["_id": 1, "x": 1, "y": 2])
-        let collChange = collChangeStream.next()
+        let collChange = try collChangeStream.nextWithTimeout()
+        expect(collChange).toNot(beNil())
         expect(collChange?.fullDocument).to(equal(expectedDoc1))
 
         guard try client.serverVersion() >= ServerVersion(major: 4, minor: 0) else {
@@ -989,11 +1008,16 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         // test that the change stream works on client and database when using withFullDocumentType
         let clientChangeStream = try client.watch(withFullDocumentType: MyFullDocumentType.self)
         let dbChangeStream = try db.watch(withFullDocumentType: MyFullDocumentType.self)
+
         let expectedDoc2 = MyFullDocumentType(id: 2, x: 1, y: 2)
         try coll.insertOne(["_id": 2, "x": 1, "y": 2])
-        let clientChange = clientChangeStream.next()
-        let dbChange = dbChangeStream.next()
+
+        let clientChange = try clientChangeStream.nextWithTimeout()
+        expect(clientChange).toNot(beNil())
         expect(clientChange?.fullDocument).to(equal(expectedDoc2))
+
+        let dbChange = try dbChangeStream.nextWithTimeout()
+        expect(dbChange).toNot(beNil())
         expect(dbChange?.fullDocument).to(equal(expectedDoc2))
     }
 
@@ -1018,10 +1042,11 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
         let myType = MyType(foo: "blah", bar: 123)
         try coll.insertOne(myType)
-        let change1 = changeStream.next()
+
+        let change = try changeStream.nextWithTimeout()
         expect(changeStream.error).to(beNil())
-        expect(change1).toNot(beNil())
-        expect(change1?.operationType).to(equal(.insert))
-        expect(change1?.fullDocument).to(equal(myType))
+        expect(change).toNot(beNil())
+        expect(change?.operationType).to(equal(.insert))
+        expect(change?.fullDocument).to(equal(myType))
     }
 }

--- a/Tests/MongoSwiftTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/SyncTestUtils.swift
@@ -159,3 +159,19 @@ internal func captureCommandEvents(
         try f(client)
     }
 }
+
+extension ChangeStream {
+    /// Repeatedly poll the change stream until either an event/error is returned or the timeout is hit.
+    /// The default timeout is ChangeStreamTests.TIMEOUT.
+    func nextWithTimeout(_ timeout: TimeInterval = ChangeStreamTests.TIMEOUT) throws -> T? {
+        let start = DispatchTime.now()
+        while DispatchTime.now() < start + timeout {
+            if let event = self.next() {
+                return event
+            } else if let error = self.error {
+                throw error
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
[SWIFT-644](https://jira.mongodb.org/browse/SWIFT-644)

This fixes the failing change stream tests by running `nextWithError` in a loop with a timeout, as suggested in [SPEC-1506](https://jira.mongodb.org/browse/SPEC-1506). This is necessary due to the performance regression in change streams on sharded clusters in the latest version of the server (see [SERVER-44356](https://jira.mongodb.org/browse/SERVER-44356)). Without re-polling, it is possible to miss events because the change stream hasn't received them yet, which was leading to test failures.

[evg patch](https://evergreen.mongodb.com/version/5df3f2bcc9ec4462097dfcd2)