### PR TITLE
Remove OperationExecutor protocol and executeOperationAsync helper 

### DIFF
--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -31,7 +31,7 @@ extension MongoCollection {
                 .makeFailedFuture(InvalidArgumentError(message: "requests cannot be empty"))
         }
         let operation = BulkWriteOperation(collection: self, models: requests, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -110,7 +110,7 @@ extension MongoCollection {
         session: ClientSession?
     ) -> EventLoopFuture<CollectionType?> {
         let operation = FindAndModifyOperation(collection: self, filter: filter, update: update, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -244,7 +244,7 @@ extension MongoCollection {
                 .makeFailedFuture(InvalidArgumentError(message: "models cannot be empty"))
         }
         let operation = CreateIndexesOperation(collection: self, models: models, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 
     /**
@@ -357,7 +357,7 @@ extension MongoCollection {
         session: ClientSession?
     ) -> EventLoopFuture<DropIndexesResult> {
         let operation = DropIndexesOperation(collection: self, index: index, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 
     /**

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -94,7 +94,7 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<Int> {
         let operation = CountDocumentsOperation(collection: self, filter: filter, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 
     /**
@@ -111,7 +111,7 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<Int> {
         let operation = EstimatedDocumentCountOperation(collection: self, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 
     /**
@@ -138,6 +138,6 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<[BSON]> {
         let operation = DistinctOperation(collection: self, fieldName: fieldName, filter: filter, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 }

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -95,7 +95,7 @@ public struct MongoCollection<T: Codable> {
      */
     public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {
         let operation = DropCollectionOperation(collection: self, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 
     /// Uses the provided `Connection` to get a pointer to a `mongoc_collection_t` corresponding to this

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -123,7 +123,7 @@ public struct MongoDatabase {
      */
     public func drop(options: DropDatabaseOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {
         let operation = DropDatabaseOperation(database: self, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 
     /**
@@ -214,7 +214,7 @@ public struct MongoDatabase {
         session: ClientSession? = nil
     ) -> EventLoopFuture<MongoCollection<T>> {
         let operation = CreateCollectionOperation(database: self, name: name, type: type, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 
     /**
@@ -288,12 +288,13 @@ public struct MongoDatabase {
         session: ClientSession? = nil
     ) -> EventLoopFuture<[String]> {
         let operation = ListCollectionsOperation(database: self, nameOnly: true, filter: filter, options: options)
-        return self._client.executeOperationAsync(operation, session: session).flatMapThrowing { result in
-            guard case let .names(names) = result else {
-                throw InternalError(message: "Invalid result")
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
+            .flatMapThrowing { result in
+                guard case let .names(names) = result else {
+                    throw InternalError(message: "Invalid result")
+                }
+                return names
             }
-            return names
-        }
     }
 
     /**
@@ -320,7 +321,7 @@ public struct MongoDatabase {
         session: ClientSession? = nil
     ) -> EventLoopFuture<Document> {
         let operation = RunCommandOperation(database: self, command: command, options: options)
-        return self._client.executeOperationAsync(operation, session: session)
+        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }
 
     /**

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -11,25 +11,8 @@ internal protocol Operation {
     func execute(using connection: Connection, session: ClientSession?) throws -> OperationResult
 }
 
-/// A protocol for types that can be used to execute `Operation`s.
-internal protocol OperationExecutor {
-    /// Asynchronously executes an operation using the provided client and optionally provided session.
-    func execute<T: Operation>(
-        _ operation: T,
-        using connection: Connection?,
-        client: MongoClient,
-        session: ClientSession?
-    ) -> EventLoopFuture<T.OperationResult>
-    /// Asynchronously executes a block of code.
-    func execute<T>(body: @escaping () throws -> T) -> EventLoopFuture<T>
-    /// Closes the executor.
-    func close() -> EventLoopFuture<Void>
-    /// Makes a failed `EventLoopFuture` with the provided error.
-    func makeFailedFuture<T>(_ error: Error) -> EventLoopFuture<T>
-}
-
-/// Default executor type used by `MongoClient`s.
-internal class DefaultOperationExecutor: OperationExecutor {
+/// Operation executor used by `MongoClient`s.
+internal class OperationExecutor {
     /// A group of event loops to use for running operations in the thread pool.
     private let eventLoopGroup: EventLoopGroup
     /// The thread pool to execute operations in.
@@ -56,7 +39,7 @@ internal class DefaultOperationExecutor: OperationExecutor {
 
     internal func execute<T: Operation>(
         _ operation: T,
-        using connection: Connection?,
+        using connection: Connection? = nil,
         client: MongoClient,
         session: ClientSession?
     ) -> EventLoopFuture<T.OperationResult> {


### PR DESCRIPTION
Per discussion today, this PR:
* removes the `OperationExecutor` protocol
* renames `DefaultOperationExecutor` to `OperationExecutor`
* Removes the `executeOperationAsync` helper. Note that the `executeOperation` helper still exists for the sake of the API methods relying on it still compiling, but it can be deleted once we've finished up converting cursor + change stream methods to async