### PR TITLE
Update to swiftlint 0.39.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,3 +57,9 @@ excluded:
 
 trailing_whitespace:
   ignores_comments: false
+
+# Once we drop Swift 5.0, we can remove this section and start applying the
+# rule to all 3 possible included types: closures, functions, and getters.
+implicit_return:
+  included:
+    - closure

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -58,7 +58,7 @@ excluded:
 trailing_whitespace:
   ignores_comments: false
 
-# Once we drop Swift 5.0, we can remove this section and start applying the
+# TODO SWIFT-618: Once we drop Swift 5.0, we can remove this section and start applying the
 # rule to all 3 possible included types: closures, functions, and getters.
 implicit_return:
   included:

--- a/etc/install_dependencies.sh
+++ b/etc/install_dependencies.sh
@@ -29,7 +29,7 @@ then
 
 elif [[ $1 = "swiftlint" ]]
 then
-	install_from_gh swiftlint https://github.com/realm/SwiftLint/releases/download/0.35.0/portable_swiftlint.zip
+	install_from_gh swiftlint https://github.com/realm/SwiftLint/releases/download/0.39.1/portable_swiftlint.zip
 
 elif [[ $1 = "swiftformat" ]]
 then


### PR DESCRIPTION
Updates the swiftlint version used on Travis and updates the config to work with the changes made to the implicit_return rule.