### PR TITLE
SWIFT-690 Don't archive logs until cluster has finished shutting down

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -92,7 +92,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone -b blocking-stop git://github.com/patrickfreed/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 
@@ -120,6 +120,10 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
+          MONGODB_VERSION=${MONGODB_VERSION} \
+            TOPOLOGY=${TOPOLOGY} \
+            SSL=${SSL} \
+            sh ${DRIVERS_TOOLS}/.evergreen/stop-cluster.sh
           sh ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
 
   "run tests":
@@ -177,7 +181,6 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          sleep 5 # wait for existing mongod instances to finish shutting down
           find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
     - command: s3.put
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -177,6 +177,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
+          sleep 1 # wait for existing mongod instances to finish shutting down
           find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
     - command: s3.put
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -177,7 +177,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          sleep 1 # wait for existing mongod instances to finish shutting down
+          sleep 5 # wait for existing mongod instances to finish shutting down
           find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
     - command: s3.put
       params:


### PR DESCRIPTION
This is a follow-up to SWIFT-690. Right now, we're seeing some purple failures on the waterfall due to the log upload function beginning before the mongods are all finished shutting down. [The logs are still changing while we attempt to archive them, and it results in the task failing.](https://evergreen.mongodb.com/task_log_raw/mongo_swift_driver_tests_all__os_fully_featured~ubuntu_18.04_swift_version~5.0_ssl~ssl_test_4.0_replica_set_865b5660a707b2445279d70f695321bae534252c_20_01_06_16_34_45/0?type=T#L1641) I think this is due "upload-mo-artifacts" being called directly after "stop-mongo-orchestration", rather than in post.

To alleviate this, I simply added a 1 second sleep to "upload mo artifacts", and it seems to be enough breathing room to prevent this issue. [example patch](https://evergreen.mongodb.com/version/5e1388b4e3c3315b3af19253)
