### PR TITLE
SWIFT-779 Funnel all bson_t access through helper methods

### DIFF
--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -754,8 +754,8 @@ private class MutableArray: BSONValue {
 
     /// methods required by the BSONValue protocol that we don't actually need/use. MutableArray
     /// is just a BSONValue to simplify usage alongside true BSONValues within the encoder.
-    fileprivate func encode(to _: DocumentStorage, forKey _: String) throws {
-        fatalError("`MutableArray` is not meant to be encoded to a `DocumentStorage`")
+    fileprivate func encode(to _: inout Document, forKey _: String) throws {
+        fatalError("`MutableArray` is not meant to be encoded to a `Document`")
     }
 
     internal static func from(iterator _: DocumentIterator) -> BSON {
@@ -818,8 +818,8 @@ private class MutableDictionary: BSONValue {
 
     /// methods required by the BSONValue protocol that we don't actually need/use. MutableDictionary
     /// is just a BSONValue to simplify usage alongside true BSONValues within the encoder.
-    fileprivate func encode(to _: DocumentStorage, forKey _: String) throws {
-        fatalError("`MutableDictionary` is not meant to be encoded to a `DocumentStorage`")
+    fileprivate func encode(to _: inout Document, forKey _: String) throws {
+        fatalError("`MutableDictionary` is not meant to be encoded to a `Document`")
     }
 
     internal static func from(iterator _: DocumentIterator) -> BSON {

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -127,8 +127,8 @@ extension Array: BSONValue where Element == BSON {
             try arr.setValue(for: String(i), to: v)
         }
 
-        try withMutableBSONPointer(to: &document) { docPtr in
-            try withBSONPointer(to: arr) { arrPtr in
+        try document.withMutableBSONPointer { docPtr in
+            try arr.withBSONPointer { arrPtr in
                 guard bson_append_array(docPtr, key, Int32(key.utf8.count), arrPtr) else {
                     throw bsonTooLargeError(value: self, forKey: key)
                 }
@@ -174,7 +174,7 @@ internal struct BSONNull: BSONValue, Codable, Equatable {
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_null(docPtr, key, Int32(key.utf8.count)) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -290,7 +290,7 @@ public struct Binary: BSONValue, Equatable, Codable, Hashable {
         let subtype = bson_subtype_t(UInt32(self.subtype))
         let length = self.data.count
         let byteArray = [UInt8](self.data)
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_binary(docPtr, key, Int32(key.utf8.count), subtype, byteArray, UInt32(length)) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -330,7 +330,7 @@ extension Bool: BSONValue {
     internal var bson: BSON { .bool(self) }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_bool(docPtr, key, Int32(key.utf8.count), self) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -364,7 +364,7 @@ extension Date: BSONValue {
     public var msSinceEpoch: Int64 { Int64((self.timeIntervalSince1970 * 1000.0).rounded()) }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_date_time(docPtr, key, Int32(key.utf8.count), self.msSinceEpoch) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -409,7 +409,7 @@ public struct DBPointer: BSONValue, Codable, Equatable, Hashable {
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             try withUnsafePointer(to: self.id.oid) { oidPtr in
                 guard bson_append_dbpointer(docPtr, key, Int32(key.utf8.count), self.ref, oidPtr) else {
                     throw bsonTooLargeError(value: self, forKey: key)
@@ -487,7 +487,7 @@ public struct Decimal128: BSONValue, Equatable, Codable, CustomStringConvertible
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             try withUnsafePointer(to: self.decimal128) { ptr in
                 guard bson_append_decimal128(docPtr, key, Int32(key.utf8.count), ptr) else {
                     throw bsonTooLargeError(value: self, forKey: key)
@@ -538,7 +538,7 @@ extension Double: BSONValue {
     internal var bson: BSON { .double(self) }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_double(docPtr, key, Int32(key.utf8.count), self) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -563,7 +563,7 @@ extension Int32: BSONValue {
     internal var bson: BSON { .int32(self) }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_int32(docPtr, key, Int32(key.utf8.count), self) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -588,7 +588,7 @@ extension Int64: BSONValue {
     internal var bson: BSON { .int64(self) }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_int64(docPtr, key, Int32(key.utf8.count), self) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -634,8 +634,8 @@ public struct CodeWithScope: BSONValue, Equatable, Codable, Hashable {
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
-            try withBSONPointer(to: self.scope) { scopePtr in
+        try document.withMutableBSONPointer { docPtr in
+            try self.scope.withBSONPointer { scopePtr in
                 guard bson_append_code_with_scope(docPtr, key, Int32(key.utf8.count), self.code, scopePtr) else {
                     throw bsonTooLargeError(value: self, forKey: key)
                 }
@@ -691,7 +691,7 @@ public struct Code: BSONValue, Equatable, Codable, Hashable {
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_code(docPtr, key, Int32(key.utf8.count), self.code) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -716,7 +716,7 @@ internal struct MaxKey: BSONValue, Equatable, Codable, Hashable {
     internal static var bsonType: BSONType { .maxKey }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_maxkey(docPtr, key, Int32(key.utf8.count)) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -749,7 +749,7 @@ internal struct MinKey: BSONValue, Equatable, Codable, Hashable {
     internal static var bsonType: BSONType { .minKey }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_minkey(docPtr, key, Int32(key.utf8.count)) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -848,7 +848,7 @@ public struct ObjectId: BSONValue, Equatable, CustomStringConvertible, Codable {
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             try withUnsafePointer(to: self.oid) { oidPtr in
                 guard bson_append_oid(docPtr, key, Int32(key.utf8.count), oidPtr) else {
                     throw bsonTooLargeError(value: self, forKey: key)
@@ -984,7 +984,7 @@ public struct RegularExpression: BSONValue, Equatable, Codable, Hashable {
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_regex(docPtr, key, Int32(key.utf8.count), self.pattern, self.options) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -1021,7 +1021,7 @@ extension String: BSONValue {
     internal var bson: BSON { .string(self) }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_utf8(docPtr, key, Int32(key.utf8.count), self, Int32(self.utf8.count)) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -1083,7 +1083,7 @@ public struct Symbol: BSONValue, CustomStringConvertible, Codable, Equatable, Ha
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_symbol(
                 docPtr,
                 key,
@@ -1145,7 +1145,7 @@ public struct Timestamp: BSONValue, Equatable, Codable, Hashable {
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_timestamp(docPtr, key, Int32(key.utf8.count), self.timestamp, self.increment) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }
@@ -1185,7 +1185,7 @@ internal struct BSONUndefined: BSONValue, Equatable, Codable {
     }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
-        try withMutableBSONPointer(to: &document) { docPtr in
+        try document.withMutableBSONPointer { docPtr in
             guard bson_append_undefined(docPtr, key, Int32(key.utf8.count)) else {
                 throw bsonTooLargeError(value: self, forKey: key)
             }

--- a/Sources/MongoSwift/BSON/Document+Collection.swift
+++ b/Sources/MongoSwift/BSON/Document+Collection.swift
@@ -38,7 +38,7 @@ extension Document: Collection {
         // criticism also applies to key-based subscripting via `String`.
         // See SWIFT-250.
         self.failIndexCheck(position)
-        guard let iter = DocumentIterator(forDocument: self) else {
+        guard let iter = DocumentIterator(over: self) else {
             fatalError("Failed to initialize an iterator over document \(self)")
         }
 

--- a/Sources/MongoSwift/BSON/Document+Sequence.swift
+++ b/Sources/MongoSwift/BSON/Document+Sequence.swift
@@ -23,7 +23,7 @@ extension Document: Sequence {
 
     /// Returns a `DocumentIterator` over the values in this `Document`.
     public func makeIterator() -> DocumentIterator {
-        guard let iter = DocumentIterator(forDocument: self) else {
+        guard let iter = DocumentIterator(over: self) else {
             fatalError("Failed to initialize an iterator over document \(self)")
         }
         return iter

--- a/Sources/MongoSwift/BSON/Document.swift
+++ b/Sources/MongoSwift/BSON/Document.swift
@@ -119,7 +119,6 @@ extension Document {
         return try body(self._storage._bson)
     }
 
-    
     /**
      * Checks if the document is uniquely referenced. If not, makes a copy of the underlying `bson_t`
      * and lets the copy/copies keep the original. This allows us to provide value semantics for `Document`s.

--- a/Sources/MongoSwift/BSON/DocumentIterator.swift
+++ b/Sources/MongoSwift/BSON/DocumentIterator.swift
@@ -7,9 +7,9 @@ internal typealias MutableBSONIterPointer = UnsafeMutablePointer<bson_iter_t>
 /// An iterator over the values in a `Document`.
 public class DocumentIterator: IteratorProtocol {
     /// the libbson iterator. it must be a `var` because we use it as an inout argument.
-    internal var _iter: bson_iter_t
+    private var _iter: bson_iter_t
     /// a reference to the document we're iterating over
-    internal let document: Document
+    private let document: Document
 
     /// Initializes a new iterator over the contents of `doc`. Returns `nil` if the key is not
     /// found, or if an iterator cannot be created over `doc` due to an error from e.g. corrupt data.

--- a/Sources/MongoSwift/BSON/DocumentIterator.swift
+++ b/Sources/MongoSwift/BSON/DocumentIterator.swift
@@ -18,7 +18,7 @@ public class DocumentIterator: IteratorProtocol {
         self.document = document
 
         let initialized = self.withMutableBSONIterPointer { iterPtr in
-            withBSONPointer(to: self.document) { docPtr in
+            self.document.withBSONPointer { docPtr in
                 bson_iter_init(iterPtr, docPtr)
             }
         }
@@ -35,7 +35,7 @@ public class DocumentIterator: IteratorProtocol {
         self.document = document
 
         let initialized = self.withMutableBSONIterPointer { iterPtr in
-            withBSONPointer(to: self.document) { docPtr in
+            self.document.withBSONPointer { docPtr in
                 bson_iter_init_find(iterPtr, docPtr, key.cString(using: .utf8))
             }
         }

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -256,7 +256,9 @@ public final class ClientSession {
         case let .notStarted(opTime, _):
             self.state = .notStarted(opTime: opTime, clusterTime: clusterTime)
         case let .started(session, _):
-            mongoc_client_session_advance_cluster_time(session, clusterTime._bson)
+            withBSONPointer(to: clusterTime) { ptr in
+                mongoc_client_session_advance_cluster_time(session, ptr)
+            }
         case .ended:
             return
         }

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -256,7 +256,7 @@ public final class ClientSession {
         case let .notStarted(opTime, _):
             self.state = .notStarted(opTime: opTime, clusterTime: clusterTime)
         case let .started(session, _):
-            withBSONPointer(to: clusterTime) { ptr in
+            clusterTime.withBSONPointer { ptr in
                 mongoc_client_session_advance_cluster_time(session, ptr)
             }
         case .ended:
@@ -292,7 +292,7 @@ public final class ClientSession {
         }
 
         var error = bson_error_t()
-        try withMutableBSONPointer(to: &doc) { docPtr in
+        try doc.withMutableBSONPointer { docPtr in
             guard mongoc_client_session_append(session, docPtr, &error) else {
                 throw extractMongoError(error: error)
             }

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -82,7 +82,7 @@ public enum WriteModel<CollectionType: Codable> {
         switch self {
         case let .deleteOne(filter, options):
             let opts = try encoder.encode(options)
-            success = withBSONPointer(to: filter) { filterPtr in
+            success = filter.withBSONPointer { filterPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
                     mongoc_bulk_operation_remove_one_with_opts(bulk, filterPtr, optsPtr, &error)
                 }
@@ -90,7 +90,7 @@ public enum WriteModel<CollectionType: Codable> {
 
         case let .deleteMany(filter, options):
             let opts = try encoder.encode(options)
-            success = withBSONPointer(to: filter) { filterPtr in
+            success = filter.withBSONPointer { filterPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
                     mongoc_bulk_operation_remove_many_with_opts(bulk, filterPtr, optsPtr, &error)
                 }
@@ -98,7 +98,7 @@ public enum WriteModel<CollectionType: Codable> {
 
         case let .insertOne(value):
             let document = try encoder.encode(value).withID()
-            success = withBSONPointer(to: document) { docPtr in
+            success = document.withBSONPointer { docPtr in
                 mongoc_bulk_operation_insert_with_opts(bulk, docPtr, nil, &error)
             }
 
@@ -111,8 +111,8 @@ public enum WriteModel<CollectionType: Codable> {
         case let .replaceOne(filter, replacement, options):
             let replacement = try encoder.encode(replacement)
             let opts = try encoder.encode(options)
-            success = withBSONPointer(to: filter) { filterPtr in
-                withBSONPointer(to: replacement) { replacementPtr in
+            success = filter.withBSONPointer { filterPtr in
+                replacement.withBSONPointer { replacementPtr in
                     withOptionalBSONPointer(to: opts) { optsPtr in
                         mongoc_bulk_operation_replace_one_with_opts(bulk, filterPtr, replacementPtr, optsPtr, &error)
                     }
@@ -121,8 +121,8 @@ public enum WriteModel<CollectionType: Codable> {
 
         case let .updateOne(filter, update, options):
             let opts = try encoder.encode(options)
-            success = withBSONPointer(to: filter) { filterPtr in
-                withBSONPointer(to: update) { updatePtr in
+            success = filter.withBSONPointer { filterPtr in
+                update.withBSONPointer { updatePtr in
                     withOptionalBSONPointer(to: opts) { optsPtr in
                         mongoc_bulk_operation_update_one_with_opts(bulk, filterPtr, updatePtr, optsPtr, &error)
                     }
@@ -131,8 +131,8 @@ public enum WriteModel<CollectionType: Codable> {
 
         case let .updateMany(filter, update, options):
             let opts = try encoder.encode(options)
-            success = withBSONPointer(to: filter) { filterPtr in
-                withBSONPointer(to: update) { updatePtr in
+            success = filter.withBSONPointer { filterPtr in
+                update.withBSONPointer { updatePtr in
                     withOptionalBSONPointer(to: opts) { optsPtr in
                         mongoc_bulk_operation_update_many_with_opts(bulk, filterPtr, updatePtr, optsPtr, &error)
                     }
@@ -242,7 +242,7 @@ internal struct BulkWriteOperation<T: Codable>: Operation {
                     }
                 }
 
-                let serverId = withMutableBSONPointer(to: &reply) { replyPtr in
+                let serverId = reply.withMutableBSONPointer { replyPtr in
                     mongoc_bulk_operation_execute(bulk, replyPtr, &error)
                 }
 

--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -87,7 +87,7 @@ internal struct AggregateOperation<CollectionType: Codable>: Operation {
         let pipeline: Document = ["pipeline": .array(self.pipeline.map { .document($0) })]
 
         let result: OpaquePointer = self.collection.withMongocCollection(from: connection) { collPtr in
-            withBSONPointer(to: pipeline) { pipelinePtr in
+            pipeline.withBSONPointer { pipelinePtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
                     guard let result = mongoc_collection_aggregate(
                         collPtr,

--- a/Sources/MongoSwift/Operations/CommitTransactionOperation.swift
+++ b/Sources/MongoSwift/Operations/CommitTransactionOperation.swift
@@ -19,7 +19,7 @@ internal struct CommitTransactionOperation: Operation {
 
         var reply = Document()
         var error = bson_error_t()
-        let success = withMutableBSONPointer(to: &reply) { replyPtr in
+        let success = reply.withMutableBSONPointer { replyPtr in
             mongoc_client_session_commit_transaction(sessionPtr, replyPtr, &error)
         }
         guard success else {

--- a/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
+++ b/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
@@ -66,7 +66,7 @@ internal struct CountDocumentsOperation<T: Codable>: Operation {
         let rp = self.options?.readPreference?.pointer
         var error = bson_error_t()
         let count = self.collection.withMongocCollection(from: connection) { collPtr in
-            withBSONPointer(to: self.filter) { filterPtr in
+            self.filter.withBSONPointer { filterPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
                     mongoc_collection_count_documents(collPtr, filterPtr, optsPtr, rp, nil, &error)
                 }

--- a/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
+++ b/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
@@ -66,7 +66,11 @@ internal struct CountDocumentsOperation<T: Codable>: Operation {
         let rp = self.options?.readPreference?.pointer
         var error = bson_error_t()
         let count = self.collection.withMongocCollection(from: connection) { collPtr in
-            mongoc_collection_count_documents(collPtr, self.filter._bson, opts?._bson, rp, nil, &error)
+            withBSONPointer(to: self.filter) { filterPtr in
+                withOptionalBSONPointer(to: opts) { optsPtr in
+                    mongoc_collection_count_documents(collPtr, filterPtr, optsPtr, rp, nil, &error)
+                }
+            }
         }
 
         guard count != -1 else { throw extractMongoError(error: error) }

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -121,10 +121,12 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
         var error = bson_error_t()
 
         try self.database.withMongocDatabase(from: connection) { dbPtr in
-            guard let collection = mongoc_database_create_collection(dbPtr, self.name, opts?._bson, &error) else {
-                throw extractMongoError(error: error)
+            try withOptionalBSONPointer(to: opts) { optsPtr in
+                guard let collection = mongoc_database_create_collection(dbPtr, self.name, optsPtr, &error) else {
+                    throw extractMongoError(error: error)
+                }
+                mongoc_collection_destroy(collection)
             }
-            mongoc_collection_destroy(collection)
         }
 
         let collectionOptions = CollectionOptions(

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -43,9 +43,13 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
 
         var reply = Document()
         var error = bson_error_t()
-        let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            self.collection.withMongocCollection(from: connection) { collPtr in
-                mongoc_collection_write_command_with_opts(collPtr, command._bson, opts?._bson, replyPtr, &error)
+        let success = self.collection.withMongocCollection(from: connection) { collPtr in
+            withBSONPointer(to: command) { cmdPtr in
+                withOptionalBSONPointer(to: opts) { optsPtr in
+                    withMutableBSONPointer(to: &reply) { replyPtr in
+                        mongoc_collection_write_command_with_opts(collPtr, cmdPtr, optsPtr, replyPtr, &error)
+                    }
+                }
             }
         }
         guard success else {

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -44,9 +44,9 @@ internal struct CreateIndexesOperation<T: Codable>: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = self.collection.withMongocCollection(from: connection) { collPtr in
-            withBSONPointer(to: command) { cmdPtr in
+            command.withBSONPointer { cmdPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    withMutableBSONPointer(to: &reply) { replyPtr in
+                    reply.withMutableBSONPointer { replyPtr in
                         mongoc_collection_write_command_with_opts(collPtr, cmdPtr, optsPtr, replyPtr, &error)
                     }
                 }

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -60,9 +60,9 @@ internal struct DistinctOperation<T: Codable>: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = self.collection.withMongocCollection(from: connection) { collPtr in
-            withBSONPointer(to: command) { cmdPtr in
+            command.withBSONPointer { cmdPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    withMutableBSONPointer(to: &reply) { replyPtr in
+                    reply.withMutableBSONPointer { replyPtr in
                         mongoc_collection_read_command_with_opts(collPtr, cmdPtr, rp, optsPtr, replyPtr, &error)
                     }
                 }

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -59,9 +59,13 @@ internal struct DistinctOperation<T: Codable>: Operation {
         let rp = self.options?.readPreference?.pointer
         var reply = Document()
         var error = bson_error_t()
-        let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            self.collection.withMongocCollection(from: connection) { collPtr in
-                mongoc_collection_read_command_with_opts(collPtr, command._bson, rp, opts?._bson, replyPtr, &error)
+        let success = self.collection.withMongocCollection(from: connection) { collPtr in
+            withBSONPointer(to: command) { cmdPtr in
+                withOptionalBSONPointer(to: opts) { optsPtr in
+                    withMutableBSONPointer(to: &reply) { replyPtr in
+                        mongoc_collection_read_command_with_opts(collPtr, cmdPtr, rp, optsPtr, replyPtr, &error)
+                    }
+                }
             }
         }
         guard success else {

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -16,9 +16,13 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
 
         var reply = Document()
         var error = bson_error_t()
-        let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            self.collection.withMongocCollection(from: connection) { collPtr in
-                mongoc_collection_write_command_with_opts(collPtr, command._bson, opts?._bson, replyPtr, &error)
+        let success = self.collection.withMongocCollection(from: connection) { collPtr in
+            withBSONPointer(to: command) { cmdPtr in
+                withOptionalBSONPointer(to: opts) { optsPtr in
+                    withMutableBSONPointer(to: &reply) { replyPtr in
+                        mongoc_collection_write_command_with_opts(collPtr, cmdPtr, optsPtr, replyPtr, &error)
+                    }
+                }
             }
         }
         guard success else {

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -17,9 +17,9 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = self.collection.withMongocCollection(from: connection) { collPtr in
-            withBSONPointer(to: command) { cmdPtr in
+            command.withBSONPointer { cmdPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    withMutableBSONPointer(to: &reply) { replyPtr in
+                    reply.withMutableBSONPointer { replyPtr in
                         mongoc_collection_write_command_with_opts(collPtr, cmdPtr, optsPtr, replyPtr, &error)
                     }
                 }

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -17,9 +17,9 @@ internal struct DropDatabaseOperation: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = self.database.withMongocDatabase(from: connection) { dbPtr in
-            withBSONPointer(to: command) { cmdPtr in
+            command.withBSONPointer { cmdPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    withMutableBSONPointer(to: &reply) { replyPtr in
+                    reply.withMutableBSONPointer { replyPtr in
                         mongoc_database_write_command_with_opts(dbPtr, cmdPtr, optsPtr, replyPtr, &error)
                     }
                 }

--- a/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
+++ b/Sources/MongoSwift/Operations/DropDatabaseOperation.swift
@@ -16,9 +16,13 @@ internal struct DropDatabaseOperation: Operation {
 
         var reply = Document()
         var error = bson_error_t()
-        let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            self.database.withMongocDatabase(from: connection) { dbPtr in
-                mongoc_database_write_command_with_opts(dbPtr, command._bson, opts?._bson, replyPtr, &error)
+        let success = self.database.withMongocDatabase(from: connection) { dbPtr in
+            withBSONPointer(to: command) { cmdPtr in
+                withOptionalBSONPointer(to: opts) { optsPtr in
+                    withMutableBSONPointer(to: &reply) { replyPtr in
+                        mongoc_database_write_command_with_opts(dbPtr, cmdPtr, optsPtr, replyPtr, &error)
+                    }
+                }
             }
         }
         guard success else {

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -33,9 +33,9 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
         var reply = Document()
         var error = bson_error_t()
         let success = self.collection.withMongocCollection(from: connection) { collPtr in
-            withBSONPointer(to: command) { cmdPtr in
+            command.withBSONPointer { cmdPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    withMutableBSONPointer(to: &reply) { replyPtr in
+                    reply.withMutableBSONPointer { replyPtr in
                         mongoc_collection_write_command_with_opts(collPtr, cmdPtr, optsPtr, replyPtr, &error)
                     }
                 }

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -32,9 +32,13 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
         let opts = try encodeOptions(options: self.options, session: session)
         var reply = Document()
         var error = bson_error_t()
-        let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            self.collection.withMongocCollection(from: connection) { collPtr in
-                mongoc_collection_write_command_with_opts(collPtr, command._bson, opts?._bson, replyPtr, &error)
+        let success = self.collection.withMongocCollection(from: connection) { collPtr in
+            withBSONPointer(to: command) { cmdPtr in
+                withOptionalBSONPointer(to: opts) { optsPtr in
+                    withMutableBSONPointer(to: &reply) { replyPtr in
+                        mongoc_collection_write_command_with_opts(collPtr, cmdPtr, optsPtr, replyPtr, &error)
+                    }
+                }
             }
         }
         guard success else {

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -44,7 +44,9 @@ internal struct EstimatedDocumentCountOperation<T: Codable>: Operation {
         let rp = self.options?.readPreference?.pointer
         var error = bson_error_t()
         let count = self.collection.withMongocCollection(from: connection) { collPtr in
-            mongoc_collection_estimated_document_count(collPtr, opts?._bson, rp, nil, &error)
+            withOptionalBSONPointer(to: opts) { optsPtr in
+                mongoc_collection_estimated_document_count(collPtr, optsPtr, rp, nil, &error)
+            }
         }
 
         guard count != -1 else { throw extractMongoError(error: error) }

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -42,7 +42,7 @@ internal class FindAndModifyOptions {
         }
 
         if let fields = projection {
-            try withBSONPointer(to: fields) { fieldsPtr in
+            try fields.withBSONPointer { fieldsPtr in
                 guard mongoc_find_and_modify_opts_set_fields(self._options, fieldsPtr) else {
                     throw InvalidArgumentError(message: "Error setting fields to \(fields)")
                 }
@@ -68,7 +68,7 @@ internal class FindAndModifyOptions {
         }
 
         if let sort = sort {
-            try withBSONPointer(to: sort) { sortPtr in
+            try sort.withBSONPointer { sortPtr in
                 guard mongoc_find_and_modify_opts_set_sort(self._options, sortPtr) else {
                     throw InvalidArgumentError(message: "Error setting sort to \(sort)")
                 }
@@ -101,7 +101,7 @@ internal class FindAndModifyOptions {
         }
 
         if !extra.isEmpty {
-            try withBSONPointer(to: extra) { extraPtr in
+            try extra.withBSONPointer { extraPtr in
                 guard mongoc_find_and_modify_opts_append(self._options, extraPtr) else {
                     throw InvalidArgumentError(message: "Error appending extra fields \(extra)")
                 }
@@ -112,7 +112,7 @@ internal class FindAndModifyOptions {
     /// Sets the `update` value on a `mongoc_find_and_modify_opts_t`. We need to have this separate from the
     /// initializer because its value comes from the API methods rather than their options types.
     fileprivate func setUpdate(_ update: Document) throws {
-        try withBSONPointer(to: update) { updatePtr in
+        try update.withBSONPointer { updatePtr in
             guard mongoc_find_and_modify_opts_set_update(self._options, updatePtr) else {
                 throw InvalidArgumentError(message: "Error setting update to \(update)")
             }
@@ -126,7 +126,7 @@ internal class FindAndModifyOptions {
         var doc = Document()
         try session.append(to: &doc)
 
-        try withBSONPointer(to: doc) { docPtr in
+        try doc.withBSONPointer { docPtr in
             guard mongoc_find_and_modify_opts_append(self._options, docPtr) else {
                 throw InternalError(message: "Couldn't read session information")
             }
@@ -162,8 +162,8 @@ internal struct FindAndModifyOperation<T: Codable>: Operation {
 
         var reply = Document()
         var error = bson_error_t()
-        let success = withBSONPointer(to: filter) { filterPtr in
-            withMutableBSONPointer(to: &reply) { replyPtr in
+        let success = self.filter.withBSONPointer { filterPtr in
+            reply.withMutableBSONPointer { replyPtr in
                 self.collection.withMongocCollection(from: connection) { collPtr in
                     mongoc_collection_find_and_modify_with_opts(collPtr, filterPtr, opts._options, replyPtr, &error)
                 }

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -308,10 +308,14 @@ internal struct FindOperation<CollectionType: Codable>: Operation {
         let rp = self.options?.readPreference?.pointer
 
         let result: OpaquePointer = self.collection.withMongocCollection(from: connection) { collPtr in
-            guard let result = mongoc_collection_find_with_opts(collPtr, self.filter._bson, opts?._bson, rp) else {
-                fatalError(failedToRetrieveCursorMessage)
+            withBSONPointer(to: self.filter) { filterPtr in
+                withOptionalBSONPointer(to: opts) { optsPtr in
+                    guard let result = mongoc_collection_find_with_opts(collPtr, filterPtr, optsPtr, rp) else {
+                        fatalError(failedToRetrieveCursorMessage)
+                    }
+                    return result
+                }
             }
-            return result
         }
 
         // since mongoc_collection_find_with_opts doesn't do any I/O, use forceIO to ensure this operation fails if we

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -308,7 +308,7 @@ internal struct FindOperation<CollectionType: Codable>: Operation {
         let rp = self.options?.readPreference?.pointer
 
         let result: OpaquePointer = self.collection.withMongocCollection(from: connection) { collPtr in
-            withBSONPointer(to: self.filter) { filterPtr in
+            self.filter.withBSONPointer { filterPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
                     guard let result = mongoc_collection_find_with_opts(collPtr, filterPtr, optsPtr, rp) else {
                         fatalError(failedToRetrieveCursorMessage)

--- a/Sources/MongoSwift/Operations/ListCollectionsOperation.swift
+++ b/Sources/MongoSwift/Operations/ListCollectionsOperation.swift
@@ -118,10 +118,12 @@ internal struct ListCollectionsOperation: Operation {
         }
 
         let collections: OpaquePointer = self.database.withMongocDatabase(from: connection) { dbPtr in
-            guard let collections = mongoc_database_find_collections_with_opts(dbPtr, opts._bson) else {
-                fatalError(failedToRetrieveCursorMessage)
+            withBSONPointer(to: opts) { optsPtr in
+                guard let collections = mongoc_database_find_collections_with_opts(dbPtr, optsPtr) else {
+                    fatalError(failedToRetrieveCursorMessage)
+                }
+                return collections
             }
-            return collections
         }
 
         if self.nameOnly {

--- a/Sources/MongoSwift/Operations/ListCollectionsOperation.swift
+++ b/Sources/MongoSwift/Operations/ListCollectionsOperation.swift
@@ -118,7 +118,7 @@ internal struct ListCollectionsOperation: Operation {
         }
 
         let collections: OpaquePointer = self.database.withMongocDatabase(from: connection) { dbPtr in
-            withBSONPointer(to: opts) { optsPtr in
+            opts.withBSONPointer { optsPtr in
                 guard let collections = mongoc_database_find_collections_with_opts(dbPtr, optsPtr) else {
                     fatalError(failedToRetrieveCursorMessage)
                 }

--- a/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
@@ -56,9 +56,9 @@ internal struct ListDatabasesOperation: Operation {
         var reply = Document()
         var error = bson_error_t()
 
-        let success = withBSONPointer(to: cmd) { cmdPtr in
+        let success = cmd.withBSONPointer { cmdPtr in
             withOptionalBSONPointer(to: opts) { optsPtr in
-                withMutableBSONPointer(to: &reply) { replyPtr in
+                reply.withMutableBSONPointer { replyPtr in
                     mongoc_client_read_command_with_opts(
                         connection.clientHandle,
                         "admin",

--- a/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
@@ -56,16 +56,20 @@ internal struct ListDatabasesOperation: Operation {
         var reply = Document()
         var error = bson_error_t()
 
-        let success = withMutableBSONPointer(to: &reply) { replyPtr in
-            mongoc_client_read_command_with_opts(
-                connection.clientHandle,
-                "admin",
-                cmd._bson,
-                readPref.pointer,
-                opts?._bson,
-                replyPtr,
-                &error
-            )
+        let success = withBSONPointer(to: cmd) { cmdPtr in
+            withOptionalBSONPointer(to: opts) { optsPtr in
+                withMutableBSONPointer(to: &reply) { replyPtr in
+                    mongoc_client_read_command_with_opts(
+                        connection.clientHandle,
+                        "admin",
+                        cmdPtr,
+                        readPref.pointer,
+                        optsPtr,
+                        replyPtr,
+                        &error
+                    )
+                }
+            }
         }
 
         guard success else {

--- a/Sources/MongoSwift/Operations/ListIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListIndexesOperation.swift
@@ -26,10 +26,12 @@ internal struct ListIndexesOperation<T: Codable>: Operation {
         let opts = try encodeOptions(options: nil as Document?, session: session)
 
         let indexes: OpaquePointer = self.collection.withMongocCollection(from: connection) { collPtr in
-            guard let indexes = mongoc_collection_find_indexes_with_opts(collPtr, opts?._bson) else {
-                fatalError(failedToRetrieveCursorMessage)
+            withOptionalBSONPointer(to: opts) { optsPtr in
+                guard let indexes = mongoc_collection_find_indexes_with_opts(collPtr, optsPtr) else {
+                    fatalError(failedToRetrieveCursorMessage)
+                }
+                return indexes
             }
-            return indexes
         }
 
         if self.nameOnly {

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -47,9 +47,9 @@ internal struct RunCommandOperation: Operation {
         let opts = try encodeOptions(options: self.options, session: session)
         var reply = Document()
         var error = bson_error_t()
-        let success = withBSONPointer(to: self.command) { cmdPtr in
+        let success = self.command.withBSONPointer { cmdPtr in
             withOptionalBSONPointer(to: opts) { optsPtr in
-                withMutableBSONPointer(to: &reply) { replyPtr in
+                reply.withMutableBSONPointer { replyPtr in
                     self.database.withMongocDatabase(from: connection) { dbPtr in
                         mongoc_database_command_with_opts(dbPtr, cmdPtr, rp, optsPtr, replyPtr, &error)
                     }

--- a/Sources/MongoSwift/Operations/WatchOperation.swift
+++ b/Sources/MongoSwift/Operations/WatchOperation.swift
@@ -35,7 +35,7 @@ internal struct WatchOperation<CollectionType: Codable, ChangeStreamType: Codabl
         let pipeline: Document = ["pipeline": self.pipeline]
         let opts = try encodeOptions(options: self.options, session: session)
 
-        return try withBSONPointer(to: pipeline) { pipelinePtr in
+        return try pipeline.withBSONPointer { pipelinePtr in
             try withOptionalBSONPointer(to: opts) { optsPtr in
                 let changeStreamPtr: OpaquePointer
                 let client: MongoClient

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -250,7 +250,7 @@ private class MongocReadPreference {
 
         if let tagSets = tagSets, !tagSets.isEmpty {
             let tags = Document(tagSets.map { .document($0) })
-            withBSONPointer(to: tags) { tagsPtr in
+            tags.withBSONPointer { tagsPtr in
                 mongoc_read_prefs_set_tags(self.readPref, tagsPtr)
             }
         }

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -250,7 +250,9 @@ private class MongocReadPreference {
 
         if let tagSets = tagSets, !tagSets.isEmpty {
             let tags = Document(tagSets.map { .document($0) })
-            mongoc_read_prefs_set_tags(self.readPref, tags._bson)
+            withBSONPointer(to: tags) { tagsPtr in
+                mongoc_read_prefs_set_tags(self.readPref, tagsPtr)
+            }
         }
 
         if let maxStalenessSeconds = maxStalenessSeconds {

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -55,7 +55,6 @@
 @_exported import struct MongoSwift.DistinctOptions
 @_exported import struct MongoSwift.Document
 @_exported import class MongoSwift.DocumentIterator
-@_exported import class MongoSwift.DocumentStorage
 @_exported import struct MongoSwift.DropCollectionOptions
 @_exported import struct MongoSwift.DropDatabaseOptions
 @_exported import struct MongoSwift.DropIndexOptions

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -107,7 +107,7 @@ extension DocumentTests {
         ("testDocumentDynamicMemberLookup", testDocumentDynamicMemberLookup),
         ("testEquatable", testEquatable),
         ("testRawBSON", testRawBSON),
-        ("testValueBehavior", testValueBehavior),
+        ("testCopyOnWriteBehavior", testCopyOnWriteBehavior),
         ("testIntEncodesAsInt32OrInt64", testIntEncodesAsInt32OrInt64),
         ("testMerge", testMerge),
         ("testNilInNestedArray", testNilInNestedArray),


### PR DESCRIPTION
Putting this up as a draft as we should probably talk through the approach more but I figured I'd let you all talk a look.
This seems like a mostly reasonable approach to me aside from the fact that we really end up in nested closure hell in places where a libmongoc method takes in 3+ arguments.

I think there is more work to do to ensure these problems don't plague any other types. for example I think we might be vulnerable to similar issues with `ReadPreference` as it follows the same "struct backed by a private class wrapping a C type" pattern.

To summarize main changes here:
- `BSONValue` protocol's `encode` method now takes in an `inout Document` rather than a `DocumentStorage`
- `DocumentStorage` is a `private` type, and its property `_bson` is now `fileprivate`. this means both are only accessible within `Document.swift`.
- the only way to access a `Document`'s underlying `bson_t` is via helpers, all of which use `withExtendedLifetime` to guarantee the `Document` stays valid for the duration of the provided closure. These are:
    - the existing `withMutableBSONPointer`
    - a new `withBSONPointer`, same as the previous but the pointer is immutable
    - a new `withOptionalBSONPointer`, which is to simplify usage in places where we have an optional document we may need to pass to a libmongoc API (basically this is just used for options documents)
- `DocumentIterator` previously stored a reference to the `DocumentStorage` it came from. however I don't think this is really different than it just storing a copy of the `Document` it's iterating over -- in both cases we should get CoW behavior if someone tries to modify a copy of that document which is backed by the same storage. changing this this enabled me to make the change in the previous bullet point. 