### PR TITLE
SWIFT-719 Add a forEach method to async cursors and change streams

### DIFF
--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -193,6 +193,18 @@ public class ChangeStream<T: Codable>: CursorProtocol {
         }
     }
 
+    /**
+     * Calls the provided closure with each event in the change stream as it arrives.
+     *
+     * - Returns:
+     *     An `EventLoopFuture<Void>` which will succeed once the change stream is killed via `kill`.
+     *
+     *     If the future evaluates to an error, that error is likely one of the following:
+     *     - `CommandError` if an error occurs while fetching more results from the server.
+     *     - `LogicError` if this function is called after the change stream has died.
+     *     - `LogicError` if this function is called and the session associated with this change stream is inactive.
+     *     - `DecodingError` if an error occurs decoding the server's responses.
+     */
     public func forEach(_ body: @escaping (T) throws -> Void) -> EventLoopFuture<Void> {
         return self.client.operationExecutor.execute {
             while let next = try self.processEvent(self.wrappedCursor.next()) {

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -126,10 +126,13 @@ public class ChangeStream<T: Codable>: CursorProtocol {
      * (specified on the `ChangeStreamOptions` passed  to the method that created this change stream) before trying
      * again.
      *
-     * A thread from the pool will be occupied until the returned future is completed, so performance degradation
-     * is possible if the number of polling change streams is too close to the total number of threads in the thread
-     * pool. To configure the total number of threads in the pool, set the `ClientOptions.threadPoolSize` option
-     * during client creation.
+     * A thread from the driver's internal thread pool will be occupied until the returned future is completed, so
+     * performance degradation is possible if the number of polling change streams is too close to the total number of
+     * threads in the thread pool. To configure the total number of threads in the pool, set the
+     * `ClientOptions.threadPoolSize` option during client creation.
+     *
+     * Note: You *must not* call any change stream methods besides `kill` and `isAlive` while the future returned from
+     * this method is unresolved. Doing so will result in undefined behavior.
      *
      * - Returns:
      *   An `EventLoopFuture<T?>` evaluating to the next `T` in this change stream, `nil` if the change stream is
@@ -156,6 +159,9 @@ public class ChangeStream<T: Codable>: CursorProtocol {
      *
      * This method may be called repeatedly while `isAlive` is true to retrieve new data.
      *
+     * Note: You *must not* call any change stream methods besides `kill` and `isAlive` while the future returned from
+     * this method is unresolved. Doing so will result in undefined behavior.
+     *
      * - Returns:
      *    An `EventLoopFuture<T?>` containing the next `T` in this change stream, an error if one occurred, or `nil` if
      *    there was no data.
@@ -178,6 +184,9 @@ public class ChangeStream<T: Codable>: CursorProtocol {
      * Since `toArray` will only fetch the currently available results, it may return more data if it is called again
      * while the change stream is still alive.
      *
+     * Note: You *must not* call any change stream methods besides `kill` and `isAlive` while the future returned from
+     * this method is unresolved. Doing so will result in undefined behavior.
+     *
      * - Returns:
      *    An `EventLoopFuture<[T]>` evaluating to the results currently available in this change stream, or an error.
      *
@@ -196,8 +205,17 @@ public class ChangeStream<T: Codable>: CursorProtocol {
     /**
      * Calls the provided closure with each event in the change stream as it arrives.
      *
+     * A thread from the driver's internal thread pool will be occupied until the returned future is completed, so
+     * performance degradation is possible if the number of polling change streams is too close to the total number of
+     * threads in the thread pool. To configure the total number of threads in the pool, set the
+     * `ClientOptions.threadPoolSize` option during client creation.
+     *
+     * Note: You *must not* call any change stream methods besides `kill` and `isAlive` while the future returned from
+     * this method is unresolved. Doing so will result in undefined behavior.
+     *
      * - Returns:
-     *     An `EventLoopFuture<Void>` which will succeed once the change stream is killed via `kill`.
+     *     An `EventLoopFuture<Void>` which will complete once the change stream is closed or once an error is
+     *     encountered.
      *
      *     If the future evaluates to an error, that error is likely one of the following:
      *     - `CommandError` if an error occurs while fetching more results from the server.

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -195,6 +195,14 @@ public class ChangeStream<T: Codable>: CursorProtocol {
         }
     }
 
+    public func forEach(_ body: @escaping (T) throws -> Void) -> EventLoopFuture<Void> {
+        return self.client.operationExecutor.execute {
+            while let next = try self.processEvent(self.wrappedCursor.next()) {
+                try body(next)
+            }
+        }
+    }
+
     /**
      * Kill this change stream.
      *

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -108,13 +108,11 @@ public class ChangeStream<T: Codable>: CursorProtocol {
         }
     }
 
-    deinit {
-        assert(!self.isAlive, "change stream wasn't closed")
-    }
-
     /// Indicates whether this change stream has the potential to return more data.
-    public var isAlive: Bool {
-        return self.wrappedCursor.isAlive
+    public func isAlive() -> EventLoopFuture<Bool> {
+        return self.client.operationExecutor.execute {
+            self.wrappedCursor.isAlive
+        }
     }
 
     /// The `ResumeToken` associated with the most recent event seen by the change stream.

--- a/Sources/MongoSwift/CursorCommon.swift
+++ b/Sources/MongoSwift/CursorCommon.swift
@@ -307,7 +307,7 @@ internal class Cursor<CursorKind: MongocCursorWrapper> {
         }
     }
 
-    /// Retreive all the currently available documents in the result set.
+    /// Retrieve all the currently available documents in the result set.
     /// This will not exhaust the cursor.
     /// This method is blocking and should only be run via the executor.
     internal func toArray() throws -> [Document] {

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -183,6 +183,14 @@ public class MongoCursor<T: Codable>: CursorProtocol {
         }
     }
 
+    public func forEach(_ body: @escaping (T) throws -> Void) -> EventLoopFuture<Void> {
+        return self.client.operationExecutor.execute {
+            while let next = try self.decode(result: self.wrappedCursor.next()) {
+                try body(next)
+            }
+        }
+    }
+
     /**
      * Kill this cursor.
      *

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -42,7 +42,7 @@ public class MongoCursor<T: Codable>: CursorProtocol {
     internal let decoder: BSONDecoder
 
     /// The ID used by the server to track the cursor over time. If all of the cursor's results were returnable in a
-    /// batch, or if the cursor contained no results, this value will be nil.
+    /// single batch, or if the cursor contained no results, this value will be nil.
     public let id: Int64?
 
     /**

--- a/Sources/MongoSwiftSync/ChangeStream.swift
+++ b/Sources/MongoSwiftSync/ChangeStream.swift
@@ -29,8 +29,8 @@ public class ChangeStream<T: Codable>: CursorProtocol {
      * This change stream will be dead if `next` returns `nil` or an error. It will also be dead if `tryNext` returns
      * an error, but will still be alive if `tryNext` returns `nil`.
      */
-    public var isAlive: Bool {
-        return self.asyncChangeStream.isAlive
+    public func isAlive() throws -> Bool {
+        return try self.asyncChangeStream.isAlive().wait()
     }
 
     /**

--- a/Sources/MongoSwiftSync/ChangeStream.swift
+++ b/Sources/MongoSwiftSync/ChangeStream.swift
@@ -29,8 +29,12 @@ public class ChangeStream<T: Codable>: CursorProtocol {
      * This change stream will be dead if `next` returns `nil` or an error. It will also be dead if `tryNext` returns
      * an error, but will still be alive if `tryNext` returns `nil`.
      */
-    public func isAlive() throws -> Bool {
-        return try self.asyncChangeStream.isAlive().wait()
+    public func isAlive() -> Bool {
+        do {
+            return try self.asyncChangeStream.isAlive().wait()
+        } catch {
+            return false
+        }
     }
 
     /**

--- a/Sources/MongoSwiftSync/CursorCommon.swift
+++ b/Sources/MongoSwiftSync/CursorCommon.swift
@@ -6,14 +6,14 @@ internal protocol CursorProtocol: LazySequenceProtocol, IteratorProtocol {
     /**
      * Indicates whether this cursor has the potential to return more data.
      *
-     * This property is mainly useful if this cursor is tailable, since in that case `tryNext` may return more results
+     * This method is mainly useful if this cursor is tailable, since in that case `tryNext` may return more results
      * even after returning `nil`.
      *
      * If this cursor is non-tailable, it will always be dead as soon as either `tryNext` returns `nil` or an error.
      *
      * This cursor will be dead as soon as `next` returns `nil` or an error, regardless of the `CursorType`.
      */
-    var isAlive: Bool { get }
+    func isAlive() throws -> Bool
 
     /**
      * Get the next `T` from the cursor.

--- a/Sources/MongoSwiftSync/MongoCursor.swift
+++ b/Sources/MongoSwiftSync/MongoCursor.swift
@@ -23,8 +23,12 @@ public class MongoCursor<T: Codable>: CursorProtocol {
      *
      * This cursor will be dead as soon as `next` returns `nil` or an error, regardless of the `CursorType`.
      */
-    public func isAlive() throws -> Bool {
-        return try self.asyncCursor.isAlive().wait()
+    public func isAlive() -> Bool {
+        do {
+            return try self.asyncCursor.isAlive().wait()
+        } catch {
+            return false
+        }
     }
 
     /// Returns the ID used by the server to track the cursor. `nil` once all results have been fetched from the server.

--- a/Sources/MongoSwiftSync/MongoCursor.swift
+++ b/Sources/MongoSwiftSync/MongoCursor.swift
@@ -16,15 +16,15 @@ public class MongoCursor<T: Codable>: CursorProtocol {
     /**
      * Indicates whether this cursor has the potential to return more data.
      *
-     * This property is mainly useful if this cursor is tailable, since in that case `tryNext` may return more results
+     * This method is mainly useful if this cursor is tailable, since in that case `tryNext` may return more results
      * even after returning `nil`.
      *
      * If this cursor is non-tailable, it will always be dead as soon as either `tryNext` returns `nil` or an error.
      *
      * This cursor will be dead as soon as `next` returns `nil` or an error, regardless of the `CursorType`.
      */
-    public var isAlive: Bool {
-        return self.asyncCursor.isAlive
+    public func isAlive() throws -> Bool {
+        return try self.asyncCursor.isAlive().wait()
     }
 
     /// Returns the ID used by the server to track the cursor. `nil` once all results have been fetched from the server.

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -14,6 +14,7 @@ extension AsyncMongoCursorTests {
         ("testTailableAsyncCursor", testTailableAsyncCursor),
         ("testAsyncNext", testAsyncNext),
         ("testCursorToArray", testCursorToArray),
+        ("testForEach", testForEach),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -15,6 +15,7 @@ extension AsyncMongoCursorTests {
         ("testAsyncNext", testAsyncNext),
         ("testCursorToArray", testCursorToArray),
         ("testForEach", testForEach),
+        ("testCursorId", testCursorId),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -52,6 +52,7 @@ extension ChangeStreamTests {
         ("testChangeStreamError", testChangeStreamError),
         ("testChangeStreamEmpty", testChangeStreamEmpty),
         ("testChangeStreamToArray", testChangeStreamToArray),
+        ("testChangeStreamForEach", testChangeStreamForEach),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCursorTests.swift
@@ -14,7 +14,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             var cursor = try coll.find()
             expect(try cursor.next()?.get()).toNot(throwError())
             // cursor should immediately be closed as its empty
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
 
@@ -25,7 +25,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             expect(results).to(haveCount(1))
             expect(results[0]).to(equal(doc1))
             // cursor should be closed now that its exhausted
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError())
 
@@ -35,7 +35,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             expect(results).to(haveCount(3))
             expect(results).to(equal([doc1, doc2, doc3]))
             // cursor should be closed now that its exhausted
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
 
@@ -52,7 +52,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             )
             expect(try cursor.next()?.get()).to(throwError(expectedError2))
             // cursor should be closed now that it errored
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
         }
     }
 
@@ -64,7 +64,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             var cursor = try coll.find(options: cursorOpts)
             expect(try cursor.next()?.get()).to(beNil())
             // no documents matched initial query, so cursor is dead
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
             // iterating iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
 
@@ -78,7 +78,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
                 let result = cursor.tryNext()
                 expect(result).toNot(beNil())
                 expect(try result?.get()).to(equal(doc))
-                expect(try cursor.isAlive()).to(beTrue())
+                expect(cursor.isAlive()).to(beTrue())
             }
             try checkNextResult(doc1)
 
@@ -90,7 +90,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
 
             // no more docs, but should still be alive
             expect(try cursor.tryNext()?.get()).to(beNil())
-            expect(try cursor.isAlive()).to(beTrue())
+            expect(cursor.isAlive()).to(beTrue())
 
             // insert 3 docs so the cursor loses track of its position
             for i in 4..<7 {
@@ -105,7 +105,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             )
             expect(try cursor.next()?.get()).to(throwError(expectedError))
             // cursor should be closed now that it errored
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
 
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
@@ -128,7 +128,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             expect(try result?.get()).to(equal(doc1))
 
             expect(cursor.next()).to(beNil())
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
 
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
         }
@@ -138,13 +138,13 @@ final class MongoCursorTests: MongoSwiftTestCase {
         try self.withTestNamespace { _, _, coll in
             _ = try coll.insertMany([[:], [:], [:]])
             let cursor = try coll.find()
-            expect(try cursor.isAlive()).to(beTrue())
+            expect(cursor.isAlive()).to(beTrue())
 
             expect(cursor.next()).toNot(beNil())
-            expect(try cursor.isAlive()).to(beTrue())
+            expect(cursor.isAlive()).to(beTrue())
 
             cursor.kill()
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
         }
     }
@@ -155,7 +155,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             let docs: [Document] = [["_id": 1], ["_id": 2], ["_id": 3]]
             _ = try coll.insertMany(docs)
             let cursor = try coll.find(options: FindOptions(cursorType: .tailable))
-            expect(try cursor.isAlive()).to(beTrue())
+            expect(cursor.isAlive()).to(beTrue())
 
             let queue = DispatchQueue(label: "tailable close")
             let allDocsLock = DispatchSemaphore(value: 0)
@@ -194,12 +194,12 @@ final class MongoCursorTests: MongoSwiftTestCase {
 
             var cursor = try coll.find()
             expect(Array(cursor).count).to(equal(3))
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
 
             cursor = try coll.find()
             let mapped = Array(cursor.map { _ in 1 })
             expect(mapped).to(equal([1, 1, 1]))
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
 
             cursor = try coll.find()
             let filteredMapped = cursor.filter {
@@ -233,9 +233,9 @@ final class MongoCursorTests: MongoSwiftTestCase {
                 return results
             }
             expect(results.sorted()).to(equal([1, 2, 3]))
-            expect(try cursor.isAlive()).to(beTrue())
+            expect(cursor.isAlive()).to(beTrue())
             cursor.kill()
-            expect(try cursor.isAlive()).to(beFalse())
+            expect(cursor.isAlive()).to(beFalse())
         }
     }
 }

--- a/Tests/MongoSwiftSyncTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCursorTests.swift
@@ -14,7 +14,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             var cursor = try coll.find()
             expect(try cursor.next()?.get()).toNot(throwError())
             // cursor should immediately be closed as its empty
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
 
@@ -25,7 +25,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             expect(results).to(haveCount(1))
             expect(results[0]).to(equal(doc1))
             // cursor should be closed now that its exhausted
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError())
 
@@ -35,7 +35,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             expect(results).to(haveCount(3))
             expect(results).to(equal([doc1, doc2, doc3]))
             // cursor should be closed now that its exhausted
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
 
@@ -52,7 +52,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             )
             expect(try cursor.next()?.get()).to(throwError(expectedError2))
             // cursor should be closed now that it errored
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
         }
     }
 
@@ -64,7 +64,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             var cursor = try coll.find(options: cursorOpts)
             expect(try cursor.next()?.get()).to(beNil())
             // no documents matched initial query, so cursor is dead
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
             // iterating iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
 
@@ -78,7 +78,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
                 let result = cursor.tryNext()
                 expect(result).toNot(beNil())
                 expect(try result?.get()).to(equal(doc))
-                expect(cursor.isAlive).to(beTrue())
+                expect(try cursor.isAlive()).to(beTrue())
             }
             try checkNextResult(doc1)
 
@@ -90,7 +90,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
 
             // no more docs, but should still be alive
             expect(try cursor.tryNext()?.get()).to(beNil())
-            expect(cursor.isAlive).to(beTrue())
+            expect(try cursor.isAlive()).to(beTrue())
 
             // insert 3 docs so the cursor loses track of its position
             for i in 4..<7 {
@@ -105,7 +105,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             )
             expect(try cursor.next()?.get()).to(throwError(expectedError))
             // cursor should be closed now that it errored
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
 
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
@@ -128,7 +128,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             expect(try result?.get()).to(equal(doc1))
 
             expect(cursor.next()).to(beNil())
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
 
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
         }
@@ -138,13 +138,13 @@ final class MongoCursorTests: MongoSwiftTestCase {
         try self.withTestNamespace { _, _, coll in
             _ = try coll.insertMany([[:], [:], [:]])
             let cursor = try coll.find()
-            expect(cursor.isAlive).to(beTrue())
+            expect(try cursor.isAlive()).to(beTrue())
 
             expect(cursor.next()).toNot(beNil())
-            expect(cursor.isAlive).to(beTrue())
+            expect(try cursor.isAlive()).to(beTrue())
 
             cursor.kill()
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
             expect(try cursor.next()?.get()).to(throwError(errorType: LogicError.self))
         }
     }
@@ -155,7 +155,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             let docs: [Document] = [["_id": 1], ["_id": 2], ["_id": 3]]
             _ = try coll.insertMany(docs)
             let cursor = try coll.find(options: FindOptions(cursorType: .tailable))
-            expect(cursor.isAlive).to(beTrue())
+            expect(try cursor.isAlive()).to(beTrue())
 
             let queue = DispatchQueue(label: "tailable close")
             let allDocsLock = DispatchSemaphore(value: 0)
@@ -194,12 +194,12 @@ final class MongoCursorTests: MongoSwiftTestCase {
 
             var cursor = try coll.find()
             expect(Array(cursor).count).to(equal(3))
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
 
             cursor = try coll.find()
             let mapped = Array(cursor.map { _ in 1 })
             expect(mapped).to(equal([1, 1, 1]))
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
 
             cursor = try coll.find()
             let filteredMapped = cursor.filter {
@@ -233,9 +233,9 @@ final class MongoCursorTests: MongoSwiftTestCase {
                 return results
             }
             expect(results.sorted()).to(equal([1, 2, 3]))
-            expect(cursor.isAlive).to(beTrue())
+            expect(try cursor.isAlive()).to(beTrue())
             cursor.kill()
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive()).to(beFalse())
         }
     }
 }

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -1082,9 +1082,9 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
                 return results
             }
             expect(results.sorted()).to(equal([1, 2, 3]))
-            expect(stream.isAlive).to(beTrue())
+            expect(try stream.isAlive()).to(beTrue())
             stream.kill()
-            expect(stream.isAlive).to(beFalse())
+            expect(try stream.isAlive()).to(beFalse())
         }
     }
 }

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -1082,9 +1082,9 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
                 return results
             }
             expect(results.sorted()).to(equal([1, 2, 3]))
-            expect(try stream.isAlive()).to(beTrue())
+            expect(stream.isAlive()).to(beTrue())
             stream.kill()
-            expect(try stream.isAlive()).to(beFalse())
+            expect(stream.isAlive()).to(beFalse())
         }
     }
 }

--- a/Tests/MongoSwiftTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftTests/MongoCursorTests.swift
@@ -255,4 +255,19 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             expect(try cursor.forEach(increment).wait()).to(throwError(errorType: LogicError.self))
         }
     }
+
+    func testCursorId() throws {
+        try self.withTestNamespace { _, _, coll in
+            _ = try coll.insertMany([["x": 1], ["x": 2]]).wait()
+            // use batchSize of 1 so the cursor has to use multiple batches and will have an id
+            let options = FindOptions(batchSize: 1)
+            let cursorWithId = try coll.find(options: options).wait()
+            defer { try? cursorWithId.kill().wait() }
+            expect(cursorWithId.id).toNot(beNil())
+
+            let cursorNoId = try coll.find().wait()
+            defer { try? cursorNoId.kill().wait() }
+            expect(cursorNoId.id).to(beNil())
+        }
+    }
 }

--- a/Tests/MongoSwiftTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftTests/MongoCursorTests.swift
@@ -20,7 +20,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             var cursor = try coll.find().wait()
             expect(try cursor.next().wait()).toNot(throwError())
             // cursor should immediately be closed as its empty
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next().wait()).to(throwError(errorType: LogicError.self))
 
@@ -31,7 +31,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             expect(results).to(haveCount(1))
             expect(results[0]).to(equal(doc1))
             // cursor should be closed now that its exhausted
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
             // iterating a dead cursor should error
             expect(try cursor.next().wait()).to(throwError())
 
@@ -48,7 +48,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             )
             expect(try cursor.next().wait()).to(throwError(expectedError))
             // cursor should be closed now that it errored
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
         }
     }
 
@@ -85,7 +85,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             var cursor = try coll.find(options: cursorOpts).wait()
             expect(try cursor.next().wait()).to(beNil())
             // no documents matched initial query, so cursor is dead
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
             expect(try cursor.next().wait()).to(throwError(errorType: LogicError.self))
 
             // insert a doc so something matches initial query
@@ -98,7 +98,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
                 let results = try cursor.toArray().wait()
                 expect(results).to(haveCount(1))
                 expect(results[0]).to(equal(doc))
-                expect(cursor.isAlive).to(beTrue())
+                expect(try cursor.isAlive().wait()).to(beTrue())
             }
             try checkNextResult(doc1)
 
@@ -110,7 +110,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
 
             // no more docs, but should still be alive
             expect(try cursor.tryNext().wait()).to(beNil())
-            expect(cursor.isAlive).to(beTrue())
+            expect(try cursor.isAlive().wait()).to(beTrue())
 
             // insert 3 docs so the cursor loses track of its position
             for i in 4..<7 {
@@ -125,7 +125,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             )
             expect(try cursor.next().wait()).to(throwError(expectedError))
             // cursor should be closed now that it errored
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
 
             // iterating dead cursor should error
             expect(try cursor.next().wait()).to(throwError(errorType: LogicError.self))
@@ -137,7 +137,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             // query empty collection
             var cursor = try coll.find().wait()
             expect(try cursor.next().wait()).to(beNil())
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
 
             // insert a doc so something matches initial query
             _ = try coll.insertOne(doc1).wait()
@@ -148,7 +148,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             expect(doc).to(equal(doc1))
 
             expect(try cursor.next().wait()).to(beNil())
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
 
             expect(try cursor.next().wait()).to(throwError(errorType: LogicError.self))
         }
@@ -160,7 +160,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             // query empty collection
             var cursor = try coll.find().wait()
             expect(try cursor.toArray().wait()).to(equal([]))
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next().wait()).to(throwError(errorType: LogicError.self))
 
@@ -170,7 +170,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             var results = try cursor.toArray().wait()
             expect(results).to(equal([doc1, doc2, doc3]))
             // cursor should be closed now that its exhausted
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
             // iterating dead cursor should error
             expect(try cursor.next().wait()).to(throwError(errorType: LogicError.self))
 
@@ -191,19 +191,19 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
 
             expect(try cursor.toArray().wait()).to(beEmpty())
             // no documents matched initial query, so cursor is dead
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
             expect(try cursor.next().wait()).to(throwError(errorType: LogicError.self))
 
             // insert a doc so something matches initial query
             _ = try coll.insertOne(doc1).wait()
             cursor = try coll.find(options: cursorOpts).wait()
             expect(try cursor.toArray().wait()).to(equal([doc1]))
-            expect(cursor.isAlive).to(beTrue())
+            expect(try cursor.isAlive().wait()).to(beTrue())
 
             // newly inserted docs will be returned by toArray
             _ = try coll.insertMany([doc2, doc3]).wait()
             expect(try cursor.toArray().wait()).to(equal([doc2, doc3]))
-            expect(cursor.isAlive).to(beTrue())
+            expect(try cursor.isAlive().wait()).to(beTrue())
         }
     }
 
@@ -217,7 +217,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             var cursor = try coll.find().wait()
             _ = try cursor.forEach(increment).wait()
             expect(count).to(equal(0))
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
 
             _ = try coll.insertMany([doc1, doc2]).wait()
 
@@ -225,7 +225,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             cursor = try coll.find().wait()
             _ = try cursor.forEach(increment).wait()
             expect(count).to(equal(2))
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
         }
 
         count = 0
@@ -238,7 +238,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             _ = try cursor.forEach(increment).wait()
             expect(count).to(equal(0))
             // no documents matched initial query, so cursor is dead
-            expect(cursor.isAlive).to(beFalse())
+            expect(try cursor.isAlive().wait()).to(beFalse())
 
             _ = try coll.insertMany([doc1, doc2]).wait()
             cursor = try coll.find(options: cursorOpts).wait()
@@ -247,10 +247,9 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             let future = cursor.forEach(increment)
             expect(count).toEventually(equal(2))
 
-            expect(cursor.isAlive).to(beTrue())
             // killing the cursor should resolve the future and not error
             expect(try cursor.kill().wait()).toNot(throwError())
-            expect(try future.wait()).to(beAnInstanceOf(Void.self))
+            expect(try future.wait()).toNot(throwError())
 
             // calling forEach on a dead cursor should error
             expect(try cursor.forEach(increment).wait()).to(throwError(errorType: LogicError.self))


### PR DESCRIPTION
Adds `forEach` to both types and does some internal refactoring, will explain in inline comments