### PR TITLE
minor: skip failing DNS seedlist test

### DIFF
--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -60,8 +60,13 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
             specName: "initial-dns-seedlist-discovery",
             asType: DNSSeedlistTestCase.self
         )
-        for (_, testCase) in tests {
+        for (fileName, testCase) in tests {
             let topologyWatcher = TopologyDescriptionWatcher()
+
+            // TODO: DRIVERS-796 or DRIVERS-990: unskip this test
+            guard fileName != "txt-record-with-overridden-uri-option.json" else {
+                return
+            }
 
             // Enclose all of the potentially throwing code in `doTest`. Sometimes the expected errors come when
             // parsing the URI, and other times they are not until we try to select a server.


### PR DESCRIPTION
This skips the initial dns seedlist discovery test that's currently failing on master.

[evg patch](https://evergreen.mongodb.com/version/5e876f0732f417510b73a85d)