### PR TITLE
SWIFT-670 Make MongoSwift.MongoDatabase async and implement MongoSwiftSync.MongoDatabase

### DIFF
--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -172,7 +172,7 @@ public struct MongoDatabase {
      *   - options: Optional `CreateCollectionOptions` to use for the collection
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: the newly created `MongoCollection<Document>`
+     * - Returns: an `EventLoopFuture` containing the newly created `MongoCollection<Document>`
      *
      * - Throws:
      *   - `CommandError` if an error occurs that prevents the command from executing.
@@ -199,7 +199,7 @@ public struct MongoDatabase {
      *   - options: Optional `CreateCollectionOptions` to use for the collection
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: the newly created `MongoCollection<T>`
+     * - Returns: An `EventLoopFuture` containing the newly created `MongoCollection<T>`
      *
      * - Throws:
      *   - `CommandError` if an error occurs that prevents the command from executing.

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -251,7 +251,7 @@ public struct MongoDatabase {
      *   - options: Optional `ListCollectionsOptions` to use when executing this command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[MongoCollection<Document>]>`s containing collections that match the provided
+     * - Returns: An `EventLoopFuture<[MongoCollection<Document>]>` containing collections that match the provided
      *            filter.
      *
      * - Throws:

--- a/Sources/MongoSwiftSync/MongoClient.swift
+++ b/Sources/MongoSwiftSync/MongoClient.swift
@@ -22,7 +22,7 @@ public class MongoClient {
     private let eventLoopGroup: MultiThreadedEventLoopGroup
 
     /// The underlying async client.
-    private let asyncClient: MongoSwift.MongoClient
+    internal let asyncClient: MongoSwift.MongoClient
 
     /**
      * Create a new client connection to a MongoDB server. For options that included in both the connection string URI
@@ -128,7 +128,7 @@ public class MongoClient {
         _ filter: Document? = nil,
         session: ClientSession? = nil
     ) throws -> [MongoDatabase] {
-        fatalError("unimplemented")
+        return try self.listDatabaseNames(filter, session: session).map { self.db($0) }
     }
 
     /**

--- a/Sources/MongoSwiftSync/MongoDatabase.swift
+++ b/Sources/MongoSwiftSync/MongoDatabase.swift
@@ -25,7 +25,7 @@ public struct MongoDatabase {
     internal let client: MongoClient
 
     /// The underlying asynchronous database.
-    private let asyncDB: MongoSwift.MongoDatabase 
+    private let asyncDB: MongoSwift.MongoDatabase
 
     /// Initializes a new `MongoDatabase` instance, not meant to be instantiated directly.
     internal init(name: String, client: MongoClient, options: DatabaseOptions?) {

--- a/Sources/MongoSwiftSync/MongoDatabase.swift
+++ b/Sources/MongoSwiftSync/MongoDatabase.swift
@@ -2,31 +2,35 @@ import MongoSwift
 
 /// A MongoDB Database.
 public struct MongoDatabase {
-    /// The client which this database was derived from.
-    internal let _client: MongoClient
-
     /// Encoder used by this database for BSON conversions. This encoder's options are inherited by collections derived
     /// from this database.
-    public var encoder: BSONEncoder { fatalError("unimplemented") }
+    public var encoder: BSONEncoder { return self.asyncDB.encoder }
 
     /// Decoder whose options are inherited by collections derived from this database.
-    public var decoder: BSONDecoder { fatalError("unimplemented") }
+    public var decoder: BSONDecoder { return self.asyncDB.decoder }
 
     /// The name of this database.
-    public var name: String { fatalError("unimplemented") }
+    public var name: String { return self.asyncDB.name }
 
     /// The `ReadConcern` set on this database, or `nil` if one is not set.
-    public var readConcern: ReadConcern? { fatalError("unimplemented") }
+    public var readConcern: ReadConcern? { return self.asyncDB.readConcern }
 
     /// The `ReadPreference` set on this database
-    public let readPreference: ReadPreference
+    public var readPreference: ReadPreference { return self.asyncDB.readPreference }
 
     /// The `WriteConcern` set on this database, or `nil` if one is not set.
-    public let writeConcern: WriteConcern?
+    public var writeConcern: WriteConcern? { return self.asyncDB.writeConcern }
+
+    /// The client which this database was derived from.
+    internal let client: MongoClient
+
+    /// The underlying asynchronous database.
+    private let asyncDB: MongoSwift.MongoDatabase 
 
     /// Initializes a new `MongoDatabase` instance, not meant to be instantiated directly.
     internal init(name: String, client: MongoClient, options: DatabaseOptions?) {
-        fatalError("unimplemented")
+        self.client = client
+        self.asyncDB = client.asyncClient.db(name, options: options)
     }
 
     /**
@@ -39,7 +43,7 @@ public struct MongoDatabase {
      *   - `CommandError` if an error occurs that prevents the command from executing.
      */
     public func drop(options: DropDatabaseOptions? = nil, session: ClientSession? = nil) throws {
-        fatalError("unimplemented")
+        return try self.asyncDB.drop(options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -195,7 +199,7 @@ public struct MongoDatabase {
         options: ListCollectionsOptions? = nil,
         session: ClientSession? = nil
     ) throws -> [String] {
-        fatalError("unimplemented")
+        return try self.asyncDB.listCollectionNames(filter, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -221,7 +225,7 @@ public struct MongoDatabase {
         options: RunCommandOptions? = nil,
         session: ClientSession? = nil
     ) throws -> Document {
-        fatalError("unimplemented")
+        return try self.asyncDB.runCommand(command, options: options, session: session?.asyncSession).wait()
     }
 
     /**

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -218,6 +218,15 @@ public enum AuthMechanism: String, Decodable {
     case plain = "PLAIN"
 }
 
+/// Makes `ConnectionId` `Decodable` for the sake of constructing it from spec test files.
+extension ConnectionId: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let hostPortPair = try container.decode(String.self)
+        self.init(hostPortPair)
+    }
+}
+
 extension CommandError {
     public static func new(
         code: ServerErrorCode,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -46,6 +46,12 @@ extension CodecTests {
     ]
 }
 
+extension DNSSeedlistTests {
+    static var allTests = [
+        ("testInitialDNSSeedlistDiscovery", testInitialDNSSeedlistDiscovery),
+    ]
+}
+
 extension DocumentTests {
     static var allTests = [
         ("testDocument", testDocument),
@@ -137,6 +143,12 @@ extension ReadWriteConcernSpecTests {
     ]
 }
 
+extension SyncAuthTests {
+    static var allTests = [
+        ("testAuthProseTests", testAuthProseTests),
+    ]
+}
+
 extension WriteConcernTests {
     static var allTests = [
         ("testWriteConcernType", testWriteConcernType),
@@ -150,6 +162,7 @@ XCTMain([
     testCase(BSONCorpusTests.allTests),
     testCase(BSONValueTests.allTests),
     testCase(CodecTests.allTests),
+    testCase(DNSSeedlistTests.allTests),
     testCase(DocumentTests.allTests),
     testCase(Document_CollectionTests.allTests),
     testCase(Document_SequenceTests.allTests),
@@ -158,5 +171,6 @@ XCTMain([
     testCase(ReadConcernTests.allTests),
     testCase(ReadPreferenceTests.allTests),
     testCase(ReadWriteConcernSpecTests.allTests),
+    testCase(SyncAuthTests.allTests),
     testCase(WriteConcernTests.allTests),
 ])

--- a/Tests/MongoSwiftSyncTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftSyncTests/DNSSeedlistTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-@testable import MongoSwift
 import MongoSwiftSync
 import Nimble
 import TestsCommon
@@ -22,15 +21,6 @@ struct DNSSeedlistTestCase: Decodable {
     let error: Bool?
     /// A comment to indicate why a test would fail.
     let comment: String?
-}
-
-/// Makes `ConnectionId` `Decodable` for the sake of constructing it from the test files.
-extension ConnectionId: Decodable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let hostPortPair = try container.decode(String.self)
-        self.init(hostPortPair)
-    }
 }
 
 final class DNSSeedlistTests: MongoSwiftTestCase {

--- a/Tests/MongoSwiftSyncTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftSyncTests/DNSSeedlistTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import MongoSwift
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 import XCTest

--- a/Tests/MongoSwiftSyncTests/SyncAuthTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncAuthTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MongoSwift
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -147,13 +147,13 @@ final class ReadConcernTests: MongoSwiftTestCase {
 
         try self.withTestClient { client in
             let db1 = client.db(type(of: self).testDatabase)
-            defer { try? db1.drop() }
+            defer { try? db1.drop().wait() }
 
             let dbDesc = "db created with no RC provided"
 
             let coll1Name = self.getCollectionName(suffix: "1")
             // expect that a collection created from a DB with unset RC also has unset RC
-            var coll1 = try db1.createCollection(coll1Name)
+            var coll1 = try db1.createCollection(coll1Name).wait()
             try checkReadConcern(coll1, empty, "collection created with no RC provided from \(dbDesc)")
 
             // expect that a collection retrieved from a DB with unset RC also has unset RC
@@ -177,17 +177,17 @@ final class ReadConcernTests: MongoSwiftTestCase {
                 db1.collection(self.getCollectionName(suffix: "3"), options: CollectionOptions(readConcern: unknown))
             try checkReadConcern(coll3, unknown, "collection retrieved with unknown RC level from \(dbDesc)")
 
-            try db1.drop()
+            try db1.drop().wait()
 
             let db2 = client.db(
                 type(of: self).testDatabase,
                 options: DatabaseOptions(readConcern: local)
             )
-            defer { try? db2.drop() }
+            defer { try? db2.drop().wait() }
 
             let coll4Name = self.getCollectionName(suffix: "4")
             // expect that a collection created from a DB with local RC also has local RC
-            var coll4 = try db2.createCollection(coll4Name)
+            var coll4 = try db2.createCollection(coll4Name).wait()
             try checkReadConcern(coll4, local, "collection created with no RC provided from \(dbDesc)")
 
             // expect that a collection retrieved from a DB with local RC also has local RC

--- a/Tests/MongoSwiftTests/WriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/WriteConcernTests.swift
@@ -130,12 +130,12 @@ final class WriteConcernTests: MongoSwiftTestCase {
 
         try self.withTestClient { client in
             let db1 = client.db(type(of: self).testDatabase)
-            defer { try? db1.drop() }
+            defer { try? db1.drop().wait() }
 
             var dbDesc = "db created with no WC provided"
 
             // expect that a collection created from a DB with default WC also has default WC
-            var coll1 = try db1.createCollection(self.getCollectionName(suffix: "1"))
+            var coll1 = try db1.createCollection(self.getCollectionName(suffix: "1")).wait()
             try checkWriteConcern(coll1, empty, "collection created with no WC provided from \(dbDesc)")
 
             // expect that a collection retrieved from a DB with default WC also has default WC
@@ -147,14 +147,14 @@ final class WriteConcernTests: MongoSwiftTestCase {
                 db1.collection(self.getCollectionName(suffix: "2"), options: CollectionOptions(writeConcern: w1))
             try checkWriteConcern(coll2, w1, "collection retrieved with w:1 from \(dbDesc)")
 
-            try db1.drop()
+            try db1.drop().wait()
 
             let db2 = client.db(type(of: self).testDatabase, options: DatabaseOptions(writeConcern: w1))
-            defer { try? db2.drop() }
+            defer { try? db2.drop().wait() }
             dbDesc = "db created with w:1"
 
             // expect that a collection created from a DB with w:1 also has w:1
-            var coll3 = try db2.createCollection(self.getCollectionName(suffix: "3"))
+            var coll3 = try db2.createCollection(self.getCollectionName(suffix: "3")).wait()
             try checkWriteConcern(coll3, w1, "collection created with no WC provided from \(dbDesc)")
 
             // expect that a collection retrieved from a DB with w:1 also has w:1


### PR DESCRIPTION
This PR updates `MongoSwift.MongoDatabase` to be async by using the client's new `executeOperationAsync` method, and implements `MongoSwiftSync.MongoDatabase` as a wrapper of the newly async DB.

This allowed me to reenable some tests and also required minor changes to already-enabled read/write concern tests to `wait()` on results.