### PR TITLE
SWIFT-779 Safe access to ReadPreference pointer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .target(name: "AtlasConnectivity", dependencies: ["MongoSwiftSync"]),
         .target(name: "TestsCommon", dependencies: ["MongoSwift", "Nimble"]),
         .testTarget(name: "BSONTests", dependencies: ["MongoSwift", "TestsCommon", "Nimble", "CLibMongoC"]),
-        .testTarget(name: "MongoSwiftTests", dependencies: ["MongoSwift", "TestsCommon", "Nimble", "NIO", "CLibMongoC"]),
+        .testTarget(name: "MongoSwiftTests", dependencies: ["MongoSwift", "TestsCommon", "Nimble", "NIO"]),
         .testTarget(name: "MongoSwiftSyncTests", dependencies: ["MongoSwiftSync", "TestsCommon", "Nimble", "MongoSwift"]),
         .target(
             name: "CLibMongoC",

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -160,7 +160,7 @@ internal class ConnectionPool {
     /// started already. This method may block.
     internal func selectServer(forWrites: Bool, readPreference: ReadPreference? = nil) throws -> ServerDescription {
         try self.withConnection { conn in
-            try withOptionalMongocReadPreference(from: readPreference) { rpPtr in
+            try ReadPreference.withOptionalMongocReadPreference(from: readPreference) { rpPtr in
                 var error = bson_error_t()
                 guard let desc = mongoc_client_select_server(
                     conn.clientHandle,

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -47,7 +47,7 @@ internal class ConnectionString {
     /// The `ReadConcern` for this connection string.
     internal var readConcern: ReadConcern {
         get {
-            ReadConcern(from: mongoc_uri_get_read_concern(self._uri))
+            ReadConcern(copying: mongoc_uri_get_read_concern(self._uri))
         }
         set(rc) {
             rc.withMongocReadConcern { rcPtr in
@@ -59,7 +59,7 @@ internal class ConnectionString {
     /// The `WriteConcern` for this connection string.
     internal var writeConcern: WriteConcern {
         get {
-            WriteConcern(from: mongoc_uri_get_write_concern(self._uri))
+            WriteConcern(copying: mongoc_uri_get_write_concern(self._uri))
         }
         set(wc) {
             wc.withMongocWriteConcern { wcPtr in

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -74,7 +74,9 @@ internal class ConnectionString {
             ReadPreference(copying: mongoc_uri_get_read_prefs_t(self._uri))
         }
         set(rp) {
-            mongoc_uri_set_read_prefs_t(self._uri, rp.pointer)
+            rp.withMongocReadPreference { rpPtr in
+                mongoc_uri_set_read_prefs_t(self._uri, rpPtr)
+            }
         }
     }
 

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -1,3 +1,4 @@
+import CLibMongoC
 import Foundation
 import NIO
 import NIOConcurrencyHelpers
@@ -608,6 +609,30 @@ public class MongoClient {
         session: ClientSession? = nil
     ) throws -> T.OperationResult {
         try self.operationExecutor.execute(operation, using: connection, client: self, session: session).wait()
+    }
+
+    /// Internal method to check the `ReadConcern` that was ultimately set on this client. **This method may block
+    /// and is for testing purposes only**.
+    internal func getMongocReadConcern() throws -> ReadConcern? {
+        try self.connectionPool.withConnection { conn in
+            ReadConcern(copying: mongoc_client_get_read_concern(conn.clientHandle))
+        }
+    }
+
+    /// Internal method to check the `ReadPreference` that was ultimately set on this client. **This method may block
+    /// and is for testing purposes only**.
+    internal func getMongocReadPreference() throws -> ReadPreference {
+        try self.connectionPool.withConnection { conn in
+            ReadPreference(copying: mongoc_client_get_read_prefs(conn.clientHandle))
+        }
+    }
+
+    /// Internal method to check the `WriteConcern` that was ultimately set on this client. **This method may block
+    /// and is for testing purposes only**.
+    internal func getMongocWriteConcern() throws -> WriteConcern? {
+        try self.connectionPool.withConnection { conn in
+            WriteConcern(copying: mongoc_client_get_write_concern(conn.clientHandle))
+        }
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -257,7 +257,7 @@ internal struct BulkWriteOperation<T: Codable>: Operation {
                     // transactions do not support unacknowledged writes.
                     writeConcernAcknowledged = true
                 } else {
-                    let writeConcern = WriteConcern(from: mongoc_bulk_operation_get_write_concern(bulk))
+                    let writeConcern = WriteConcern(copying: mongoc_bulk_operation_get_write_concern(bulk))
                     writeConcernAcknowledged = writeConcern.isAcknowledged
                 }
 

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -139,7 +139,9 @@ public struct MongoCollection<T: Codable> {
 
         if self.readPreference != self._client.readPreference {
             // there is no concept of an empty read preference so we will always have a value here.
-            mongoc_collection_set_read_prefs(collection, self.readPreference.pointer)
+            self.readPreference.withMongocReadPreference { rpPtr in
+                mongoc_collection_set_read_prefs(collection, rpPtr)
+            }
         }
 
         return try body(collection)

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -146,4 +146,34 @@ public struct MongoCollection<T: Codable> {
 
         return try body(collection)
     }
+
+    /// Internal method to check the `ReadConcern` that is set on `mongoc_collection_t`s via `withMongocCollection`.
+    /// **This method may block and is for testing purposes only**.
+    internal func getMongocReadConcern() throws -> ReadConcern? {
+        try self._client.connectionPool.withConnection { conn in
+            self.withMongocCollection(from: conn) { collPtr in
+                ReadConcern(copying: mongoc_collection_get_read_concern(collPtr))
+            }
+        }
+    }
+
+    /// Internal method to check the `ReadPreference` that is set on `mongoc_collection_t`s via `withMongocCollection`.
+    /// **This method may block and is for testing purposes only**.
+    internal func getMongocReadPreference() throws -> ReadPreference {
+        try self._client.connectionPool.withConnection { conn in
+            self.withMongocCollection(from: conn) { collPtr in
+                ReadPreference(copying: mongoc_collection_get_read_prefs(collPtr))
+            }
+        }
+    }
+
+    /// Internal method to check the `WriteConcern` that is set on `mongoc_collection_t`s via `withMongocCollection`.
+    /// **This method may block and is for testing purposes only**.
+    internal func getMongocWriteConcern() throws -> WriteConcern? {
+        try self._client.connectionPool.withConnection { conn in
+            self.withMongocCollection(from: conn) { collPtr in
+                WriteConcern(copying: mongoc_collection_get_write_concern(collPtr))
+            }
+        }
+    }
 }

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -491,7 +491,9 @@ public struct MongoDatabase {
 
         if self.readPreference != self._client.readPreference {
             // there is no concept of an empty read preference so we will always have a value here.
-            mongoc_database_set_read_prefs(db, self.readPreference.pointer)
+            self.readPreference.withMongocReadPreference { rpPtr in
+                mongoc_database_set_read_prefs(db, rpPtr)
+            }
         }
 
         return try body(db)

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -498,4 +498,34 @@ public struct MongoDatabase {
 
         return try body(db)
     }
+
+    /// Internal method to check the `ReadConcern` that is set on `mongoc_database_t`s via `withMongocDatabase`.
+    /// **This method may block and is for testing purposes only**.
+    internal func getMongocReadConcern() throws -> ReadConcern? {
+        try self._client.connectionPool.withConnection { conn in
+            self.withMongocDatabase(from: conn) { dbPtr in
+                ReadConcern(copying: mongoc_database_get_read_concern(dbPtr))
+            }
+        }
+    }
+
+    /// Internal method to check the `ReadPreference` that is set on `mongoc_database_t`s via `withMongocDatabase`.
+    /// **This method may block and is for testing purposes only**.
+    internal func getMongocReadPreference() throws -> ReadPreference {
+        try self._client.connectionPool.withConnection { conn in
+            self.withMongocDatabase(from: conn) { dbPtr in
+                ReadPreference(copying: mongoc_database_get_read_prefs(dbPtr))
+            }
+        }
+    }
+
+    /// Internal method to check the `WriteConcern` that is set on `mongoc_database_t`s via `withMongocDatabase`.
+    /// **This method may block and is for testing purposes only**.
+    internal func getMongocWriteConcern() throws -> WriteConcern? {
+        try self._client.connectionPool.withConnection { conn in
+            self.withMongocDatabase(from: conn) { dbPtr in
+                WriteConcern(copying: mongoc_database_get_write_concern(dbPtr))
+            }
+        }
+    }
 }

--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -88,7 +88,7 @@ internal struct AggregateOperation<CollectionType: Codable>: Operation {
         let result: OpaquePointer = self.collection.withMongocCollection(from: connection) { collPtr in
             pipeline.withBSONPointer { pipelinePtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                    ReadPreference.withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
                         guard let result = mongoc_collection_aggregate(
                             collPtr,
                             MONGOC_QUERY_NONE,

--- a/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
+++ b/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
@@ -67,7 +67,7 @@ internal struct CountDocumentsOperation<T: Codable>: Operation {
         let count = self.collection.withMongocCollection(from: connection) { collPtr in
             self.filter.withBSONPointer { filterPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                    ReadPreference.withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
                         mongoc_collection_count_documents(collPtr, filterPtr, optsPtr, rpPtr, nil, &error)
                     }
                 }

--- a/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
+++ b/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
@@ -63,12 +63,13 @@ internal struct CountDocumentsOperation<T: Codable>: Operation {
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> Int {
         let opts = try encodeOptions(options: options, session: session)
-        let rp = self.options?.readPreference?.pointer
         var error = bson_error_t()
         let count = self.collection.withMongocCollection(from: connection) { collPtr in
             self.filter.withBSONPointer { filterPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    mongoc_collection_count_documents(collPtr, filterPtr, optsPtr, rp, nil, &error)
+                    withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                        mongoc_collection_count_documents(collPtr, filterPtr, optsPtr, rpPtr, nil, &error)
+                    }
                 }
             }
         }

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -60,7 +60,7 @@ internal struct DistinctOperation<T: Codable>: Operation {
         var error = bson_error_t()
         let success = self.collection.withMongocCollection(from: connection) { collPtr in
             command.withBSONPointer { cmdPtr in
-                withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                ReadPreference.withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
                     withOptionalBSONPointer(to: opts) { optsPtr in
                         reply.withMutableBSONPointer { replyPtr in
                             mongoc_collection_read_command_with_opts(collPtr, cmdPtr, rpPtr, optsPtr, replyPtr, &error)

--- a/Sources/MongoSwift/Operations/DistinctOperation.swift
+++ b/Sources/MongoSwift/Operations/DistinctOperation.swift
@@ -56,14 +56,15 @@ internal struct DistinctOperation<T: Codable>: Operation {
         ]
 
         let opts = try encodeOptions(options: self.options, session: session)
-        let rp = self.options?.readPreference?.pointer
         var reply = Document()
         var error = bson_error_t()
         let success = self.collection.withMongocCollection(from: connection) { collPtr in
             command.withBSONPointer { cmdPtr in
-                withOptionalBSONPointer(to: opts) { optsPtr in
-                    reply.withMutableBSONPointer { replyPtr in
-                        mongoc_collection_read_command_with_opts(collPtr, cmdPtr, rp, optsPtr, replyPtr, &error)
+                withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                    withOptionalBSONPointer(to: opts) { optsPtr in
+                        reply.withMutableBSONPointer { replyPtr in
+                            mongoc_collection_read_command_with_opts(collPtr, cmdPtr, rpPtr, optsPtr, replyPtr, &error)
+                        }
                     }
                 }
             }

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -44,7 +44,7 @@ internal struct EstimatedDocumentCountOperation<T: Codable>: Operation {
         var error = bson_error_t()
         let count = self.collection.withMongocCollection(from: connection) { collPtr in
             withOptionalBSONPointer(to: opts) { optsPtr in
-                withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                ReadPreference.withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
                     mongoc_collection_estimated_document_count(collPtr, optsPtr, rpPtr, nil, &error)
                 }
             }

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -41,11 +41,12 @@ internal struct EstimatedDocumentCountOperation<T: Codable>: Operation {
 
     internal func execute(using connection: Connection, session: ClientSession?) throws -> Int {
         let opts = try encodeOptions(options: options, session: session)
-        let rp = self.options?.readPreference?.pointer
         var error = bson_error_t()
         let count = self.collection.withMongocCollection(from: connection) { collPtr in
             withOptionalBSONPointer(to: opts) { optsPtr in
-                mongoc_collection_estimated_document_count(collPtr, optsPtr, rp, nil, &error)
+                withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                    mongoc_collection_estimated_document_count(collPtr, optsPtr, rpPtr, nil, &error)
+                }
             }
         }
 

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -305,15 +305,16 @@ internal struct FindOperation<CollectionType: Codable>: Operation {
         session: ClientSession?
     ) throws -> MongoCursor<CollectionType> {
         let opts = try encodeOptions(options: self.options, session: session)
-        let rp = self.options?.readPreference?.pointer
 
         let result: OpaquePointer = self.collection.withMongocCollection(from: connection) { collPtr in
             self.filter.withBSONPointer { filterPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    guard let result = mongoc_collection_find_with_opts(collPtr, filterPtr, optsPtr, rp) else {
-                        fatalError(failedToRetrieveCursorMessage)
+                    withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                        guard let result = mongoc_collection_find_with_opts(collPtr, filterPtr, optsPtr, rpPtr) else {
+                            fatalError(failedToRetrieveCursorMessage)
+                        }
+                        return result
                     }
-                    return result
                 }
             }
         }

--- a/Sources/MongoSwift/Operations/FindOperation.swift
+++ b/Sources/MongoSwift/Operations/FindOperation.swift
@@ -309,7 +309,7 @@ internal struct FindOperation<CollectionType: Codable>: Operation {
         let result: OpaquePointer = self.collection.withMongocCollection(from: connection) { collPtr in
             self.filter.withBSONPointer { filterPtr in
                 withOptionalBSONPointer(to: opts) { optsPtr in
-                    withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                    ReadPreference.withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
                         guard let result = mongoc_collection_find_with_opts(collPtr, filterPtr, optsPtr, rpPtr) else {
                             fatalError(failedToRetrieveCursorMessage)
                         }

--- a/Sources/MongoSwift/Operations/RunCommandOperation.swift
+++ b/Sources/MongoSwift/Operations/RunCommandOperation.swift
@@ -48,7 +48,7 @@ internal struct RunCommandOperation: Operation {
         var error = bson_error_t()
         let success = self.database.withMongocDatabase(from: connection) { dbPtr in
             self.command.withBSONPointer { cmdPtr in
-                withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
+                ReadPreference.withOptionalMongocReadPreference(from: self.options?.readPreference) { rpPtr in
                     withOptionalBSONPointer(to: opts) { optsPtr in
                         reply.withMutableBSONPointer { replyPtr in
                             mongoc_database_command_with_opts(dbPtr, cmdPtr, rpPtr, optsPtr, replyPtr, &error)

--- a/Sources/MongoSwift/Operations/StartTransactionOperation.swift
+++ b/Sources/MongoSwift/Operations/StartTransactionOperation.swift
@@ -49,8 +49,10 @@ internal func withMongocTransactionOpts<T>(
         }
     }
 
-    if let rpPtr = options?.readPreference?.pointer {
-        mongoc_transaction_opts_set_read_prefs(optionsPtr, rpPtr)
+    if let rp = options?.readPreference {
+        rp.withMongocReadPreference { rpPtr in
+            mongoc_transaction_opts_set_read_prefs(optionsPtr, rpPtr)
+        }
     }
 
     if let maxCommitTimeMS = options?.maxCommitTimeMS {

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -62,7 +62,7 @@ public struct ReadConcern: Codable {
 
     // Initializes a new `ReadConcern` with the same level as the provided `mongoc_read_concern_t`.
     // The caller is responsible for freeing the original `mongoc_read_concern_t`.
-    internal init(from readConcern: OpaquePointer) {
+    internal init(copying readConcern: OpaquePointer) {
         if let level = mongoc_read_concern_get_level(readConcern) {
             self.level = Level(rawValue: String(cString: level))
         }

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -232,7 +232,7 @@ public struct ReadPreference: Equatable {
         let rp = mongoc_read_prefs_new(self.mode.mongocMode)! // never returns nil
         defer { mongoc_read_prefs_destroy(rp) }
 
-        if let tagSets = self.tagSets, tagSets.isEmpty {
+        if let tagSets = self.tagSets, !tagSets.isEmpty {
             let tags = Document(tagSets.map { .document($0) })
             tags.withBSONPointer { tagsPtr in
                 mongoc_read_prefs_set_tags(rp, tagsPtr)

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -108,7 +108,7 @@ public struct WriteConcern: Codable {
 
     /// Initializes a new `WriteConcern` with the same values as the provided `mongoc_write_concern_t`.
     /// The caller is responsible for freeing the original `mongoc_write_concern_t`.
-    internal init(from writeConcern: OpaquePointer?) {
+    internal init(copying writeConcern: OpaquePointer) {
         if mongoc_write_concern_journal_is_set(writeConcern) {
             self.journal = mongoc_write_concern_get_journal(writeConcern)
         } else {

--- a/Tests/BSONTests/CodecTests.swift
+++ b/Tests/BSONTests/CodecTests.swift
@@ -777,7 +777,7 @@ final class CodecTests: MongoSwiftTestCase {
 
         let rc = ReadConcern(.majority)
         let wc = try WriteConcern(wtimeoutMS: 123)
-        let rp = ReadPreference(.primary)
+        let rp = ReadPreference.primary
 
         let agg = AggregateOptions(
             allowDiskUse: true,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -264,6 +264,7 @@ extension ReadConcernTests {
         ("testReadConcernType", testReadConcernType),
         ("testClientReadConcern", testClientReadConcern),
         ("testDatabaseReadConcern", testDatabaseReadConcern),
+        ("testRoundTripThroughLibmongoc", testRoundTripThroughLibmongoc),
     ]
 }
 
@@ -278,7 +279,7 @@ extension ReadPreferenceTests {
         ("testMode", testMode),
         ("testTagSets", testTagSets),
         ("testMaxStalenessSeconds", testMaxStalenessSeconds),
-        ("testInitFromPointer", testInitFromPointer),
+        ("testRoundTripThroughLibmongoc", testRoundTripThroughLibmongoc),
         ("testEquatable", testEquatable),
         ("testClientReadPreference", testClientReadPreference),
         ("testDatabaseReadPreference", testDatabaseReadPreference),
@@ -383,6 +384,7 @@ extension WriteConcernTests {
         ("testWriteConcernType", testWriteConcernType),
         ("testClientWriteConcern", testClientWriteConcern),
         ("testDatabaseWriteConcern", testDatabaseWriteConcern),
+        ("testRoundTripThroughLibmongoc", testRoundTripThroughLibmongoc),
     ]
 }
 

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -177,4 +177,23 @@ final class ReadConcernTests: MongoSwiftTestCase {
             try checkReadConcern(coll5, majority, "collection retrieved with majority RC from \(dbDesc)")
         }
     }
+
+    func testRoundTripThroughLibmongoc() throws {
+        let rcs: [ReadConcern] = [
+            ReadConcern(),
+            ReadConcern(.local),
+            ReadConcern(.available),
+            ReadConcern(.majority),
+            ReadConcern(.linearizable),
+            ReadConcern(.snapshot),
+            ReadConcern(.other(level: "a"))
+        ]
+
+        for original in rcs {
+            let copy = original.withMongocReadConcern { rcPtr in
+                ReadConcern(copying: rcPtr)
+            }
+            expect(copy).to(equal(original))
+        }
+    }
 }

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -5,41 +5,17 @@ import TestsCommon
 
 /// Indicates that a type has a read concern property, as well as a way to get a read concern from an instance of the
 /// corresponding mongoc type.
-protocol ReadConcernable {
+private protocol ReadConcernable {
     var readConcern: ReadConcern? { get }
     func getMongocReadConcern() throws -> ReadConcern?
 }
 
-extension MongoClient: ReadConcernable {
-    func getMongocReadConcern() throws -> ReadConcern? {
-        try self.connectionPool.withConnection { conn in
-            ReadConcern(from: mongoc_client_get_read_concern(conn.clientHandle))
-        }
-    }
-}
-
-extension MongoDatabase: ReadConcernable {
-    func getMongocReadConcern() throws -> ReadConcern? {
-        try self._client.connectionPool.withConnection { conn in
-            self.withMongocDatabase(from: conn) { dbPtr in
-                ReadConcern(from: mongoc_database_get_read_concern(dbPtr))
-            }
-        }
-    }
-}
-
-extension MongoCollection: ReadConcernable {
-    func getMongocReadConcern() throws -> ReadConcern? {
-        try self._client.connectionPool.withConnection { conn in
-            self.withMongocCollection(from: conn) { collPtr in
-                ReadConcern(from: mongoc_collection_get_read_concern(collPtr))
-            }
-        }
-    }
-}
+extension MongoClient: ReadConcernable {}
+extension MongoDatabase: ReadConcernable {}
+extension MongoCollection: ReadConcernable {}
 
 /// Checks that a type T, as well as pointers to corresponding libmongoc instances, has the expected read concern.
-func checkReadConcern<T: ReadConcernable>(
+private func checkReadConcern<T: ReadConcernable>(
     _ instance: T,
     _ expected: ReadConcern,
     _ description: String

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -1,4 +1,3 @@
-import CLibMongoC
 @testable import MongoSwift
 import Nimble
 import TestsCommon

--- a/Tests/MongoSwiftTests/ReadPreferenceTests.swift
+++ b/Tests/MongoSwiftTests/ReadPreferenceTests.swift
@@ -3,6 +3,27 @@ import Nimble
 import TestsCommon
 import XCTest
 
+/// Indicates that a type has a read preference property, as well as a way to get a read preference from an instance
+/// of the corresponding mongoc type.
+private protocol ReadPreferenceable {
+    var readPreference: ReadPreference { get }
+    func getMongocReadPreference() throws -> ReadPreference
+}
+
+extension MongoClient: ReadPreferenceable {}
+extension MongoDatabase: ReadPreferenceable {}
+extension MongoCollection: ReadPreferenceable {}
+
+/// Checks that a type T, as well as pointers to corresponding libmongoc instances, has the expected read preference.
+private func checkReadPreference<T: ReadPreferenceable>(
+    _ instance: T,
+    _ expected: ReadPreference,
+    _ description: String
+) throws {
+    expect(instance.readPreference).to(equal(expected), description: description)
+    expect(try instance.getMongocReadPreference()).to(equal(expected))
+}
+
 final class ReadPreferenceTests: MongoSwiftTestCase {
     override func setUp() {
         self.continueAfterFailure = false
@@ -78,30 +99,32 @@ final class ReadPreferenceTests: MongoSwiftTestCase {
 
     func testClientReadPreference() throws {
         try self.withTestClient { client in
+            let clientDesc = "client created with no RP provided"
             // expect that a client with an unset read preference has it default to primary
-            expect(client.readPreference).to(equal(.primary))
+            try checkReadPreference(client, .primary, clientDesc)
 
             // expect that a database created from this client inherits its read preference
             let db1 = client.db(Self.testDatabase)
-            expect(db1.readPreference).to(equal(.primary))
+            try checkReadPreference(db1, .primary, "db created with no RP provided from \(clientDesc)")
 
             // expect that a database can override the readPreference it inherited from a client
             let opts = DatabaseOptions(readPreference: .secondary)
             let db2 = client.db(Self.testDatabase, options: opts)
-            expect(db2.readPreference).to(equal(.secondary))
+            try checkReadPreference(db2, .secondary, "db created with secondary RP from \(clientDesc)")
         }
 
         try self.withTestClient(options: ClientOptions(readPreference: .primaryPreferred)) { client in
-            expect(client.readPreference).to(equal(.primaryPreferred))
+            let clientDesc = "client created with RP primaryPreferred"
+            try checkReadPreference(client, .primaryPreferred, clientDesc)
 
             // expect that a database created from this client inherits its read preference
             let db1 = client.db(Self.testDatabase)
-            expect(db1.readPreference).to(equal(.primaryPreferred))
+            try checkReadPreference(db1, .primaryPreferred, "db created with no RP provided from \(clientDesc)")
 
             // expect that a database can override the readPreference it inherited from a client
             let opts = DatabaseOptions(readPreference: .secondary)
             let db2 = client.db(Self.testDatabase, options: opts)
-            expect(db2.readPreference).to(equal(.secondary))
+            try checkReadPreference(db2, .secondary, "db created with secondary RP from \(clientDesc)")
         }
     }
 
@@ -109,33 +132,35 @@ final class ReadPreferenceTests: MongoSwiftTestCase {
         try self.withTestClient { client in
             do {
                 // expect that a database with an unset read preference defaults to primary
+                let dbDesc = "db created with no RP provided"
                 let db = client.db(Self.testDatabase)
-                expect(db.readPreference).to(equal(.primary))
+                try checkReadPreference(db, .primary, dbDesc)
 
                 // expect that a collection inherits its database default read preference
                 let coll1 = db.collection(self.getCollectionName(suffix: "1"))
-                expect(coll1.readPreference).to(equal(.primary))
+                try checkReadPreference(coll1, .primary, "coll created with no RP provided from \(dbDesc)")
 
                 // expect that a collection can override its inherited read preference
                 let coll2 = db.collection(
                     self.getCollectionName(suffix: "2"),
                     options: CollectionOptions(readPreference: .secondary)
                 )
-                expect(coll2.readPreference).to(equal(.secondary))
+                try checkReadPreference(coll2, .secondary, "coll created with secondary RP from \(dbDesc)")
             }
 
             do {
                 // expect that a collection inherits its database read preference
+                let dbDesc = "db created with secondary RP"
                 let db = client.db(Self.testDatabase, options: DatabaseOptions(readPreference: .secondary))
                 let coll1 = db.collection(self.getCollectionName(suffix: "1"))
-                expect(coll1.readPreference).to(equal(.secondary))
+                try checkReadPreference(coll1, .secondary, "coll created with no RP provided from \(dbDesc)")
 
                 // expect that a collection can override its database read preference
                 let coll2 = db.collection(
                     self.getCollectionName(suffix: "2"),
                     options: CollectionOptions(readPreference: .primary)
                 )
-                expect(coll2.readPreference).to(equal(.primary))
+                try checkReadPreference(coll1, .secondary, "coll created with secondary RP from \(dbDesc)")
             }
         }
     }

--- a/Tests/MongoSwiftTests/ReadPreferenceTests.swift
+++ b/Tests/MongoSwiftTests/ReadPreferenceTests.swift
@@ -44,11 +44,11 @@ final class ReadPreferenceTests: MongoSwiftTestCase {
             .to(throwError(errorType: InvalidArgumentError.self))
     }
 
-    func testInitFromPointer() {
-        let rpOrig = ReadPreference.primaryPreferred
-        let rpCopy = ReadPreference(copying: rpOrig.pointer)
-        expect(rpCopy).to(equal(rpOrig))
-    }
+    // func testInitFromPointer() {
+    //     let rpOrig = ReadPreference.primaryPreferred
+    //     let rpCopy = ReadPreference(copying: rpOrig.pointer)
+    //     expect(rpCopy).to(equal(rpOrig))
+    // }
 
     func testEquatable() throws {
         expect(ReadPreference.primary).to(equal(.primary))

--- a/Tests/MongoSwiftTests/ReadPreferenceTests.swift
+++ b/Tests/MongoSwiftTests/ReadPreferenceTests.swift
@@ -44,11 +44,13 @@ final class ReadPreferenceTests: MongoSwiftTestCase {
             .to(throwError(errorType: InvalidArgumentError.self))
     }
 
-    // func testInitFromPointer() {
-    //     let rpOrig = ReadPreference.primaryPreferred
-    //     let rpCopy = ReadPreference(copying: rpOrig.pointer)
-    //     expect(rpCopy).to(equal(rpOrig))
-    // }
+    func testInitFromPointer() {
+        let rpOrig = ReadPreference.primaryPreferred
+        let rpCopy = rpOrig.withMongocReadPreference { origPtr in
+            ReadPreference(copying: origPtr)
+        }
+        expect(rpCopy).to(equal(rpOrig))
+    }
 
     func testEquatable() throws {
         expect(ReadPreference.primary).to(equal(.primary))

--- a/Tests/MongoSwiftTests/WriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/WriteConcernTests.swift
@@ -142,4 +142,22 @@ final class WriteConcernTests: MongoSwiftTestCase {
             try checkWriteConcern(coll4, w2, "collection retrieved with w:2 from \(dbDesc)")
         }
     }
+
+    func testRoundTripThroughLibmongoc() throws {
+        let wcs: [WriteConcern] = [
+            WriteConcern(),
+            try WriteConcern(w: .number(2)),
+            try WriteConcern(w: .tag("hi")),
+            try WriteConcern(w: .majority),
+            try WriteConcern(journal: true),
+            try WriteConcern(wtimeoutMS: 200)
+        ]
+
+        for original in wcs {
+            let copy = original.withMongocWriteConcern { wcPtr in
+                WriteConcern(copying: wcPtr)
+            }
+            expect(copy).to(equal(original))
+        }
+    }
 }

--- a/Tests/MongoSwiftTests/WriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/WriteConcernTests.swift
@@ -5,41 +5,17 @@ import TestsCommon
 
 /// Indicates that a type has a write concern property, as well as a way to get a write concern from an instance of the
 /// corresponding mongoc type.
-protocol WriteConcernable {
+private protocol WriteConcernable {
     var writeConcern: WriteConcern? { get }
     func getMongocWriteConcern() throws -> WriteConcern?
 }
 
-extension MongoClient: WriteConcernable {
-    func getMongocWriteConcern() throws -> WriteConcern? {
-        try self.connectionPool.withConnection { conn in
-            WriteConcern(from: mongoc_client_get_write_concern(conn.clientHandle))
-        }
-    }
-}
-
-extension MongoDatabase: WriteConcernable {
-    func getMongocWriteConcern() throws -> WriteConcern? {
-        try self._client.connectionPool.withConnection { conn in
-            self.withMongocDatabase(from: conn) { dbPtr in
-                WriteConcern(from: mongoc_database_get_write_concern(dbPtr))
-            }
-        }
-    }
-}
-
-extension MongoCollection: WriteConcernable {
-    func getMongocWriteConcern() throws -> WriteConcern? {
-        try self._client.connectionPool.withConnection { conn in
-            self.withMongocCollection(from: conn) { collPtr in
-                WriteConcern(from: mongoc_collection_get_write_concern(collPtr))
-            }
-        }
-    }
-}
+extension MongoClient: WriteConcernable {}
+extension MongoDatabase: WriteConcernable {}
+extension MongoCollection: WriteConcernable {}
 
 /// Checks that a type T, as well as pointers to corresponding libmongoc instances, has the expected write concern.
-func checkWriteConcern<T: WriteConcernable>(
+private func checkWriteConcern<T: WriteConcernable>(
     _ instance: T,
     _ expected: WriteConcern,
     _ description: String

--- a/Tests/MongoSwiftTests/WriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/WriteConcernTests.swift
@@ -1,4 +1,3 @@
-import CLibMongoC
 @testable import MongoSwift
 import Nimble
 import TestsCommon


### PR DESCRIPTION
@mbroadst I'm not sure if you want me to keep including you on these, LMK.

This PR switches `ReadPreference` over to the "create a temporary libmongoc equivalent, use it to execute a closure, and then clean it up" approach we follow for `ReadConcern`, `WriteConcern`, `MongoDatabase`, and `MongoCollection`. 

We had existing tests regarding `ReadConcern` and `WriteConcern` that verified these got set correctly on mongoc clients, dbs, and collections. I think we skipped these for `ReadPreference` at the time because it was just wrapping a `mongoc_read_prefs_t` so there was no need to test out the temporary creation of the libmongoc type.

I have now added similar tests for `ReadPreference`. As part of that I also moved libmongoc-dependent helper methods for getting the `ReadConcern`/`WriteConcern` on a temporary db/collection into the driver itself. This allowed me to remove the CLibMongoC dependency from `MongoSwiftTests` 🎉Now we just need to remove it from `BSONTests`. 

I also added some round trip testing between Swift and libmongoc types for all three of RC, WC, RP.