### PR TITLE
minor: fix race condition in testTailableAwaitAsyncCursor

### DIFF
--- a/Tests/MongoSwiftTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftTests/MongoCursorTests.swift
@@ -70,6 +70,8 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
 
             // start polling and interrupt with close
             let interruptedFuture = cursor.next()
+            // ensure the "next" loop is scheduled before the subsequent "kill".
+            Thread.sleep(forTimeInterval: 0.25)
 
             expect(try cursor.kill().wait()).toNot(throwError())
             expect(try interruptedFuture.wait()).to(beNil())


### PR DESCRIPTION
This PR (probably) fixes the race condition in `testTailableAwaitAsyncCursor` that occurs between the call to `next` and the subsequent call to `kill`. If the latter happens to get scheduled before the former, an error is erroneously returned. This PR adds a small waiting period between the two to give the former time to start before the `kill` is issued.

example failure: https://evergreen.mongodb.com/task_log_raw/mongo_swift_driver_tests_all__os_fully_featured~ubuntu_18.04_swift_version~5.0_ssl_auth~nossl_noauth_test_4.2_sharded_cluster_17652a3ff3bd113e136b56ec34134f45ba059a5c_20_03_06_21_41_23/0?type=T#L802

evg patch: https://evergreen.mongodb.com/version/5e6800e92fbabe51d77c1dca 
