### PR TITLE
SWIFT-689, SWIFT-539 Bump libmongoc version to 1.15.3

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -425,14 +425,6 @@ buildvariants:
       ssl: "ssl"
     then:
       remove_tasks: ".3.6"
-  # workaround for CDRIVER-3318 preventing us from doing any version checks
-  # on sharded clusters. remove in SWIFT-539
-  - if:
-      os-fully-featured: "macos-1014"
-      swift-version: "*"
-      ssl: "ssl"
-    then:
-      remove_tasks: ".sharded_cluster"
 
 - matrix_name: "atlas-connect"
   matrix_spec: 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Core Server (i.e. SERVER) project are **public**.
 Installation is supported via [Swift Package Manager](https://swift.org/package-manager/).
 
 ### Step 1: Install the MongoDB C Driver
-The driver wraps the MongoDB C driver, and using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. **The minimum required version of the C Driver is 1.15.1**.
+The driver wraps the MongoDB C driver, and using it requires having the C driver's two components, `libbson` and `libmongoc`, installed on your system. **The minimum required version of the C Driver is 1.15.3**.
 
 *On a Mac*, you can install both components at once using [Homebrew](https://brew.sh/):
 `brew install mongo-c-driver`.

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -79,16 +79,6 @@ open class MongoSwiftTestCase: XCTestCase {
     public static var sslCAFilePath: String? {
         return ProcessInfo.processInfo.environment["SSL_CA_FILE"]
     }
-
-    /// Temporary helper to assist with skipping tests due to CDRIVER-3318. Returns whether we are running on MacOS.
-    /// Remove when SWIFT-539 is completed.
-    public static var isMacOS: Bool {
-#if os(OSX)
-        return true
-#else
-        return false
-#endif
-    }
 }
 
 extension Document {

--- a/Tests/MongoSwiftSyncTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/ChangeStreamTests.swift
@@ -246,12 +246,6 @@ final class ChangeStreamSpecTests: MongoSwiftTestCase, FailPointConfigured {
     }
 
     func testChangeStreamSpec() throws {
-        // TODO: SWIFT-539: unskip
-        if MongoSwiftTestCase.ssl && MongoSwiftTestCase.isMacOS {
-            print("Skipping test, fails with SSL, see CDRIVER-3318")
-            return
-        }
-
         let tests = try retrieveSpecTestFiles(specName: "change-streams", asType: ChangeStreamTestFile.self)
 
         let globalClient = try MongoClient.makeTestClient()

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -73,12 +73,6 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
     }
 
     func testIndexOptions() throws {
-        // TODO: SWIFT-539: unskip
-        if MongoSwiftTestCase.ssl && MongoSwiftTestCase.isMacOS {
-            print("Skipping test, fails with SSL, see CDRIVER-3318")
-            return
-        }
-
         let options = IndexOptions(
             background: true,
             bits: 32,

--- a/Tests/MongoSwiftSyncTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoDatabaseTests.swift
@@ -80,12 +80,6 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
     }
 
     func testCreateCollection() throws {
-        // TODO: SWIFT-539: unskip
-        if MongoSwiftTestCase.ssl && MongoSwiftTestCase.isMacOS {
-            print("Skipping test, fails with SSL, see CDRIVER-3318")
-            return
-        }
-
         let client = try MongoClient.makeTestClient()
         let db = client.db(type(of: self).testDatabase)
 

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -49,7 +49,7 @@ extension MongoSwiftTestCase {
 extension MongoClient {
     internal func serverVersion() throws -> ServerVersion {
         let reply = try self.db("admin").runCommand(
-            [cmd: "buildInfo"],
+            ["buildInfo": 1],
             options: RunCommandOptions(
                 readPreference: ReadPreference(.primary)
             )

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -48,10 +48,8 @@ extension MongoSwiftTestCase {
 
 extension MongoClient {
     internal func serverVersion() throws -> ServerVersion {
-        // TODO: SWIFT-539: switch to always using buildInfo. fails on MacOS + SSL due to CDRIVER-3318
-        let cmd = MongoSwiftTestCase.ssl && MongoSwiftTestCase.isMacOS ? "serverStatus" : "buildInfo"
         let reply = try self.db("admin").runCommand(
-            [cmd: 1],
+            [cmd: "buildInfo"],
             options: RunCommandOptions(
                 readPreference: ReadPreference(.primary)
             )


### PR DESCRIPTION
No changes needed in how we install libmongoc since we depend on the r1.15 branch. This is just updating the README and deleting workarounds we had in place.