### PR TITLE
SWIFT-705 Tune NIOThreadPool size

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -30,7 +30,6 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
     /// Determines whether the client should retry supported write operations (on by default).
     public var retryWrites: Bool?
 
-    // TODO: SWIFT-705 update size
     /**
      * `MongoSwift.MongoClient` provides an asynchronous API by running all blocking operations off of their
      * originating threads in a thread pool. `MongoSwiftSync.MongoClient` is implemented as a wrapper of the async
@@ -156,7 +155,6 @@ public class MongoClient {
 
     internal let operationExecutor: OperationExecutor
 
-    // TODO: SWIFT-705 document size justification.
     /// Default size for a client's NIOThreadPool.
     internal static let defaultThreadPoolSize = 5
 


### PR DESCRIPTION
Remove TODOs about changing default thread pool size since we've decided to stick with 5. 

I had a comment here about justifying the default but I'm not sure it's really useful to anyone to put "we ran some benchmarks and performance peaked around there". But I added a link to my spreadsheet on the ticket so we can refer back to it if needed in the future.