### PR TITLE
SWIFT-711 remove DropIndexesResult

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -255,19 +255,17 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing the result of dropping the index.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `EncodingError` if an error occurs while encoding the options.
+     * - Returns: An `EventLoopFuture<Void>`. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndex(
         _ name: String,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) -> EventLoopFuture<DropIndexesResult> {
+    ) -> EventLoopFuture<Void> {
         guard name != "*" else {
             return self._client.operationExecutor.makeFailedFuture(InvalidArgumentError(
                 message: "Invalid index name '*'; use dropIndexes() to drop all indexes"
@@ -284,20 +282,18 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing the result of dropping the index.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options.
+     * - Returns: An `EventLoopFuture<Void>`. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndex(
         _ keys: Document,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) -> EventLoopFuture<DropIndexesResult> {
+    ) -> EventLoopFuture<Void> {
         return self._dropIndexes(index: .document(keys), options: options, session: session)
     }
 
@@ -309,20 +305,18 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing the result of dropping the index.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options.
+     * - Returns: An `EventLoopFuture<Void>`. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndex(
         _ model: IndexModel,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) -> EventLoopFuture<DropIndexesResult> {
+    ) -> EventLoopFuture<Void> {
         return self._dropIndexes(index: .document(model.keys), options: options, session: session)
     }
 
@@ -333,19 +327,17 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing the result of dropping the indexes.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options.
+     * - Returns: An `EventLoopFuture<Void>`. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndexes(
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) -> EventLoopFuture<DropIndexesResult> {
+    ) -> EventLoopFuture<Void> {
         return self._dropIndexes(index: "*", options: options, session: session)
     }
 
@@ -355,7 +347,7 @@ extension MongoCollection {
         index: BSON,
         options: DropIndexOptions?,
         session: ClientSession?
-    ) -> EventLoopFuture<DropIndexesResult> {
+    ) -> EventLoopFuture<Void> {
         let operation = DropIndexesOperation(collection: self, index: index, options: options)
         return self._client.operationExecutor.execute(operation, client: self._client, session: session)
     }

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -15,12 +15,6 @@ public struct DropIndexOptions: Encodable {
     }
 }
 
-/// The result of performing a "dropIndexes" command.
-public struct DropIndexesResult: Decodable {
-    /// The number of indexes that were present in the collection prior to performing the drop.
-    public let nIndexesWas: Int
-}
-
 /// An operation corresponding to a "dropIndexes" command.
 internal struct DropIndexesOperation<T: Codable>: Operation {
     private let collection: MongoCollection<T>
@@ -33,7 +27,7 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
         self.options = options
     }
 
-    internal func execute(using connection: Connection, session: ClientSession?) throws -> DropIndexesResult {
+    internal func execute(using connection: Connection, session: ClientSession?) throws {
         let command: Document = ["dropIndexes": .string(self.collection.name), "index": self.index]
         let opts = try encodeOptions(options: self.options, session: session)
         var reply = Document()
@@ -46,7 +40,5 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
         guard success else {
             throw extractMongoError(error: error, reply: reply)
         }
-
-        return try self.collection.decoder.decode(DropIndexesResult.self, from: reply)
     }
 }

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -58,7 +58,6 @@
 @_exported import struct MongoSwift.DropCollectionOptions
 @_exported import struct MongoSwift.DropDatabaseOptions
 @_exported import struct MongoSwift.DropIndexOptions
-@_exported import struct MongoSwift.DropIndexesResult
 @_exported import struct MongoSwift.EstimatedDocumentCountOptions
 @_exported import struct MongoSwift.FindOneAndDeleteOptions
 @_exported import struct MongoSwift.FindOneAndReplaceOptions

--- a/Sources/MongoSwiftSync/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwiftSync/MongoCollection+Indexes.swift
@@ -94,21 +94,18 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: The result of dropping the index.
-     *
      * - Throws:
      *   - `WriteError` if an error occurs while performing the command.
      *   - `CommandError` if an error occurs that prevents the command from executing.
      *   - `InvalidArgumentError` if the options passed in form an invalid combination.
      *   - `EncodingError` if an error occurs while encoding the options.
      */
-    @discardableResult
     public func dropIndex(
         _ name: String,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> DropIndexesResult {
-        return try self.asyncColl.dropIndex(name, options: options, session: session?.asyncSession).wait()
+    ) throws {
+        try self.asyncColl.dropIndex(name, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -119,8 +116,6 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: The result of dropping the index.
-     *
      * - Throws:
      *   - `WriteError` if an error occurs while performing the command.
      *   - `CommandError` if an error occurs that prevents the command from executing.
@@ -128,13 +123,12 @@ extension MongoCollection {
      *   - `LogicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options.
      */
-    @discardableResult
     public func dropIndex(
         _ keys: Document,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> DropIndexesResult {
-        return try self.asyncColl.dropIndex(keys, options: options, session: session?.asyncSession).wait()
+    ) throws {
+        try self.asyncColl.dropIndex(keys, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -145,8 +139,6 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: The result of dropping the index.
-     *
      * - Throws:
      *   - `WriteError` if an error occurs while performing the command.
      *   - `CommandError` if an error occurs that prevents the command from executing.
@@ -154,13 +146,12 @@ extension MongoCollection {
      *   - `LogicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options.
      */
-    @discardableResult
     public func dropIndex(
         _ model: IndexModel,
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> DropIndexesResult {
-        return try self.asyncColl.dropIndex(model, options: options, session: session?.asyncSession).wait()
+    ) throws {
+        try self.asyncColl.dropIndex(model, options: options, session: session?.asyncSession).wait()
     }
 
     /**
@@ -170,8 +161,6 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: The result of dropping the indexes.
-     *
      * - Throws:
      *   - `WriteError` if an error occurs while performing the command.
      *   - `CommandError` if an error occurs that prevents the command from executing.
@@ -179,12 +168,11 @@ extension MongoCollection {
      *   - `LogicError` if the provided session is inactive.
      *   - `EncodingError` if an error occurs while encoding the options.
      */
-    @discardableResult
     public func dropIndexes(
         options: DropIndexOptions? = nil,
         session: ClientSession? = nil
-    ) throws -> DropIndexesResult {
-        return try self.asyncColl.dropIndexes(options: options, session: session?.asyncSession).wait()
+    ) throws {
+        try self.asyncColl.dropIndexes(options: options, session: session?.asyncSession).wait()
     }
 
     /**


### PR DESCRIPTION
Removes `DropIndexesResult`. I also updated all the async docstrings for these to reflect the new behavior while I was editing them anyway.