### PR TITLE
SWIFT-709 ignore vendored files for language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore vendored code for language statistics in GitHub
+Sources/CLibMongoC/* linguist-vendored


### PR DESCRIPTION
Adding a specially crafted line to our `.gitattributes` file will indicate that GitHub should skip certain directories when doing language statistics on the project.
