### PR TITLE
SWIFT-735 Support using ObjectId with JSONEncoder and JSONDecoder

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -1165,7 +1165,7 @@ extension BSONUndefined: Hashable {
 }
 
 /// Error thrown when a BSONValue type introduced by the driver (e.g. ObjectId) is encoded not using BSONEncoder
-private func bsonEncodingUnsupportedError<T: BSONValue>(value: T, at codingPath: [CodingKey]) -> EncodingError {
+internal func bsonEncodingUnsupportedError<T: BSONValue>(value: T, at codingPath: [CodingKey]) -> EncodingError {
     let description = "Encoding \(T.self) BSONValue type with a non-BSONEncoder is currently unsupported"
 
     return EncodingError.invalidValue(

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -794,11 +794,25 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     }
 
     public init(from decoder: Decoder) throws {
-        throw getDecodingError(type: ObjectId.self, decoder: decoder)
+        // assumes that the ObjectId is stored as a valid hex string.
+        let container = try decoder.singleValueContainer()
+        let hex = try container.decode(String.self)
+        guard let oid = ObjectId(hex) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Invalid ObjectId hex string. Got: \(hex)"
+                )
+            )
+        }
+        self = oid
     }
 
-    public func encode(to: Encoder) throws {
-        throw bsonEncodingUnsupportedError(value: self, at: to.codingPath)
+    public func encode(to encoder: Encoder) throws {
+        // encodes the hex string for the `ObjectId`. this method is only ever reached by non-BSON encoders.
+        // BSONEncoder bypasses the method and inserts the ObjectId into a document, which converts it to BSON.
+        var container = encoder.singleValueContainer()
+        try container.encode(self.hex)
     }
 
     internal func encode(to storage: DocumentStorage, forKey key: String) throws {

--- a/Sources/MongoSwift/BSON/Document+Codable.swift
+++ b/Sources/MongoSwift/BSON/Document+Codable.swift
@@ -3,26 +3,12 @@ import Foundation
 /// An extension of `Document` to implement the `Codable` protocol.
 extension Document: Codable {
     public func encode(to encoder: Encoder) throws {
-        // if we're using a `BSONEncoder`, we can just short-circuit
-        // and directly add the `Document` to its storage.
-        if let bsonEncoder = encoder as? _BSONEncoder {
-            bsonEncoder.storage.containers.append(self)
-            return
+        guard let bsonEncoder = encoder as? _BSONEncoder else {
+            throw bsonEncodingUnsupportedError(value: self, at: encoder.codingPath)
         }
 
-        // otherwise, we need to go through each (key, value) pair,
-        // and then wrap the values in `AnyBSONValue`s and encode them
-        var container = encoder.container(keyedBy: _BSONKey.self)
-        for (k, v) in self {
-            // swiftlint:disable:next force_unwrapping
-            let key = _BSONKey(stringValue: k)! // the initializer never actually returns nil.
-            switch v {
-            case .null:
-                try container.encodeNil(forKey: key)
-            default:
-                try container.encode(v, forKey: key)
-            }
-        }
+        // directly add the `Document` to the encoder's storage.
+        bsonEncoder.storage.containers.append(self)
     }
 
     /// This method will work with any `Decoder`, but for non-BSON
@@ -30,30 +16,16 @@ extension Document: Codable {
     /// of decoding to `AnyBSONValue`s. See `AnyBSONValue.init(from:)` for
     /// more information.
     public init(from decoder: Decoder) throws {
-        // if it's a `BSONDecoder` we should just short-circuit and
-        // return the container `Document`
-        if let bsonDecoder = decoder as? _BSONDecoder {
-            let topContainer = bsonDecoder.storage.topContainer
-            guard let doc = topContainer.documentValue else {
-                throw DecodingError._typeMismatch(at: [], expectation: Document.self, reality: topContainer.bsonValue)
-            }
-            self = doc
-            return
+        // currently we only support decoding to a document using a BSONDecoder.
+        guard let bsonDecoder = decoder as? _BSONDecoder else {
+            throw getDecodingError(type: Document.self, decoder: decoder)
         }
 
-        // otherwise, get a keyed container and decode each key as an `AnyBSONValue`,
-        // and then extract the wrapped `BSONValue`s and store them in the doc
-        let container = try decoder.container(keyedBy: _BSONKey.self)
-        var output = Document()
-        for key in container.allKeys {
-            let k = key.stringValue
-            if try container.decodeNil(forKey: key) {
-                try output.setValue(for: k, to: .null)
-            } else {
-                let val = try container.decode(BSON.self, forKey: key)
-                try output.setValue(for: k, to: val)
-            }
+        // we can just return the top container `Document`.
+        let topContainer = bsonDecoder.storage.topContainer
+        guard let doc = topContainer.documentValue else {
+            throw DecodingError._typeMismatch(at: [], expectation: Document.self, reality: topContainer.bsonValue)
         }
-        self = output
+        self = doc
     }
 }

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -73,7 +73,7 @@ extension Document {
 
     /**
      * Initializes a `Document` from a pointer to a `bson_t`, "stealing" the `bson_t` to use for underlying storage/
-     * The `bson_t` must not be modified or freed by others after it is used here/
+     * The `bson_t` must not be modified or freed by others after it is used here.
      *
      * - Parameters:
      *   - pointer: a MutableBSONPointer
@@ -105,11 +105,11 @@ extension Document {
 
     /**
      * Initializes a `Document` using an array where the values are optional
-     * `BSONValue`s. Values are stored under a string of their index in the
+     * `BSON`s. Values are stored under a string of their index in the
      * array.
      *
      * - Parameters:
-     *   - elements: a `[BSONValue]`
+     *   - elements: a `[BSON]`
      *
      * - Returns: a new `Document`
      */
@@ -178,7 +178,7 @@ extension Document {
         }
     }
 
-    /// Retrieves the value associated with `for` as a `BSONValue?`, which can be nil if the key does not exist in the
+    /// Retrieves the value associated with `for` as a `BSON?`, which can be nil if the key does not exist in the
     /// `Document`.
     ///
     /// - Throws: `InternalError` if the BSON buffer is too small (< 5 bytes).
@@ -247,7 +247,7 @@ extension Document {
         return self.makeIterator().keys
     }
 
-    /// Returns a `[BSONValue]` containing the values stored in this `Document`.
+    /// Returns a `[BSON]` containing the values stored in this `Document`.
     public var values: [BSON] {
         return self.makeIterator().values
     }
@@ -495,11 +495,11 @@ extension Document: CustomStringConvertible {
 extension Document: ExpressibleByDictionaryLiteral {
     /**
      * Initializes a `Document` using a dictionary literal where the
-     * keys are `String`s and the values are `BSONValue`s. For example:
+     * keys are `String`s and the values are `BSON`s. For example:
      * `d: Document = ["a" : 1 ]`
      *
      * - Parameters:
-     *   - dictionaryLiteral: a [String: BSONValue]
+     *   - dictionaryLiteral: a [String: BSON]
      *
      * - Returns: a new `Document`
      */

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -37,6 +37,7 @@ extension BSONValueTests {
         ("testUUIDBytes", testUUIDBytes),
         ("testBSONEquatable", testBSONEquatable),
         ("testObjectIdRoundTrip", testObjectIdRoundTrip),
+        ("testObjectIdJSONCodable", testObjectIdJSONCodable),
         ("testBSONNumber", testBSONNumber),
     ]
 }


### PR DESCRIPTION
As part of this I also made it so you can't use `Document` directly with `JSONEncoder` and `JSONDecoder`, and I updated some outdated docstrings.