### PR TITLE
Skip change streams test case on 4.3+

### DIFF
--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -269,8 +269,14 @@ final class ChangeStreamSpecTests: MongoSwiftTestCase, FailPointConfigured {
                 }
 
                 guard version >= test.minServerVersion else {
-                    print("Skipping tests case \"\(test.description)\": minimum required server " +
+                    print("Skipping test case \"\(test.description)\": minimum required server " +
                         "version \(test.minServerVersion) not met.")
+                    continue
+                }
+
+                guard !(test.description == "Change Stream should error when _id is projected out" &&
+                    version >= ServerVersion(major: 4, minor: 3)) else {
+                    print("Skipping test case \"\(test.description)\"; see SWIFT-722")
                     continue
                 }
 

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -275,7 +275,7 @@ final class ChangeStreamSpecTests: MongoSwiftTestCase, FailPointConfigured {
                 }
 
                 guard !(test.description == "Change Stream should error when _id is projected out" &&
-                    version >= ServerVersion(major: 4, minor: 3, patch: 4)) else {
+                    version >= ServerVersion(major: 4, minor: 3, patch: 3)) else {
                     print("Skipping test case \"\(test.description)\"; see SWIFT-722")
                     continue
                 }
@@ -350,7 +350,7 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
             return
         }
 
-        guard try MongoClient.makeTestClient().serverVersion() < ServerVersion(major: 4, minor: 3, patch: 4) else {
+        guard try MongoClient.makeTestClient().serverVersion() < ServerVersion(major: 4, minor: 3, patch: 3) else {
             print("Skipping test; see SWIFT-722")
             return
         }
@@ -542,8 +542,8 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
             return
         }
 
-        // skip on 4.3.4+ due to removal of NonResumableChangeStreamError label; see SWIFT-722
-        guard version < ServerVersion(major: 4, minor: 3, patch: 4) else {
+        // skip on 4.3.3+ due to removal of NonResumableChangeStreamError label; see SWIFT-722
+        guard version < ServerVersion(major: 4, minor: 3, patch: 3) else {
             return
         }
 

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -28,6 +28,20 @@ extension MongoClient {
             XCTFail("Error closing test client: \(error)")
         }
     }
+
+    internal func serverVersion() -> EventLoopFuture<ServerVersion> {
+        return self.db("admin").runCommand(
+            ["buildInfo": 1],
+            options: RunCommandOptions(
+                readPreference: ReadPreference(.primary)
+            )
+        ).flatMapThrowing { reply in
+            guard let versionString = reply["version"]?.stringValue else {
+                throw TestError(message: " reply missing version string: \(reply)")
+            }
+            return try ServerVersion(versionString)
+        }
+    }
 }
 
 extension MongoDatabase {

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -48,6 +48,11 @@ final class ChangeStreamTests: MongoSwiftTestCase {
         }
 
         try self.withTestClient { client in
+            guard try client.serverVersion().wait() < ServerVersion(major: 4, minor: 3, patch: 3) else {
+                print("Skipping test; see SWIFT-722")
+                return
+            }
+
             let db = client.db(type(of: self).testDatabase)
             try? db.collection(self.getCollectionName()).drop().wait()
             let coll = try db.createCollection(self.getCollectionName()).wait()


### PR DESCRIPTION
Due to changes introduced in [SERVER-45505](https://jira.mongodb.org/browse/SERVER-45505), this particular test case now hangs indefinitely on latest.
SPEC-1505 will introduce changes to the change streams spec to account for the new behavior.

I've opened SWIFT-722 to remind us that we should unskip this test later on.