### PR TITLE
SWIFT-621 Provide default values for WriteModel options associated values

### DIFF
--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -43,12 +43,12 @@ public enum WriteModel<CollectionType: Codable> {
     /// Parameters:
     /// - A `Document` representing the match criteria.
     /// - `options`: Optional `DeleteModelOptions`.
-    case deleteOne(Document, options: DeleteModelOptions?)
+    case deleteOne(Document, options: DeleteModelOptions? = nil)
     /// A `deleteMany`.
     /// Parameters:
     /// - A `Document` representing the match criteria.
     /// - `options`: Optional `DeleteModelOptions`.
-    case deleteMany(Document, options: DeleteModelOptions?)
+    case deleteMany(Document, options: DeleteModelOptions? = nil)
     /// An `insertOne`.
     /// Parameters:
     /// - A `T` to insert.
@@ -58,19 +58,19 @@ public enum WriteModel<CollectionType: Codable> {
     /// - `filter`: A `Document` representing the match criteria.
     /// - `replacement`: A `T` to use as the replacement value.
     /// - `options`: Optional `ReplaceOneModelOptions`.
-    case replaceOne(filter: Document, replacement: CollectionType, options: ReplaceOneModelOptions?)
+    case replaceOne(filter: Document, replacement: CollectionType, options: ReplaceOneModelOptions? = nil)
     /// An `updateOne`.
     /// Parameters:
     /// - `filter`: A `Document` representing the match criteria.
     /// - `update`: A `Document` containing update operators.
     /// - `options`: Optional `UpdateModelOptions`.
-    case updateOne(filter: Document, update: Document, options: UpdateModelOptions?)
+    case updateOne(filter: Document, update: Document, options: UpdateModelOptions? = nil)
     /// An `updateMany`.
     /// Parameters:
     /// - `filter`: A `Document` representing the match criteria.
     /// - `update`: A `Document` containing update operators.
     /// - `options`: Optional `UpdateModelOptions`.
-    case updateMany(filter: Document, update: Document, options: UpdateModelOptions?)
+    case updateMany(filter: Document, update: Document, options: UpdateModelOptions? = nil)
 
     /// Adds this model to the provided `mongoc_bulk_t`, using the provided encoder for encoding options and
     /// `CollectionType` values if needed. If this is an `insertOne`, returns the `_id` field of the inserted

--- a/Tests/MongoSwiftSyncTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+BulkWriteTests.swift
@@ -123,8 +123,8 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         try self.createFixtures(4)
 
         let requests: [WriteModel<Document>] = [
-            .updateOne(filter: ["_id": 2], update: ["$inc": ["x": 1]], options: nil),
-            .updateMany(filter: ["_id": ["$gt": 2]], update: ["$inc": ["x": -1]], options: nil),
+            .updateOne(filter: ["_id": 2], update: ["$inc": ["x": 1]]),
+            .updateMany(filter: ["_id": ["$gt": 2]], update: ["$inc": ["x": -1]]),
             .updateOne(
                 filter: ["_id": 5],
                 update: ["$set": ["x": 55]],
@@ -135,7 +135,7 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
                 update: ["$set": ["x": 66]],
                 options: UpdateModelOptions(upsert: true)
             ),
-            .updateMany(filter: ["x": ["$gt": 50]], update: ["$inc": ["x": 1]], options: nil)
+            .updateMany(filter: ["x": ["$gt": 50]], update: ["$inc": ["x": 1]])
         ]
 
         let result: BulkWriteResult! = try self.coll.bulkWrite(requests)
@@ -160,8 +160,8 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
         try self.createFixtures(4)
 
         let requests: [WriteModel<Document>] = [
-            .deleteOne(["_id": 1], options: nil),
-            .deleteMany(["_id": ["$gt": 2]], options: nil)
+            .deleteOne(["_id": 1]),
+            .deleteMany(["_id": ["$gt": 2]])
         ]
 
         let result: BulkWriteResult! = try self.coll.bulkWrite(requests)
@@ -182,9 +182,9 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
                 update: ["$inc": ["x": 1]],
                 options: nil
             ),
-            .updateMany(filter: ["_id": ["$gt": 1]], update: ["$inc": ["x": 1]], options: nil),
+            .updateMany(filter: ["_id": ["$gt": 1]], update: ["$inc": ["x": 1]]),
             .insertOne(["_id": 4]),
-            .deleteMany(["x": ["$nin": [24, 34]]], options: nil),
+            .deleteMany(["x": ["$nin": [24, 34]]]),
             .replaceOne(
                 filter: ["_id": 4],
                 replacement: ["_id": 4, "x": 44],


### PR DESCRIPTION
[SWIFT-621](https://jira.mongodb.org/browse/SWIFT-621)

I looked through the [rest of our enums](https://mongodb.github.io/mongo-swift-driver/MongoSwift/Enums.html) (ty jazzy) and didn't see anything else that needed this treatment besides `WriteModel`.