### PR TITLE
SWIFT-730 Make ChangeStream.kill result discardable

### DIFF
--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -241,6 +241,7 @@ public class ChangeStream<T: Codable>: CursorProtocol {
      * - Returns:
      *   An `EventLoopFuture` that evaluates when the change stream has completed closing. This future should not fail.
      */
+    @discardableResult
     public func kill() -> EventLoopFuture<Void> {
         return self.client.operationExecutor.execute {
             self.wrappedCursor.kill()


### PR DESCRIPTION
I got to the point of making the PR before I realized this, so I'm not sure we should actually merge this but I figured I'd open for discussion anyway...

while this can never fail for reasons related to the future itself having an issue, it _can_ still fail if, for example, you close the parent client before calling this method, or if you shut down the `EventLoopGroup` you provided to the client.

these are definitely weird edge cases, but, I'm not sure it's fair to say this *never* fails.

but I also don't remember if we already discussed this before and I just forgot to put the justification in the ticket.

what do you think?