### PR TITLE
feat: Add allowDiskUse find option

### DIFF
--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Options to use when executing an `aggregate` command on a `MongoCollection`.
 public struct AggregateOptions: Codable {
-    /// Enables the server to write to temporary files. When set to true, the find operation
+    /// Enables the server to write to temporary files. When set to true, the aggregate operation
     /// can write data to the _tmp subdirectory in the dbPath directory.
     public var allowDiskUse: Bool?
 

--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Options to use when executing an `aggregate` command on a `MongoCollection`.
 public struct AggregateOptions: Codable {
-    /// Enables writing to temporary files. When set to true, aggregation stages
+    /// Enables the server to write to temporary files. When set to true, the find operation
     /// can write data to the _tmp subdirectory in the dbPath directory.
     public var allowDiskUse: Bool?
 

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -32,6 +32,9 @@ public enum CursorType {
 
 /// Options to use when executing a `find` command on a `MongoCollection`.
 public struct FindOptions: Codable {
+    /// Enables writing to temporary files on the server.
+    public var allowDiskUse: Bool?
+
     /// Get partial results from a mongos if some shards are down (instead of throwing an error).
     public var allowPartialResults: Bool?
 
@@ -130,6 +133,7 @@ public struct FindOptions: Codable {
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(
+        allowDiskUse: Bool? = nil,
         allowPartialResults: Bool? = nil,
         batchSize: Int32? = nil,
         collation: Document? = nil,
@@ -150,6 +154,7 @@ public struct FindOptions: Codable {
         skip: Int64? = nil,
         sort: Document? = nil
     ) {
+        self.allowDiskUse = allowDiskUse
         self.allowPartialResults = allowPartialResults
         self.batchSize = batchSize
         self.collation = collation
@@ -191,9 +196,9 @@ public struct FindOptions: Codable {
 
     // Encode everything except `self.readPreference`, because this is sent to libmongoc separately
     private enum CodingKeys: String, CodingKey {
-        case allowPartialResults, awaitData, batchSize, collation, comment, hint, limit, max, maxAwaitTimeMS,
-            maxTimeMS, min, noCursorTimeout, projection, readConcern, returnKey, showRecordId, tailable, skip,
-            sort
+        case allowDiskUse, allowPartialResults, awaitData, batchSize, collation, comment, hint, limit, max,
+        maxAwaitTimeMS, maxTimeMS, min, noCursorTimeout, projection, readConcern, returnKey, showRecordId,
+        tailable, skip, sort
     }
 }
 

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -32,7 +32,8 @@ public enum CursorType {
 
 /// Options to use when executing a `find` command on a `MongoCollection`.
 public struct FindOptions: Codable {
-    /// Enables writing to temporary files on the server.
+    /// Enables writing to temporary files. When set to true, the find operation
+    /// can write data to the _tmp subdirectory in the dbPath directory.
     public var allowDiskUse: Bool?
 
     /// Get partial results from a mongos if some shards are down (instead of throwing an error).

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -197,8 +197,8 @@ public struct FindOptions: Codable {
     // Encode everything except `self.readPreference`, because this is sent to libmongoc separately
     private enum CodingKeys: String, CodingKey {
         case allowDiskUse, allowPartialResults, awaitData, batchSize, collation, comment, hint, limit, max,
-        maxAwaitTimeMS, maxTimeMS, min, noCursorTimeout, projection, readConcern, returnKey, showRecordId,
-        tailable, skip, sort
+            maxAwaitTimeMS, maxTimeMS, min, noCursorTimeout, projection, readConcern, returnKey, showRecordId,
+            tailable, skip, sort
     }
 }
 

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -32,7 +32,7 @@ public enum CursorType {
 
 /// Options to use when executing a `find` command on a `MongoCollection`.
 public struct FindOptions: Codable {
-    /// Enables writing to temporary files. When set to true, the find operation
+    /// Enables the server to write to temporary files. When set to true, the find operation
     /// can write data to the _tmp subdirectory in the dbPath directory.
     public var allowDiskUse: Bool?
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 
@@ -227,6 +227,14 @@ extension MongoCollection_IndexTests {
     ]
 }
 
+extension MongoCrudV2Tests {
+    static var allTests = [
+        ("testFindOptionsAllowDiskUseNotSpecified", testFindOptionsAllowDiskUseNotSpecified),
+        ("testFindOptionsAllowDiskUseFalse", testFindOptionsAllowDiskUseFalse),
+        ("testFindOptionsAllowDiskUseTrue", testFindOptionsAllowDiskUseTrue),
+    ]
+}
+
 extension MongoCursorTests {
     static var allTests = [
         ("testNonTailableCursor", testNonTailableCursor),
@@ -399,6 +407,7 @@ XCTMain([
     testCase(MongoCollectionTests.allTests),
     testCase(MongoCollection_BulkWriteTests.allTests),
     testCase(MongoCollection_IndexTests.allTests),
+    testCase(MongoCrudV2Tests.allTests),
     testCase(MongoCursorTests.allTests),
     testCase(MongoDatabaseTests.allTests),
     testCase(OptionsTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -229,9 +229,7 @@ extension MongoCollection_IndexTests {
 
 extension MongoCrudV2Tests {
     static var allTests = [
-        ("testFindOptionsAllowDiskUseNotSpecified", testFindOptionsAllowDiskUseNotSpecified),
-        ("testFindOptionsAllowDiskUseFalse", testFindOptionsAllowDiskUseFalse),
-        ("testFindOptionsAllowDiskUseTrue", testFindOptionsAllowDiskUseTrue),
+        ("testFindOptionsAllowDiskUse", testFindOptionsAllowDiskUse),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
@@ -12,7 +12,7 @@ final class MongoCrudV2Tests: MongoSwiftTestCase {
             let monitor = client.addCommandMonitor()
             try coll.insertOne(["dog": "notCat"])
 
-            try monitor.captureEvents({
+            try monitor.captureEvents {
                 let optionAllowDiskUseNil = FindOptions()
                 expect(try coll.find(["dog": "notCat"], options: optionAllowDiskUseNil)).toNot(throwError())
 
@@ -21,7 +21,7 @@ final class MongoCrudV2Tests: MongoSwiftTestCase {
 
                 let optionAllowDiskUseTrue = FindOptions(allowDiskUse: true)
                 expect(try coll.find(["dog": "notCat"], options: optionAllowDiskUseTrue)).toNot(throwError())
-            })
+            }
 
             let events = monitor.commandStartedEvents()
             expect(events).to(haveCount(3))

--- a/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
@@ -8,13 +8,11 @@ import XCTest
 /// A place for CrudV2 Tests until the swift crud v2 runner is shipped
 final class MongoCrudV2Tests: MongoSwiftTestCase {
     func testFindOptionsAllowDiskUse() throws {
-        let client = try MongoClient.makeTestClient()
-        let monitor = client.addCommandMonitor()
-
-        try self.withTestNamespace { _, _, coll in
+        try self.withTestNamespace { client, _, coll in
+            let monitor = client.addCommandMonitor()
             try coll.insertOne(["dog": "notCat"])
 
-            try monitor.captureEvents {
+            try monitor.captureEvents({
                 let optionAllowDiskUseNil = FindOptions()
                 expect(try coll.find(["dog": "notCat"], options: optionAllowDiskUseNil)).toNot(throwError())
 
@@ -23,7 +21,7 @@ final class MongoCrudV2Tests: MongoSwiftTestCase {
 
                 let optionAllowDiskUseTrue = FindOptions(allowDiskUse: true)
                 expect(try coll.find(["dog": "notCat"], options: optionAllowDiskUseTrue)).toNot(throwError())
-            }
+            })
 
             let events = monitor.commandStartedEvents()
             expect(events).to(haveCount(3))

--- a/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
@@ -8,6 +8,10 @@ import XCTest
 /// A place for CrudV2 Tests until the swift crud v2 runner is shipped
 final class MongoCrudV2Tests: MongoSwiftTestCase {
     func testFindOptionsAllowDiskUse() throws {
+        guard try MongoClient.makeTestClient().serverVersion() < ServerVersion(major: 4, minor: 3, patch: 5) else {
+            print("Skipping test; MongoDB 4.3.5+ feature")
+            return
+        }
         try self.withTestNamespace { client, _, coll in
             let monitor = client.addCommandMonitor()
             try coll.insertOne(["dog": "notCat"])

--- a/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
@@ -13,7 +13,7 @@ final class MongoCrudV2Tests: MongoSwiftTestCase {
                 print("Skipping test; MongoDB 4.3.5+ feature")
                 return
             }
-            
+
             let monitor = client.addCommandMonitor()
             try coll.insertOne(["dog": "notCat"])
 

--- a/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MongoSwiftSync
+import Nimble
+import TestsCommon
+import XCTest
+
+private var _client: MongoSwiftSync.MongoClient?
+
+/// A place for CrudV2 Tests until the swift crud v2 runner is shipped
+final class MongoCrudV2Tests: MongoSwiftTestCase {
+    func testFindOptionsAllowDiskUseNotSpecified() throws {
+        let client = try MongoClient.makeTestClient()
+        let monitor = client.addCommandMonitor()
+
+        let db = client.db(Self.testDatabase)
+
+        let collection = db.collection("collection")
+        try collection.insertOne(["test": "blahblah"])
+
+        try monitor.captureEvents {
+            let options = FindOptions()
+            expect(try collection.find(["test": "blahblah"], options: options)).toNot(throwError())
+        }
+
+        let event = monitor.commandStartedEvents().first
+        expect(event).toNot(beNil())
+        expect(event?.command["find"]).toNot(beNil())
+        expect(event?.command["allowDiskUse"]).to(beNil())
+    }
+
+    func testFindOptionsAllowDiskUseFalse() throws {
+        let client = try MongoClient.makeTestClient()
+        let monitor = client.addCommandMonitor()
+
+        let db = client.db(Self.testDatabase)
+
+        let collection = db.collection("collection")
+        try collection.insertOne(["test": "blahblah"])
+
+        try monitor.captureEvents {
+            let options = FindOptions(allowDiskUse: false)
+            expect(try collection.find(["test": "blahblah"], options: options)).toNot(throwError())
+        }
+
+        let event = monitor.commandStartedEvents().first
+        expect(event).toNot(beNil())
+        expect(event?.command["find"]).toNot(beNil())
+        expect(event?.command["allowDiskUse"]?.boolValue).to(beFalse())
+    }
+
+    func testFindOptionsAllowDiskUseTrue() throws {
+        let client = try MongoClient.makeTestClient()
+        let monitor = client.addCommandMonitor()
+
+        let db = client.db(Self.testDatabase)
+
+        let collection = db.collection("collection")
+        try collection.insertOne(["test": "blahblah"])
+
+        try monitor.captureEvents {
+            let options = FindOptions(allowDiskUse: true)
+            expect(try collection.find(["test": "blahblah"], options: options)).toNot(throwError())
+        }
+
+        let event = monitor.commandStartedEvents().first
+        expect(event).toNot(beNil())
+        expect(event?.command["find"]).toNot(beNil())
+        expect(event?.command["allowDiskUse"]?.boolValue).to(beTrue())
+    }
+}

--- a/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
@@ -4,7 +4,8 @@ import Nimble
 import TestsCommon
 import XCTest
 
-/// A place for CrudV2 Tests until the swift crud v2 runner is shipped (SWIFT-780)
+// TODO: remove with SWIFT-780
+/// A place for CrudV2 Tests until the swift crud v2 runner is shipped
 final class MongoCrudV2Tests: MongoSwiftTestCase {
     func testFindOptionsAllowDiskUse() throws {
         let client = try MongoClient.makeTestClient()

--- a/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
@@ -27,17 +27,14 @@ final class MongoCrudV2Tests: MongoSwiftTestCase {
             expect(events).to(haveCount(3))
 
             let eventAllowDiskUseNil = events[0]
-            expect(eventAllowDiskUseNil).toNot(beNil())
             expect(eventAllowDiskUseNil.command["find"]).toNot(beNil())
             expect(eventAllowDiskUseNil.command["allowDiskUse"]).to(beNil())
 
             let eventAllowDiskUseFalse = events[1]
-            expect(eventAllowDiskUseFalse).toNot(beNil())
             expect(eventAllowDiskUseFalse.command["find"]).toNot(beNil())
             expect(eventAllowDiskUseFalse.command["allowDiskUse"]?.boolValue).to(beFalse())
 
             let eventAllowDiskUseTrue = events[2]
-            expect(eventAllowDiskUseTrue).toNot(beNil())
             expect(eventAllowDiskUseTrue.command["find"]).toNot(beNil())
             expect(eventAllowDiskUseTrue.command["allowDiskUse"]?.boolValue).to(beTrue())
         }

--- a/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudV2Tests.swift
@@ -8,11 +8,12 @@ import XCTest
 /// A place for CrudV2 Tests until the swift crud v2 runner is shipped
 final class MongoCrudV2Tests: MongoSwiftTestCase {
     func testFindOptionsAllowDiskUse() throws {
-        guard try MongoClient.makeTestClient().serverVersion() < ServerVersion(major: 4, minor: 3, patch: 5) else {
-            print("Skipping test; MongoDB 4.3.5+ feature")
-            return
-        }
         try self.withTestNamespace { client, _, coll in
+            guard try client.serverVersion() >= ServerVersion(major: 4, minor: 3, patch: 5) else {
+                print("Skipping test; MongoDB 4.3.5+ feature")
+                return
+            }
+            
             let monitor = client.addCommandMonitor()
             try coll.insertOne(["dog": "notCat"])
 


### PR DESCRIPTION
[SWIFT-772](https://jira.mongodb.org/browse/SWIFT-772)
[SPEC](https://github.com/mongodb/specifications/commit/92255e0e57027646e8ef23399d3f33fdc114221f)

Added the option `allowDiskUse` and tests that mirror the CRUDv2 tests. I figured a new file was prudent given the any tests needed here can be dropped in the future when the CRUDv2 runner is implemented.