### PR TITLE
SWIFT-710 Audit tests to ensure all are re-enabled

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -190,6 +190,21 @@ extension MongoCollection_BulkWriteTests {
     ]
 }
 
+extension MongoCollection_IndexTests {
+    static var allTests = [
+        ("testCreateIndexFromModel", testCreateIndexFromModel),
+        ("testIndexOptions", testIndexOptions),
+        ("testCreateIndexesFromModels", testCreateIndexesFromModels),
+        ("testCreateIndexFromKeys", testCreateIndexFromKeys),
+        ("testDropIndexByName", testDropIndexByName),
+        ("testDropIndexByModel", testDropIndexByModel),
+        ("testDropIndexByKeys", testDropIndexByKeys),
+        ("testDropAllIndexes", testDropAllIndexes),
+        ("testListIndexNames", testListIndexNames),
+        ("testCreateDropIndexByModelWithMaxTimeMS", testCreateDropIndexByModelWithMaxTimeMS),
+    ]
+}
+
 extension MongoCursorTests {
     static var allTests = [
         ("testNonTailableCursor", testNonTailableCursor),
@@ -329,6 +344,7 @@ XCTMain([
     testCase(MongoClientTests.allTests),
     testCase(MongoCollectionTests.allTests),
     testCase(MongoCollection_BulkWriteTests.allTests),
+    testCase(MongoCollection_IndexTests.allTests),
     testCase(MongoCursorTests.allTests),
     testCase(MongoDatabaseTests.allTests),
     testCase(OptionsTests.allTests),

--- a/Tests/MongoSwiftSyncTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftSyncTests/CommandMonitoringTests.swift
@@ -111,17 +111,17 @@ private struct CMTestFile: Decodable {
     }
 }
 
+extension ReadPreference.Mode: Decodable {}
+
 extension ReadPreference: Decodable {
     public convenience init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let rpDoc = try container.decode(Document.self)
-        guard let modeStr = rpDoc["mode"]?.stringValue else {
-            throw TestError(message: "Read preference document missing mode string: \(rpDoc)")
-        }
-        guard let mode = Mode(rawValue: modeStr) else {
-            throw TestError(message: "Unrecognized read preference mode \(modeStr)")
-        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let mode = try container.decode(Mode.self, forKey: .mode)
         self.init(mode)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case mode
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -1,4 +1,4 @@
-import MongoSwift
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 import XCTest
@@ -161,8 +161,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
 
-        let res = try self.coll.dropIndex(model)
-        expect(res["ok"]?.asDouble()).to(equal(1.0))
+        expect(try self.coll.dropIndex(model)).toNot(throwError())
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
@@ -175,8 +174,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
 
-        let res = try self.coll.dropIndex(["cat": 1])
-        expect(res["ok"]?.asDouble()).to(equal(1.0))
+        expect(try self.coll.dropIndex(["cat": 1])).toNot(throwError())
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
@@ -189,8 +187,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         let model = IndexModel(keys: ["cat": 1])
         expect(try self.coll.createIndex(model)).to(equal("cat_1"))
 
-        let res = try self.coll.dropIndexes()
-        expect(res["ok"]?.asDouble()).to(equal(1.0))
+        expect(try self.coll.dropIndexes()).toNot(throwError())
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()
@@ -236,8 +233,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         expect(try collection.createIndex(model, options: createIndexOpts)).to(equal("cat_1"))
 
         let dropIndexOpts = DropIndexOptions(maxTimeMS: maxTimeMS, writeConcern: wc)
-        let res = try collection.dropIndex(model, options: dropIndexOpts)
-        expect(res["ok"]?.asDouble()).to(equal(1.0))
+        expect(try collection.dropIndex(model, options: dropIndexOpts)).toNot(throwError())
 
         // now there should only be _id_ left
         let indexes = try coll.listIndexes()

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -182,17 +182,16 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
         expect(try coll.deleteMany(["x": 9], options: DeleteOptions(writeConcern: wc1))).toNot(throwError())
         expect(try coll.deleteMany(["x": 10], options: DeleteOptions(writeConcern: wc3))).toNot(throwError())
 
-        // TODO: SWIFT-702: uncomment these assertions
-        // expect(try coll.createIndex(
-        //     ["x": 1],
-        //     options: CreateIndexOptions(writeConcern: wc1)
-        // )).toNot(throwError())
-        // expect(try coll.createIndexes(
-        //     [IndexModel(keys: ["x": -1])],
-        //     options: CreateIndexOptions(writeConcern: wc3)
-        // )).toNot(throwError())
+        expect(try coll.createIndex(
+            ["x": 1],
+            options: CreateIndexOptions(writeConcern: wc1)
+        )).toNot(throwError())
+        expect(try coll.createIndexes(
+            [IndexModel(keys: ["x": -1])],
+            options: CreateIndexOptions(writeConcern: wc3)
+        )).toNot(throwError())
 
-        // expect(try coll.dropIndex(["x": 1], options: DropIndexOptions(writeConcern: wc1))).toNot(throwError())
-        // expect(try coll.dropIndexes(options: DropIndexOptions(writeConcern: wc3))).toNot(throwError())
+        expect(try coll.dropIndex(["x": 1], options: DropIndexOptions(writeConcern: wc1))).toNot(throwError())
+        expect(try coll.dropIndexes(options: DropIndexOptions(writeConcern: wc3))).toNot(throwError())
     }
 }


### PR DESCRIPTION
Went through all of the test files and made sure everything has been uncommented / reenabled. 

We missed some related to indexes which I've turned on here.

Also noticed we never completed a TODO to send read preferences when specified in the command monitoring tests. It's not clear to me why they are in the tests as they don't affect the generated command events (see [here](https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.rst#read-preference)). I guess the idea might have been to future-proof the tests if we ever did start including that kind of metadata in command events. 

The only tests not running as of this PR are the change stream ones, and @patrickfreed enables all of those in #395. 