### PR TITLE
SWIFT-784 Disable BSON_EXTRA_ALIGN

### DIFF
--- a/Sources/CLibMongoC/include/CLibMongoC_bson-config.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-config.h
@@ -128,7 +128,7 @@
 /*
  * Define to 1 if you want extra aligned types in libbson
  */
-#define BSON_EXTRA_ALIGN 1
+#define BSON_EXTRA_ALIGN 0
 #if BSON_EXTRA_ALIGN != 1
 # undef BSON_EXTRA_ALIGN
 #endif

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -50,7 +50,7 @@ public struct Document {
 extension Document {
     /// Read-only access to the storage's underlying bson_t.
     internal var _bson: BSONPointer {
-        return UnsafePointer(self._storage._bson)
+        UnsafePointer(self._storage._bson)
     }
 
     /**

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -1,13 +1,8 @@
 import CLibMongoC
 import Foundation
 
-#if compiler(>=5.0)
-internal typealias BSONPointer = OpaquePointer
-internal typealias MutableBSONPointer = OpaquePointer
-#else
 internal typealias BSONPointer = UnsafePointer<bson_t>
 internal typealias MutableBSONPointer = UnsafeMutablePointer<bson_t>
-#endif
 
 /// The storage backing a MongoSwift `Document`.
 public class DocumentStorage {
@@ -55,11 +50,7 @@ public struct Document {
 extension Document {
     /// Read-only access to the storage's underlying bson_t.
     internal var _bson: BSONPointer {
-#if compiler(>=5.0)
-        return self._storage._bson
-#else
         return UnsafePointer(self._storage._bson)
-#endif
     }
 
     /**

--- a/Sources/MongoSwift/BSON/DocumentIterator.swift
+++ b/Sources/MongoSwift/BSON/DocumentIterator.swift
@@ -1,13 +1,8 @@
 import CLibMongoC
 import Foundation
 
-#if compiler(>=5.0)
-internal typealias BSONIterPointer = OpaquePointer
-internal typealias MutableBSONIterPointer = OpaquePointer
-#else
 internal typealias BSONIterPointer = UnsafePointer<bson_iter_t>
 internal typealias MutableBSONIterPointer = UnsafeMutablePointer<bson_iter_t>
-#endif
 
 /// An iterator over the values in a `Document`.
 public class DocumentIterator: IteratorProtocol {

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -115,14 +115,13 @@ internal class ConnectionString {
     internal var authMechanismProperties: Document? {
         var props = bson_t()
         return withUnsafeMutablePointer(to: &props) { propsPtr in
-            let opaquePtr = OpaquePointer(propsPtr)
-            guard mongoc_uri_get_mechanism_properties(self._uri, opaquePtr) else {
+            guard mongoc_uri_get_mechanism_properties(self._uri, propsPtr) else {
                 return nil
             }
             /// This copy should not be returned directly as its only guaranteed valid for as long as the
             /// `mongoc_uri_t`, as `props` was statically initialized from data stored in the URI and may contain
             /// pointers that will be invalidated once the URI is.
-            let copy = Document(copying: opaquePtr)
+            let copy = Document(copying: propsPtr)
 
             return copy.mapValues { value in
                 // mongoc returns boolean options e.g. CANONICALIZE_HOSTNAME as strings, but they are boolean values.

--- a/etc/generated_headers/bson-config.h
+++ b/etc/generated_headers/bson-config.h
@@ -128,7 +128,7 @@
 /*
  * Define to 1 if you want extra aligned types in libbson
  */
-#define BSON_EXTRA_ALIGN 1
+#define BSON_EXTRA_ALIGN 0
 #if BSON_EXTRA_ALIGN != 1
 # undef BSON_EXTRA_ALIGN
 #endif


### PR DESCRIPTION
This was done experimentally while investigating the C interop issue in [SWIFT-779](https://jira.mongodb.org/browse/SWIFT-779). 
The required changes ended up being pretty minimal so we should just go ahead with them now.