### PR TITLE
SWIFT-754: Use Int in public API as much as possible

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
           "branch": null,
-          "revision": "a27a07719ca785bcaca019a5b9fe1814b981b4a2",
-          "version": "2.15.0"
+          "revision": "e876fb37410e0036b98b5361bb18e6854739572b",
+          "version": "2.16.0"
         }
       }
     ]

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -167,7 +167,7 @@ public struct CommandSucceededEvent: MongoSwiftEvent, CommandEventProtocol {
     }
 
     /// The execution time of the event, in microseconds.
-    public let duration: Int64
+    public let duration: Int
 
     /// The command reply.
     public let reply: Document
@@ -186,7 +186,7 @@ public struct CommandSucceededEvent: MongoSwiftEvent, CommandEventProtocol {
     public let serverAddress: Address
 
     fileprivate init(mongocEvent: MongocCommandSucceededEvent) {
-        self.duration = mongoc_apm_command_succeeded_get_duration(mongocEvent.ptr)
+        self.duration = Int(mongoc_apm_command_succeeded_get_duration(mongocEvent.ptr))
         // we have to copy because libmongoc owns the pointer.
         self.reply = Document(copying: mongoc_apm_command_succeeded_get_reply(mongocEvent.ptr))
         self.commandName = String(cString: mongoc_apm_command_succeeded_get_command_name(mongocEvent.ptr))
@@ -216,7 +216,7 @@ public struct CommandFailedEvent: MongoSwiftEvent, CommandEventProtocol {
     }
 
     /// The execution time of the event, in microseconds.
-    public let duration: Int64
+    public let duration: Int
 
     /// The command name.
     public let commandName: String
@@ -235,7 +235,7 @@ public struct CommandFailedEvent: MongoSwiftEvent, CommandEventProtocol {
     public let serverAddress: Address
 
     fileprivate init(mongocEvent: MongocCommandFailedEvent) {
-        self.duration = mongoc_apm_command_failed_get_duration(mongocEvent.ptr)
+        self.duration = Int(mongoc_apm_command_failed_get_duration(mongocEvent.ptr))
         self.commandName = String(cString: mongoc_apm_command_failed_get_command_name(mongocEvent.ptr))
         var error = bson_error_t()
         mongoc_apm_command_failed_get_error(mongocEvent.ptr, &error)
@@ -548,7 +548,7 @@ public struct ServerHeartbeatSucceededEvent: MongoSwiftEvent {
     }
 
     /// The execution time of the event, in microseconds.
-    public let duration: Int64
+    public let duration: Int
 
     /// The command reply.
     public let reply: Document
@@ -557,7 +557,7 @@ public struct ServerHeartbeatSucceededEvent: MongoSwiftEvent {
     public let serverAddress: Address
 
     fileprivate init(mongocEvent: MongocServerHeartbeatSucceededEvent) {
-        self.duration = mongoc_apm_server_heartbeat_succeeded_get_duration(mongocEvent.ptr)
+        self.duration = Int(mongoc_apm_server_heartbeat_succeeded_get_duration(mongocEvent.ptr))
         // we have to copy because libmongoc owns the pointer.
         self.reply = Document(copying: mongoc_apm_server_heartbeat_succeeded_get_reply(mongocEvent.ptr))
         self.serverAddress = Address(mongoc_apm_server_heartbeat_succeeded_get_host(mongocEvent.ptr))
@@ -584,7 +584,7 @@ public struct ServerHeartbeatFailedEvent: MongoSwiftEvent {
     }
 
     /// The execution time of the event, in microseconds.
-    public let duration: Int64
+    public let duration: Int
 
     /// The failure.
     public let failure: MongoError
@@ -593,7 +593,7 @@ public struct ServerHeartbeatFailedEvent: MongoSwiftEvent {
     public let serverAddress: Address
 
     fileprivate init(mongocEvent: MongocServerHeartbeatFailedEvent) {
-        self.duration = mongoc_apm_server_heartbeat_failed_get_duration(mongocEvent.ptr)
+        self.duration = Int(mongoc_apm_server_heartbeat_failed_get_duration(mongocEvent.ptr))
         var error = bson_error_t()
         mongoc_apm_server_heartbeat_failed_get_error(mongocEvent.ptr, &error)
         self.failure = extractMongoError(error: error)

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -186,6 +186,7 @@ public struct CommandSucceededEvent: MongoSwiftEvent, CommandEventProtocol {
     public let serverAddress: Address
 
     fileprivate init(mongocEvent: MongocCommandSucceededEvent) {
+        // TODO: SWIFT-349 add logging to check and warn of unlikely int size issues
         self.duration = Int(mongoc_apm_command_succeeded_get_duration(mongocEvent.ptr))
         // we have to copy because libmongoc owns the pointer.
         self.reply = Document(copying: mongoc_apm_command_succeeded_get_reply(mongocEvent.ptr))

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -30,7 +30,7 @@ public enum FullDocument: RawRepresentable, Codable {
 public struct ChangeStreamOptions: Codable {
     /// The number of documents to return per batch. If omitted, the server will use its default batch size.
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
-    public var batchSize: Int32?
+    public var batchSize: Int?
 
     /// Specifies a collation.
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/command/aggregate
@@ -46,7 +46,7 @@ public struct ChangeStreamOptions: Codable {
 
     /// The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a
     /// change stream query. If omitted, the server will use its default timeout.
-    public var maxAwaitTimeMS: Int64?
+    public var maxAwaitTimeMS: Int?
 
     /**
      * A `ResumeToken` that manually specifies the logical starting point for the new change stream.
@@ -75,10 +75,10 @@ public struct ChangeStreamOptions: Codable {
 
     /// Initializes a `ChangeStreamOptions`.
     public init(
-        batchSize: Int32? = nil,
+        batchSize: Int? = nil,
         collation: Document? = nil,
         fullDocument: FullDocument? = nil,
-        maxAwaitTimeMS: Int64? = nil,
+        maxAwaitTimeMS: Int? = nil,
         resumeAfter: ResumeToken? = nil,
         startAtOperationTime: Timestamp? = nil
     ) {

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -147,7 +147,7 @@ public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible, Decodabl
     public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// Limits the fields to return for the matching document.
     public var projection: Document?
@@ -172,7 +172,7 @@ public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible, Decodabl
     /// Convenience initializer allowing any/all parameters to be omitted/optional
     public init(
         collation: Document? = nil,
-        maxTimeMS: Int64? = nil,
+        maxTimeMS: Int? = nil,
         projection: Document? = nil,
         sort: Document? = nil,
         writeConcern: WriteConcern? = nil
@@ -194,7 +194,7 @@ public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible, Decodab
     public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// Limits the fields to return for the matching document.
     public var projection: Document?
@@ -228,7 +228,7 @@ public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible, Decodab
     public init(
         bypassDocumentValidation: Bool? = nil,
         collation: Document? = nil,
-        maxTimeMS: Int64? = nil,
+        maxTimeMS: Int? = nil,
         projection: Document? = nil,
         returnDocument: ReturnDocument? = nil,
         sort: Document? = nil,
@@ -258,7 +258,7 @@ public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible, Decodabl
     public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// Limits the fields to return for the matching document.
     public var projection: Document?
@@ -294,7 +294,7 @@ public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible, Decodabl
         arrayFilters: [Document]? = nil,
         bypassDocumentValidation: Bool? = nil,
         collation: Document? = nil,
-        maxTimeMS: Int64? = nil,
+        maxTimeMS: Int? = nil,
         projection: Document? = nil,
         returnDocument: ReturnDocument? = nil,
         sort: Document? = nil,

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -44,10 +44,10 @@ public struct IndexOptions: Codable {
     public var background: Bool?
 
     /// Optionally specifies the precision of the stored geo hash in the 2d index, from 1 to 32.
-    public var bits: Int32?
+    public var bits: Int?
 
     /// Optionally specifies the number of units within which to group the location values in a geo haystack index.
-    public var bucketSize: Int32?
+    public var bucketSize: Int?
 
     /// Optionally specifies a collation to use for the index in MongoDB 3.4 and higher. If not specified, no collation
     /// is sent and the default collation of the collection server-side is used.
@@ -57,7 +57,7 @@ public struct IndexOptions: Codable {
     public var defaultLanguage: String?
 
     /// Optionally specifies the length in time, in seconds, for documents to remain in a collection.
-    public var expireAfterSeconds: Int32?
+    public var expireAfterSeconds: Int?
 
     /// Optionally specifies the field in the document to override the language.
     public var languageOverride: String?
@@ -88,7 +88,7 @@ public struct IndexOptions: Codable {
 
     /// Optionally specifies the 2dsphere index version number. MongoDB 2.4 can only support version 1. MongoDB 2.6 and
     /// higher may support version 1 or 2.
-    public var sphereIndexVersion: Int32?
+    public var sphereIndexVersion: Int?
 
     /// Optionally used only in MongoDB 3.0.0 and higher. Allows users to configure the storage engine on a per-index
     /// basis when creating an index.
@@ -96,13 +96,13 @@ public struct IndexOptions: Codable {
 
     /// Optionally provides the text index version number. MongoDB 2.4 can only support version 1. MongoDB 2.6 and
     /// higher may support version 1 or 2.
-    public var textIndexVersion: Int32?
+    public var textIndexVersion: Int?
 
     /// Optionally forces the index to be unique.
     public var unique: Bool?
 
     /// Optionally specifies the index version number, either 0 or 1.
-    public var version: Int32?
+    public var version: Int?
 
     /// Optionally specifies fields in the index and their corresponding weight values.
     public var weights: Document?
@@ -110,22 +110,22 @@ public struct IndexOptions: Codable {
     /// Convenience initializer allowing any/all parameters to be omitted.
     public init(
         background: Bool? = nil,
-        bits: Int32? = nil,
-        bucketSize: Int32? = nil,
+        bits: Int? = nil,
+        bucketSize: Int? = nil,
         collation: Document? = nil,
         defaultLanguage: String? = nil,
-        expireAfterSeconds: Int32? = nil,
+        expireAfterSeconds: Int? = nil,
         languageOverride: String? = nil,
         max: Double? = nil,
         min: Double? = nil,
         name: String? = nil,
         partialFilterExpression: Document? = nil,
         sparse: Bool? = nil,
-        sphereIndexVersion: Int32? = nil,
+        sphereIndexVersion: Int? = nil,
         storageEngine: Document? = nil,
-        textIndexVersion: Int32? = nil,
+        textIndexVersion: Int? = nil,
         unique: Bool? = nil,
-        version: Int32? = nil,
+        version: Int? = nil,
         weights: Document? = nil
     ) {
         self.background = background

--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -8,7 +8,7 @@ public struct AggregateOptions: Codable {
     public var allowDiskUse: Bool?
 
     /// The number of `Document`s to return per batch.
-    public var batchSize: Int32?
+    public var batchSize: Int?
 
     /// If true, allows the write to opt-out of document level validation. This only applies
     /// when the $out stage is specified.
@@ -25,7 +25,7 @@ public struct AggregateOptions: Codable {
     public var hint: Hint?
 
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// A `ReadConcern` to use in read stages of this operation.
     public var readConcern: ReadConcern?
@@ -41,12 +41,12 @@ public struct AggregateOptions: Codable {
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(
         allowDiskUse: Bool? = nil,
-        batchSize: Int32? = nil,
+        batchSize: Int? = nil,
         bypassDocumentValidation: Bool? = nil,
         collation: Document? = nil,
         comment: String? = nil,
         hint: Hint? = nil,
-        maxTimeMS: Int64? = nil,
+        maxTimeMS: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil,
         writeConcern: WriteConcern? = nil

--- a/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
+++ b/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
@@ -9,10 +9,10 @@ public struct CountDocumentsOptions: Codable {
     public var hint: Hint?
 
     /// The maximum number of documents to count.
-    public var limit: Int64?
+    public var limit: Int?
 
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// A ReadConcern to use for this operation.
     public var readConcern: ReadConcern?
@@ -23,17 +23,17 @@ public struct CountDocumentsOptions: Codable {
     // swiftlint:enable redundant_optional_initialization
 
     /// The number of documents to skip before counting.
-    public var skip: Int64?
+    public var skip: Int?
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(
         collation: Document? = nil,
         hint: Hint? = nil,
-        limit: Int64? = nil,
-        maxTimeMS: Int64? = nil,
+        limit: Int? = nil,
+        maxTimeMS: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil,
-        skip: Int64? = nil
+        skip: Int? = nil
     ) {
         self.collation = collation
         self.hint = hint

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -25,14 +25,14 @@ public struct CreateCollectionOptions: Codable, CodingStrategyProvider {
     public var indexOptionDefaults: Document?
 
     /// Maximum number of documents allowed in the collection (if capped).
-    public var max: Int64?
+    public var max: Int?
 
     /// An array consisting of aggregation pipeline stages. When used with `viewOn`, will create the view by applying
     /// this pipeline to the source collection or view.
     public var pipeline: [Document]?
 
     /// Maximum size, in bytes, of this collection (if capped).
-    public var size: Int64?
+    public var size: Int?
 
     /// Specifies storage engine configuration for this collection.
     public var storageEngine: Document?
@@ -73,9 +73,9 @@ public struct CreateCollectionOptions: Codable, CodingStrategyProvider {
         dataCodingStrategy: DataCodingStrategy? = nil,
         dateCodingStrategy: DateCodingStrategy? = nil,
         indexOptionDefaults: Document? = nil,
-        max: Int64? = nil,
+        max: Int? = nil,
         pipeline: [Document]? = nil,
-        size: Int64? = nil,
+        size: Int? = nil,
         storageEngine: Document? = nil,
         uuidCodingStrategy: UUIDCodingStrategy? = nil,
         validationAction: String? = nil,

--- a/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateIndexesOperation.swift
@@ -3,13 +3,13 @@ import CLibMongoC
 /// Options to use when creating a new index on a `MongoCollection`.
 public struct CreateIndexOptions: Encodable {
     /// The maximum amount of time to allow the query to run - enforced server-side.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// An optional `WriteConcern` to use for the command.
     public var writeConcern: WriteConcern?
 
     /// Initializer allowing any/all parameters to be omitted.
-    public init(maxTimeMS: Int64? = nil, writeConcern: WriteConcern? = nil) {
+    public init(maxTimeMS: Int? = nil, writeConcern: WriteConcern? = nil) {
         self.maxTimeMS = maxTimeMS
         self.writeConcern = writeConcern
     }

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -6,7 +6,7 @@ public struct DistinctOptions: Codable {
     public var collation: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// A ReadConcern to use for this operation.
     public var readConcern: ReadConcern?
@@ -19,7 +19,7 @@ public struct DistinctOptions: Codable {
     /// Convenience initializer allowing any/all parameters to be optional
     public init(
         collation: Document? = nil,
-        maxTimeMS: Int64? = nil,
+        maxTimeMS: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil
     ) {

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -3,13 +3,13 @@ import CLibMongoC
 /// Options to use when dropping an index from a `MongoCollection`.
 public struct DropIndexOptions: Encodable {
     /// The maximum amount of time to allow the query to run - enforced server-side.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// An optional `WriteConcern` to use for the command.
     public var writeConcern: WriteConcern?
 
     /// Initializer allowing any/all parameters to be omitted.
-    public init(maxTimeMS: Int64? = nil, writeConcern: WriteConcern? = nil) {
+    public init(maxTimeMS: Int? = nil, writeConcern: WriteConcern? = nil) {
         self.maxTimeMS = maxTimeMS
         self.writeConcern = writeConcern
     }

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -3,7 +3,7 @@ import CLibMongoC
 /// Options to use when executing an `estimatedDocumentCount` command on a `MongoCollection`.
 public struct EstimatedDocumentCountOptions: Codable {
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// A ReadConcern to use for this operation.
     public var readConcern: ReadConcern?
@@ -15,7 +15,7 @@ public struct EstimatedDocumentCountOptions: Codable {
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(
-        maxTimeMS: Int64? = nil,
+        maxTimeMS: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil
     ) {

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -26,7 +26,7 @@ internal class FindAndModifyOptions {
         arrayFilters: [Document]? = nil,
         bypassDocumentValidation: Bool? = nil,
         collation: Document?,
-        maxTimeMS: Int64?,
+        maxTimeMS: Int?,
         projection: Document?,
         remove: Bool? = nil,
         returnDocument: ReturnDocument? = nil,
@@ -85,7 +85,7 @@ internal class FindAndModifyOptions {
             guard maxTime > 0 else {
                 throw InvalidArgumentError(message: "maxTimeMS must be positive, but got value \(maxTime)")
             }
-            try extra.setValue(for: "maxTimeMS", to: .int64(maxTime))
+            try extra.setValue(for: "maxTimeMS", to: .int64(Int64(maxTime)))
         }
 
         if let wc = writeConcern {

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -89,8 +89,8 @@ public struct FindOptions: Codable {
     /// The exclusive upper bound for a specific index.
     public var max: Document?
 
-    /// The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor
-    /// query. This only applies when used with `CursorType.tailableAwait`. Otherwise, this option is ignored.
+    /// The maximum amount of time, in milliseconds, for the server to wait on new documents to satisfy a tailable
+    /// cursor query. This only applies when used with `CursorType.tailableAwait`. Otherwise, this option is ignored.
     public var maxAwaitTimeMS: Int?
 
     /// The maximum amount of time to allow the query to run.

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -43,7 +43,7 @@ public struct FindOptions: Codable {
     private var awaitData: Bool?
 
     /// The number of documents to return per batch.
-    public var batchSize: Int32?
+    public var batchSize: Int?
 
     /// Specifies a collation.
     public var collation: Document?
@@ -84,17 +84,17 @@ public struct FindOptions: Codable {
     public var hint: Hint?
 
     /// The maximum number of documents to return.
-    public var limit: Int64?
+    public var limit: Int?
 
     /// The exclusive upper bound for a specific index.
     public var max: Document?
 
     /// The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor
     /// query. This only applies when used with `CursorType.tailableAwait`. Otherwise, this option is ignored.
-    public var maxAwaitTimeMS: Int64?
+    public var maxAwaitTimeMS: Int?
 
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// The inclusive lower bound for a specific index.
     public var min: Document?
@@ -122,7 +122,7 @@ public struct FindOptions: Codable {
     public var showRecordId: Bool?
 
     /// The number of documents to skip before returning.
-    public var skip: Int64?
+    public var skip: Int?
 
     /// The order in which to return matching documents.
     public var sort: Document?
@@ -136,15 +136,15 @@ public struct FindOptions: Codable {
     public init(
         allowDiskUse: Bool? = nil,
         allowPartialResults: Bool? = nil,
-        batchSize: Int32? = nil,
+        batchSize: Int? = nil,
         collation: Document? = nil,
         comment: String? = nil,
         cursorType: CursorType? = nil,
         hint: Hint? = nil,
-        limit: Int64? = nil,
+        limit: Int? = nil,
         max: Document? = nil,
-        maxAwaitTimeMS: Int64? = nil,
-        maxTimeMS: Int64? = nil,
+        maxAwaitTimeMS: Int? = nil,
+        maxTimeMS: Int? = nil,
         min: Document? = nil,
         noCursorTimeout: Bool? = nil,
         projection: Document? = nil,
@@ -152,7 +152,7 @@ public struct FindOptions: Codable {
         readPreference: ReadPreference? = nil,
         returnKey: Bool? = nil,
         showRecordId: Bool? = nil,
-        skip: Int64? = nil,
+        skip: Int? = nil,
         sort: Document? = nil
     ) {
         self.allowDiskUse = allowDiskUse
@@ -221,7 +221,7 @@ public struct FindOneOptions: Codable {
     public var max: Document?
 
     /// The maximum amount of time to allow the query to run.
-    public var maxTimeMS: Int64?
+    public var maxTimeMS: Int?
 
     /// The inclusive lower bound for a specific index.
     public var min: Document?
@@ -243,7 +243,7 @@ public struct FindOneOptions: Codable {
     public var showRecordId: Bool?
 
     /// The number of documents to skip before returning.
-    public var skip: Int64?
+    public var skip: Int?
 
     /// The order in which to return matching documents.
     public var sort: Document?
@@ -255,14 +255,14 @@ public struct FindOneOptions: Codable {
         comment: String? = nil,
         hint: Hint? = nil,
         max: Document? = nil,
-        maxTimeMS: Int64? = nil,
+        maxTimeMS: Int? = nil,
         min: Document? = nil,
         projection: Document? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil,
         returnKey: Bool? = nil,
         showRecordId: Bool? = nil,
-        skip: Int64? = nil,
+        skip: Int? = nil,
         sort: Document? = nil
     ) {
         self.allowPartialResults = allowPartialResults

--- a/Sources/MongoSwift/Operations/StartTransactionOperation.swift
+++ b/Sources/MongoSwift/Operations/StartTransactionOperation.swift
@@ -3,7 +3,7 @@ import CLibMongoC
 /// Options to use when starting a transaction.
 public struct TransactionOptions {
     /// The maximum amount of time to allow a single `commitTransaction` command to run.
-    public var maxCommitTimeMS: Int64?
+    public var maxCommitTimeMS: Int?
 
     /// The `ReadConcern` to use for this transaction.
     public var readConcern: ReadConcern?
@@ -16,7 +16,7 @@ public struct TransactionOptions {
 
     /// Convenience initializer allowing any/all parameters to be omitted.
     public init(
-        maxCommitTimeMS: Int64? = nil,
+        maxCommitTimeMS: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil,
         writeConcern: WriteConcern? = nil
@@ -54,7 +54,7 @@ internal func withMongocTransactionOpts<T>(
     }
 
     if let maxCommitTimeMS = options?.maxCommitTimeMS {
-        mongoc_transaction_opts_set_max_commit_time_ms(optionsPtr, maxCommitTimeMS)
+        mongoc_transaction_opts_set_max_commit_time_ms(optionsPtr, Int64(maxCommitTimeMS))
     }
 
     return try body(optionsPtr)

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -88,7 +88,7 @@ public struct ServerDescription {
     public let address: Address
 
     /// The duration in milliseconds of the server's last ismaster call.
-    public let roundTripTime: Int64?
+    public let roundTripTime: Int?
 
     /// The date of the most recent write operation seen by this server.
     public var lastWriteDate: Date?
@@ -140,7 +140,7 @@ public struct ServerDescription {
     /// mongoc_server_description_t.
     internal init(_ description: OpaquePointer) {
         self.address = Address(mongoc_server_description_host(description))
-        self.roundTripTime = mongoc_server_description_round_trip_time(description)
+        self.roundTripTime = Int(mongoc_server_description_round_trip_time(description))
         self.lastUpdateTime = Date(msSinceEpoch: mongoc_server_description_last_update_time(description))
         self.type = ServerType(rawValue: String(cString: mongoc_server_description_type(description))) ?? .unknown
 

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -26,7 +26,14 @@ public struct WriteConcern: Codable {
             var container = encoder.singleValueContainer()
             switch self {
             case let .number(wNumber):
-                try container.encode(Int32(wNumber))
+                if let wNumber = Int32(exactly: wNumber) {
+                    // Int size check is required by libmongoc
+                    try container.encode(wNumber)
+                } else {
+                    throw InvalidArgumentError(
+                        message: "Invalid WriteConcern.w \(wNumber): must be between \(Int32.min) and \(Int32.max)"
+                    )
+                }
             case let .tag(wTag):
                 try container.encode(wTag)
             case .majority:

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -31,7 +31,7 @@ public struct WriteConcern: Codable {
                     try container.encode(wNumber)
                 } else {
                     throw InvalidArgumentError(
-                        message: "Invalid WriteConcern.w \(wNumber): must be between \(Int32.min) and \(Int32.max)"
+                        message: "Invalid WriteConcern.w \(wNumber): must be between 0 and \(Int32.max)"
                     )
                 }
             case let .tag(wTag):

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -6,7 +6,7 @@ public struct WriteConcern: Codable {
     /// An option to request acknowledgement that the write operation has propagated to specified mongod instances.
     public enum W: Codable, Equatable {
         /// Specifies the number of nodes that should acknowledge the write. MUST be greater than or equal to 0.
-        case number(Int32)
+        case number(Int)
         /// Indicates a tag for nodes that should acknowledge the write.
         case tag(String)
         /// Specifies that a majority of nodes should acknowledge the write.
@@ -17,7 +17,7 @@ public struct WriteConcern: Codable {
             if let string = try? container.decode(String.self) {
                 self = string == "majority" ? .majority : .tag(string)
             } else {
-                let wNumber = try container.decode(Int32.self)
+                let wNumber = try container.decode(Int.self)
                 self = .number(wNumber)
             }
         }
@@ -26,7 +26,7 @@ public struct WriteConcern: Codable {
             var container = encoder.singleValueContainer()
             switch self {
             case let .number(wNumber):
-                try container.encode(wNumber)
+                try container.encode(Int32(wNumber))
             case let .tag(wTag):
                 try container.encode(wTag)
             case .majority:
@@ -43,7 +43,7 @@ public struct WriteConcern: Codable {
 
     /// If the write concern is not satisfied within this timeout (in milliseconds),
     /// the operation will return an error. The value MUST be greater than or equal to 0.
-    public let wtimeoutMS: Int64?
+    public let wtimeoutMS: Int?
 
     /// Indicates whether this is an acknowledged write concern.
     public var isAcknowledged: Bool {
@@ -78,7 +78,7 @@ public struct WriteConcern: Codable {
     /// Initializes a new `WriteConcern`.
     /// - Throws:
     ///   - `InvalidArgumentError` if the options form an invalid combination.
-    public init(journal: Bool? = nil, w: W? = nil, wtimeoutMS: Int64? = nil) throws {
+    public init(journal: Bool? = nil, w: W? = nil, wtimeoutMS: Int? = nil) throws {
         self.journal = journal
 
         if let wtimeoutMS = wtimeoutMS {
@@ -128,10 +128,10 @@ public struct WriteConcern: Codable {
                 self.w = nil
             }
         default:
-            self.w = .number(number)
+            self.w = .number(Int(number))
         }
 
-        let wtimeout = mongoc_write_concern_get_wtimeout_int64(writeConcern)
+        let wtimeout = Int(mongoc_write_concern_get_wtimeout_int64(writeConcern))
         if wtimeout != 0 {
             self.wtimeoutMS = wtimeout
         } else {
@@ -156,7 +156,7 @@ public struct WriteConcern: Codable {
         if let w = self.w {
             switch w {
             case let .number(wNumber):
-                mongoc_write_concern_set_w(writeConcern, wNumber)
+                mongoc_write_concern_set_w(writeConcern, Int32(wNumber))
             case let .tag(wTag):
                 mongoc_write_concern_set_wtag(writeConcern, wTag)
             case .majority:
@@ -164,7 +164,7 @@ public struct WriteConcern: Codable {
             }
         }
         if let wtimeoutMS = self.wtimeoutMS {
-            mongoc_write_concern_set_wtimeout_int64(writeConcern, wtimeoutMS)
+            mongoc_write_concern_set_wtimeout_int64(writeConcern, Int64(wtimeoutMS))
         }
         return try body(writeConcern)
     }

--- a/Tests/MongoSwiftSyncTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftSyncTests/CommandMonitoringTests.swift
@@ -134,17 +134,17 @@ private struct CMTest: Decodable {
                 hint = .indexSpec(hintDoc)
             }
             let options = FindOptions(
-                batchSize: self.op.args["batchSize"]?.asInt32(),
+                batchSize: self.op.args["batchSize"]?.asInt(),
                 comment: modifiers?["$comment"]?.stringValue,
                 hint: hint,
-                limit: self.op.args["limit"]?.asInt64(),
+                limit: self.op.args["limit"]?.asInt(),
                 max: modifiers?["$max"]?.documentValue,
-                maxTimeMS: modifiers?["$maxTimeMS"]?.asInt64(),
+                maxTimeMS: modifiers?["$maxTimeMS"]?.asInt(),
                 min: modifiers?["$min"]?.documentValue,
                 readPreference: self.op.readPreference,
                 returnKey: modifiers?["$returnKey"]?.boolValue,
                 showRecordId: modifiers?["$showDiskLoc"]?.boolValue,
-                skip: self.op.args["skip"]?.asInt64(),
+                skip: self.op.args["skip"]?.asInt(),
                 sort: self.op.args["sort"]?.documentValue
             )
 
@@ -260,12 +260,6 @@ private func normalizeCommand(_ input: Document) -> Document {
             // the server in our actual commands.
         } else if k == "maxTimeMS", let iV = v.asInt64() {
             output[k] = .int64(iV)
-
-            // The expected batch sizes are always Int64s, however, find command
-            // events actually have Int32 batch sizes... (as the spec says...)
-            // but getMores have Int64s. so only convert if it's a find command...
-        } else if k == "batchSize" && input["find"] != nil {
-            output[k] = .int32(v.asInt32()!)
 
             // recursively normalize if it's a document
         } else if let docVal = v.documentValue {

--- a/Tests/MongoSwiftSyncTests/CrudTests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudTests.swift
@@ -132,11 +132,11 @@ private class CrudTest {
     let collection: Document?
 
     var arrayFilters: [Document]? { self.args["arrayFilters"]?.arrayValue?.compactMap { $0.documentValue } }
-    var batchSize: Int32? { self.args["batchSize"]?.int32Value }
+    var batchSize: Int? { self.args["batchSize"]?.asInt() }
     var collation: Document? { self.args["collation"]?.documentValue }
     var sort: Document? { self.args["sort"]?.documentValue }
-    var skip: Int64? { self.args["skip"]?.asInt64() }
-    var limit: Int64? { self.args["limit"]?.asInt64() }
+    var skip: Int? { self.args["skip"]?.asInt() }
+    var limit: Int? { self.args["limit"]?.asInt() }
     var projection: Document? { self.args["projection"]?.documentValue }
     var returnDoc: ReturnDocument? {
         if let ret = self.args["returnDocument"]?.stringValue {

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -208,7 +208,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
     }
 
     func testCreateDropIndexByModelWithMaxTimeMS() throws {
-        let maxTimeMS: Int = 1000
+        let maxTimeMS = 1000
 
         let client = try MongoClient.makeTestClient()
         let monitor = client.addCommandMonitor()

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -208,7 +208,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
     }
 
     func testCreateDropIndexByModelWithMaxTimeMS() throws {
-        let maxTimeMS: Int64 = 1000
+        let maxTimeMS: Int = 1000
 
         let client = try MongoClient.makeTestClient()
         let monitor = client.addCommandMonitor()
@@ -238,10 +238,10 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         expect(receivedEvents.count).to(equal(2))
         expect(receivedEvents[0].command["createIndexes"]).toNot(beNil())
         expect(receivedEvents[0].command["maxTimeMS"]).toNot(beNil())
-        expect(receivedEvents[0].command["maxTimeMS"]).to(equal(.int64(maxTimeMS)))
+        expect(receivedEvents[0].command["maxTimeMS"]?.asInt()).to(equal(maxTimeMS))
         expect(receivedEvents[1].command["dropIndexes"]).toNot(beNil())
         expect(receivedEvents[1].command["maxTimeMS"]).toNot(beNil())
-        expect(receivedEvents[1].command["maxTimeMS"]).to(equal(.int64(maxTimeMS)))
+        expect(receivedEvents[1].command["maxTimeMS"]?.asInt()).to(equal(maxTimeMS))
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/CodableExtensions.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/CodableExtensions.swift
@@ -47,7 +47,7 @@ extension ClientSessionOptions: Decodable {
 extension TransactionOptions: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let maxCommitTimeMS = try container.decodeIfPresent(Int64.self, forKey: .maxCommitTimeMS)
+        let maxCommitTimeMS = try container.decodeIfPresent(Int.self, forKey: .maxCommitTimeMS)
         let readConcern = try container.decodeIfPresent(ReadConcern.self, forKey: .readConcern)
         let readPreference = try container.decodeIfPresent(ReadPreference.self, forKey: .readPreference)
         let writeConcern = try container.decodeIfPresent(WriteConcern.self, forKey: .writeConcern)

--- a/Tests/MongoSwiftTests/ReadWriteConcernSpecTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernSpecTests.swift
@@ -13,11 +13,11 @@ extension WriteConcern {
         var w: W?
         if let wtag = doc["w"]?.stringValue {
             w = wtag == "majority" ? .majority : .tag(wtag)
-        } else if let wInt = doc["w"]?.asInt32() {
+        } else if let wInt = doc["w"]?.asInt() {
             w = .number(wInt)
         }
 
-        let wt = doc["wtimeoutMS"]?.asInt64()
+        let wt = doc["wtimeoutMS"]?.asInt()
 
         try self.init(journal: j, w: w, wtimeoutMS: wt)
     }


### PR DESCRIPTION
https://jira.mongodb.org/browse/SWIFT-754
A more swifty driver with `Int` dropping the bit width specification in the user API.