### PR TITLE
SWIFT-690 Store mongod logs after evergreen runs

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -122,7 +122,6 @@ functions:
         script: |
           ${PREPARE_SHELL}
           sh ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
-  "upload-mo-artifacts":
     - command: shell.exec
       params:
         script: |
@@ -198,7 +197,6 @@ pre:
 
 post:
   - func: "stop mongo-orchestration"
-  - func: "upload-mo-artifacts"
   - func: "cleanup"
 
 tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -122,6 +122,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           sh ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
+  "upload-mo-artifacts":
     - command: shell.exec
       params:
         script: |
@@ -197,6 +198,7 @@ pre:
 
 post:
   - func: "stop mongo-orchestration"
+  - func: "upload-mo-artifacts"
   - func: "cleanup"
 
 tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -122,6 +122,21 @@ functions:
         script: |
           ${PREPARE_SHELL}
           sh ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongodb-logs.tar.gz
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/x-gzip}
+        display_name: "mongodb-logs.tar.gz"
 
   "run tests":
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -122,6 +122,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           sh ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
+  "upload-mo-artifacts":
     - command: shell.exec
       params:
         script: |
@@ -196,6 +197,8 @@ pre:
   - func: "install dependencies"
 
 post:
+  - func: "stop mongo-orchestration"
+  - func: "upload-mo-artifacts"
   - func: "cleanup"
 
 tasks:
@@ -209,7 +212,6 @@ tasks:
             MONGODB_VERSION: "3.6"
             TOPOLOGY: "server"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-3.6-replica_set"
       tags: ["3.6", "replica_set"]
@@ -221,7 +223,6 @@ tasks:
             MONGODB_VERSION: "3.6"
             TOPOLOGY: "replica_set"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-3.6-sharded_cluster"
       tags: ["3.6", "sharded_cluster"]
@@ -233,7 +234,6 @@ tasks:
             MONGODB_VERSION: "3.6"
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-4.0-standalone"
       tags: ["4.0", "standalone"]
@@ -245,7 +245,6 @@ tasks:
             MONGODB_VERSION: "4.0"
             TOPOLOGY: "server"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-4.0-replica_set"
       tags: ["4.0", "replica_set"]
@@ -257,7 +256,6 @@ tasks:
             MONGODB_VERSION: "4.0"
             TOPOLOGY: "replica_set"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-4.0-sharded_cluster"
       tags: ["4.0", "sharded_cluster"]
@@ -269,7 +267,6 @@ tasks:
             MONGODB_VERSION: "4.0"
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-4.2-standalone"
       tags: ["4.2", "standalone"]
@@ -281,7 +278,6 @@ tasks:
             MONGODB_VERSION: "4.2"
             TOPOLOGY: "server"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-4.2-replica_set"
       tags: ["4.2", "replica_set"]
@@ -293,7 +289,6 @@ tasks:
             MONGODB_VERSION: "4.2"
             TOPOLOGY: "replica_set"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-4.2-sharded_cluster"
       tags: ["4.2", "sharded_cluster"]
@@ -305,7 +300,6 @@ tasks:
             MONGODB_VERSION: "4.2"
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-latest-standalone"
       tags: ["latest", "standalone"]
@@ -317,7 +311,6 @@ tasks:
             MONGODB_VERSION: "latest"
             TOPOLOGY: "server"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-latest-replica_set"
       tags: ["latest", "replica_set"]
@@ -329,7 +322,6 @@ tasks:
             MONGODB_VERSION: "latest"
             TOPOLOGY: "replica_set"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-latest-sharded_cluster"
       tags: ["latest", "sharded_cluster"]
@@ -341,7 +333,6 @@ tasks:
             MONGODB_VERSION: "latest"
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
-        - func: "stop mongo-orchestration"
 
     - name: "test-atlas-connectivity"
       tags: ["atlas-connect"]


### PR DESCRIPTION
[SWIFT-690](https://jira.mongodb.org/browse/SWIFT-690)

Now that `mongo-orchestration stop` waits for the clusters to shut down, we can safely run `"upload mo artifacts"` without potentially failing. 

Unfortunately, we must run that function and `"stop mongo-orchestration"` from `post`, because if the `"run tests"` function fails, later ones defined as part of the task do not run, meaning the logs wouldn't be uploaded and the clusters wouldn't be shut down. Running in `post` causes the atlas connectivity tests to silently ignore some errors, but doing so already seems to be the standard in other drivers (e.g. [go driver](https://evergreen.mongodb.com/task_log_raw/mongo_go_driver_atlas_test_atlas_test_0d3123c45e386a6de8f2443ab0d981b685e54e56_20_02_21_16_08_33/0?type=T#L1094))

[example evg patch](https://evergreen.mongodb.com/version/5e5025e0d6d80a6e645b6cbc)