### PR TITLE
SWIFT-750 Don't block in thread pool while waiting for a connection

### DIFF
--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -11,6 +11,14 @@ internal protocol Operation {
     func execute(using connection: Connection, session: ClientSession?) throws -> OperationResult
 }
 
+/// Contains the result of attempting to execute an operation in the thread pool.
+private enum ExecuteResult<T> {
+    /// Indicates that the operation was successfully executed and returned the associated value.
+    case success(T)
+    /// Indicates that a connection was not available and the operation should be resubmitted to the pool.
+    case resubmit
+}
+
 /// Operation executor used by `MongoClient`s.
 internal class OperationExecutor {
     /// A group of event loops to use for running operations in the thread pool.
@@ -48,17 +56,45 @@ internal class OperationExecutor {
         client: MongoClient,
         session: ClientSession?
     ) -> EventLoopFuture<T.OperationResult> {
+        // early exit and don't attempt to use the thread pool if we've already closed the client.
         guard !client.isClosed else {
             return self.makeFailedFuture(MongoClient.ClosedClientError)
         }
 
-        let doOperation = { () -> T.OperationResult in
+        // closure containing the work to run in the thread pool: obtain a connection and execute the operation.
+        let doOperation = { () -> ExecuteResult<T.OperationResult> in
+            // it's possible that the client was closed in between submitting this task and it being executed, so we
+            // check again here.
+            guard !client.isClosed else {
+                throw MongoClient.ClosedClientError
+            }
+
             // select a connection in following order of priority:
             // 1. connection specifically provided for use with this operation
             // 2. if a session was provided, use its underlying connection
-            // 3. a new connection from the pool
-            let connection = try connection ?? resolveConnection(client: client, session: session)
-            return try operation.execute(using: connection, session: session)
+            // 3. a new connection from the pool, if available
+            guard let connection = try connection ??
+                session?.getConnection(forUseWith: client) ??
+                client.connectionPool.tryCheckOut() else {
+                return .resubmit
+            }
+            return try .success(operation.execute(using: connection, session: session))
+        }
+
+        // if a connection isn't immediately available, we exit the thread pool and resubmit the operation. we can't
+        // just block until one is available within the pool because it can lead to deadlock. one such scenario:
+        // - connection pool size 4, thread pool size 2
+        // - 4 cursors are created, each one holding onto a connection
+        // - user issues 2 commands that generate 2 new operations and block both threads in the pool
+        // - cursors can't finish iterating and give up their connections, because they need threads, but ops in pool
+        //   can't complete and free up threads, because they need connections!
+        let resubmitIfNeeded = { (result: ExecuteResult<T.OperationResult>) -> EventLoopFuture<T.OperationResult> in
+            switch result {
+            case let .success(res):
+                return self.makeSucceededFuture(res)
+            case .resubmit:
+                return self.execute(operation, using: connection, client: client, session: session)
+            }
         }
 
         if let session = session {
@@ -70,11 +106,13 @@ internal class OperationExecutor {
             }
 
             // start the session if needed (which generates a new operation itself), and then execute the operation.
-            return session.startIfNeeded().flatMap { self.execute(doOperation) }
+            return session.startIfNeeded()
+                .flatMap { self.execute(doOperation) }
+                .flatMap { resubmitIfNeeded($0) }
         }
 
         // no session was provided, so we can just jump to executing the operation.
-        return self.execute(doOperation)
+        return self.execute(doOperation).flatMap { resubmitIfNeeded($0) }
     }
 
     internal func execute<T>(_ body: @escaping () throws -> T) -> EventLoopFuture<T> {
@@ -92,13 +130,6 @@ internal class OperationExecutor {
     internal func makePromise<T>(of type: T.Type) -> EventLoopPromise<T> {
         return self.eventLoopGroup.next().makePromise(of: type)
     }
-}
-
-/// Given a client and optionally a session associated which are to be associated with an operation, returns a
-/// connection for the operation to use. After the connection is no longer in use, it should be returned by
-/// passing it to `returnConnection` along with the same client and session that were passed into this method.
-internal func resolveConnection(client: MongoClient, session: ClientSession?) throws -> Connection {
-    return try session?.getConnection(forUseWith: client) ?? client.connectionPool.checkOut()
 }
 
 /// Internal function for generating an options `Document` for passing to libmongoc.

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -158,6 +158,7 @@ extension MongoClientTests {
         ("testUsingClosedClient", testUsingClosedClient),
         ("testListDatabases", testListDatabases),
         ("testClientIdGeneration", testClientIdGeneration),
+        ("testResubmittingToThreadPool", testResubmittingToThreadPool),
     ]
 }
 


### PR DESCRIPTION
Fixes the problem I found the other day where we can end up deadlocked if there are no connections free and all the threads in the thread pool are waiting for connections.