### PR TITLE
SWIFT-727 Re-export cleanupMongoSwift from sync API

### DIFF
--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -12,18 +12,6 @@ private final class MongocInitializer {
     }
 }
 
-/// :nodoc:
-@available(*, deprecated, message: "Calling this method no longer has any effect.")
-public func initialize() {
-    initializeMongoc()
-}
-
-/// :nodoc:
-@available(*, deprecated, message: "Use cleanupMongoSwift() instead.")
-public func cleanup() {
-    cleanupMongoSwift()
-}
-
 /// Initializes libmongoc. Repeated calls to this method have no effect.
 internal func initializeMongoc() {
     _ = MongocInitializer.shared

--- a/Sources/MongoSwiftSync/Exports.stencil
+++ b/Sources/MongoSwiftSync/Exports.stencil
@@ -16,3 +16,6 @@
 // Manually add typealiases
 @_exported import typealias MongoSwift.InsertManyOptions
 @_exported import typealias MongoSwift.ServerErrorCode
+
+// Manually add cleanup method
+@_exported import func MongoSwift.cleanupMongoSwift

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -129,3 +129,6 @@
 // Manually add typealiases
 @_exported import typealias MongoSwift.InsertManyOptions
 @_exported import typealias MongoSwift.ServerErrorCode
+
+// Manually add cleanup method
+@_exported import func MongoSwift.cleanupMongoSwift


### PR DESCRIPTION
Re-exports the cleanup method so it can be called by importers of `MongoSwiftSync`.