### PR TITLE
SWIFT-574 Implement asynchronous convenient transactions API

### DIFF
--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -481,4 +481,28 @@ internal func wrongIterTypeError(_ iter: DocumentIterator, expected type: BSONVa
     )
 }
 
+internal func isMaxTimeMSExpiredError(_ error: Error) -> Bool {
+    let maxTimeMSExpiredErrorCode = 50
+
+    if let commandError = error as? CommandError, commandError.code == maxTimeMSExpiredErrorCode {
+        return true
+    } else if let writeError = error as? WriteError {
+        if writeError.writeFailure?.code == maxTimeMSExpiredErrorCode ||
+            writeError.writeConcernFailure?.code == maxTimeMSExpiredErrorCode {
+            return true
+        }
+    } else if let bulkWriteError = error as? BulkWriteError {
+        if let writeFailures = bulkWriteError.writeFailures {
+            for writeFailure in writeFailures where writeFailure.code == maxTimeMSExpiredErrorCode {
+                return true
+            }
+        }
+        if bulkWriteError.writeConcernFailure?.code == maxTimeMSExpiredErrorCode {
+            return true
+        }
+    }
+
+    return false
+}
+
 internal let failedToRetrieveCursorMessage = "Couldn't get cursor from the server"


### PR DESCRIPTION
I've got a working implementation of the async convenient transactions API. I'm not quite sure what the best way to implement the synchronous API would be, given that you cannot just call `wait()`. I suppose that could be left to another PR.