### PR TITLE
Fix subscript and dynamicMemberLookup docstrings

### DIFF
--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -382,8 +382,8 @@ extension Document {
      *  d["a"] = 1
      *  print(d["a"]) // prints 1
      *  ```
-     * A nil return indicates that the subscripted key does not exist in the `Document`. A true BSON null is returned as
-     * `BSON.null`.
+     * A nil return value indicates that the subscripted key does not exist in the `Document`. A true BSON null is
+     * returned as `BSON.null`.
      */
     public subscript(key: String) -> BSON? {
         // TODO: This `get` method _should_ guarantee constant-time O(1) access, and it is possible to make it do so.
@@ -426,7 +426,7 @@ extension Document {
      *  d.a = 1
      *  print(d.a) // prints 1
      *  ```
-     * A nil return indicates that the key does not exist in the `Document`. A true BSON null is returned as
+     * A nil return value indicates that the key does not exist in the `Document`. A true BSON null is returned as
      * `BSON.null`.
      *
      * Only available in Swift 4.2+.

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -428,10 +428,7 @@ extension Document {
      *  ```
      * A nil return value indicates that the key does not exist in the `Document`. A true BSON null is returned as
      * `BSON.null`.
-     *
-     * Only available in Swift 4.2+.
      */
-    @available(swift 4.2)
     public subscript(dynamicMember member: String) -> BSON? {
         get {
             return self[member]

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -382,8 +382,8 @@ extension Document {
      *  d["a"] = 1
      *  print(d["a"]) // prints 1
      *  ```
-     * A nil return suggests that the subscripted key does not exist in the `Document`. A true BSON null is returned as
-     * a `BSONNull`.
+     * A nil return indicates that the subscripted key does not exist in the `Document`. A true BSON null is returned as
+     * `BSON.null`.
      */
     public subscript(key: String) -> BSON? {
         // TODO: This `get` method _should_ guarantee constant-time O(1) access, and it is possible to make it do so.
@@ -426,8 +426,8 @@ extension Document {
      *  d.a = 1
      *  print(d.a) // prints 1
      *  ```
-     * A nil return suggests that the key does not exist in the `Document`. A true BSON null is returned as
-     * a `BSONNull`.
+     * A nil return indicates that the key does not exist in the `Document`. A true BSON null is returned as
+     * `BSON.null`.
      *
      * Only available in Swift 4.2+.
      */


### PR DESCRIPTION
Realized these were both a bit out of date and could be worded more clearly.
Also since we don't support Swift 4 at all I just removed the `@available`.