### PR TITLE
updates Package.swift for Vapor 4

### DIFF
--- a/Examples/VaporExample/Package.swift
+++ b/Examples/VaporExample/Package.swift
@@ -1,17 +1,20 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
     name: "VaporExample",
     platforms: [
-        .macOS(.v10_14)
+        .macOS(.v10_15)
     ],
     dependencies: [
         // The driver depends on SwiftNIO 2 and therefore is only compatible with Vapor 4.
-        .package(url: "https://github.com/vapor/vapor", .exact("4.0.0-beta.3.24")),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.2.1"),
         .package(url: "https://github.com/mongodb/mongo-swift-driver", .upToNextMajor(from: "1.0.0-rc0"))
     ],
     targets: [
-        .target(name: "VaporExample", dependencies: ["Vapor", "MongoSwift"])
+        .target(name: "VaporExample", dependencies: [
+            .product(name: "MongoSwift", package: "mongo-swift-driver"),
+            .product(name: "Vapor", package: "vapor"),
+        ])
     ]
 )


### PR DESCRIPTION
Updates the `Package.swift` file for Vapor 4 release, which now requires `10_15` platform specification and Swift version 5.2

This built fine once the xcode project was generated.