### PR TITLE
SWIFT-671 Make MongoCollection read/write methods async, and implement synchronous equivalents

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -1,4 +1,5 @@
 import CLibMongoC
+import NIO
 
 /// An extension of `MongoCollection` encapsulating read operations.
 extension MongoCollection {
@@ -85,15 +86,15 @@ extension MongoCollection {
      *   - options: Optional `CountDocumentsOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: The count of the documents that matched the filter
+     * - Returns: An `EventLoopFuture<Int>` containing the count of the documents that matched the filter
      */
     public func countDocuments(
         _ filter: Document = [:],
         options: CountDocumentsOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> Int {
+    ) -> EventLoopFuture<Int> {
         let operation = CountDocumentsOperation(collection: self, filter: filter, options: options)
-        return try self._client.executeOperation(operation, session: session)
+        return self._client.executeOperationAsync(operation, session: session)
     }
 
     /**
@@ -103,14 +104,14 @@ extension MongoCollection {
      *   - options: Optional `EstimatedDocumentCountOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: an estimate of the count of documents in this collection
+     * - Returns: An `EventLoopFuture<Int>` containing an estimate of the count of documents in this collection
      */
     public func estimatedDocumentCount(
         options: EstimatedDocumentCountOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> Int {
+    ) -> EventLoopFuture<Int> {
         let operation = EstimatedDocumentCountOperation(collection: self, options: options)
-        return try self._client.executeOperation(operation, session: session)
+        return self._client.executeOperationAsync(operation, session: session)
     }
 
     /**
@@ -122,7 +123,7 @@ extension MongoCollection {
      *   - options: Optional `DistinctOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: A `[BSONValue]` containing the distinct values for the specified criteria
+     * - Returns: An `EventLoopFuture<[BSON]>` containing the distinct values for the specified criteria
      *
      * - Throws:
      *   - `CommandError` if an error occurs that prevents the command from executing.
@@ -135,8 +136,8 @@ extension MongoCollection {
         filter: Document = [:],
         options: DistinctOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> [BSON] {
+    ) -> EventLoopFuture<[BSON]> {
         let operation = DistinctOperation(collection: self, fieldName: fieldName, filter: filter, options: options)
-        return try self._client.executeOperation(operation, session: session)
+        return self._client.executeOperationAsync(operation, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -1,4 +1,5 @@
 import CLibMongoC
+import NIO
 
 /// Options to use when dropping a collection.
 public struct DropCollectionOptions: Codable {
@@ -92,9 +93,9 @@ public struct MongoCollection<T: Codable> {
      * - Throws:
      *   - `CommandError` if an error occurs that prevents the command from executing.
      */
-    public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) throws {
+    public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {
         let operation = DropCollectionOperation(collection: self, options: options)
-        return try self._client.executeOperation(operation, session: session)
+        return self._client.executeOperationAsync(operation, session: session)
     }
 
     /// Uses the provided `Connection` to get a pointer to a `mongoc_collection_t` corresponding to this

--- a/Sources/MongoSwiftSync/MongoClient.swift
+++ b/Sources/MongoSwiftSync/MongoClient.swift
@@ -22,7 +22,7 @@ public class MongoClient {
     private let eventLoopGroup: MultiThreadedEventLoopGroup
 
     /// The underlying async client.
-    internal let asyncClient: MongoSwift.MongoClient
+    private let asyncClient: MongoSwift.MongoClient
 
     /**
      * Create a new client connection to a MongoDB server. For options that included in both the connection string URI
@@ -160,7 +160,7 @@ public class MongoClient {
      * - Returns: a `MongoDatabase` corresponding to the provided database name
      */
     public func db(_ name: String, options: DatabaseOptions? = nil) -> MongoDatabase {
-        return MongoDatabase(name: name, client: self, options: options)
+        return MongoDatabase(asyncDB: self.asyncClient.db(name, options: options))
     }
 
     /**

--- a/Sources/MongoSwiftSync/MongoCollection+Read.swift
+++ b/Sources/MongoSwiftSync/MongoCollection+Read.swift
@@ -87,7 +87,7 @@ extension MongoCollection {
         options: CountDocumentsOptions? = nil,
         session: ClientSession? = nil
     ) throws -> Int {
-        fatalError("unimplemented")
+        return try self.asyncColl.countDocuments(filter, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -103,7 +103,7 @@ extension MongoCollection {
         options: EstimatedDocumentCountOptions? = nil,
         session: ClientSession? = nil
     ) throws -> Int {
-        fatalError("unimplemented")
+        return try self.asyncColl.estimatedDocumentCount(options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -129,6 +129,10 @@ extension MongoCollection {
         options: DistinctOptions? = nil,
         session: ClientSession? = nil
     ) throws -> [BSON] {
-        fatalError("unimplemented")
+        return try self.asyncColl.distinct(fieldName: fieldName,
+                                           filter: filter,
+                                           options: options,
+                                           session: session?.asyncSession)
+                                            .wait()
     }
 }

--- a/Sources/MongoSwiftSync/MongoCollection+Write.swift
+++ b/Sources/MongoSwiftSync/MongoCollection+Write.swift
@@ -27,7 +27,7 @@ extension MongoCollection {
         options: InsertOneOptions? = nil,
         session: ClientSession? = nil
     ) throws -> InsertOneResult? {
-        fatalError("unimplemented")
+        return try self.asyncColl.insertOne(value, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -54,7 +54,7 @@ extension MongoCollection {
         options: InsertManyOptions? = nil,
         session: ClientSession? = nil
     ) throws -> InsertManyResult? {
-        fatalError("unimplemented")
+        return try self.asyncColl.insertMany(values, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -83,7 +83,11 @@ extension MongoCollection {
         options: ReplaceOptions? = nil,
         session: ClientSession? = nil
     ) throws -> UpdateResult? {
-        fatalError("unimplemented")
+        return try self.asyncColl.replaceOne(filter: filter,
+                                             replacement: replacement,
+                                             options: options,
+                                             session: session?.asyncSession)
+                                            .wait()
     }
 
     /**
@@ -112,7 +116,11 @@ extension MongoCollection {
         options: UpdateOptions? = nil,
         session: ClientSession? = nil
     ) throws -> UpdateResult? {
-        fatalError("unimplemented")
+        return try self.asyncColl.updateOne(filter: filter,
+                                            update: update,
+                                            options: options,
+                                            session: session?.asyncSession)
+                                            .wait()
     }
 
     /**
@@ -141,7 +149,11 @@ extension MongoCollection {
         options: UpdateOptions? = nil,
         session: ClientSession? = nil
     ) throws -> UpdateResult? {
-        fatalError("unimplemented")
+        return try self.asyncColl.updateMany(filter: filter,
+                                             update: update,
+                                             options: options,
+                                             session: session?.asyncSession)
+                                            .wait()
     }
 
     /**
@@ -168,7 +180,7 @@ extension MongoCollection {
         options: DeleteOptions? = nil,
         session: ClientSession? = nil
     ) throws -> DeleteResult? {
-        fatalError("unimplemented")
+        return try self.asyncColl.deleteOne(filter, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -195,7 +207,7 @@ extension MongoCollection {
         options: DeleteOptions? = nil,
         session: ClientSession? = nil
     ) throws -> DeleteResult? {
-        fatalError("unimplemented")
+        return try self.asyncColl.deleteMany(filter, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -221,6 +233,6 @@ extension MongoCollection {
         options: BulkWriteOptions? = nil,
         session: ClientSession? = nil
     ) throws -> BulkWriteResult? {
-        fatalError("unimplemented")
+        return try self.asyncColl.bulkWrite(requests, options: options, session: session?.asyncSession).wait()
     }
 }

--- a/Sources/MongoSwiftSync/MongoCollection.swift
+++ b/Sources/MongoSwiftSync/MongoCollection.swift
@@ -2,15 +2,12 @@ import MongoSwift
 
 /// A MongoDB collection.
 public struct MongoCollection<T: Codable> {
-    /// The client which this collection was derived from.
-    internal let _client: MongoClient
-
     /// Encoder used by this collection for BSON conversions. (e.g. converting `CollectionType`s, indexes, and options
     /// to documents).
-    public var encoder: BSONEncoder { fatalError("unimplemented") }
+    public var encoder: BSONEncoder { return self.asyncColl.encoder }
 
     /// Decoder used by this collection for BSON conversions (e.g. converting documents to `CollectionType`s).
-    public var decoder: BSONDecoder { fatalError("unimplemented") }
+    public var decoder: BSONDecoder { return self.asyncColl.decoder }
 
     /**
      * A `Codable` type associated with this `MongoCollection` instance.
@@ -27,21 +24,23 @@ public struct MongoCollection<T: Codable> {
     public typealias CollectionType = T
 
     /// The name of this collection.
-    public var name: String { fatalError("unimplemented") }
+    public var name: String { return self.asyncColl.name }
 
     /// The `ReadConcern` set on this collection, or `nil` if one is not set.
-    public var readConcern: ReadConcern? { fatalError("unimplemented") }
+    public var readConcern: ReadConcern? { return self.asyncColl.readConcern }
 
     /// The `ReadPreference` set on this collection.
-    public var readPreference: ReadPreference { fatalError("unimplemented") }
+    public var readPreference: ReadPreference { return self.asyncColl.readPreference }
 
     /// The `WriteConcern` set on this collection, or nil if one is not set.
-    public var writeConcern: WriteConcern? { fatalError("unimplemented") }
+    public var writeConcern: WriteConcern? { return self.asyncColl.writeConcern }
 
-    /// Initializes a new `MongoCollection` instance corresponding to a collection with name `name` in database with
-    /// the provided options.
-    internal init(name: String, database: MongoDatabase, options: CollectionOptions?) {
-        fatalError("unimplemented")
+    /// The underlying asynchronous collection.
+    internal let asyncColl: MongoSwift.MongoCollection<T>
+
+    /// Initializes a new `MongoCollection` instance wrapping the provided async collection.
+    internal init(asyncCollection: MongoSwift.MongoCollection<T>) {
+        self.asyncColl = asyncCollection
     }
 
     /**
@@ -54,6 +53,6 @@ public struct MongoCollection<T: Codable> {
      *   - `CommandError` if an error occurs that prevents the command from executing.
      */
     public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) throws {
-        fatalError("unimplemented")
+        try self.asyncColl.drop(options: options, session: session?.asyncSession).wait()
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -124,6 +124,12 @@ extension ReadConcernTests {
     ]
 }
 
+extension ReadPreferenceOperationTests {
+    static var allTests = [
+        ("testOperationReadPreference", testOperationReadPreference),
+    ]
+}
+
 extension ReadPreferenceTests {
     static var allTests = [
         ("testMode", testMode),
@@ -136,6 +142,14 @@ extension ReadPreferenceTests {
     ]
 }
 
+extension ReadWriteConcernOperationTests {
+    static var allTests = [
+        ("testOperationReadConcerns", testOperationReadConcerns),
+        ("testWriteConcernErrors", testWriteConcernErrors),
+        ("testOperationWriteConcerns", testOperationWriteConcerns),
+    ]
+}
+
 extension ReadWriteConcernSpecTests {
     static var allTests = [
         ("testConnectionStrings", testConnectionStrings),
@@ -143,9 +157,24 @@ extension ReadWriteConcernSpecTests {
     ]
 }
 
+extension SDAMTests {
+    static var allTests = [
+        ("testMonitoring", testMonitoring),
+    ]
+}
+
 extension SyncAuthTests {
     static var allTests = [
         ("testAuthProseTests", testAuthProseTests),
+    ]
+}
+
+extension SyncMongoClientTests {
+    static var allTests = [
+        ("testListDatabases", testListDatabases),
+        ("testFailedClientInitialization", testFailedClientInitialization),
+        ("testServerVersion", testServerVersion),
+        ("testCodingStrategies", testCodingStrategies),
     ]
 }
 
@@ -169,8 +198,12 @@ XCTMain([
     testCase(MongoClientTests.allTests),
     testCase(OptionsTests.allTests),
     testCase(ReadConcernTests.allTests),
+    testCase(ReadPreferenceOperationTests.allTests),
     testCase(ReadPreferenceTests.allTests),
+    testCase(ReadWriteConcernOperationTests.allTests),
     testCase(ReadWriteConcernSpecTests.allTests),
+    testCase(SDAMTests.allTests),
     testCase(SyncAuthTests.allTests),
+    testCase(SyncMongoClientTests.allTests),
     testCase(WriteConcernTests.allTests),
 ])

--- a/Tests/MongoSwiftSyncTests/ReadPreferenceOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadPreferenceOperationTests.swift
@@ -1,4 +1,4 @@
-@testable import MongoSwift
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 import XCTest
@@ -22,14 +22,16 @@ final class ReadPreferenceOperationTests: MongoSwiftTestCase {
         let res = try db.runCommand(command, options: opts)
         expect(res["ok"]?.asDouble()).to(equal(1.0))
 
+        // TODO: SWIFT-672: uncomment these assertions
         // expect running other commands to not throw errors when passing in a valid read preference
-        expect(try coll.find(options: FindOptions(readPreference: ReadPreference(.primary)))).toNot(throwError())
-        expect(try coll.findOne(options: FindOneOptions(readPreference: ReadPreference(.primary)))).toNot(throwError())
+        // expect(try coll.find(options: FindOptions(readPreference: ReadPreference(.primary)))).toNot(throwError())
+        // expect(try coll.findOne(options: FindOneOptions(readPreference: ReadPreference(.primary))
+        // )).toNot(throwError())
 
-        expect(try coll.aggregate(
-            [["$project": ["a": 1]]],
-            options: AggregateOptions(readPreference: ReadPreference(.secondaryPreferred))
-        )).toNot(throwError())
+        // expect(try coll.aggregate(
+        //     [["$project": ["a": 1]]],
+        //     options: AggregateOptions(readPreference: ReadPreference(.secondaryPreferred))
+        // )).toNot(throwError())
 
         expect(try coll.countDocuments(
             options:

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -1,5 +1,6 @@
-import mongoc
+import CLibMongoC
 @testable import MongoSwift
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 
@@ -39,13 +40,14 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
             )))
 
         // try various command + read concern pairs to make sure they work
-        expect(try coll.find(options: FindOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
-        expect(try coll.findOne(options: FindOneOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
+        // TODO: SWIFT-672: uncomment these assertions
+        // expect(try coll.find(options: FindOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
+        // expect(try coll.findOne(options: FindOneOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
 
-        expect(try coll.aggregate(
-            [["$project": ["a": 1]]],
-            options: AggregateOptions(readConcern: ReadConcern(.majority))
-        )).toNot(throwError())
+        // expect(try coll.aggregate(
+        //     [["$project": ["a": 1]]],
+        //     options: AggregateOptions(readConcern: ReadConcern(.majority))
+        // )).toNot(throwError())
 
         expect(try coll.countDocuments(options: CountDocumentsOptions(readConcern: ReadConcern(.majority))))
             .toNot(throwError())
@@ -160,8 +162,9 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
 
         let coll2 = try db.createCollection(self.getCollectionName(suffix: "2"))
         defer { try? coll2.drop() }
-        let pipeline: [Document] = [["$out": .string("\(db.name).\(coll2.name)")]]
-        expect(try coll.aggregate(pipeline, options: AggregateOptions(writeConcern: wc1))).toNot(throwError())
+        // TODO: SWIFT-672: uncomment these lines
+        // let pipeline: [Document] = [["$out": .string("\(db.name).\(coll2.name)")]]
+        // expect(try coll.aggregate(pipeline, options: AggregateOptions(writeConcern: wc1))).toNot(throwError())
 
         expect(try coll.replaceOne(
             filter: ["x": 5],
@@ -180,16 +183,17 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
         expect(try coll.deleteMany(["x": 9], options: DeleteOptions(writeConcern: wc1))).toNot(throwError())
         expect(try coll.deleteMany(["x": 10], options: DeleteOptions(writeConcern: wc3))).toNot(throwError())
 
-        expect(try coll.createIndex(
-            ["x": 1],
-            options: CreateIndexOptions(writeConcern: wc1)
-        )).toNot(throwError())
-        expect(try coll.createIndexes(
-            [IndexModel(keys: ["x": -1])],
-            options: CreateIndexOptions(writeConcern: wc3)
-        )).toNot(throwError())
+        // TODO: SWIFT-702: uncomment these assertions
+        // expect(try coll.createIndex(
+        //     ["x": 1],
+        //     options: CreateIndexOptions(writeConcern: wc1)
+        // )).toNot(throwError())
+        // expect(try coll.createIndexes(
+        //     [IndexModel(keys: ["x": -1])],
+        //     options: CreateIndexOptions(writeConcern: wc3)
+        // )).toNot(throwError())
 
-        expect(try coll.dropIndex(["x": 1], options: DropIndexOptions(writeConcern: wc1))).toNot(throwError())
-        expect(try coll.dropIndexes(options: DropIndexOptions(writeConcern: wc3))).toNot(throwError())
+        // expect(try coll.dropIndex(["x": 1], options: DropIndexOptions(writeConcern: wc1))).toNot(throwError())
+        // expect(try coll.dropIndexes(options: DropIndexOptions(writeConcern: wc3))).toNot(throwError())
     }
 }

--- a/Tests/MongoSwiftSyncTests/SDAMMonitoringTests.swift
+++ b/Tests/MongoSwiftSyncTests/SDAMMonitoringTests.swift
@@ -1,6 +1,7 @@
 import CLibMongoC
 import Foundation
 @testable import MongoSwift
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 import XCTest

--- a/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
@@ -1,10 +1,10 @@
 import Foundation
-import MongoSwift
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 import XCTest
 
-final class MongoClientTests: MongoSwiftTestCase {
+final class SyncMongoClientTests: MongoSwiftTestCase {
     func testListDatabases() throws {
         let client = try MongoClient.makeTestClient()
 
@@ -127,7 +127,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         let data = Data(base64Encoded: "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wZWQgb3ZlciB0aGUgbGF6eSBzaGVlcCBkb2cu")!
 
         let wrapperWithId = { id in Wrapper(_id: id, date: date, uuid: uuid, data: data) }
-        let wrapper = wrapperWithId("baseline")
+        // let wrapper = wrapperWithId("baseline")
 
         let defaultClient = try MongoClient.makeTestClient()
         let defaultDb = defaultClient.db(type(of: self).testDatabase)
@@ -139,13 +139,14 @@ final class MongoClientTests: MongoSwiftTestCase {
         let defaultId: BSON = "default"
         try collDefault.insertOne(wrapperWithId(defaultId.stringValue!))
 
-        var doc = try collDoc.find(["_id": defaultId]).nextOrError()
-        expect(doc).toNot(beNil())
-        expect(doc?["date"]?.dateValue).to(equal(date))
-        expect(doc?["uuid"]?.binaryValue).to(equal(try Binary(from: uuid)))
-        expect(doc?["data"]?.binaryValue).to(equal(try Binary(data: data, subtype: .generic)))
+        // TODO: SWIFT-672: enable these assertions
+        // var doc = try collDoc.find(["_id": defaultId]).nextOrError()
+        // expect(doc).toNot(beNil())
+        // expect(doc?["date"]?.dateValue).to(equal(date))
+        // expect(doc?["uuid"]?.binaryValue).to(equal(try Binary(from: uuid)))
+        // expect(doc?["data"]?.binaryValue).to(equal(try Binary(data: data, subtype: .generic)))
 
-        expect(try collDefault.find(["_id": defaultId]).nextOrError()).to(equal(wrapper))
+        // expect(try collDefault.find(["_id": defaultId]).nextOrError()).to(equal(wrapper))
 
         // Customize strategies on the client
         let custom = ClientOptions(
@@ -159,13 +160,14 @@ final class MongoClientTests: MongoSwiftTestCase {
         let collClientId: BSON = "customClient"
         try collClient.insertOne(wrapperWithId(collClientId.stringValue!))
 
-        doc = try collDoc.find(["_id": collClientId]).nextOrError()
-        expect(doc).toNot(beNil())
-        expect(doc?["date"]?.doubleValue).to(beCloseTo(date.timeIntervalSince1970, within: 0.001))
-        expect(doc?["uuid"]?.stringValue).to(equal(uuid.uuidString))
-        expect(doc?["data"]?.stringValue).to(equal(data.base64EncodedString()))
+        // TODO: SWIFT-672: enable these assertions
+        // doc = try collDoc.find(["_id": collClientId]).nextOrError()
+        // expect(doc).toNot(beNil())
+        // expect(doc?["date"]?.doubleValue).to(beCloseTo(date.timeIntervalSince1970, within: 0.001))
+        // expect(doc?["uuid"]?.stringValue).to(equal(uuid.uuidString))
+        // expect(doc?["data"]?.stringValue).to(equal(data.base64EncodedString()))
 
-        expect(try collClient.find(["_id": collClientId]).nextOrError()).to(equal(wrapper))
+        // expect(try collClient.find(["_id": collClientId]).nextOrError()).to(equal(wrapper))
 
         // Construct db with differing strategies from client
         let dbOpts = DatabaseOptions(
@@ -179,13 +181,14 @@ final class MongoClientTests: MongoSwiftTestCase {
         let customDbId: BSON = "customDb"
         try collDb.insertOne(wrapperWithId(customDbId.stringValue!))
 
-        doc = try collDoc.find(["_id": customDbId]).next()
-        expect(doc).toNot(beNil())
-        expect(doc?["date"]?.doubleValue).to(beCloseTo(date.timeIntervalSinceReferenceDate, within: 0.001))
-        expect(doc?["uuid"]?.binaryValue).to(equal(try Binary(from: uuid)))
-        expect(doc?["data"]?.binaryValue).to(equal(try Binary(data: data, subtype: .generic)))
+        // TODO: SWIFT-672: enable these assertions
+        // doc = try collDoc.find(["_id": customDbId]).next()
+        // expect(doc).toNot(beNil())
+        // expect(doc?["date"]?.doubleValue).to(beCloseTo(date.timeIntervalSinceReferenceDate, within: 0.001))
+        // expect(doc?["uuid"]?.binaryValue).to(equal(try Binary(from: uuid)))
+        // expect(doc?["data"]?.binaryValue).to(equal(try Binary(data: data, subtype: .generic)))
 
-        expect(try collDb.find(["_id": customDbId]).nextOrError()).to(equal(wrapper))
+        // expect(try collDb.find(["_id": customDbId]).nextOrError()).to(equal(wrapper))
 
         // Construct collection with differing strategies from database
         let dbCollOpts = CollectionOptions(
@@ -197,15 +200,16 @@ final class MongoClientTests: MongoSwiftTestCase {
 
         let customDbCollId: BSON = "customDbColl"
         try collCustom.insertOne(wrapperWithId(customDbCollId.stringValue!))
-        doc = try collDoc.find(["_id": customDbCollId]).nextOrError()
+        // TODO: SWIFT-672: enable these assertions
+        // doc = try collDoc.find(["_id": customDbCollId]).nextOrError()
 
-        expect(doc).toNot(beNil())
-        expect(doc?["date"]?.int64Value).to(equal(date.msSinceEpoch))
-        expect(doc?["uuid"]?.stringValue).to(equal(uuid.uuidString))
-        expect(doc?["data"]?.stringValue).to(equal(data.base64EncodedString()))
+        // expect(doc).toNot(beNil())
+        // expect(doc?["date"]?.int64Value).to(equal(date.msSinceEpoch))
+        // expect(doc?["uuid"]?.stringValue).to(equal(uuid.uuidString))
+        // expect(doc?["data"]?.stringValue).to(equal(data.base64EncodedString()))
 
-        expect(try collCustom.find(["_id": customDbCollId]).nextOrError())
-            .to(equal(wrapper))
+        // expect(try collCustom.find(["_id": customDbCollId]).nextOrError())
+        //     .to(equal(wrapper))
 
         try defaultDb.drop()
     }


### PR DESCRIPTION
This PR makes the non-cursor read/write methods on `MongoCollection` async, and implements their synchronous equivalents.

There were a few test files that *mostly* can run but needed cursors so I enabled them and commented out the cursor portions of the files.