### PR TITLE
SWIFT-434 Document how to use the driver with TLS/SSL

### DIFF
--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -32,7 +32,7 @@ To require that connections to MongoDB made by the driver use TLS/SSL, simply sp
 let client = try MongoClient("mongodb://example.com", using: elg, options: ClientOptions(tls: true))
 ```
 
-Alternatively, `tls=true` can be specified in the [MongoDB Connection String]() passed to the initializer:
+Alternatively, `tls=true` can be specified in the [MongoDB Connection String](https://docs.mongodb.com/manual/reference/connection-string/) passed to the initializer:
 ```swift
 let client = try MongoClient("mongodb://example.com/?tls=true", using: elg)
 ```
@@ -47,7 +47,7 @@ A path to a file with either a single or bundle of certificate authorities to be
 let client = try MongoClient("mongodb://example.com", using: elg, options: ClientOptions(tlsCAFile: URL(string: "/path/to/ca.pem")))
 ```
 
-Alternatively, the path can be specified via the `tlsCAFile` option in the [MongoDB Connection String]() passed to the client's initializer:
+Alternatively, the path can be specified via the `tlsCAFile` option in the [MongoDB Connection String](https://docs.mongodb.com/manual/reference/connection-string/) passed to the client's initializer:
 ```swift
 let client = try MongoClient("mongodb://example.com/?tlsCAFile=/path/to/ca.pem", using: elg)
 ```
@@ -67,7 +67,7 @@ let client = try MongoClient(
 )
 ```
 
-Alternatively, these options can be set via the `tlsCertificateKeyFile` and `tlsCertificateKeyFilePassword` options in the [MongoDB Connection String]() passed into the initializer:
+Alternatively, these options can be set via the `tlsCertificateKeyFile` and `tlsCertificateKeyFilePassword` options in the [MongoDB Connection String](https://docs.mongodb.com/manual/reference/connection-string/) passed into the initializer:
 ```swift
 let client = try MongoClient(
     "mongodb://example.com/?tlsCertificateKeyFile=/path/to/cert.pem&tlsCertificateKeyFilePassword=<password>"

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -27,7 +27,7 @@ macOS 10.13 (High Sierra) and newer support TLS 1.1+.
 
 ## Basic Configuration
 
-To connect to MongoDB over TLS/SSL, simply specify `tls: true` in the `ClientOptions` passed to a `MongoClient`'s initializer:
+To require that connections to MongoDB made by the driver use TLS/SSL, simply specify `tls: true` in the `ClientOptions` passed to a `MongoClient`'s initializer:
 ```swift
 let client = try MongoClient("mongodb://example.com", using: elg, options: ClientOptions(tls: true))
 ```

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -49,7 +49,7 @@ let client = try MongoClient("mongodb://example.com", using: elg, options: Clien
 
 Alternatively, the path can be specified via the `tlsCAFile` option in the [MongoDB Connection String](https://docs.mongodb.com/manual/reference/connection-string/) passed to the client's initializer:
 ```swift
-let caFile = "/path/to/ca.pem".addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
+let caFile = "/path/to/ca.pem".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
 let client = try MongoClient("mongodb://example.com/?tlsCAFile=\(caFile)", using: elg)
 ```
 
@@ -70,8 +70,8 @@ let client = try MongoClient(
 
 Alternatively, these options can be set via the `tlsCertificateKeyFile` and `tlsCertificateKeyFilePassword` options in the [MongoDB Connection String](https://docs.mongodb.com/manual/reference/connection-string/) passed into the initializer:
 ```swift
-let certificatePath = "/path/to/cert.pem".addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
-let password = "not a secure password".addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
+let certificatePath = "/path/to/cert.pem".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
+let password = "not a secure password".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
 let client = try MongoClient(
     "mongodb://example.com/?tlsCertificateKeyFile=\(certificatePath)&tlsCertificateKeyFilePassword=\(password)"
     using: elg

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -1,0 +1,76 @@
+# TLS/SSL and MongoSwift
+
+MongoSwift supports connecting to MongoDB over TLS/SSL. This guide covers the installation requirements and configuration options for enabling this functionality in MongoSwift. See the [server documentation](https://docs.mongodb.com/manual/tutorial/configure-ssl/) to configure MongoDB to use TLS/SSL.
+
+## Dependencies
+
+MongoSwift relies on the the TLS/SSL library installed on your system for making secure connections to the database. 
+ - On macOS, the driver depends on SecureTransport, the native TLS library for macOS, so no additional installation is required.
+ - On Linux, the driver depends on OpenSSL, which is usually bundled with your OS but may require specific installation. The driver also supports LibreSSL through the use of OpenSSL compatibility checks.
+ 
+### Ensuring TLS 1.1+
+
+Industry best practices recommend, and some regulations require, the use of TLS 1.1 or newer. Though no application changes are required for MongoSwift to make use of the newest protocols, some operating systems or versions may not provide a TLS library version new enough to support them.
+
+#### ...on Linux
+
+Users of Linux or other non-macOS Unix can check their OpenSSL version like this:
+```
+$ openssl version
+```
+If the version number is less than 1.0.1, support for TLS 1.1 or newer is not available. Contact your operating system vendor for a solution, upgrade to a newer distribution, or manually upgrade your installation of OpenSSL.
+
+#### ...on macOS
+
+macOS 10.13 (High Sierra) and newer support TLS 1.1+.
+
+
+## Basic Configuration
+
+To connect to MongoDB over TLS/SSL, simply specify `tls: true` in the `ClientOptions` passed to a `MongoClient`'s initializer:
+```swift
+let client = try MongoClient("mongodb://example.com", options: ClientOptions(tls: true))
+```
+
+Alternatively, `tls=true` can be specified in the [MongoDB Connection String]() passed to the initializer:
+```swift
+let client = try MongoClient("mongodb://example.com/?tls=true")
+```
+**Note:** Specifying any `tls` prefixed option in the connection string or `ClientOptions` will cause MongoSwift to attempt to connect using TLS.
+
+## Specifying a CA File
+
+MongoSwift can be configured to use a specific set of CA certificates. This is most often used with “self-signed” server certificates. 
+
+A path to a file with either a single or bundle of certificate authorities to be considered trusted when making a TLS connection can be specified via the `tlsCAFile` option on `ClientOptions`:
+```swift
+let client = try MongoClient("mongodb://example.com", options: ClientOptions(tlsCAFile: "/path/to/ca.pem"))
+```
+
+Alternatively, the path can be specified via the `tlsCAFile` option in the [MongoDB Connection String]() passed to the client's initializer:
+```swift
+let client = try MongoClient("mongodb://example.com/?tlsCAFile=/path/to/ca.pem")
+```
+
+## Specifying a Client Certificate or Private Key File
+
+MongoSwift can be configured to present the client certificate file or the client private key file via the `tlsCertificateKeyFile` option on `ClientOptions`:
+```swift
+let client = try MongoClient("mongodb://example.com", options: ClientOptions(tlsCertificateKeyFile: "/path/to/cert.pem"))
+```
+If the private key is password protected, a password can be supplied via `tlsCertificateKeyFilePassword` on `ClientOptions`:
+```swift
+let client = try MongoClient(
+    "mongodb://example.com", 
+    options: ClientOptions(tlsCertificateKeyFile: "/path/to/cert.pem", tlsCertificateKeyFilePassword: <password>)
+)
+```
+
+Alternatively, these options can be set via the `tlsCertificateKeyFile` and `tlsCertificateKeyFilePassword` options in the [MongoDB Connection String]() passed into the initializer:
+```swift
+let client = try MongoClient(
+    "mongodb://example.com/?tlsCertificateKeyFile=/path/to/cert.pem&tlsCertificateKeyFilePassword=<password>"
+)
+```
+**Note**: In both cases, if both a client certificate and a client private key are needed, the files should be concatenated into a single file which is specified by `tlsCertificateKeyFile`.
+

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -29,12 +29,12 @@ macOS 10.13 (High Sierra) and newer support TLS 1.1+.
 
 To connect to MongoDB over TLS/SSL, simply specify `tls: true` in the `ClientOptions` passed to a `MongoClient`'s initializer:
 ```swift
-let client = try MongoClient("mongodb://example.com", options: ClientOptions(tls: true))
+let client = try MongoClient("mongodb://example.com", using: elg, options: ClientOptions(tls: true))
 ```
 
 Alternatively, `tls=true` can be specified in the [MongoDB Connection String]() passed to the initializer:
 ```swift
-let client = try MongoClient("mongodb://example.com/?tls=true")
+let client = try MongoClient("mongodb://example.com/?tls=true", using: elg)
 ```
 **Note:** Specifying any `tls` prefixed option in the connection string or `ClientOptions` will cause MongoSwift to attempt to connect using TLS.
 
@@ -44,25 +44,26 @@ MongoSwift can be configured to use a specific set of CA certificates. This is m
 
 A path to a file with either a single or bundle of certificate authorities to be considered trusted when making a TLS connection can be specified via the `tlsCAFile` option on `ClientOptions`:
 ```swift
-let client = try MongoClient("mongodb://example.com", options: ClientOptions(tlsCAFile: "/path/to/ca.pem"))
+let client = try MongoClient("mongodb://example.com", using: elg, options: ClientOptions(tlsCAFile: URL(string: "/path/to/ca.pem")))
 ```
 
 Alternatively, the path can be specified via the `tlsCAFile` option in the [MongoDB Connection String]() passed to the client's initializer:
 ```swift
-let client = try MongoClient("mongodb://example.com/?tlsCAFile=/path/to/ca.pem")
+let client = try MongoClient("mongodb://example.com/?tlsCAFile=/path/to/ca.pem", using: elg)
 ```
 
 ## Specifying a Client Certificate or Private Key File
 
 MongoSwift can be configured to present the client certificate file or the client private key file via the `tlsCertificateKeyFile` option on `ClientOptions`:
 ```swift
-let client = try MongoClient("mongodb://example.com", options: ClientOptions(tlsCertificateKeyFile: "/path/to/cert.pem"))
+let client = try MongoClient("mongodb://example.com", using: elg, options: ClientOptions(tlsCertificateKeyFile: URL(string: "/path/to/cert.pem")))
 ```
 If the private key is password protected, a password can be supplied via `tlsCertificateKeyFilePassword` on `ClientOptions`:
 ```swift
 let client = try MongoClient(
-    "mongodb://example.com", 
-    options: ClientOptions(tlsCertificateKeyFile: "/path/to/cert.pem", tlsCertificateKeyFilePassword: <password>)
+    "mongodb://example.com",
+    using: elg,
+    options: ClientOptions(tlsCertificateKeyFile: URL(string: "/path/to/cert.pem"), tlsCertificateKeyFilePassword: <password>)
 )
 ```
 
@@ -70,6 +71,7 @@ Alternatively, these options can be set via the `tlsCertificateKeyFile` and `tls
 ```swift
 let client = try MongoClient(
     "mongodb://example.com/?tlsCertificateKeyFile=/path/to/cert.pem&tlsCertificateKeyFilePassword=<password>"
+    using: elg
 )
 ```
 **Note**: In both cases, if both a client certificate and a client private key are needed, the files should be concatenated into a single file which is specified by `tlsCertificateKeyFile`.

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -49,7 +49,8 @@ let client = try MongoClient("mongodb://example.com", using: elg, options: Clien
 
 Alternatively, the path can be specified via the `tlsCAFile` option in the [MongoDB Connection String](https://docs.mongodb.com/manual/reference/connection-string/) passed to the client's initializer:
 ```swift
-let client = try MongoClient("mongodb://example.com/?tlsCAFile=/path/to/ca.pem", using: elg)
+let caFile = "/path/to/ca.pem".addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
+let client = try MongoClient("mongodb://example.com/?tlsCAFile=\(caFile)", using: elg)
 ```
 
 ## Specifying a Client Certificate or Private Key File
@@ -69,8 +70,10 @@ let client = try MongoClient(
 
 Alternatively, these options can be set via the `tlsCertificateKeyFile` and `tlsCertificateKeyFilePassword` options in the [MongoDB Connection String](https://docs.mongodb.com/manual/reference/connection-string/) passed into the initializer:
 ```swift
+let certificatePath = "/path/to/cert.pem".addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
+let password = "not a secure password".addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
 let client = try MongoClient(
-    "mongodb://example.com/?tlsCertificateKeyFile=/path/to/cert.pem&tlsCertificateKeyFilePassword=<password>"
+    "mongodb://example.com/?tlsCertificateKeyFile=\(certificatePath)&tlsCertificateKeyFilePassword=\(password)"
     using: elg
 )
 ```

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -36,7 +36,7 @@ Alternatively, `tls=true` can be specified in the [MongoDB Connection String](ht
 ```swift
 let client = try MongoClient("mongodb://example.com/?tls=true", using: elg)
 ```
-**Note:** Specifying any `tls` prefixed option in the connection string or `ClientOptions` will cause the driver to attempt to connect using TLS.
+**Note:** Specifying any `tls`-prefixed option in the connection string or `ClientOptions` will require all connections made by the driver to use TLS/SSL.
 
 ## Specifying a CA File
 

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -40,7 +40,7 @@ let client = try MongoClient("mongodb://example.com/?tls=true", using: elg)
 
 ## Specifying a CA File
 
-The driver can be configured to use a specific set of CA certificates. This is most often used with “self-signed” server certificates. 
+The driver can be configured to use a specific set of CA certificates. This is most often used with "self-signed" server certificates. 
 
 A path to a file with either a single or bundle of certificate authorities to be considered trusted when making a TLS connection can be specified via the `tlsCAFile` option on `ClientOptions`:
 ```swift

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -1,16 +1,16 @@
 # TLS/SSL and MongoSwift
 
-MongoSwift supports connecting to MongoDB over TLS/SSL. This guide covers the installation requirements and configuration options for enabling this functionality in MongoSwift. See the [server documentation](https://docs.mongodb.com/manual/tutorial/configure-ssl/) to configure MongoDB to use TLS/SSL.
+This guide covers the installation requirements and configuration options for connecting to MongoDB over TLS/SSL in the driver. See the [server documentation](https://docs.mongodb.com/manual/tutorial/configure-ssl/) to configure MongoDB to use TLS/SSL.
 
 ## Dependencies
 
-MongoSwift relies on the the TLS/SSL library installed on your system for making secure connections to the database. 
+The driver relies on the the TLS/SSL library installed on your system for making secure connections to the database. 
  - On macOS, the driver depends on SecureTransport, the native TLS library for macOS, so no additional installation is required.
  - On Linux, the driver depends on OpenSSL, which is usually bundled with your OS but may require specific installation. The driver also supports LibreSSL through the use of OpenSSL compatibility checks.
  
 ### Ensuring TLS 1.1+
 
-Industry best practices recommend, and some regulations require, the use of TLS 1.1 or newer. Though no application changes are required for MongoSwift to make use of the newest protocols, some operating systems or versions may not provide a TLS library version new enough to support them.
+Industry best practices recommend, and some regulations require, the use of TLS 1.1 or newer. Though no application changes are required for the driver to make use of the newest protocols, some operating systems or versions may not provide a TLS library version new enough to support them.
 
 #### ...on Linux
 
@@ -36,11 +36,11 @@ Alternatively, `tls=true` can be specified in the [MongoDB Connection String]() 
 ```swift
 let client = try MongoClient("mongodb://example.com/?tls=true", using: elg)
 ```
-**Note:** Specifying any `tls` prefixed option in the connection string or `ClientOptions` will cause MongoSwift to attempt to connect using TLS.
+**Note:** Specifying any `tls` prefixed option in the connection string or `ClientOptions` will cause the driver to attempt to connect using TLS.
 
 ## Specifying a CA File
 
-MongoSwift can be configured to use a specific set of CA certificates. This is most often used with “self-signed” server certificates. 
+The driver can be configured to use a specific set of CA certificates. This is most often used with “self-signed” server certificates. 
 
 A path to a file with either a single or bundle of certificate authorities to be considered trusted when making a TLS connection can be specified via the `tlsCAFile` option on `ClientOptions`:
 ```swift
@@ -54,7 +54,7 @@ let client = try MongoClient("mongodb://example.com/?tlsCAFile=/path/to/ca.pem",
 
 ## Specifying a Client Certificate or Private Key File
 
-MongoSwift can be configured to present the client certificate file or the client private key file via the `tlsCertificateKeyFile` option on `ClientOptions`:
+The driver can be configured to present the client certificate file or the client private key file via the `tlsCertificateKeyFile` option on `ClientOptions`:
 ```swift
 let client = try MongoClient("mongodb://example.com", using: elg, options: ClientOptions(tlsCertificateKeyFile: URL(string: "/path/to/cert.pem")))
 ```

--- a/Guides/TLS.md
+++ b/Guides/TLS.md
@@ -1,4 +1,4 @@
-# TLS/SSL and MongoSwift
+# Swift Driver TLS/SSL Guide
 
 This guide covers the installation requirements and configuration options for connecting to MongoDB over TLS/SSL in the driver. See the [server documentation](https://docs.mongodb.com/manual/tutorial/configure-ssl/) to configure MongoDB to use TLS/SSL.
 

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -114,7 +114,9 @@ internal class ConnectionPool {
     private func setTLSOptions(_ options: ClientOptions) throws {
         // return early so we don't set an empty options struct on the libmongoc pool. doing so will make libmongoc
         // attempt to use TLS for connections.
-        guard options.tlsAllowInvalidCertificates != nil || options.tlsAllowInvalidHostnames != nil ||
+        guard options.tls == true ||
+            options.tlsAllowInvalidCertificates != nil ||
+            options.tlsAllowInvalidHostnames != nil ||
             options.tlsCAFile != nil || options.tlsCertificateKeyFile != nil ||
             options.tlsCertificateKeyFilePassword != nil else {
             return

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -39,7 +39,7 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
      */
     public var threadPoolSize: Int?
 
-    /// Whether or not to require TLS for connections to the server
+    /// Whether or not to require TLS for connections to the server. By default this is set to false.
     ///
     /// - Note: Specifying any other "tls"-prefixed option will require TLS for connections to the server.
     public var tls: Bool?

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -39,6 +39,11 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
      */
     public var threadPoolSize: Int?
 
+    /// Whether or not to require TLS for connections to the server
+    ///
+    /// - Note: Specifying any other "tls"-prefixed option will require TLS for connections to the server.
+    public var tls: Bool?
+
     /// Indicates whether to bypass validation of the certificate presented by the mongod/mongos instance. By default
     /// this is set to false.
     public var tlsAllowInvalidCertificates: Bool?
@@ -81,6 +86,7 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
         retryReads: Bool? = nil,
         retryWrites: Bool? = nil,
         threadPoolSize: Int? = nil,
+        tls: Bool? = nil,
         tlsAllowInvalidCertificates: Bool? = nil,
         tlsAllowInvalidHostnames: Bool? = nil,
         tlsCAFile: URL? = nil,
@@ -97,6 +103,7 @@ public struct ClientOptions: CodingStrategyProvider, Decodable {
         self.retryWrites = retryWrites
         self.retryReads = retryReads
         self.threadPoolSize = threadPoolSize
+        self.tls = tls
         self.tlsAllowInvalidCertificates = tlsAllowInvalidCertificates
         self.tlsAllowInvalidHostnames = tlsAllowInvalidHostnames
         self.tlsCAFile = tlsCAFile


### PR DESCRIPTION
[SWIFT-434](https://jira.mongodb.org/browse/SWIFT-434)

As the ticket describes, this PR adds documentation for describing how to ensure clients are using the latest TLS protocols. As part of that,  figured it made sense to write the rest of the guide, since we didn't already have one. The guide was heavily influenced by [pymongo's guide](https://api.mongodb.com/python/current/examples/tls.html) on the same topic.

One API change that's important to note: I added a generic `tls` option to `ClientOptions`, since it seems reasonable to me that a user would want to enable TLS but not necessarily identify all the client's connecting to the database. This option is included in the URI options spec, and I think most drivers support it (pymongo does at least). cc @mbroadst 