### PR TITLE
SWIFT-702 Make index management and find-and-modify methods async, implement sync versions

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -189,7 +189,7 @@ public struct TLSOptions {
 public class MongoClient {
     internal let connectionPool: ConnectionPool
 
-    private let operationExecutor: OperationExecutor
+    internal let operationExecutor: OperationExecutor
 
     // TODO: SWIFT-705 document size justification.
     /// Default size for a client's NIOThreadPool.
@@ -548,25 +548,7 @@ public class MongoClient {
         using connection: Connection? = nil,
         session: ClientSession? = nil
     ) -> EventLoopFuture<T.OperationResult> {
-        guard !self.isClosed else {
-            return self.makeFailedFuture(MongoClient.ClosedClientError)
-        }
-
-        if let session = session {
-            if case .ended = session.state {
-                return self.makeFailedFuture(ClientSession.SessionInactiveError)
-            }
-            guard session.client == self else {
-                return self.makeFailedFuture(ClientSession.ClientMismatchError)
-            }
-        }
-
         return self.operationExecutor.execute(operation, using: connection, client: self, session: session)
-    }
-
-    /// Creates an `EventLoopFuture<T>` that fails with the provided error.
-    internal func makeFailedFuture<T>(_ error: Error) -> EventLoopFuture<T> {
-        return self.operationExecutor.makeFailedFuture(error)
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -27,7 +27,8 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<BulkWriteResult?> {
         guard !requests.isEmpty else {
-            return self._client.operationExecutor.makeFailedFuture(InvalidArgumentError(message: "requests cannot be empty"))
+            return self._client.operationExecutor
+                .makeFailedFuture(InvalidArgumentError(message: "requests cannot be empty"))
         }
         let operation = BulkWriteOperation(collection: self, models: requests, options: options)
         return self._client.executeOperationAsync(operation, session: session)

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -27,7 +27,7 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<BulkWriteResult?> {
         guard !requests.isEmpty else {
-            return self._client.makeFailedFuture(InvalidArgumentError(message: "requests cannot be empty"))
+            return self._client.operationExecutor.makeFailedFuture(InvalidArgumentError(message: "requests cannot be empty"))
         }
         let operation = BulkWriteOperation(collection: self, models: requests, options: options)
         return self._client.executeOperationAsync(operation, session: session)

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -26,6 +26,9 @@ extension MongoCollection {
         options: BulkWriteOptions? = nil,
         session: ClientSession? = nil
     ) -> EventLoopFuture<BulkWriteResult?> {
+        guard !requests.isEmpty else {
+            return self._client.makeFailedFuture(InvalidArgumentError(message: "requests cannot be empty"))
+        }
         let operation = BulkWriteOperation(collection: self, models: requests, options: options)
         return self._client.executeOperationAsync(operation, session: session)
     }
@@ -186,10 +189,6 @@ internal struct BulkWriteOperation<T: Codable>: Operation {
      *   - `BulkWriteError` if an error occurs while performing the writes.
      */
     internal func execute(using connection: Connection, session: ClientSession?) throws -> BulkWriteResult? {
-        guard !self.models.isEmpty else {
-            throw InvalidArgumentError(message: "requests cannot be empty")
-        }
-
         var reply = Document()
         var error = bson_error_t()
         let opts = try encodeOptions(options: options, session: session)

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -61,7 +61,7 @@ extension MongoCollection {
             let update = try self.encoder.encode(replacement)
             return self.findAndModify(filter: filter, update: update, options: options, session: session)
         } catch {
-            return self._client.makeFailedFuture(error)
+            return self._client.operationExecutor.makeFailedFuture(error)
         }
     }
 

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -240,7 +240,7 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<[String]> {
         guard !models.isEmpty else {
-            return self._client.makeFailedFuture(InvalidArgumentError(message: "models cannot be empty"))
+            return self._client.operationExecutor.makeFailedFuture(InvalidArgumentError(message: "models cannot be empty"))
         }
         let operation = CreateIndexesOperation(collection: self, models: models, options: options)
         return self._client.executeOperationAsync(operation, session: session)
@@ -268,7 +268,7 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<DropIndexesResult> {
         guard name != "*" else {
-            return self._client.makeFailedFuture(InvalidArgumentError(
+            return self._client.operationExecutor.makeFailedFuture(InvalidArgumentError(
                 message: "Invalid index name '*'; use dropIndexes() to drop all indexes"
             ))
         }

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -240,7 +240,8 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<[String]> {
         guard !models.isEmpty else {
-            return self._client.operationExecutor.makeFailedFuture(InvalidArgumentError(message: "models cannot be empty"))
+            return self._client.operationExecutor
+                .makeFailedFuture(InvalidArgumentError(message: "models cannot be empty"))
         }
         let operation = CreateIndexesOperation(collection: self, models: models, options: options)
         return self._client.executeOperationAsync(operation, session: session)

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -59,7 +59,6 @@ extension MongoCollection {
     ) -> EventLoopFuture<InsertManyResult?> {
         return self.bulkWrite(values.map { .insertOne($0) }, options: options, session: session)
             .flatMapThrowing { InsertManyResult(from: $0) }
-            .flatMapErrorThrowing { throw convertBulkWriteError($0) }
     }
 
     /**

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -58,6 +58,7 @@
 @_exported import struct MongoSwift.DropCollectionOptions
 @_exported import struct MongoSwift.DropDatabaseOptions
 @_exported import struct MongoSwift.DropIndexOptions
+@_exported import struct MongoSwift.DropIndexesResult
 @_exported import struct MongoSwift.EstimatedDocumentCountOptions
 @_exported import struct MongoSwift.FindOneAndDeleteOptions
 @_exported import struct MongoSwift.FindOneAndReplaceOptions

--- a/Sources/MongoSwiftSync/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwiftSync/MongoCollection+FindAndModify.swift
@@ -25,7 +25,7 @@ extension MongoCollection {
         options: FindOneAndDeleteOptions? = nil,
         session: ClientSession? = nil
     ) throws -> CollectionType? {
-        fatalError("unimplemented")
+        return try self.asyncColl.findOneAndDelete(filter, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -55,7 +55,11 @@ extension MongoCollection {
         options: FindOneAndReplaceOptions? = nil,
         session: ClientSession? = nil
     ) throws -> CollectionType? {
-        fatalError("unimplemented")
+        return try self.asyncColl.findOneAndReplace(filter: filter,
+                                                    replacement: replacement,
+                                                    options: options,
+                                                    session: session?.asyncSession)
+                                                .wait()
     }
 
     /**
@@ -84,6 +88,10 @@ extension MongoCollection {
         options: FindOneAndUpdateOptions? = nil,
         session: ClientSession? = nil
     ) throws -> CollectionType? {
-        fatalError("unimplemented")
+        return try self.asyncColl.findOneAndUpdate(filter: filter,
+                                                   update: update,
+                                                   options: options,
+                                                   session: session?.asyncSession)
+                                                .wait()
     }
 }

--- a/Sources/MongoSwiftSync/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwiftSync/MongoCollection+Indexes.swift
@@ -27,7 +27,11 @@ extension MongoCollection {
         options: CreateIndexOptions? = nil,
         session: ClientSession? = nil
     ) throws -> String {
-        fatalError("unimplemented")
+        return try self.asyncColl.createIndex(keys,
+                                              indexOptions: indexOptions,
+                                              options: options,
+                                              session: session?.asyncSession)
+                                            .wait()
     }
 
     /**
@@ -53,7 +57,7 @@ extension MongoCollection {
         options: CreateIndexOptions? = nil,
         session: ClientSession? = nil
     ) throws -> String {
-        fatalError("unimplemented")
+        return try self.asyncColl.createIndex(model, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -79,7 +83,7 @@ extension MongoCollection {
         options: CreateIndexOptions? = nil,
         session: ClientSession? = nil
     ) throws -> [String] {
-        fatalError("unimplemented")
+        return try self.asyncColl.createIndexes(models, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -89,6 +93,8 @@ extension MongoCollection {
      *   - name: The name of the index to drop
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
+     *
+     * - Returns: The result of dropping the index.
      *
      * - Throws:
      *   - `WriteError` if an error occurs while performing the command.
@@ -101,8 +107,8 @@ extension MongoCollection {
         _ name: String,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> Document {
-        fatalError("unimplemented")
+    ) throws -> DropIndexesResult {
+        return try self.asyncColl.dropIndex(name, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -113,7 +119,7 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: a `Document` containing the server's response to the command.
+     * - Returns: The result of dropping the index.
      *
      * - Throws:
      *   - `WriteError` if an error occurs while performing the command.
@@ -127,8 +133,8 @@ extension MongoCollection {
         _ keys: Document,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> Document {
-        fatalError("unimplemented")
+    ) throws -> DropIndexesResult {
+        return try self.asyncColl.dropIndex(keys, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -139,7 +145,7 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: a `Document` containing the server's response to the command.
+     * - Returns: The result of dropping the index.
      *
      * - Throws:
      *   - `WriteError` if an error occurs while performing the command.
@@ -153,8 +159,8 @@ extension MongoCollection {
         _ model: IndexModel,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> Document {
-        fatalError("unimplemented")
+    ) throws -> DropIndexesResult {
+        return try self.asyncColl.dropIndex(model, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -164,7 +170,7 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: a `Document` containing the server's response to the command.
+     * - Returns: The result of dropping the indexes.
      *
      * - Throws:
      *   - `WriteError` if an error occurs while performing the command.
@@ -174,8 +180,11 @@ extension MongoCollection {
      *   - `EncodingError` if an error occurs while encoding the options.
      */
     @discardableResult
-    public func dropIndexes(options: DropIndexOptions? = nil, session: ClientSession? = nil) throws -> Document {
-        fatalError("unimplemented")
+    public func dropIndexes(
+        options: DropIndexOptions? = nil,
+        session: ClientSession? = nil
+    ) throws -> DropIndexesResult {
+        return try self.asyncColl.dropIndexes(options: options, session: session?.asyncSession).wait()
     }
 
     /**

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -110,6 +110,37 @@ extension MongoClientTests {
     ]
 }
 
+extension MongoCollectionTests {
+    static var allTests = [
+        ("testCount", testCount),
+        ("testInsertOne", testInsertOne),
+        ("testInsertOneWithUnacknowledgedWriteConcern", testInsertOneWithUnacknowledgedWriteConcern),
+        ("testDrop", testDrop),
+        ("testInsertMany", testInsertMany),
+        ("testInsertManyWithEmptyValues", testInsertManyWithEmptyValues),
+        ("testInsertManyWithUnacknowledgedWriteConcern", testInsertManyWithUnacknowledgedWriteConcern),
+        ("testDeleteOne", testDeleteOne),
+        ("testDeleteOneWithUnacknowledgedWriteConcern", testDeleteOneWithUnacknowledgedWriteConcern),
+        ("testDeleteMany", testDeleteMany),
+        ("testDeleteManyWithUnacknowledgedWriteConcern", testDeleteManyWithUnacknowledgedWriteConcern),
+        ("testReplaceOne", testReplaceOne),
+        ("testReplaceOneWithUnacknowledgedWriteConcern", testReplaceOneWithUnacknowledgedWriteConcern),
+        ("testUpdateOne", testUpdateOne),
+        ("testUpdateOneWithUnacknowledgedWriteConcern", testUpdateOneWithUnacknowledgedWriteConcern),
+        ("testUpdateMany", testUpdateMany),
+        ("testUpdateManyWithUnacknowledgedWriteConcern", testUpdateManyWithUnacknowledgedWriteConcern),
+        ("testDistinct", testDistinct),
+        ("testGetName", testGetName),
+        ("testCodableCollection", testCodableCollection),
+        ("testCursorType", testCursorType),
+        ("testEncodeHint", testEncodeHint),
+        ("testFindOneAndDelete", testFindOneAndDelete),
+        ("testFindOneAndReplace", testFindOneAndReplace),
+        ("testFindOneAndUpdate", testFindOneAndUpdate),
+        ("testNullIds", testNullIds),
+    ]
+}
+
 extension OptionsTests {
     static var allTests = [
         ("testOptionsAlphabeticalOrder", testOptionsAlphabeticalOrder),
@@ -196,6 +227,7 @@ XCTMain([
     testCase(Document_CollectionTests.allTests),
     testCase(Document_SequenceTests.allTests),
     testCase(MongoClientTests.allTests),
+    testCase(MongoCollectionTests.allTests),
     testCase(OptionsTests.allTests),
     testCase(ReadConcernTests.allTests),
     testCase(ReadPreferenceOperationTests.allTests),

--- a/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
@@ -1,13 +1,14 @@
 @testable import MongoSwift
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 import XCTest
 
-private var _client: MongoClient?
+private var _client: MongoSwiftSync.MongoClient?
 
 final class MongoCollectionTests: MongoSwiftTestCase {
     var collName: String = ""
-    var coll: MongoCollection<Document>!
+    var coll: MongoSwiftSync.MongoCollection<Document>!
     let doc1: Document = ["_id": 1, "cat": "dog"]
     let doc2: Document = ["_id": 2, "cat": "cat"]
 
@@ -99,10 +100,11 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(insertOneResult).to(beNil())
     }
 
-    func testAggregate() throws {
-        expect(try self.coll.aggregate([["$project": ["_id": 0, "cat": 1]]]).all())
-            .to(equal([["cat": "dog"], ["cat": "cat"]] as [Document]))
-    }
+    // TODO: SWIFT-672: enable
+    // func testAggregate() throws {
+    //     expect(try self.coll.aggregate([["$project": ["_id": 0, "cat": 1]]]).all())
+    //         .to(equal([["cat": "dog"], ["cat": "cat"]] as [Document]))
+    // }
 
     func testDrop() throws {
         let encoder = BSONEncoder()
@@ -207,27 +209,28 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(insertManyResult).to(beNil())
     }
 
-    func testFind() throws {
-        let findResult = try coll.find(["cat": "cat"])
-        expect(try findResult.next()?.get()).to(equal(["_id": 2, "cat": "cat"]))
-        expect(try findResult.next()?.get()).to(beNil())
-    }
+    // TODO: SWIFT-672: enable next 4 tests
+    // func testFind() throws {
+    //     let findResult = try coll.find(["cat": "cat"])
+    //     expect(try findResult.next()?.get()).to(equal(["_id": 2, "cat": "cat"]))
+    //     expect(try findResult.next()?.get()).to(beNil())
+    // }
 
-    func testFindOne() throws {
-        let findOneResult = try self.coll.findOne(["cat": "dog"])
-        expect(findOneResult).to(equal(["_id": 1, "cat": "dog"]))
-    }
+    // func testFindOne() throws {
+    //     let findOneResult = try self.coll.findOne(["cat": "dog"])
+    //     expect(findOneResult).to(equal(["_id": 1, "cat": "dog"]))
+    // }
 
-    func testFindOneMultipleMatches() throws {
-        let findOneOptions = FindOneOptions(sort: ["_id": 1])
-        let findOneResult = try self.coll.findOne(options: findOneOptions)
-        expect(findOneResult).to(equal(["_id": 1, "cat": "dog"]))
-    }
+    // func testFindOneMultipleMatches() throws {
+    //     let findOneOptions = FindOneOptions(sort: ["_id": 1])
+    //     let findOneResult = try self.coll.findOne(options: findOneOptions)
+    //     expect(findOneResult).to(equal(["_id": 1, "cat": "dog"]))
+    // }
 
-    func testFindOneNoMatch() throws {
-        let findOneResult = try self.coll.findOne(["dog": "cat"])
-        expect(findOneResult).to(beNil())
-    }
+    // func testFindOneNoMatch() throws {
+    //     let findOneResult = try self.coll.findOne(["dog": "cat"])
+    //     expect(findOneResult).to(beNil())
+    // }
 
     func testDeleteOne() throws {
         expect(try self.coll.deleteOne(["cat": "cat"])?.deletedCount).to(equal(1))
@@ -314,13 +317,14 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(self.coll.name).to(equal(self.collName))
     }
 
-    func testCursorIteration() throws {
-        let findResult1 = try coll.find(["cat": "cat"])
-        while let _ = try findResult1.next()?.get() {}
+    // TODO: SWIFT-672: enable
+    // func testCursorIteration() throws {
+    //     let findResult1 = try coll.find(["cat": "cat"])
+    //     while let _ = try findResult1.next()?.get() {}
 
-        let findResult2 = try coll.find(["cat": "cat"])
-        for _ in findResult2 {}
-    }
+    //     let findResult2 = try coll.find(["cat": "cat"])
+    //     for _ in findResult2 {}
+    // }
 
     struct Basic: Codable, Equatable {
         let x: Int
@@ -344,9 +348,10 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         try coll1.replaceOne(filter: ["x": 2], replacement: b4)
         expect(try coll1.countDocuments()).to(equal(3))
 
-        for doc in try coll1.find().all() {
-            expect(doc).to(beAnInstanceOf(Basic.self))
-        }
+        // TODO: SWIFT-672: uncomment
+        // for doc in try coll1.find().all() {
+        //     expect(doc).to(beAnInstanceOf(Basic.self))
+        // }
 
         // find one and replace w/ collection type replacement
         expect(try coll1.findOneAndReplace(filter: ["x": 1], replacement: b5)).to(equal(b1))


### PR DESCRIPTION
This PR implements non-cursor index management and find-and-modify methods on `MongoCollection`.

Per our discussion on Slack I also added a new `DropIndexesResult` type.

Unfortunately basically all of the index tests rely on `MongoCursor` being implemented (they use `listIndexes` to verify results) so I can't really enable that file without commenting out most of it yet. 

Also made some other small changes I'll explain in inline comments