### PR TITLE
SWIFT-749 use ELG provider, update shutdown API

### DIFF
--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -125,7 +125,8 @@ internal class ConnectionPool {
     }
 
     /// Checks out a connection. This connection will return itself to the pool when its reference count drops to 0.
-    /// This method will block until a connection is available.
+    /// This method will block until a connection is available. Throws an error if the pool is in the process of
+    /// closing or has finished closing.
     internal func checkOut() throws -> Connection {
         try self.stateLock.withLock {
             switch self.state {
@@ -138,7 +139,8 @@ internal class ConnectionPool {
         }
     }
 
-    /// Checks out a connection from the pool, or returns `nil` if none are currently available.
+    /// Checks out a connection from the pool, or returns `nil` if none are currently available. Throws an error if the
+    /// pool is not open.
     internal func tryCheckOut() throws -> Connection? {
         try self.stateLock.withLock {
             switch self.state {
@@ -154,6 +156,8 @@ internal class ConnectionPool {
         }
     }
 
+    /// Checks  a connection into the pool. Accepts the connection if the pool is still open or in the process of
+    /// closing; throws an error if the pool has already finished closing.
     fileprivate func checkIn(_ connection: Connection) throws {
         try self.stateLock.withLock {
             switch self.state {

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -257,7 +257,9 @@ internal class ConnectionPool {
     }
 
     /// Sets the provided APM callbacks on this pool, using the provided client as the "context" value. **This method
-    /// may only be called before any connections are checked out of the pool.**
+    /// may only be called before any connections are checked out of the pool.** Ideally this code would just live in
+    /// `ConnectionPool.init`. However, the client we accept here has to be fully initialized before we can pass it
+    /// as the context. In order for it to be fully initialized its pool must exist already.
     internal func setAPMCallbacks(callbacks: OpaquePointer, client: MongoClient) {
         self.stateLock.withLock {
             switch self.state {

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -113,7 +113,7 @@ internal class ConnectionPool {
                 if self.connCount == 0 {
                     switch self.state {
                     case .open, .closed:
-                        throw InternalError(message: "ConnectionPool in unexpected state during close()")
+                        throw InternalError(message: "ConnectionPool in unexpected state \(self.state) during close()")
                     case let .closing(pool):
                         mongoc_client_pool_destroy(pool)
                         self.state = .closed
@@ -218,7 +218,7 @@ internal class ConnectionPool {
                 mongoc_client_pool_set_ssl_opts(pool, &opts)
             case .closing, .closed:
                 // if we get here, we must have called this method outside of `ConnectionPool.init`.
-                fatalError("ConnectionPool unexpectedly in .closing or .closed state")
+                fatalError("ConnectionPool in unexpected state \(self.state) while setting TLS options")
             }
         }
     }
@@ -266,7 +266,7 @@ internal class ConnectionPool {
             case .closing, .closed:
                 // this method is called via `initializeMonitoring()`, which is called from `MongoClient.init`.
                 // unless we have a bug it's impossible that the pool is already closed.
-                fatalError("ConnectionPool unexpectedly in .closed state")
+                fatalError("ConnectionPool in unexpected state \(self.state) while setting APM callbacks")
             }
         }
     }

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -1,4 +1,5 @@
 import CLibMongoC
+import NIOConcurrencyHelpers
 
 /// A connection to the database.
 internal class Connection {
@@ -13,11 +14,10 @@ internal class Connection {
     }
 
     deinit {
-        switch self.pool.state {
-        case let .open(pool):
-            mongoc_client_pool_push(pool, self.clientHandle)
-        case .closed:
-            assertionFailure("ConnectionPool was already closed")
+        do {
+            try self.pool.checkIn(self)
+        } catch {
+            assertionFailure("Failed to check connection back in: \(error)")
         }
     }
 }
@@ -28,12 +28,38 @@ internal class ConnectionPool {
     internal enum State {
         /// Indicates that the `ConnectionPool` is open and using the associated pointer to a `mongoc_client_pool_t`.
         case open(pool: OpaquePointer)
+        /// Indicates that the `ConnectionPool` is in the process of closing. Connections can be checked back in, but
+        /// no new connections can be checked out.
+        case closing(pool: OpaquePointer)
         /// Indicates that the `ConnectionPool` has been closed and contains no connections.
         case closed
     }
 
     /// The state of this `ConnectionPool`.
-    internal private(set) var state: State
+    private var state: State
+    /// The number of connections currently checked out of the pool.
+    private var connCount = 0
+    /// Lock over `state` and `connCount`.
+    private let stateLock = Lock()
+
+    /// Internal helper for testing purposes that returns whether the pool is in the `closing` state.
+    internal var isClosing: Bool {
+        self.stateLock.withLock {
+            guard case .closing = self.state else {
+                return false
+            }
+            return true
+        }
+    }
+
+    /// Internal helper for testing purposes that returns the number of connections currently checked out from the pool.
+    internal var checkedOutConnections: Int {
+        self.stateLock.withLock {
+            self.connCount
+        }
+    }
+
+    private static let PoolClosedError = LogicError(message: "ConnectionPool was already closed")
 
     /// Initializes the pool using the provided `ConnectionString` and options.
     internal init(from connString: ConnectionString, options: ClientOptions?) throws {
@@ -56,7 +82,7 @@ internal class ConnectionPool {
 
         self.state = .open(pool: pool)
         if let options = options {
-            try self.setTLSOptions(options)
+            self.setTLSOptions(options)
         }
     }
 
@@ -67,38 +93,76 @@ internal class ConnectionPool {
         }
     }
 
-    /// Closes the pool, cleaning up underlying resources. This method blocks as it sends `endSessions` to the server.
-    internal func shutdown() {
-        switch self.state {
-        case let .open(pool):
-            mongoc_client_pool_destroy(pool)
-        case .closed:
-            return
+    /// Closes the pool, cleaning up underlying resources. **This method blocks until all connections are returned to
+    /// the pool.**
+    internal func close() throws {
+        try self.stateLock.withLock {
+            switch self.state {
+            case let .open(pool):
+                self.state = .closing(pool: pool)
+            case .closing, .closed:
+                throw Self.PoolClosedError
+            }
         }
-        self.state = .closed
+
+        // continually loop and wait to get all connections back before destroying the pool. release the lock on each
+        // iteration to allow other methods to acquire the lock.
+        var done = false
+        while !done {
+            try self.stateLock.withLock {
+                if self.connCount == 0 {
+                    switch self.state {
+                    case .open, .closed:
+                        throw InternalError(message: "ConnectionPool in unexpected state during close()")
+                    case let .closing(pool):
+                        mongoc_client_pool_destroy(pool)
+                        self.state = .closed
+                    }
+                    done = true
+                }
+            }
+        }
     }
 
     /// Checks out a connection. This connection will return itself to the pool when its reference count drops to 0.
     /// This method will block until a connection is available.
     internal func checkOut() throws -> Connection {
-        switch self.state {
-        case let .open(pool):
-            return Connection(clientHandle: mongoc_client_pool_pop(pool), pool: self)
-        case .closed:
-            throw InternalError(message: "ConnectionPool was already closed")
+        try self.stateLock.withLock {
+            switch self.state {
+            case let .open(pool):
+                self.connCount += 1
+                return Connection(clientHandle: mongoc_client_pool_pop(pool), pool: self)
+            case .closing, .closed:
+                throw Self.PoolClosedError
+            }
         }
     }
 
     /// Checks out a connection from the pool, or returns `nil` if none are currently available.
     internal func tryCheckOut() throws -> Connection? {
-        switch self.state {
-        case let .open(pool):
-            guard let handle = mongoc_client_pool_try_pop(pool) else {
-                return nil
+        try self.stateLock.withLock {
+            switch self.state {
+            case let .open(pool):
+                guard let handle = mongoc_client_pool_try_pop(pool) else {
+                    return nil
+                }
+                self.connCount += 1
+                return Connection(clientHandle: handle, pool: self)
+            case .closing, .closed:
+                throw Self.PoolClosedError
             }
-            return Connection(clientHandle: handle, pool: self)
-        case .closed:
-            throw InternalError(message: "ConnectionPool was already closed")
+        }
+    }
+
+    fileprivate func checkIn(_ connection: Connection) throws {
+        try self.stateLock.withLock {
+            switch self.state {
+            case let .open(pool), let .closing(pool):
+                mongoc_client_pool_push(pool, connection.clientHandle)
+                self.connCount -= 1
+            case .closed:
+                throw Self.PoolClosedError
+            }
         }
     }
 
@@ -109,9 +173,9 @@ internal class ConnectionPool {
         return try body(connection)
     }
 
-    // Sets TLS/SSL options that the user passes in through the client level. This must be called from
-    // the ConnectionPool init before the pool is used.
-    private func setTLSOptions(_ options: ClientOptions) throws {
+    // Sets TLS/SSL options that the user passes in through the client level. **This must only be called from
+    // the ConnectionPool initializer**.
+    private func setTLSOptions(_ options: ClientOptions) {
         // return early so we don't set an empty options struct on the libmongoc pool. doing so will make libmongoc
         // attempt to use TLS for connections.
         guard options.tls == true ||
@@ -147,11 +211,15 @@ internal class ConnectionPool {
         if let invalidHosts = options.tlsAllowInvalidHostnames {
             opts.allow_invalid_hostname = invalidHosts
         }
-        switch self.state {
-        case let .open(pool):
-            mongoc_client_pool_set_ssl_opts(pool, &opts)
-        case .closed:
-            throw InternalError(message: "ConnectionPool was already closed")
+
+        self.stateLock.withLock {
+            switch self.state {
+            case let .open(pool):
+                mongoc_client_pool_set_ssl_opts(pool, &opts)
+            case .closing, .closed:
+                // if we get here, we must have called this method outside of `ConnectionPool.init`.
+                fatalError("ConnectionPool unexpectedly in .closing or .closed state")
+            }
         }
     }
 
@@ -185,6 +253,21 @@ internal class ConnectionPool {
                 throw InternalError(message: "Couldn't retrieve client's connection string")
             }
             return ConnectionString(copying: uri)
+        }
+    }
+
+    /// Sets the provided APM callbacks on this pool, using the provided client as the "context" value. **This method
+    /// may only be called before any connections are checked out of the pool.**
+    internal func setAPMCallbacks(callbacks: OpaquePointer, client: MongoClient) {
+        self.stateLock.withLock {
+            switch self.state {
+            case let .open(pool):
+                mongoc_client_pool_set_apm_callbacks(pool, callbacks, Unmanaged.passUnretained(client).toOpaque())
+            case .closing, .closed:
+                // this method is called via `initializeMonitoring()`, which is called from `MongoClient.init`.
+                // unless we have a bug it's impossible that the pool is already closed.
+                fatalError("ConnectionPool unexpectedly in .closed state")
+            }
         }
     }
 }

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -59,7 +59,7 @@ internal class ConnectionPool {
         }
     }
 
-    private static let PoolClosedError = LogicError(message: "ConnectionPool was already closed")
+    internal static let PoolClosedError = LogicError(message: "ConnectionPool was already closed")
 
     /// Initializes the pool using the provided `ConnectionString` and options.
     internal init(from connString: ConnectionString, options: ClientOptions?) throws {

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -283,10 +283,18 @@ public class MongoClient {
         )
     }
 
-    /// Closes this `MongoClient`, closing all connections to the server and cleaning up internal state.
-    /// Call this method exactly once when you are finished using the client. You must ensure that all operations
-    /// using the client have completed before calling this. The returned future must be fulfilled before the
-    /// `EventLoopGroup` provided to this client's constructor is shut down.
+    /**
+     * Closes this `MongoClient`, closing all connections to the server and cleaning up internal state.
+     *
+     * Call this method exactly once when you are finished using the client. You must ensure that all operations using
+     * the client have completed before calling this.
+     *
+     * The returned future will not be fulfilled until all cursors and change streams created from this client have been
+     * been killed, and all sessions created from this client have been ended.
+     *
+     * The returned future must be fulfilled before the `EventLoopGroup` provided to this client's constructor is shut
+     * down.
+     */
     public func close() -> EventLoopFuture<Void> {
         let stateError: Error? = self.stateLock.withLock {
             switch self.state {
@@ -323,7 +331,8 @@ public class MongoClient {
      * internal state.
      *
      * Call this method exactly once when you are finished using the client. You must ensure that all operations
-     * using the client have completed before calling this.
+     * using the client have completed before calling this. This method will block until all cursors and change streams
+     * created from this client have been killed, and all sessions created from this client have been ended.
      *
      * This method must complete before the `EventLoopGroup` provided to this client's constructor is shut down.
      */

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -169,7 +169,9 @@ public class MongoClient {
     /// Default maximum size for connection pools created by this client.
     internal static let defaultMaxConnectionPoolSize = 100
 
-    /// Indicates whether this client has been closed.
+    /// Indicates whether this client has been closed. We don't need a lock because:
+    /// - This value is only modified on success of `ConnectionPool.close()`. That method will succeed exactly once.
+    /// - This value is only read in `deinit`. That occurs exactly once after the above modification is complete.
     private var wasClosed = false
 
     /// Handlers for command monitoring events.

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -169,7 +169,7 @@ public class MongoClient {
     /// Default maximum size for connection pools created by this client.
     internal static let defaultMaxConnectionPoolSize = 100
 
-    /// Indicates whether this client has been closed. We don't need a lock because:
+    /// Indicates whether this client has been closed. A lock around this variable is not needed because:
     /// - This value is only modified on success of `ConnectionPool.close()`. That method will succeed exactly once.
     /// - This value is only read in `deinit`. That occurs exactly once after the above modification is complete.
     private var wasClosed = false

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -33,7 +33,7 @@ internal class OperationExecutor {
     }
 
     /// Closes the executor's underlying thread pool.
-    internal func close() -> EventLoopFuture<Void> {
+    internal func shutdown() -> EventLoopFuture<Void> {
         let promise = self.eventLoopGroup.next().makePromise(of: Void.self)
         self.threadPool.shutdownGracefully { error in
             if let error = error {
@@ -46,18 +46,17 @@ internal class OperationExecutor {
     }
 
     /// Closes the executor's underlying thread pool synchronously.
-    internal func syncClose() throws {
+    internal func syncShutdown() throws {
         try self.threadPool.syncShutdownGracefully()
     }
 
     internal func execute<T: Operation>(
         _ operation: T,
-        using connection: Connection? = nil,
         client: MongoClient,
         session: ClientSession?
     ) -> EventLoopFuture<T.OperationResult> {
         // early exit and don't attempt to use the thread pool if we've already closed the client.
-        guard !client.isClosed else {
+        guard client.isOpen else {
             return self.makeFailedFuture(MongoClient.ClosedClientError)
         }
 
@@ -65,7 +64,7 @@ internal class OperationExecutor {
         let doOperation = { () -> ExecuteResult<T.OperationResult> in
             // it's possible that the client was closed in between submitting this task and it being executed, so we
             // check again here.
-            guard !client.isClosed else {
+            guard client.isOpen else {
                 throw MongoClient.ClosedClientError
             }
 
@@ -73,8 +72,8 @@ internal class OperationExecutor {
             // 1. connection specifically provided for use with this operation
             // 2. if a session was provided, use its underlying connection
             // 3. a new connection from the pool, if available
-            guard let connection = try connection ??
-                session?.getConnection(forUseWith: client) ??
+            guard let connection =
+                try session?.getConnection(forUseWith: client) ??
                 client.connectionPool.tryCheckOut() else {
                 return .resubmit
             }
@@ -93,7 +92,7 @@ internal class OperationExecutor {
             case let .success(res):
                 return self.makeSucceededFuture(res)
             case .resubmit:
-                return self.execute(operation, using: connection, client: client, session: session)
+                return self.execute(operation, client: client, session: session)
             }
         }
 

--- a/Sources/MongoSwiftSync/MongoClient.swift
+++ b/Sources/MongoSwiftSync/MongoClient.swift
@@ -53,7 +53,7 @@ public class MongoClient {
 
     deinit {
         do {
-            try self.asyncClient.shutdown().wait()
+            try self.asyncClient.syncClose()
         } catch {
             assertionFailure("Error closing async client: \(error)")
         }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -160,6 +160,7 @@ extension MongoClientTests {
         ("testListDatabases", testListDatabases),
         ("testClientIdGeneration", testClientIdGeneration),
         ("testResubmittingToThreadPool", testResubmittingToThreadPool),
+        ("testConnectionPoolClose", testConnectionPoolClose),
     ]
 }
 

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -5,7 +5,7 @@ import TestsCommon
 import XCTest
 
 extension MongoClient {
-    fileprivate static func makeTestClient(
+    internal static func makeTestClient(
         _ uri: String = MongoSwiftTestCase.getConnectionString(),
         eventLoopGroup: EventLoopGroup,
         options: ClientOptions? = nil
@@ -21,7 +21,7 @@ extension MongoClient {
 
     internal func syncCloseOrFail() {
         do {
-            try self.shutdown().wait()
+            try self.syncClose()
         } catch {
             XCTFail("Error closing test client: \(error)")
         }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -102,7 +102,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         let ns = MongoNamespace(db: "connPoolTest", collection: "foo")
 
         // clean up this test's namespace after we're done
-        // defer { try? self.withTestNamespace(ns: ns) { _, _, _ in } }
+        defer { try? self.withTestNamespace(ns: ns) { _, _, _ in } }
 
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { elg.syncShutdownOrFail() }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -125,6 +125,9 @@ final class MongoClientTests: MongoSwiftTestCase {
         expect(client.connectionPool.isClosing).toEventually(beTrue())
         expect(client.connectionPool.checkedOutConnections).to(equal(2))
 
+        // calling a method that will request a new connection errors
+        expect(try client.listDatabases().wait()).to(throwError(MongoClient.ClosedClientError))
+
         // cursor can still be used and successfully killed while closing occurs
         expect(try cursor.next().wait()).toNot(throwError())
         try cursor.kill().wait()

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -8,7 +8,7 @@ final class MongoClientTests: MongoSwiftTestCase {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { elg.syncShutdownOrFail() }
         let client = try MongoClient(using: elg)
-        client.syncShutdown()
+        try client.syncClose()
         expect(try client.listDatabases().wait()).to(throwError(MongoClient.ClosedClientError))
     }
 
@@ -96,5 +96,54 @@ final class MongoClientTests: MongoSwiftTestCase {
             // waiting operations can eventually finish too
             _ = try waitingOperations.map { try $0.wait() }
         }
+    }
+
+    func testConnectionPoolClose() throws {
+        let ns = MongoNamespace(db: "connPoolTest", collection: "foo")
+
+        // clean up this test's namespace after we're done
+        defer { try? self.withTestNamespace(ns: ns) { _, _, _ in } }
+
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { elg.syncShutdownOrFail() }
+        let client = try MongoClient.makeTestClient(eventLoopGroup: elg)
+
+        // create a cursor
+        let collection = client.db(ns.db).collection(ns.collection!)
+        _ = try collection.insertMany([["x": 1], ["x": 2]]).wait()
+        let cursor = try collection.find().wait()
+
+        // create a session
+        let session = client.startSession()
+        // run a command to trigger starting libmongoc session
+        _ = try client.listDatabases(session: session).wait()
+
+        // start the client's closing process
+        let closeFuture = client.close()
+
+        // the pool should enter the closing state, with 2 connections out
+        expect(client.connectionPool.isClosing).toEventually(beTrue())
+        expect(client.connectionPool.checkedOutConnections).to(equal(2))
+
+        // cursor can still be used and successfully killed while closing occurs
+        expect(try cursor.next().wait()).toNot(throwError())
+        try cursor.kill().wait()
+
+        // still in closing state; got connection back from cursor
+        expect(client.connectionPool.isClosing).to(beTrue())
+        expect(client.connectionPool.checkedOutConnections).to(equal(1))
+
+        // attempting to use session errors
+        expect(try client.listDatabases(session: session).wait())
+            .to(throwError(MongoClient.ClosedClientError))
+        // ending session succeeds
+        expect(try session.end().wait()).toNot(throwError())
+
+        // once session releases connection, the pool can close
+        expect(client.connectionPool.isClosing).toEventually(beFalse())
+        expect(client.connectionPool.checkedOutConnections).to(equal(0))
+
+        // wait to ensure all resource cleanup happens correctly
+        try closeFuture.wait()
     }
 }


### PR DESCRIPTION
This PR updates our client initializer to accept an `EventLoopGroupProvider` rather than an `EventLoopGroup`.
As a result I needed to update our shutdown API since it can no longer return a future. 

I took a lot of inspiration writing shutdown code from:
- [NIOThreadPool](https://github.com/apple/swift-nio/blob/e876fb37410e0036b98b5361bb18e6854739572b/Sources/NIO/NIOThreadPool.swift#L233)
- [MultiThreadedEventLoopGroup](https://github.com/apple/swift-nio/blob/2ad77f9a9b7e4e61bd9a9639473f716e835091d9/Sources/NIO/EventLoop.swift#L834)
- [AsyncHTTPClient](https://github.com/swift-server/async-http-client/blob/master/Sources/AsyncHTTPClient/HTTPClient.swift)

Comments inline