### PR TITLE
SWIFT-717 Add syncClose method to MongoClient

### DIFF
--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -59,7 +59,7 @@ internal class ConnectionPool {
     }
 
     /// Closes the pool, cleaning up underlying resources. This method blocks as it sends `endSessions` to the server.
-    internal func close() {
+    internal func shutdown() {
         switch self.state {
         case let .open(pool):
             mongoc_client_pool_destroy(pool)

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -301,6 +301,20 @@ public class MongoClient {
         }
     }
 
+    /**
+     * Closes this `MongoClient` in a blocking fashion.
+     * Call this method exactly once when you are finished using the client. You must ensure that all operations
+     * using the client have completed before calling this.
+     *
+     * This method must complete before the `EventLoopGroup` provided to this client's constructor is shut down.
+     */
+    public func syncClose() {
+        self.connectionPool.close()
+        self.isClosed = true
+        // TODO: SWIFT-349 log any errors encountered here.
+        try? self.operationExecutor.syncClose()
+    }
+
     /// Starts a new `ClientSession` with the provided options. When you are done using this session, you must call
     /// `ClientSession.end()` on it.
     public func startSession(options: ClientSessionOptions? = nil) -> ClientSession {

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -288,12 +288,13 @@ public class MongoClient {
         assert(self.isClosed, "MongoClient was not closed before deinitialization")
     }
 
-    /// Closes this `MongoClient`. Call this method exactly once when you are finished using the client. You must
-    /// ensure that all operations using the client have completed before calling this. The returned future must be
-    /// fulfilled before the `EventLoopGroup` provided to this client's constructor is shut down.
-    public func close() -> EventLoopFuture<Void> {
+    /// Shuts this `MongoClient` down, closing all connection to the server and cleaning up internal state.
+    /// Call this method exactly once when you are finished using the client. You must ensure that all operations
+    /// using the client have completed before calling this. The returned future must be fulfilled before the
+    /// `EventLoopGroup` provided to this client's constructor is shut down.
+    public func shutdown() -> EventLoopFuture<Void> {
         return self.operationExecutor.execute {
-            self.connectionPool.close()
+            self.connectionPool.shutdown()
             self.isClosed = true
         }
         .flatMap {
@@ -302,14 +303,16 @@ public class MongoClient {
     }
 
     /**
-     * Closes this `MongoClient` in a blocking fashion.
+     * Shuts this `MongoClient` down in a blocking fashion, closing all connections to the server and cleaning up
+     * internal state.
+     *
      * Call this method exactly once when you are finished using the client. You must ensure that all operations
      * using the client have completed before calling this.
      *
      * This method must complete before the `EventLoopGroup` provided to this client's constructor is shut down.
      */
-    public func syncClose() {
-        self.connectionPool.close()
+    public func syncShutdown() {
+        self.connectionPool.shutdown()
         self.isClosed = true
         // TODO: SWIFT-349 log any errors encountered here.
         try? self.operationExecutor.syncClose()

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -37,6 +37,11 @@ internal class OperationExecutor {
         return promise.futureResult
     }
 
+    /// Closes the executor's underlying thread pool synchronously.
+    internal func syncClose() throws {
+        try self.threadPool.syncShutdownGracefully()
+    }
+
     internal func execute<T: Operation>(
         _ operation: T,
         using connection: Connection? = nil,

--- a/Sources/MongoSwiftSync/MongoClient.swift
+++ b/Sources/MongoSwiftSync/MongoClient.swift
@@ -53,7 +53,7 @@ public class MongoClient {
 
     deinit {
         do {
-            try self.asyncClient.close().wait()
+            try self.asyncClient.shutdown().wait()
         } catch {
             assertionFailure("Error closing async client: \(error)")
         }

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -22,7 +22,7 @@ extension MongoClient {
 
     internal func syncCloseOrFail() {
         do {
-            try self.close().wait()
+            try self.shutdown().wait()
         } catch {
             XCTFail("Error closing test client: \(error)")
         }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -8,7 +8,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { elg.syncShutdownOrFail() }
         let client = try MongoClient(using: elg)
-        try client.close().wait()
+        try client.shutdown().wait()
         expect(try client.listDatabases().wait()).to(throwError(MongoClient.ClosedClientError))
     }
 


### PR DESCRIPTION
[SWIFT-717](https://jira.mongodb.org/browse/SWIFT-717)

This PR adds a `syncClose` method to `MongoClient`. Right now, it simply ignores any errors encountered while shutting down the thread pool, but once we add logger support, we can log these errors instead. This is [the approach vapor takes](https://github.com/vapor/vapor/blob/857eb912b8bde8662e765cbec7675b10cfe924f6/Sources/Vapor/Application.swift#L108-L122).

One remaining question I have is whether we want to rename `close` and `syncClose` to `shutdown` and `syncShutdown` / `shutdownSync` to more closely match vapor's naming.
