### PR TITLE
SWIFT-639 Update Vapor example

### DIFF
--- a/Examples/.swiftlint.yml
+++ b/Examples/.swiftlint.yml
@@ -1,2 +1,3 @@
 disabled_rules:
   - explicit_acl
+  - nesting

--- a/Examples/VaporExample/Package.swift
+++ b/Examples/VaporExample/Package.swift
@@ -1,11 +1,14 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "VaporExample",
+    platforms: [
+       .macOS(.v10_14)
+    ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor", .upToNextMajor(from: "3.3.0")),
-        .package(url: "https://github.com/mongodb/mongo-swift-driver", .upToNextMajor(from: "0.1.0"))
+        .package(url: "https://github.com/vapor/vapor", .exact("4.0.0-beta.3.24")),
+        .package(url: "https://github.com/mongodb/mongo-swift-driver", .branch("master"))
     ],
     targets: [
         .target(name: "VaporExample", dependencies: ["Vapor", "MongoSwift"])

--- a/Examples/VaporExample/Package.swift
+++ b/Examples/VaporExample/Package.swift
@@ -7,8 +7,9 @@ let package = Package(
         .macOS(.v10_14)
     ],
     dependencies: [
+        // The driver depends on SwiftNIO 2 and therefore is only compatible with Vapor 4.
         .package(url: "https://github.com/vapor/vapor", .exact("4.0.0-beta.3.24")),
-        .package(url: "https://github.com/mongodb/mongo-swift-driver", .branch("master"))
+        .package(url: "https://github.com/mongodb/mongo-swift-driver", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
         .target(name: "VaporExample", dependencies: ["Vapor", "MongoSwift"])

--- a/Examples/VaporExample/Package.swift
+++ b/Examples/VaporExample/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "VaporExample",
     platforms: [
-       .macOS(.v10_14)
+        .macOS(.v10_14)
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor", .exact("4.0.0-beta.3.24")),

--- a/Examples/VaporExample/README.md
+++ b/Examples/VaporExample/README.md
@@ -2,6 +2,8 @@
 
 This is a minimal working example of using the driver in a Vapor application.
 
+**Note**: Since the driver depends on SwiftNIO 2 as of the 1.0.0-rc0 release, it is only compatible with Vapor 4. 
+
 To test it out, do the following:
 1. Run `mongod` to start MongoDB running on `localhost:27017`.
 1. Navigate to the `Examples/` directory (one level up from this one.)

--- a/Examples/VaporExample/Sources/VaporExample/configure.swift
+++ b/Examples/VaporExample/Sources/VaporExample/configure.swift
@@ -2,6 +2,7 @@ import MongoSwift
 import Vapor
 
 extension Application {
+    /// A global `MongoClient` for use throughout the application.
     var mongoClient: MongoClient {
         get {
             return self.storage[MongoClientKey.self]!
@@ -17,6 +18,7 @@ extension Application {
 }
 
 func configure(_ app: Application) throws {
+    // Initialize a client using the application's EventLoopGroup.
     let client = try MongoClient(using: app.eventLoopGroup)
     app.mongoClient = client
     try routes(app)

--- a/Examples/VaporExample/Sources/VaporExample/configure.swift
+++ b/Examples/VaporExample/Sources/VaporExample/configure.swift
@@ -1,0 +1,23 @@
+import MongoSwift
+import Vapor
+
+extension Application {
+    var mongoClient: MongoClient {
+        get {
+            return self.storage[MongoClientKey.self]!
+        }
+        set {
+            self.storage[MongoClientKey.self] = newValue
+        }
+    }
+
+    private struct MongoClientKey: StorageKey {
+        typealias Value = MongoClient
+    }
+}
+
+func configure(_ app: Application) throws {
+    let client = try MongoClient(using: app.eventLoopGroup)
+    app.mongoClient = client
+    try routes(app)
+}

--- a/Examples/VaporExample/Sources/VaporExample/main.swift
+++ b/Examples/VaporExample/Sources/VaporExample/main.swift
@@ -1,3 +1,4 @@
+import MongoSwift
 import Vapor
 
 var env = try Environment.detect()

--- a/Examples/VaporExample/Sources/VaporExample/main.swift
+++ b/Examples/VaporExample/Sources/VaporExample/main.swift
@@ -2,10 +2,15 @@ import Vapor
 
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)
+
 let app = Application(env)
+
 defer {
+    // shut down the client and clean up the driver's global resources.
     app.mongoClient.syncShutdown()
+    cleanupMongoSwift()
     app.shutdown()
 }
+
 try configure(app)
 try app.run()

--- a/Examples/VaporExample/Sources/VaporExample/main.swift
+++ b/Examples/VaporExample/Sources/VaporExample/main.swift
@@ -1,26 +1,11 @@
-import MongoSwift
 import Vapor
 
-/// A Codable type that matches the data in our home.kittens collection.
-private struct Kitten: Content {
-    var name: String
-    var color: String
+var env = try Environment.detect()
+try LoggingSystem.bootstrap(from: &env)
+let app = Application(env)
+defer {
+    app.mongoClient.syncShutdown()
+    app.shutdown()
 }
-
-private let app = try Application()
-private let router = try app.make(Router.self)
-
-/// A single collection with type `Kitten`. This allows us to directly retrieve instances of
-/// `Kitten` from the collection.  `MongoCollection` is safe to share across threads.
-private let collection = try MongoClient().db("home").collection("kittens", withType: Kitten.self)
-
-router.get("kittens") { _ -> [Kitten] in
-    let cursor = try collection.find()
-    let results = Array(cursor)
-    if let error = cursor.error {
-        throw error
-    }
-    return results
-}
-
+try configure(app)
 try app.run()

--- a/Examples/VaporExample/Sources/VaporExample/routes.swift
+++ b/Examples/VaporExample/Sources/VaporExample/routes.swift
@@ -1,0 +1,20 @@
+import MongoSwift
+import Vapor
+
+/// A Codable type that matches the data in our home.kittens collection.
+struct Kitten: Content {
+    var name: String
+    var color: String
+}
+
+func routes(_ app: Application) throws {
+    /// A collection with type `Kitten`. This allows us to directly retrieve instances of
+    /// `Kitten` from the collection.  `MongoCollection` is safe to share across threads.
+    let collection = app.mongoClient.db("home").collection("kittens", withType: Kitten.self)
+
+    app.get("kittens") { _ -> EventLoopFuture<[Kitten]> in
+        collection.find().flatMap { cursor in
+            cursor.toArray()
+        }
+    }
+}


### PR DESCRIPTION
Putting up a draft PR. We probably don't want to merge this for a while because:

1) It depends on master, and not a tagged release
2) It's `@testable` importing in order to use the `all` method on `MongoCursor`
3) It's depending on a beta release of Vapor 4
4) If we do add a `syncClose` method to `MongoClient` as proposed in SWIFT-717 we'll want to use that here