### PR TITLE
SWIFT-704 Update async docstrings to reflect error propagation

### DIFF
--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -17,9 +17,10 @@ import NIO
  *   ```
  *   let opts = CollectionOptions(readConcern: ReadConcern(.majority), writeConcern: try WriteConcern(w: .majority))
  *   let collection = database.collection("mycoll", options: opts)
- *   try client.withSession { session in
- *       try collection.insertOne(["x": 1], session: session)
- *       try collection.find(["x": 1], session: session)
+ *   let futureCount = client.withSession { session in
+ *       collection.insertOne(["x": 1], session: session).flatMap { _ in
+ *           collection.countDocuments(session: session)
+ *       }
  *   }
  *   ```
  *

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -38,7 +38,7 @@ internal class ConnectionPool {
     /// Initializes the pool using the provided `ConnectionString`.
     internal init(from connString: ConnectionString, options: TLSOptions? = nil) throws {
         guard let pool = mongoc_client_pool_new(connString._uri) else {
-            throw InvalidArgumentError(message: "libmongoc not built with TLS support")
+            throw InternalError(message: "Failed to initialize libmongoc client pool")
         }
 
         guard mongoc_client_pool_set_error_api(pool, MONGOC_ERROR_API_VERSION_2) else {

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -242,8 +242,6 @@ public class MongoClient {
      *
      * - Throws:
      *   - A `InvalidArgumentError` if the connection string passed in is improperly formatted.
-     *   - A `InvalidArgumentError` if the connection string specifies the use of TLS but libmongoc was not
-     *     built with TLS support.
      */
     public init(
         _ connectionString: String = "mongodb://localhost:27017",
@@ -344,18 +342,17 @@ public class MongoClient {
     }
 
     /**
-     * Run the `listDatabases` command.
+     * Retrieves a list of databases in this client's MongoDB deployment.
      *
      * - Parameters:
      *   - filter: Optional `Document` specifying a filter that the listed databases must pass. This filter can be based
      *     on the "name", "sizeOnDisk", "empty", or "shards" fields of the output.
      *   - session: Optional `ClientSession` to use when executing this command.
      *
-     * - Returns: An `EventLoopFuture<[DatabaseSpecification]>` containing the databases matching provided criteria.
-     *
-     * - Throws:
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error is encountered while encoding the options to BSON.
+     * - Returns: An `EventLoopFuture<[DatabaseSpecification]>`. On success, the future contains an array of the
+     *            specifications of databases matching the provided criteria. On failure, contains:
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error is encountered while encoding the options to BSON.
      *
      * - SeeAlso: https://docs.mongodb.com/manual/reference/command/listDatabases/
      */
@@ -373,16 +370,15 @@ public class MongoClient {
     }
 
     /**
-     * Get a list of `MongoDatabase`s.
+     * Get a list of `MongoDatabase`s corresponding to the databases in this client's MongoDB deployment.
      *
      * - Parameters:
      *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[MongoDatabase]>` containing databases that match the provided filter.
-     *
-     * - Throws:
-     *   - `LogicError` if the provided session is inactive.
+     * - Returns: An `EventLoopFuture<[MongoDatabase]>`. On success, the future contains an array of `MongoDatabase`s
+     *            that match the provided filter. On failure, contains:
+     *            - `LogicError` if the provided session is inactive.
      */
     public func listMongoDatabases(
         _ filter: Document? = nil,
@@ -392,16 +388,15 @@ public class MongoClient {
     }
 
     /**
-     * Get a list of names of databases.
+     * Get the names of databases in this client's MongoDB deployment.
      *
      * - Parameters:
      *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[String]>` containing names of databases that match the provided filter.
-     *
-     * - Throws:
-     *   - `LogicError` if the provided session is inactive.
+     * - Returns: An `EventLoopFuture<[String]>`. On success, the future contains an array of names of databases that
+     *            match the provided filter. On failure, contains:
+     *            - `LogicError` if the provided session is inactive.
      */
     public func listDatabaseNames(
         _ filter: Document? = nil,

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -315,9 +315,12 @@ public class MongoClient {
      *   - options: Options to use when creating the session.
      *   - sessionBody: A closure which takes in a `ClientSession` and returns an `EventLoopFuture<T>`.
      *
-     * - Returns: An `EventLoopFuture<T>`. If the deployment does not support sessions, returns a failed future
-     *            containing a `CompatibilityError`. If the user-provided closure throws any other error, returns a
-     *            failed future containing that error. Otherwise, returns the future returned by `sessionBody`.
+     * - Returns:
+     *    An `EventLoopFuture<T>`, the return value of the user-provided closure.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `CompatibilityError` if the deployment does not support sessions.
+     *    - `LogicError` if this client has already been closed.
      */
     public func withSession<T>(
         options: ClientSessionOptions? = nil,
@@ -355,10 +358,14 @@ public class MongoClient {
      *     on the "name", "sizeOnDisk", "empty", or "shards" fields of the output.
      *   - session: Optional `ClientSession` to use when executing this command.
      *
-     * - Returns: An `EventLoopFuture<[DatabaseSpecification]>`. On success, the future contains an array of the
-     *            specifications of databases matching the provided criteria. On failure, contains:
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error is encountered while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<[DatabaseSpecification]>`. On success, the future contains an array of the specifications
+     *    of databases matching the provided criteria.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this client has already been closed.
+     *    - `EncodingError` if an error is encountered while encoding the options to BSON.
      *
      * - SeeAlso: https://docs.mongodb.com/manual/reference/command/listDatabases/
      */
@@ -382,9 +389,13 @@ public class MongoClient {
      *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[MongoDatabase]>`. On success, the future contains an array of `MongoDatabase`s
-     *            that match the provided filter. On failure, contains:
-     *            - `LogicError` if the provided session is inactive.
+     * - Returns:
+     *    An `EventLoopFuture<[MongoDatabase]>`. On success, the future contains an array of `MongoDatabase`s that
+     *    match the provided filter.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this client has already been closed.
      */
     public func listMongoDatabases(
         _ filter: Document? = nil,
@@ -400,9 +411,13 @@ public class MongoClient {
      *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[String]>`. On success, the future contains an array of names of databases that
-     *            match the provided filter. On failure, contains:
-     *            - `LogicError` if the provided session is inactive.
+     * - Returns:
+     *    An `EventLoopFuture<[String]>`. On success, the future contains an array of names of databases that
+     *    match the provided filter.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this client has already been closed.
      */
     public func listDatabaseNames(
         _ filter: Document? = nil,
@@ -427,7 +442,7 @@ public class MongoClient {
      *   - name: the name of the database to retrieve
      *   - options: Optional `DatabaseOptions` to use for the retrieved database
      *
-     * - Returns: a `MongoDatabase` corresponding to the provided database name
+     * - Returns: a `MongoDatabase` corresponding to the provided database name.
      */
     public func db(_ name: String, options: DatabaseOptions? = nil) -> MongoDatabase {
         return MongoDatabase(name: name, client: self, options: options)

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -301,7 +301,8 @@ public class MongoClient {
         }
     }
 
-    /// Starts a new `ClientSession` with the provided options.
+    /// Starts a new `ClientSession` with the provided options. When you are done using this session, you must call
+    /// `ClientSession.end()` on it.
     public func startSession(options: ClientSessionOptions? = nil) -> ClientSession {
         return ClientSession(client: self, options: options)
     }
@@ -310,8 +311,13 @@ public class MongoClient {
      * Starts a new `ClientSession` with the provided options and passes it to the provided closure.
      * The session is only valid within the body of the closure and will be ended after the body completes.
      *
-     * - Throws:
-     *   - `RuntimeError.compatibilityError` if the deployment does not support sessions.
+     * - Parameters:
+     *   - options: Options to use when creating the session.
+     *   - sessionBody: A closure which takes in a `ClientSession` and returns an `EventLoopFuture<T>`.
+     *
+     * - Returns: An `EventLoopFuture<T>`. If the deployment does not support sessions, returns a failed future
+     *            containing a `CompatibilityError`. If the user-provided closure throws any other error, returns a
+     *            failed future containing that error. Otherwise, returns the future returned by `sessionBody`.
      */
     public func withSession<T>(
         options: ClientSessionOptions? = nil,

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -11,15 +11,13 @@ extension MongoCollection {
      *   - options: optional `BulkWriteOptions` to use while executing the operation.
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: an `EventLoopFuture` containing the `BulkWriteResult`, or containing `nil` if the write concern is
-     *            unacknowledged.
-     *
-     * - Throws:
-     *   - `InvalidArgumentError` if `requests` is empty.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `BulkWriteError` if any error occurs while performing the writes. This includes errors that would
-     *     typically be thrown as `RuntimeError`s or `CommandError`s elsewhere.
-     *   - `EncodingError` if an error occurs while encoding the `CollectionType` or the options to BSON.
+     * - Returns: An `EventLoopFuture<BulkWriteResult?>`. On success, the future contains either a `BulkWriteResult`,
+     *            or contains `nil` if the write concern is unacknowledged. On failure, contains:
+     *            - `InvalidArgumentError` if `requests` is empty.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `BulkWriteError` if any error occurs while performing the writes. This includes errors that would
+     *               typically be propagated as `RuntimeError`s or `CommandError`s elsewhere.
+     *            - `EncodingError` if an error occurs while encoding the `CollectionType` or the options to BSON.
      */
     public func bulkWrite(
         _ requests: [WriteModel<T>],

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -11,13 +11,16 @@ extension MongoCollection {
      *   - options: optional `BulkWriteOptions` to use while executing the operation.
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<BulkWriteResult?>`. On success, the future contains either a `BulkWriteResult`,
-     *            or contains `nil` if the write concern is unacknowledged. On failure, contains:
-     *            - `InvalidArgumentError` if `requests` is empty.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `BulkWriteError` if any error occurs while performing the writes. This includes errors that would
-     *               typically be propagated as `RuntimeError`s or `CommandError`s elsewhere.
-     *            - `EncodingError` if an error occurs while encoding the `CollectionType` or the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<BulkWriteResult?>`. On success, the future contains either a `BulkWriteResult`, or
+     *    contains `nil` if the write concern is unacknowledged.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if `requests` is empty.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `BulkWriteError` if any error occurs while performing the writes. This includes errors that would
+     *       typically be propagated as `RuntimeError`s or `CommandError`s elsewhere.
+     *    - `EncodingError` if an error occurs while encoding the `CollectionType` or the options to BSON.
      */
     public func bulkWrite(
         _ requests: [WriteModel<T>],

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -18,6 +18,7 @@ extension MongoCollection {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if `requests` is empty.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `BulkWriteError` if any error occurs while performing the writes. This includes errors that would
      *       typically be propagated as `RuntimeError`s or `CommandError`s elsewhere.
      *    - `EncodingError` if an error occurs while encoding the `CollectionType` or the options to BSON.

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -11,15 +11,13 @@ extension MongoCollection {
      *   - options: Optional `FindOneAndDeleteOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing the deleted document, represented as a `CollectionType`, or
-     *            containing `nil` if no document was deleted.
-     *
-     * - Throws:
-     *   - `InvalidArgumentError` if any of the provided options are invalid.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `WriteError` if an error occurs while executing the command.
-     *   - `DecodingError` if the deleted document cannot be decoded to a `CollectionType` value.
+     * - Returns: An `EventLoopFuture<CollectionType?>`. On success, contains either the deleted document, represented
+     *            as a `CollectionType`, or contains `nil` if no document was deleted. On failure, contains:
+     *            - `InvalidArgumentError` if any of the provided options are invalid.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `WriteError` if an error occurs while executing the command.
+     *            - `DecodingError` if the deleted document cannot be decoded to a `CollectionType` value.
      */
     public func findOneAndDelete(
         _ filter: Document,
@@ -40,16 +38,15 @@ extension MongoCollection {
      *   - options: Optional `FindOneAndReplaceOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing a `CollectionType`, representing either the original document or its
-     *            replacement, depending on selected options, or containing `nil` if there was no match.
-     *
-     * - Throws:
-     *   - `InvalidArgumentError` if any of the provided options are invalid.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `WriteError` if an error occurs while executing the command.
-     *   - `DecodingError` if the replaced document cannot be decoded to a `CollectionType` value.
-     *   - `EncodingError` if `replacement` cannot be encoded to a `Document`.
+     * - Returns: An `EventLoopFuture<CollectionType?>`. On success, contains a `CollectionType`, representing either
+     *            the original document or its replacement, depending on selected options; or containing `nil` if there
+     *             was no matching document. On failure, contains:
+     *             - `InvalidArgumentError` if any of the provided options are invalid.
+     *             - `LogicError` if the provided session is inactive.
+     *             - `CommandError` if an error occurs that prevents the command from executing.
+     *             - `WriteError` if an error occurs while executing the command.
+     *             - `DecodingError` if the replaced document cannot be decoded to a `CollectionType` value.
+     *             - `EncodingError` if `replacement` cannot be encoded to a `Document`.
      */
     public func findOneAndReplace(
         filter: Document,
@@ -74,15 +71,13 @@ extension MongoCollection {
      *   - options: Optional `FindOneAndUpdateOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing a `CollectionType` representing either the original or updated
-     *            document, depending on selected options, or containing `nil` if there was no match.
-     *
-     * - Throws:
-     *   - `InvalidArgumentError` if any of the provided options are invalid.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `WriteError` if an error occurs while executing the command.
-     *   - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
+     * - Returns: An `EventLoopFuture<CollectionType>`. On success, contains either the original or updated document,
+     *            depending on selected options, or contains `nil` if there was no match. On failure, contains:
+     *            - `InvalidArgumentError` if any of the provided options are invalid.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `WriteError` if an error occurs while executing the command.
+     *            - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
      */
     public func findOneAndUpdate(
         filter: Document,
@@ -96,12 +91,13 @@ extension MongoCollection {
     /**
      * A private helper method for findAndModify operations to use.
      *
-     * - Throws:
-     *   - `InvalidArgumentError` if any of the provided options are invalid.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `WriteError` if an error occurs while executing the command.
-     *   - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
+     * - Returns: an `EventLoopFuture<CollectionType?>. On success, contains the document returned by the server, if
+     *            one exists. On failure, contains:
+     *            - `InvalidArgumentError` if any of the provided options are invalid.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `WriteError` if an error occurs while executing the command.
+     *            - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
      */
     private func findAndModify(
         filter: Document,

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -18,6 +18,7 @@ extension MongoCollection {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if any of the provided options are invalid.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `WriteError` if an error occurs while executing the command.
      *    - `DecodingError` if the deleted document cannot be decoded to a `CollectionType` value.
@@ -49,6 +50,7 @@ extension MongoCollection {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if any of the provided options are invalid.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `WriteError` if an error occurs while executing the command.
      *    - `DecodingError` if the replaced document cannot be decoded to a `CollectionType` value.
@@ -84,6 +86,7 @@ extension MongoCollection {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if any of the provided options are invalid.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `WriteError` if an error occurs while executing the command.
      *    - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
@@ -106,6 +109,7 @@ extension MongoCollection {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if any of the provided options are invalid.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `WriteError` if an error occurs while executing the command.
      *    - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -11,13 +11,16 @@ extension MongoCollection {
      *   - options: Optional `FindOneAndDeleteOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<CollectionType?>`. On success, contains either the deleted document, represented
-     *            as a `CollectionType`, or contains `nil` if no document was deleted. On failure, contains:
-     *            - `InvalidArgumentError` if any of the provided options are invalid.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `WriteError` if an error occurs while executing the command.
-     *            - `DecodingError` if the deleted document cannot be decoded to a `CollectionType` value.
+     * - Returns:
+     *    An `EventLoopFuture<CollectionType?>`. On success, contains either the deleted document, represented as a
+     *    `CollectionType`, or contains `nil` if no document was deleted.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if any of the provided options are invalid.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `WriteError` if an error occurs while executing the command.
+     *    - `DecodingError` if the deleted document cannot be decoded to a `CollectionType` value.
      */
     public func findOneAndDelete(
         _ filter: Document,
@@ -38,15 +41,18 @@ extension MongoCollection {
      *   - options: Optional `FindOneAndReplaceOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<CollectionType?>`. On success, contains a `CollectionType`, representing either
-     *            the original document or its replacement, depending on selected options; or containing `nil` if there
-     *             was no matching document. On failure, contains:
-     *             - `InvalidArgumentError` if any of the provided options are invalid.
-     *             - `LogicError` if the provided session is inactive.
-     *             - `CommandError` if an error occurs that prevents the command from executing.
-     *             - `WriteError` if an error occurs while executing the command.
-     *             - `DecodingError` if the replaced document cannot be decoded to a `CollectionType` value.
-     *             - `EncodingError` if `replacement` cannot be encoded to a `Document`.
+     * - Returns:
+     *    An `EventLoopFuture<CollectionType?>`. On success, contains a `CollectionType`, representing either the
+     *    original document or its replacement, depending on selected options; or containing `nil` if there was no
+     *    matching document.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if any of the provided options are invalid.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `WriteError` if an error occurs while executing the command.
+     *    - `DecodingError` if the replaced document cannot be decoded to a `CollectionType` value.
+     *    - `EncodingError` if `replacement` cannot be encoded to a `Document`.
      */
     public func findOneAndReplace(
         filter: Document,
@@ -71,13 +77,16 @@ extension MongoCollection {
      *   - options: Optional `FindOneAndUpdateOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<CollectionType>`. On success, contains either the original or updated document,
-     *            depending on selected options, or contains `nil` if there was no match. On failure, contains:
-     *            - `InvalidArgumentError` if any of the provided options are invalid.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `WriteError` if an error occurs while executing the command.
-     *            - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
+     * - Returns:
+     *    An `EventLoopFuture<CollectionType>`. On success, contains either the original or updated document, depending
+     *    on selected options, or contains `nil` if there was no match.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if any of the provided options are invalid.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `WriteError` if an error occurs while executing the command.
+     *    - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
      */
     public func findOneAndUpdate(
         filter: Document,
@@ -91,13 +100,15 @@ extension MongoCollection {
     /**
      * A private helper method for findAndModify operations to use.
      *
-     * - Returns: an `EventLoopFuture<CollectionType?>. On success, contains the document returned by the server, if
-     *            one exists. On failure, contains:
-     *            - `InvalidArgumentError` if any of the provided options are invalid.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `WriteError` if an error occurs while executing the command.
-     *            - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
+     * - Returns:
+     *    An `EventLoopFuture<CollectionType?>. On success, contains the document returned by the server, if one exists.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if any of the provided options are invalid.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `WriteError` if an error occurs while executing the command.
+     *    - `DecodingError` if the updated document cannot be decoded to a `CollectionType` value.
      */
     private func findAndModify(
         filter: Document,

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -167,13 +167,15 @@ extension MongoCollection {
      *   - options: Optional `CreateIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<String>`. On success, contains the name of the created index. On failure,
-     *            contains:
-     *            - `WriteError` if an error occurs while performing the write.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the index specification or options.
+     * - Returns:
+     *    An `EventLoopFuture<String>`. On success, contains the name of the created index.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the write.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the index specification or options.
      */
     public func createIndex(
         _ keys: Document,
@@ -193,13 +195,15 @@ extension MongoCollection {
      *   - options: Optional `CreateIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<String>`. On success, contains the name of the created index. On failure,
-     *            contains:
-     *            - `WriteError` if an error occurs while performing the write.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the index specification or options.
+     * - Returns:
+     *    An `EventLoopFuture<String>`. On success, contains the name of the created index.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the write.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the index specification or options.
      */
     public func createIndex(
         _ model: IndexModel,
@@ -222,14 +226,16 @@ extension MongoCollection {
      *   - options: Optional `CreateIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[String]>`. On success, contains the names of the created indexes. On failure,
-     *            contains:
-     *            - `WriteError` if an error occurs while performing the write.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if `models` is empty.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the index specifications or options.
+     * - Returns:
+     *    An `EventLoopFuture<[String]>`. On success, contains the names of the created indexes.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the write.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if `models` is empty.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the index specifications or options.
      */
     public func createIndexes(
         _ models: [IndexModel],
@@ -252,11 +258,14 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Void>`. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `EncodingError` if an error occurs while encoding the options.
+     * - Returns:
+     *    An `EventLoopFuture<Void>` that succeeds when the drop is successful.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndex(
         _ name: String,
@@ -279,12 +288,15 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Void>`. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options.
+     * - Returns:
+     *    An `EventLoopFuture<Void>` that succeeds when the drop is successful.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndex(
         _ keys: Document,
@@ -302,12 +314,15 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Void>`. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options.
+     * - Returns:
+     *    An `EventLoopFuture<Void>` that succeeds when the drop is successful.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndex(
         _ model: IndexModel,
@@ -324,12 +339,15 @@ extension MongoCollection {
      *   - options: Optional `DropIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Void>`. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options.
+     * - Returns:
+     *    An `EventLoopFuture<Void>` that succeeds when the drop is successful.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndexes(
         options: DropIndexOptions? = nil,
@@ -355,9 +373,12 @@ extension MongoCollection {
      * - Parameters:
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: A `MongoCursor` over the `IndexModel`s.
+     * - Returns:
+     *    An `EventLoopFuture<MongoCursor<IndexModel>>`. On success, contains a cursor over the indexes.
      *
-     * - Throws: `LogicError` if the provided session is inactive.
+     *    If the future fails, the error is likely one of the following:
+     *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      */
     public func listIndexes(session: ClientSession? = nil) -> EventLoopFuture<MongoCursor<IndexModel>> {
         let operation = ListIndexesOperation(collection: self)
@@ -370,9 +391,11 @@ extension MongoCollection {
      * - Parameters:
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[String]>` containing the index names.
+     * - Returns:
+     *    An `EventLoopFuture<[String]>` containing the index names.
      *
-     * - Throws: `LogicError` if the provided session is inactive.
+     *    If the future fails, the error is likely one of the following:
+     *    - `LogicError` if the provided session is inactive.
      */
     public func listIndexNames(session _: ClientSession? = nil) throws -> EventLoopFuture<[String]> {
         return self.listIndexes().flatMap { cursor in

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -167,14 +167,13 @@ extension MongoCollection {
      *   - options: Optional `CreateIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing the name of the created index.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the write.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the index specification or options.
+     * - Returns: An `EventLoopFuture<String>`. On success, contains the name of the created index. On failure,
+     *            contains:
+     *            - `WriteError` if an error occurs while performing the write.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the index specification or options.
      */
     public func createIndex(
         _ keys: Document,
@@ -194,14 +193,13 @@ extension MongoCollection {
      *   - options: Optional `CreateIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing the name of the created index.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the write.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the index specification or options.
+     * - Returns: An `EventLoopFuture<String>`. On success, contains the name of the created index. On failure,
+     *            contains:
+     *            - `WriteError` if an error occurs while performing the write.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the index specification or options.
      */
     public func createIndex(
         _ model: IndexModel,
@@ -224,15 +222,14 @@ extension MongoCollection {
      *   - options: Optional `CreateIndexOptions` to use for the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[String]>` containing the names of all the indexes that were created.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the write.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if `models` is empty.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the index specifications or options.
+     * - Returns: An `EventLoopFuture<[String]>`. On success, contains the names of the created indexes. On failure,
+     *            contains:
+     *            - `WriteError` if an error occurs while performing the write.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if `models` is empty.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the index specifications or options.
      */
     public func createIndexes(
         _ models: [IndexModel],

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -175,6 +175,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the index specification or options.
      */
     public func createIndex(
@@ -203,6 +204,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the index specification or options.
      */
     public func createIndex(
@@ -235,6 +237,7 @@ extension MongoCollection {
      *    - `InvalidArgumentError` if `models` is empty.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the index specifications or options.
      */
     public func createIndexes(
@@ -263,6 +266,8 @@ extension MongoCollection {
      *
      *    If the future fails, the error is likely one of the following:
      *    - `WriteError` if an error occurs while performing the command.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `EncodingError` if an error occurs while encoding the options.
@@ -296,6 +301,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndex(
@@ -322,6 +328,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndex(
@@ -347,6 +354,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options.
      */
     public func dropIndexes(
@@ -396,6 +404,7 @@ extension MongoCollection {
      *
      *    If the future fails, the error is likely one of the following:
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      */
     public func listIndexNames(session _: ClientSession? = nil) throws -> EventLoopFuture<[String]> {
         return self.listIndexes().flatMap { cursor in

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -87,7 +87,12 @@ extension MongoCollection {
      *   - options: Optional `CountDocumentsOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Int>` containing the count of the documents that matched the filter
+     * - Returns: An `EventLoopFuture<Int>`. On success, contains the count of the documents that matched the filter.
+     *            On failure, contains:
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func countDocuments(
         _ filter: Document = [:],
@@ -105,7 +110,12 @@ extension MongoCollection {
      *   - options: Optional `EstimatedDocumentCountOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Int>` containing an estimate of the count of documents in this collection
+     * - Returns: An `EventLoopFuture<Int>`. On success, contains an estimate of the count of documents in this
+     *            collection. On failure, contains:
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func estimatedDocumentCount(
         options: EstimatedDocumentCountOptions? = nil,
@@ -124,13 +134,12 @@ extension MongoCollection {
      *   - options: Optional `DistinctOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[BSON]>` containing the distinct values for the specified criteria
-     *
-     * - Throws:
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns: An `EventLoopFuture<[BSON]>`. On success, contains the distinct values for the specified criteria.
+     *            on failure, contains:
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func distinct(
         fieldName: String,

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -11,12 +11,13 @@ extension MongoCollection {
      *   - options: Optional `FindOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: A `MongoCursor` over the resulting `Document`s
+     * - Returns:
+     *    An `EventLoopFuture<MongoCursor<CollectionType>`. On success, contains a cursor over the resulting documents.
      *
-     * - Throws:
-     *   - `InvalidArgumentError` if the options passed are an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if the options passed are an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func find(
         _ filter: Document = [:],
@@ -35,12 +36,14 @@ extension MongoCollection {
      *   - options: Optional `FindOneOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns:  the resulting `Document`, or nil if there is no match
+     * - Returns:
+     *    An `EventLoopFuture<CollectionType?>`. On success, contains the matching document, or nil if there was no
+     *    match.
      *
-     * - Throws:
-     *   - `InvalidArgumentError` if the options passed are an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if the options passed are an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func findOne(
         _ filter: Document = [:],
@@ -61,12 +64,13 @@ extension MongoCollection {
      *   - options: Optional `AggregateOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: A `MongoCursor` over the resulting `Document`s
+     * - Returns:
+     *    An `EventLoopFuture<MongoCursor<CollectionType>`. On success, contains a cursor over the resulting documents.
      *
-     * - Throws:
-     *   - `InvalidArgumentError` if the options passed are an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if the options passed are an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func aggregate(
         _ pipeline: [Document],
@@ -87,12 +91,14 @@ extension MongoCollection {
      *   - options: Optional `CountDocumentsOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Int>`. On success, contains the count of the documents that matched the filter.
-     *            On failure, contains:
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<Int>`. On success, contains the count of the documents that matched the filter.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func countDocuments(
         _ filter: Document = [:],
@@ -110,12 +116,14 @@ extension MongoCollection {
      *   - options: Optional `EstimatedDocumentCountOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Int>`. On success, contains an estimate of the count of documents in this
-     *            collection. On failure, contains:
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<Int>`. On success, contains an estimate of the count of documents in this collection.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func estimatedDocumentCount(
         options: EstimatedDocumentCountOptions? = nil,
@@ -134,12 +142,14 @@ extension MongoCollection {
      *   - options: Optional `DistinctOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[BSON]>`. On success, contains the distinct values for the specified criteria.
-     *            on failure, contains:
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<[BSON]>`. On success, contains the distinct values for the specified criteria.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func distinct(
         fieldName: String,

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -17,6 +17,7 @@ extension MongoCollection {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if the options passed are an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func find(
@@ -43,6 +44,7 @@ extension MongoCollection {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if the options passed are an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func findOne(
@@ -70,6 +72,7 @@ extension MongoCollection {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if the options passed are an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func aggregate(
@@ -98,6 +101,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func countDocuments(
@@ -123,6 +127,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func estimatedDocumentCount(
@@ -149,6 +154,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func distinct(

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -12,15 +12,17 @@ extension MongoCollection {
      *   - options: Optional `InsertOneOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<InsertOneResult?>`. On success, contains the result of performing the insert, or
-     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *             - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<InsertOneResult?>`. On success, contains the result of performing the insert, or contains
+     *    `nil` if the write concern is unacknowledged.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
      */
-    @discardableResult
     public func insertOne(
         _ value: CollectionType,
         options: InsertOneOptions? = nil,
@@ -40,13 +42,16 @@ extension MongoCollection {
      *   - options: optional `InsertManyOptions` to use while executing the operation
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<InsertManyResult?>`. On success, contains the result of performing the inserts,
-     *            or contains `nil` if the write concern is unacknowledged. On failure, contains:
-     *            - `BulkWriteError` if an error occurs while performing any of the writes.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<InsertManyResult?>`. On success, contains the result of performing the inserts, or
+     *    contains `nil` if the write concern is unacknowledged.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `BulkWriteError` if an error occurs while performing any of the writes.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     public func insertMany(
         _ values: [CollectionType],
@@ -66,13 +71,16 @@ extension MongoCollection {
      *   - options: Optional `ReplaceOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the replacement,
-     *            or contains `nil` if the write concern is unacknowledged. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the replacement, or
+     *    contains `nil` if the write concern is unacknowledged.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     public func replaceOne(
         filter: Document,
@@ -96,13 +104,16 @@ extension MongoCollection {
      *   - options: Optional `UpdateOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the update, or
-     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the update, or contains
+     *    `nil` if the write concern is unacknowledged.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func updateOne(
         filter: Document,
@@ -130,13 +141,16 @@ extension MongoCollection {
      *   - options: Optional `UpdateOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the update, or
-     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the update, or contains
+     *    `nil` if the write concern is unacknowledged.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func updateMany(
         filter: Document,
@@ -163,13 +177,16 @@ extension MongoCollection {
      *   - options: Optional `DeleteOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<DeleteResult?>`. On success, contains the result of performing the deletion, or
-     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<DeleteResult?>`. On success, contains the result of performing the deletion, or contains
+     *    `nil` if the write concern is unacknowledged.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func deleteOne(
         _ filter: Document,
@@ -191,13 +208,16 @@ extension MongoCollection {
      *   - options: Optional `DeleteOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<DeleteResult?>`. On success, contains the result of performing the deletions, or
-     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
-     *            - `WriteError` if an error occurs while performing the command.
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<DeleteResult?>`. On success, contains the result of performing the deletions, or contains
+     *    `nil` if the write concern is unacknowledged.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `WriteError` if an error occurs while performing the command.
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func deleteMany(
         _ filter: Document,

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -12,15 +12,13 @@ extension MongoCollection {
      *   - options: Optional `InsertOneOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing an `InsertOneResult`, or containing `nil` if the write concern is
-     *            unacknowledged.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
+     * - Returns: An `EventLoopFuture<InsertOneResult?>`. On success, contains the result of performing the insert, or
+     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *             - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
      */
     @discardableResult
     public func insertOne(
@@ -42,15 +40,13 @@ extension MongoCollection {
      *   - options: optional `InsertManyOptions` to use while executing the operation
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing an `InsertManyResult`, or containing `nil` if the write concern is
-     *            unacknowledged.
-     *
-     * - Throws:
-     *   - `BulkWriteError` if an error occurs while performing any of the writes.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
+     * - Returns: An `EventLoopFuture<InsertManyResult?>`. On success, contains the result of performing the inserts,
+     *            or contains `nil` if the write concern is unacknowledged. On failure, contains:
+     *            - `BulkWriteError` if an error occurs while performing any of the writes.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     public func insertMany(
         _ values: [CollectionType],
@@ -70,15 +66,13 @@ extension MongoCollection {
      *   - options: Optional `ReplaceOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing an `UpdateResult`, or containing `nil` if the write concern is
-     *            unacknowledged.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
+     * - Returns: An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the replacement,
+     *            or contains `nil` if the write concern is unacknowledged. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     public func replaceOne(
         filter: Document,
@@ -102,15 +96,13 @@ extension MongoCollection {
      *   - options: Optional `UpdateOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing an `UpdateResult`, or containing `nil` if the write concern is
-     *            unacknowledged.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns: An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the update, or
+     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func updateOne(
         filter: Document,
@@ -138,15 +130,13 @@ extension MongoCollection {
      *   - options: Optional `UpdateOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing an `UpdateResult`, or containing `nil` if the write concern is
-     *            unacknowledged.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns: An `EventLoopFuture<UpdateResult?>`. On success, contains the result of performing the update, or
+     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func updateMany(
         filter: Document,
@@ -173,15 +163,13 @@ extension MongoCollection {
      *   - options: Optional `DeleteOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing a `DeleteResult`, or containing `nil` if the write concern is
-     *            unacknowledged.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns: An `EventLoopFuture<DeleteResult?>`. On success, contains the result of performing the deletion, or
+     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func deleteOne(
         _ filter: Document,
@@ -196,22 +184,20 @@ extension MongoCollection {
     }
 
     /**
-     * Deletes multiple documents
+     * Deletes all matching documents from the collection.
      *
      * - Parameters:
      *   - filter: Document representing the match criteria
      *   - options: Optional `DeleteOptions` to use when executing the command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing a `DeleteResult`, or containing `nil` if the write concern is
-     *            unacknowledged.
-     *
-     * - Throws:
-     *   - `WriteError` if an error occurs while performing the command.
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns: An `EventLoopFuture<DeleteResult?>`. On success, contains the result of performing the deletions, or
+     *            contains `nil` if the write concern is unacknowledged. On failure, contains:
+     *            - `WriteError` if an error occurs while performing the command.
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func deleteMany(
         _ filter: Document,

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -21,6 +21,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the `CollectionType` to BSON.
      */
     public func insertOne(
@@ -51,6 +52,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     public func insertMany(
@@ -80,6 +82,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the `CollectionType` or options to BSON.
      */
     public func replaceOne(
@@ -113,6 +116,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func updateOne(
@@ -150,6 +154,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func updateMany(
@@ -186,6 +191,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func deleteOne(
@@ -217,6 +223,7 @@ extension MongoCollection {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func deleteMany(

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -90,7 +90,7 @@ public struct MongoCollection<T: Codable> {
      *   - options: An optional `DropCollectionOptions` to use when executing this command
      *   - session: An optional `ClientSession` to use when executing this command
      *
-     * - Throws:
+     * - Returns: An `EventLoopFuture<Void>`. On success, contains `Void`. On failure, contains:
      *   - `CommandError` if an error occurs that prevents the command from executing.
      */
     public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -95,6 +95,8 @@ public struct MongoCollection<T: Codable> {
      *
      *    If the future fails, the error is likely one of the following:
      *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this collection's parent client has already been closed.
      */
     public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {
         let operation = DropCollectionOperation(collection: self, options: options)

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -90,8 +90,11 @@ public struct MongoCollection<T: Codable> {
      *   - options: An optional `DropCollectionOptions` to use when executing this command
      *   - session: An optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<Void>`. On success, contains `Void`. On failure, contains:
-     *   - `CommandError` if an error occurs that prevents the command from executing.
+     * - Returns:
+     *    An `EventLoopFuture<Void>` that succeeds when the drop is successful.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `CommandError` if an error occurs that prevents the command from executing.
      */
     public func drop(options: DropCollectionOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {
         let operation = DropCollectionOperation(collection: self, options: options)

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -273,12 +273,11 @@ public class MongoCursor<T: Codable>: Cursor {
      * or the cursor is closed.
      *
      * - Returns:
-     *   An `EventLoopFuture<T?>` evaluating to the next `T` in this cursor, `nil` if the cursor is exhausted,
-     *   or an error if one occurred. If the underlying cursor is tailable, the future will not resolve
-     *   until data is returned (potentially after multiple requests to the server), the cursor is closed, or an error
-     *   occurs.
+     *   An `EventLoopFuture<T?>` evaluating to the next `T` in this cursor, or `nil` if the cursor is exhausted. If
+     *   the underlying cursor is tailable, the future will not resolve until data is returned (potentially after
+     *   multiple requests to the server), the cursor is closed, or an error occurs.
      *
-     *   If the future evaluates to an error, it is likely one of the following:
+     *   If the future fails, the error is likely one of the following:
      *     - `CommandError` if an error occurs while fetching more results from the server.
      *     - `LogicError` if this function is called after the cursor has died.
      *     - `LogicError` if this function is called and the session associated with this cursor is inactive.

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -256,6 +256,7 @@ public class MongoCursor<T: Codable>: Cursor {
      *      - `CommandError` if an error occurs while fetching more results from the server.
      *      - `LogicError` if this function is called after the cursor has died.
      *      - `LogicError` if this function is called and the session associated with this cursor is inactive.
+     *      - `LogicError` if this cursor's parent client has already been closed.
      *      - `DecodingError` if an error occurs decoding the server's response.
      */
     public func tryNext() -> EventLoopFuture<T?> {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -118,8 +118,11 @@ public struct MongoDatabase {
      *   - options: An optional `DropDatabaseOptions` to use when executing this command
      *   - session: An optional `ClientSession` to use for this command
      *
-     * - Returns: An `EventLoopFuture<Void>`. On success, contains `Void`. On failure, contains:
-     *   - `CommandError` if an error occurs that prevents the command from executing.
+     * - Returns:
+     *    An `EventLoopFuture<Void>` that succeeds when the drop is successful.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `CommandError` if an error occurs that prevents the command from executing.
      */
     public func drop(options: DropDatabaseOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {
         let operation = DropDatabaseOperation(database: self, options: options)
@@ -172,12 +175,14 @@ public struct MongoDatabase {
      *   - options: Optional `CreateCollectionOptions` to use for the collection
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: an `EventLoopFuture<MongoCollection<Document>>`. On success, contains the newly created collection.
-     *            On failure, contains:
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<MongoCollection<Document>>`. On success, contains the newly created collection.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func createCollection(
         _ name: String,
@@ -198,12 +203,14 @@ public struct MongoDatabase {
      *   - options: Optional `CreateCollectionOptions` to use for the collection
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<MongoCollection<T>>`. On success, contains the newly created collection. On
-     *            failure, contains:
-     *            - `CommandError` if an error occurs that prevents the command from executing.
-     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<MongoCollection<T>>`. On success, contains the newly created collection.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func createCollection<T: Codable>(
         _ name: String,
@@ -223,11 +230,12 @@ public struct MongoDatabase {
      *   - options: Optional `ListCollectionsOptions` to use when executing this command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: a `MongoCursor` over an array of `CollectionSpecification`s
+     * - Returns:
+     *    An `EventLoopFuture<MongoCursor<CollectionSpecification>>` containing a cursor over the collections.
      *
-     * - Throws:
-     *   - `InvalidArgumentError` if the options passed are an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
+    *     If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if the options passed are an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
      */
     public func listCollections(
         _ filter: Document? = nil,
@@ -253,10 +261,13 @@ public struct MongoDatabase {
      *   - options: Optional `ListCollectionsOptions` to use when executing this command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[MongoCollection<Document>]>`. On success, contains collections that match the
-     *            provided filter. On failure, contains:
-     *            - `InvalidArgumentError` if the options passed are an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
+     * - Returns:
+     *    An `EventLoopFuture<[MongoCollection<Document>]>`. On success, contains collections that match the
+     *    provided filter.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if the options passed are an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
      */
     public func listMongoCollections(
         _ filter: Document? = nil,
@@ -276,10 +287,12 @@ public struct MongoDatabase {
      *   - options: Optional `ListCollectionsOptions` to use when executing this command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[String]>`. On success, contains names of collections that match the provided
-     *            filter. On failure, contains:
-     *            - `InvalidArgumentError` if the options passed are an invalid combination.
-     *            - `LogicError` if the provided session is inactive.
+     * - Returns:
+     *    An `EventLoopFuture<[String]>`. On success, contains names of collections that match the provided filter.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if the options passed are an invalid combination.
+     *    - `LogicError` if the provided session is inactive.
      */
     public func listCollectionNames(
         _ filter: Document? = nil,
@@ -304,13 +317,15 @@ public struct MongoDatabase {
      *   - options: Optional `RunCommandOptions` to use when executing this command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: an `EventLoopFuture<Document>`. On success, contains the server response to the command. On failure,
-     *            contains:
-     *            - `InvalidArgumentError` if `requests` is empty.
-     *            - `LogicError` if the provided session is inactive.
-     *            - `WriteError` if any error occurs while the command was performing a write.
-     *            - `CommandError` if an error occurs that prevents the command from being performed.
-     *            - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns:
+     *    An `EventLoopFuture<Document>`. On success, contains the server response to the command.
+     *
+     *    If the future fails, the error is likely one of the following:
+     *    - `InvalidArgumentError` if `requests` is empty.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `WriteError` if any error occurs while the command was performing a write.
+     *    - `CommandError` if an error occurs that prevents the command from being performed.
+     *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
     public func runCommand(

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -237,7 +237,7 @@ public struct MongoDatabase {
      * - Returns:
      *    An `EventLoopFuture<MongoCursor<CollectionSpecification>>` containing a cursor over the collections.
      *
-    *     If the future fails, the error is likely one of the following:
+     *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if the options passed are an invalid combination.
      *    - `LogicError` if the provided session is inactive.
      *    - `LogicError` if this databases's parent client has already been closed.

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -118,7 +118,7 @@ public struct MongoDatabase {
      *   - options: An optional `DropDatabaseOptions` to use when executing this command
      *   - session: An optional `ClientSession` to use for this command
      *
-     * - Throws:
+     * - Returns: An `EventLoopFuture<Void>`. On success, contains `Void`. On failure, contains:
      *   - `CommandError` if an error occurs that prevents the command from executing.
      */
     public func drop(options: DropDatabaseOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {
@@ -172,13 +172,12 @@ public struct MongoDatabase {
      *   - options: Optional `CreateCollectionOptions` to use for the collection
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: an `EventLoopFuture` containing the newly created `MongoCollection<Document>`
-     *
-     * - Throws:
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns: an `EventLoopFuture<MongoCollection<Document>>`. On success, contains the newly created collection.
+     *            On failure, contains:
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func createCollection(
         _ name: String,
@@ -199,13 +198,12 @@ public struct MongoDatabase {
      *   - options: Optional `CreateCollectionOptions` to use for the collection
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture` containing the newly created `MongoCollection<T>`
-     *
-     * - Throws:
-     *   - `CommandError` if an error occurs that prevents the command from executing.
-     *   - `InvalidArgumentError` if the options passed in form an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns: An `EventLoopFuture<MongoCollection<T>>`. On success, contains the newly created collection. On
+     *            failure, contains:
+     *            - `CommandError` if an error occurs that prevents the command from executing.
+     *            - `InvalidArgumentError` if the options passed in form an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func createCollection<T: Codable>(
         _ name: String,
@@ -228,7 +226,7 @@ public struct MongoDatabase {
      * - Returns: a `MongoCursor` over an array of `CollectionSpecification`s
      *
      * - Throws:
-     *   - `userError.invalidArgumentError` if the options passed are an invalid combination.
+     *   - `InvalidArgumentError` if the options passed are an invalid combination.
      *   - `LogicError` if the provided session is inactive.
      */
     public func listCollections(
@@ -248,19 +246,17 @@ public struct MongoDatabase {
     }
 
     /**
-     * Gets a list of `MongoCollection`s in this database.
+     * Gets a list of `MongoCollection`s corresponding to collections in this database.
      *
      * - Parameters:
      *   - filter: a `Document`, optional criteria to filter results by
      *   - options: Optional `ListCollectionsOptions` to use when executing this command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[MongoCollection<Document>]>` containing collections that match the provided
-     *            filter.
-     *
-     * - Throws:
-     *   - `userError.invalidArgumentError` if the options passed are an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
+     * - Returns: An `EventLoopFuture<[MongoCollection<Document>]>`. On success, contains collections that match the
+     *            provided filter. On failure, contains:
+     *            - `InvalidArgumentError` if the options passed are an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
      */
     public func listMongoCollections(
         _ filter: Document? = nil,
@@ -280,11 +276,10 @@ public struct MongoDatabase {
      *   - options: Optional `ListCollectionsOptions` to use when executing this command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: An `EventLoopFuture<[String]>` containing names of collections that match the provided filter.
-     *
-     * - Throws:
-     *   - `userError.invalidArgumentError` if the options passed are an invalid combination.
-     *   - `LogicError` if the provided session is inactive.
+     * - Returns: An `EventLoopFuture<[String]>`. On success, contains names of collections that match the provided
+     *            filter. On failure, contains:
+     *            - `InvalidArgumentError` if the options passed are an invalid combination.
+     *            - `LogicError` if the provided session is inactive.
      */
     public func listCollectionNames(
         _ filter: Document? = nil,
@@ -309,14 +304,13 @@ public struct MongoDatabase {
      *   - options: Optional `RunCommandOptions` to use when executing this command
      *   - session: Optional `ClientSession` to use when executing this command
      *
-     * - Returns: an `EventLoopFuture<Document>` containing the server response for the command
-     *
-     * - Throws:
-     *   - `InvalidArgumentError` if `requests` is empty.
-     *   - `LogicError` if the provided session is inactive.
-     *   - `WriteError` if any error occurs while the command was performing a write.
-     *   - `CommandError` if an error occurs that prevents the command from being performed.
-     *   - `EncodingError` if an error occurs while encoding the options to BSON.
+     * - Returns: an `EventLoopFuture<Document>`. On success, contains the server response to the command. On failure,
+     *            contains:
+     *            - `InvalidArgumentError` if `requests` is empty.
+     *            - `LogicError` if the provided session is inactive.
+     *            - `WriteError` if any error occurs while the command was performing a write.
+     *            - `CommandError` if an error occurs that prevents the command from being performed.
+     *            - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     @discardableResult
     public func runCommand(

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -123,6 +123,8 @@ public struct MongoDatabase {
      *
      *    If the future fails, the error is likely one of the following:
      *    - `CommandError` if an error occurs that prevents the command from executing.
+     *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this database's parent client has already been closed.
      */
     public func drop(options: DropDatabaseOptions? = nil, session: ClientSession? = nil) -> EventLoopFuture<Void> {
         let operation = DropDatabaseOperation(database: self, options: options)
@@ -182,6 +184,7 @@ public struct MongoDatabase {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this databases's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func createCollection(
@@ -210,6 +213,7 @@ public struct MongoDatabase {
      *    - `CommandError` if an error occurs that prevents the command from executing.
      *    - `InvalidArgumentError` if the options passed in form an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this databases's parent client has already been closed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
     public func createCollection<T: Codable>(
@@ -236,6 +240,7 @@ public struct MongoDatabase {
     *     If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if the options passed are an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this databases's parent client has already been closed.
      */
     public func listCollections(
         _ filter: Document? = nil,
@@ -268,6 +273,7 @@ public struct MongoDatabase {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if the options passed are an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this databases's parent client has already been closed.
      */
     public func listMongoCollections(
         _ filter: Document? = nil,
@@ -293,6 +299,7 @@ public struct MongoDatabase {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if the options passed are an invalid combination.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this databases's parent client has already been closed.
      */
     public func listCollectionNames(
         _ filter: Document? = nil,
@@ -323,11 +330,11 @@ public struct MongoDatabase {
      *    If the future fails, the error is likely one of the following:
      *    - `InvalidArgumentError` if `requests` is empty.
      *    - `LogicError` if the provided session is inactive.
+     *    - `LogicError` if this databases's parent client has already been closed.
      *    - `WriteError` if any error occurs while the command was performing a write.
      *    - `CommandError` if an error occurs that prevents the command from being performed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
      */
-    @discardableResult
     public func runCommand(
         _ command: Document,
         options: RunCommandOptions? = nil,

--- a/Sources/MongoSwiftSync/MongoDatabase.swift
+++ b/Sources/MongoSwiftSync/MongoDatabase.swift
@@ -154,7 +154,7 @@ public struct MongoDatabase {
      * - Returns: a `MongoCursor` over an array of `CollectionSpecification`s
      *
      * - Throws:
-     *   - `userError.invalidArgumentError` if the options passed are an invalid combination.
+     *   - `InvalidArgumentError` if the options passed are an invalid combination.
      *   - `LogicError` if the provided session is inactive.
      */
     public func listCollections(
@@ -178,7 +178,7 @@ public struct MongoDatabase {
      * - Returns: An array of `MongoCollection`s that match the provided filter.
      *
      * - Throws:
-     *   - `userError.invalidArgumentError` if the options passed are an invalid combination.
+     *   - `InvalidArgumentError` if the options passed are an invalid combination.
      *   - `LogicError` if the provided session is inactive.
      */
     public func listMongoCollections(
@@ -202,7 +202,7 @@ public struct MongoDatabase {
      * - Returns: A `[String]` containing names of collections that match the provided filter.
      *
      * - Throws:
-     *   - `userError.invalidArgumentError` if the options passed are an invalid combination.
+     *   - `InvalidArgumentError` if the options passed are an invalid combination.
      *   - `LogicError` if the provided session is inactive.
      */
     public func listCollectionNames(


### PR DESCRIPTION
Most of this PR is just slightly reformatting docstrings to clarify that futures fail with particular errors now, rather than the errors being thrown.

This excludes the docstrings for cursors and change streams, and methods that return cursors and change streams, as I think you started on those already, but if you think I should pick up any of that while you work on implementing those types let me know.