### PR TITLE
SWIFT-640: Add authentication options to ClientOptions

### DIFF
--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -114,7 +114,7 @@ internal class ConnectionString {
             return nil
         }
         let str = String(cString: mechanism)
-        return MongoCredential.Mechanism(name: str)
+        return MongoCredential.Mechanism(str)
     }
 
     /// Returns a document containing the auth mechanism properties if any were provided, otherwise nil.

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -202,18 +202,32 @@ internal class ConnectionString {
 
     /// Sets credential properties in the URI string
     internal func setCredential(from credential: Credential) throws {
-        guard mongoc_uri_set_username(self._uri, credential.username) else {
-            throw InvalidArgumentError(message: "Cannot set username to \(String(describing: credential.username))")
+        if let username = credential.username {
+            guard mongoc_uri_set_username(self._uri, username) else {
+                throw InvalidArgumentError(message: "Cannot set username to \(username).")
+            }
+        } else {
+            throw InvalidArgumentError(message: "Credential must specify username.")
         }
-        guard mongoc_uri_set_password(self._uri, credential.password) else {
-            throw InvalidArgumentError(message: "Cannot set password")
+
+        if let password = credential.password {
+            guard mongoc_uri_set_password(self._uri, password) else {
+                throw InvalidArgumentError(message: "Cannot set password")
+            }
         }
-        guard mongoc_uri_set_auth_source(self._uri, credential.source) else {
-            throw InvalidArgumentError(message: "Cannot set authSource to \(String(describing: credential.source))")
+
+        if let authSource = credential.source {
+            guard mongoc_uri_set_auth_source(self._uri, authSource) else {
+                throw InvalidArgumentError(message: "Cannot set authSource to \(authSource)")
+            }
         }
-        guard mongoc_uri_set_auth_mechanism(self._uri, credential.mechanism?.rawValue) else {
-            throw InvalidArgumentError(message: "Cannot set mechanism to \(String(describing: credential.mechanism))")
+
+        if let mechanism = credential.mechanism {
+            guard mongoc_uri_set_auth_mechanism(self._uri, mechanism.rawValue) else {
+                throw InvalidArgumentError(message: "Cannot set mechanism to \(mechanism))")
+            }
         }
+
         try credential.mechanismProperties?.withBSONPointer { mechanismPropertiesPtr in
             guard mongoc_uri_set_mechanism_properties(self._uri, mechanismPropertiesPtr) else {
                 throw InvalidArgumentError(

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -34,7 +34,7 @@ internal class ConnectionString {
         }
 
         if let credential = options?.credential {
-            try self.setCredential(credential)
+            try self.setMongoCredential(credential)
         }
     }
 
@@ -109,12 +109,12 @@ internal class ConnectionString {
     }
 
     /// Returns the auth mechanism if one was provided, otherwise nil.
-    internal var authMechanism: Credential.Mechanism? {
+    internal var authMechanism: MongoCredential.Mechanism? {
         guard let mechanism = mongoc_uri_get_auth_mechanism(self._uri) else {
             return nil
         }
         let str = String(cString: mechanism)
-        return Credential.Mechanism(rawValue: str)
+        return MongoCredential.Mechanism(name: str)
     }
 
     /// Returns a document containing the auth mechanism properties if any were provided, otherwise nil.
@@ -144,8 +144,8 @@ internal class ConnectionString {
     }
 
     /// Returns the credential configured on this URI. Will be empty if no options are set.
-    internal var credential: Credential {
-        Credential(
+    internal var credential: MongoCredential {
+        MongoCredential(
             username: self.username,
             password: self.password,
             source: self.authSource,
@@ -221,7 +221,7 @@ internal class ConnectionString {
         }
 
         if let mechanism = credential.mechanism {
-            guard mongoc_uri_set_auth_mechanism(self._uri, mechanism.rawValue) else {
+            guard mongoc_uri_set_auth_mechanism(self._uri, mechanism.name) else {
                 throw InvalidArgumentError(message: "Cannot set mechanism to \(mechanism)).")
             }
         }

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -201,7 +201,7 @@ internal class ConnectionString {
     }
 
     /// Sets credential properties in the URI string
-    internal func setCredential(from credential: Credential) throws {
+    internal func setMongoCredential(_ credential: MongoCredential) throws {
         if let username = credential.username {
             guard mongoc_uri_set_username(self._uri, username) else {
                 throw InvalidArgumentError(message: "Cannot set username to \(username).")

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -34,7 +34,7 @@ internal class ConnectionString {
         }
 
         if let credential = options?.credential {
-            try self.setCredential(from: credential)
+            try self.setCredential(credential)
         }
     }
 
@@ -109,12 +109,12 @@ internal class ConnectionString {
     }
 
     /// Returns the auth mechanism if one was provided, otherwise nil.
-    internal var authMechanism: AuthMechanism? {
+    internal var authMechanism: Credential.Mechanism? {
         guard let mechanism = mongoc_uri_get_auth_mechanism(self._uri) else {
             return nil
         }
         let str = String(cString: mechanism)
-        return AuthMechanism(rawValue: str)
+        return Credential.Mechanism(rawValue: str)
     }
 
     /// Returns a document containing the auth mechanism properties if any were provided, otherwise nil.
@@ -206,32 +206,30 @@ internal class ConnectionString {
             guard mongoc_uri_set_username(self._uri, username) else {
                 throw InvalidArgumentError(message: "Cannot set username to \(username).")
             }
-        } else {
-            throw InvalidArgumentError(message: "Credential must specify username.")
         }
 
         if let password = credential.password {
             guard mongoc_uri_set_password(self._uri, password) else {
-                throw InvalidArgumentError(message: "Cannot set password")
+                throw InvalidArgumentError(message: "Cannot set password.")
             }
         }
 
         if let authSource = credential.source {
             guard mongoc_uri_set_auth_source(self._uri, authSource) else {
-                throw InvalidArgumentError(message: "Cannot set authSource to \(authSource)")
+                throw InvalidArgumentError(message: "Cannot set authSource to \(authSource).")
             }
         }
 
         if let mechanism = credential.mechanism {
             guard mongoc_uri_set_auth_mechanism(self._uri, mechanism.rawValue) else {
-                throw InvalidArgumentError(message: "Cannot set mechanism to \(mechanism))")
+                throw InvalidArgumentError(message: "Cannot set mechanism to \(mechanism)).")
             }
         }
 
         try credential.mechanismProperties?.withBSONPointer { mechanismPropertiesPtr in
             guard mongoc_uri_set_mechanism_properties(self._uri, mechanismPropertiesPtr) else {
                 throw InvalidArgumentError(
-                    message: "Cannot set mechanismProperties to \(String(describing: credential.mechanismProperties))"
+                    message: "Cannot set mechanismProperties to \(String(describing: credential.mechanismProperties))."
                 )
             }
         }

--- a/Sources/MongoSwift/Credential.swift
+++ b/Sources/MongoSwift/Credential.swift
@@ -35,7 +35,7 @@ public struct Credential: Decodable, Equatable {
     public enum Mechanism: RawRepresentable, Decodable, Equatable {
         /// See https://docs.mongodb.com/manual/core/kerberos/
         case gssAPI
-        /// See https://docs.mongodb.com/v3.0/core/security-mongodb-cr/#authentication-mongodb-cr
+        /// Deprecated: see https://docs.mongodb.com/manual/release-notes/3.0-scram/
         case mongodbCR
         /// See https://docs.mongodb.com/manual/core/security-x.509/#security-auth-x509
         case mongodbX509

--- a/Sources/MongoSwift/Credential.swift
+++ b/Sources/MongoSwift/Credential.swift
@@ -2,28 +2,42 @@
 public struct Credential: Decodable, Equatable {
     /// A string containing the username. For auth mechanisms that do not utilize a password, this may be the entire
     /// `userinfo` token from the connection string.
-    internal let username: String?
+    public var username: String?
     /// A string containing the password.
-    internal let password: String?
+    public var password: String?
     /// A string containing the authentication database.
-    internal let source: String?
+    public var source: String?
     /// The authentication mechanism. A nil value for this property indicates that a mechanism wasn't specified and
     /// that mechanism negotiation is required.
-    internal let mechanism: AuthMechanism?
+    public var mechanism: Mechanism?
     /// A document containing mechanism-specific properties.
-    internal let mechanismProperties: Document?
+    public var mechanismProperties: Document?
 
     private enum CodingKeys: String, CodingKey {
         case username, password, source, mechanism, mechanismProperties = "mechanism_properties"
     }
-}
 
-/// Possible authentication mechanisms.
-public enum AuthMechanism: String, Decodable {
-    case scramSHA1 = "SCRAM-SHA-1"
-    case scramSHA256 = "SCRAM-SHA-256"
-    case gssAPI = "GSSAPI"
-    case mongodbCR = "MONGODB-CR"
-    case mongodbX509 = "MONGODB-X509"
-    case plain = "PLAIN"
+    public init(
+        username: String? = nil,
+        password: String? = nil,
+        source: String? = nil,
+        mechanism: Mechanism? = nil,
+        mechanismProperties: Document? = nil
+    ) {
+        self.username = username
+        self.password = password
+        self.source = source
+        self.mechanism = mechanism
+        self.mechanismProperties = mechanismProperties
+    }
+
+    /// Possible authentication mechanisms.
+    public enum Mechanism: String, Decodable {
+        case scramSHA1 = "SCRAM-SHA-1"
+        case scramSHA256 = "SCRAM-SHA-256"
+        case gssAPI = "GSSAPI"
+        case mongodbCR = "MONGODB-CR"
+        case mongodbX509 = "MONGODB-X509"
+        case plain = "PLAIN"
+    }
 }

--- a/Sources/MongoSwift/Credential.swift
+++ b/Sources/MongoSwift/Credential.swift
@@ -1,5 +1,5 @@
 /// Represents an authentication credential.
-internal struct Credential: Decodable, Equatable {
+public struct Credential: Decodable, Equatable {
     /// A string containing the username. For auth mechanisms that do not utilize a password, this may be the entire
     /// `userinfo` token from the connection string.
     internal let username: String?
@@ -19,7 +19,7 @@ internal struct Credential: Decodable, Equatable {
 }
 
 /// Possible authentication mechanisms.
-internal enum AuthMechanism: String, Decodable {
+public enum AuthMechanism: String, Decodable {
     case scramSHA1 = "SCRAM-SHA-1"
     case scramSHA256 = "SCRAM-SHA-256"
     case gssAPI = "GSSAPI"

--- a/Sources/MongoSwift/Credential.swift
+++ b/Sources/MongoSwift/Credential.swift
@@ -32,12 +32,60 @@ public struct Credential: Decodable, Equatable {
     }
 
     /// Possible authentication mechanisms.
-    public enum Mechanism: String, Decodable {
-        case scramSHA1 = "SCRAM-SHA-1"
-        case scramSHA256 = "SCRAM-SHA-256"
-        case gssAPI = "GSSAPI"
-        case mongodbCR = "MONGODB-CR"
-        case mongodbX509 = "MONGODB-X509"
-        case plain = "PLAIN"
+    public enum Mechanism: RawRepresentable, Decodable, Equatable {
+        /// See https://docs.mongodb.com/manual/core/kerberos/
+        case gssAPI
+        /// See https://docs.mongodb.com/v3.0/core/security-mongodb-cr/#authentication-mongodb-cr
+        case mongodbCR
+        /// See https://docs.mongodb.com/manual/core/security-x.509/#security-auth-x509
+        case mongodbX509
+        /// See https://docs.mongodb.com/manual/core/security-ldap/
+        case plain
+        /// See https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
+        case scramSHA1
+        /// See https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
+        case scramSHA256
+        /// Any other authentication mechanism not covered by the other cases.
+        /// This case is present to provide forwards compatibility with any
+        /// future authentication mechanism which may be added to new versions of MongoDB.
+        case other(mechanism: String)
+
+        public var rawValue: String {
+            switch self {
+            case .gssAPI:
+                return "GSSAPI"
+            case .mongodbCR:
+                return "MONGODB-CR"
+            case .mongodbX509:
+                return "MONGODB-X509"
+            case .plain:
+                return "PLAIN"
+            case .scramSHA1:
+                return "SCRAM-SHA-1"
+            case .scramSHA256:
+                return "SCRAM-SHA-256"
+            case let .other(mechanism: mechanism):
+                return mechanism
+            }
+        }
+
+        public init?(rawValue: String) {
+            switch rawValue {
+            case "GSSAPI":
+                self = .gssAPI
+            case "MONGODB-CR":
+                self = .mongodbCR
+            case "MONGODB-X509":
+                self = .mongodbX509
+            case "PLAIN":
+                self = .plain
+            case "SCRAM-SHA-1":
+                self = .scramSHA1
+            case "SCRAM-SHA-256":
+                self = .scramSHA256
+            default:
+                self = .other(mechanism: rawValue)
+            }
+        }
     }
 }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -5,7 +5,7 @@ import NIOConcurrencyHelpers
 
 /// Options to use when creating a `MongoClient`.
 public struct ClientOptions: CodingStrategyProvider {
-    /// Authentication Credential
+    /// Specifies authentication options for use with the client.
     public var credential: Credential?
 
     /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -5,6 +5,9 @@ import NIOConcurrencyHelpers
 
 /// Options to use when creating a `MongoClient`.
 public struct ClientOptions: CodingStrategyProvider {
+    /// Authentication Credential
+    public var credential: Credential?
+
     /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
     /// databases or collections that derive from it.
     public var dataCodingStrategy: DataCodingStrategy?
@@ -77,6 +80,7 @@ public struct ClientOptions: CodingStrategyProvider {
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(
+        credential: Credential? = nil,
         dataCodingStrategy: DataCodingStrategy? = nil,
         dateCodingStrategy: DateCodingStrategy? = nil,
         maxPoolSize: Int? = nil,
@@ -94,6 +98,7 @@ public struct ClientOptions: CodingStrategyProvider {
         uuidCodingStrategy: UUIDCodingStrategy? = nil,
         writeConcern: WriteConcern? = nil
     ) {
+        self.credential = credential
         self.dataCodingStrategy = dataCodingStrategy
         self.dateCodingStrategy = dateCodingStrategy
         self.maxPoolSize = maxPoolSize

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -6,7 +6,7 @@ import NIOConcurrencyHelpers
 /// Options to use when creating a `MongoClient`.
 public struct ClientOptions: CodingStrategyProvider {
     /// Specifies authentication options for use with the client.
-    public var credential: Credential?
+    public var credential: MongoCredential?
 
     /// Specifies the `DataCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
     /// databases or collections that derive from it.
@@ -80,7 +80,7 @@ public struct ClientOptions: CodingStrategyProvider {
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(
-        credential: Credential? = nil,
+        credential: MongoCredential? = nil,
         dataCodingStrategy: DataCodingStrategy? = nil,
         dateCodingStrategy: DateCodingStrategy? = nil,
         maxPoolSize: Int? = nil,

--- a/Sources/MongoSwift/MongoCredential.swift
+++ b/Sources/MongoSwift/MongoCredential.swift
@@ -55,7 +55,7 @@ public struct MongoCredential: Decodable, Equatable {
         /// Name of the authentication mechanism.
         internal var name: String
 
-        public var description: String { "\(self.name)" }
+        public var description: String { self.name }
 
         internal init(_ name: String) {
             self.name = name

--- a/Sources/MongoSwift/MongoCredential.swift
+++ b/Sources/MongoSwift/MongoCredential.swift
@@ -37,19 +37,24 @@ public struct MongoCredential: Decodable, Equatable {
 
     /// Possible authentication mechanisms.
     public struct Mechanism: Decodable, Equatable, CustomStringConvertible {
-        /// See https://docs.mongodb.com/manual/core/kerberos/
+        /// GSSAPI authentication.
+        /// - SeeAlso: https://docs.mongodb.com/manual/core/kerberos/
         public static let gssAPI = Mechanism("GSSAPI")
 
-        /// See https://docs.mongodb.com/manual/core/security-x.509/#security-auth-x509
+        /// X509 authentication.
+        /// - SeeAlso: https://docs.mongodb.com/manual/core/security-x.509/#security-auth-x509
         public static let mongodbX509 = Mechanism("MONGODB-X509")
 
-        /// See https://docs.mongodb.com/manual/core/security-ldap/
+        /// PLAIN authentication.
+        /// - SeeAlso: https://docs.mongodb.com/manual/core/security-ldap/
         public static let plain = Mechanism("PLAIN")
 
-        /// See https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
+        /// SCRAM-SHA-1 authentication.
+        /// - SeeAlso: https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
         public static let scramSHA1 = Mechanism("SCRAM-SHA-1")
 
-        /// See https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
+        /// SCRAM-SHA-256 authentication.
+        /// - SeeAlso: https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
         public static let scramSHA256 = Mechanism("SCRAM-SHA-256")
 
         /// Name of the authentication mechanism.

--- a/Sources/MongoSwift/MongoCredential.swift
+++ b/Sources/MongoSwift/MongoCredential.swift
@@ -1,5 +1,5 @@
 /// Represents an authentication credential.
-public struct Credential: Decodable, Equatable {
+public struct MongoCredential: Decodable, Equatable {
     /// A string containing the username. For auth mechanisms that do not utilize a password, this may be the entire
     /// `userinfo` token from the connection string.
     public var username: String?
@@ -32,60 +32,36 @@ public struct Credential: Decodable, Equatable {
     }
 
     /// Possible authentication mechanisms.
-    public enum Mechanism: RawRepresentable, Decodable, Equatable {
+    public struct Mechanism: Codable, Equatable {
         /// See https://docs.mongodb.com/manual/core/kerberos/
-        case gssAPI
+        public static let gssAPI = Mechanism(name: "GSSAPI")
         /// Deprecated: see https://docs.mongodb.com/manual/release-notes/3.0-scram/
-        case mongodbCR
+        public static let mongodbCR = Mechanism(name: "MONGODB-CR")
         /// See https://docs.mongodb.com/manual/core/security-x.509/#security-auth-x509
-        case mongodbX509
+        public static let mongodbX509 = Mechanism(name: "MONGODB-X509")
         /// See https://docs.mongodb.com/manual/core/security-ldap/
-        case plain
+        public static let plain = Mechanism(name: "PLAIN")
         /// See https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
-        case scramSHA1
+        public static let scramSHA1 = Mechanism(name: "SCRAM-SHA-1")
         /// See https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
-        case scramSHA256
-        /// Any other authentication mechanism not covered by the other cases.
-        /// This case is present to provide forwards compatibility with any
-        /// future authentication mechanism which may be added to new versions of MongoDB.
-        case other(mechanism: String)
+        public static let scramSHA256 = Mechanism(name: "SCRAM-SHA-256")
 
-        public var rawValue: String {
-            switch self {
-            case .gssAPI:
-                return "GSSAPI"
-            case .mongodbCR:
-                return "MONGODB-CR"
-            case .mongodbX509:
-                return "MONGODB-X509"
-            case .plain:
-                return "PLAIN"
-            case .scramSHA1:
-                return "SCRAM-SHA-1"
-            case .scramSHA256:
-                return "SCRAM-SHA-256"
-            case let .other(mechanism: mechanism):
-                return mechanism
-            }
+        /// Name of the authentication mechanism.
+        public var name: String
+
+        public init(name: String) {
+            self.name = name
         }
 
-        public init?(rawValue: String) {
-            switch rawValue {
-            case "GSSAPI":
-                self = .gssAPI
-            case "MONGODB-CR":
-                self = .mongodbCR
-            case "MONGODB-X509":
-                self = .mongodbX509
-            case "PLAIN":
-                self = .plain
-            case "SCRAM-SHA-1":
-                self = .scramSHA1
-            case "SCRAM-SHA-256":
-                self = .scramSHA256
-            default:
-                self = .other(mechanism: rawValue)
-            }
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            self.name = string
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(self.name)
         }
     }
 }

--- a/Sources/MongoSwift/MongoCredential.swift
+++ b/Sources/MongoSwift/MongoCredential.swift
@@ -3,13 +3,17 @@ public struct MongoCredential: Decodable, Equatable {
     /// A string containing the username. For auth mechanisms that do not utilize a password, this may be the entire
     /// `userinfo` token from the connection string.
     public var username: String?
+
     /// A string containing the password.
     public var password: String?
+
     /// A string containing the authentication database.
     public var source: String?
+
     /// The authentication mechanism. A nil value for this property indicates that a mechanism wasn't specified and
     /// that mechanism negotiation is required.
     public var mechanism: Mechanism?
+
     /// A document containing mechanism-specific properties.
     public var mechanismProperties: Document?
 

--- a/Sources/MongoSwift/MongoCredential.swift
+++ b/Sources/MongoSwift/MongoCredential.swift
@@ -36,24 +36,28 @@ public struct MongoCredential: Decodable, Equatable {
     }
 
     /// Possible authentication mechanisms.
-    public struct Mechanism: Codable, Equatable {
+    public struct Mechanism: Decodable, Equatable, CustomStringConvertible {
         /// See https://docs.mongodb.com/manual/core/kerberos/
-        public static let gssAPI = Mechanism(name: "GSSAPI")
-        /// Deprecated: see https://docs.mongodb.com/manual/release-notes/3.0-scram/
-        public static let mongodbCR = Mechanism(name: "MONGODB-CR")
+        public static let gssAPI = Mechanism("GSSAPI")
+
         /// See https://docs.mongodb.com/manual/core/security-x.509/#security-auth-x509
-        public static let mongodbX509 = Mechanism(name: "MONGODB-X509")
+        public static let mongodbX509 = Mechanism("MONGODB-X509")
+
         /// See https://docs.mongodb.com/manual/core/security-ldap/
-        public static let plain = Mechanism(name: "PLAIN")
+        public static let plain = Mechanism("PLAIN")
+
         /// See https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
-        public static let scramSHA1 = Mechanism(name: "SCRAM-SHA-1")
+        public static let scramSHA1 = Mechanism("SCRAM-SHA-1")
+
         /// See https://docs.mongodb.com/manual/core/security-scram/#authentication-scram
-        public static let scramSHA256 = Mechanism(name: "SCRAM-SHA-256")
+        public static let scramSHA256 = Mechanism("SCRAM-SHA-256")
 
         /// Name of the authentication mechanism.
-        public var name: String
+        internal var name: String
 
-        public init(name: String) {
+        public var description: String { "\(self.name)" }
+
+        internal init(_ name: String) {
             self.name = name
         }
 
@@ -61,11 +65,6 @@ public struct MongoCredential: Decodable, Equatable {
             let container = try decoder.singleValueContainer()
             let string = try container.decode(String.self)
             self.name = string
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.singleValueContainer()
-            try container.encode(self.name)
         }
     }
 }

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 
@@ -42,7 +42,6 @@
 @_exported import struct MongoSwift.CountDocumentsOptions
 @_exported import struct MongoSwift.CreateCollectionOptions
 @_exported import struct MongoSwift.CreateIndexOptions
-@_exported import struct MongoSwift.Credential
 @_exported import enum MongoSwift.CursorType
 @_exported import struct MongoSwift.DBPointer
 @_exported import enum MongoSwift.DataCodingStrategy
@@ -77,6 +76,7 @@
 @_exported import struct MongoSwift.ListCollectionsOptions
 @_exported import struct MongoSwift.ListDatabasesOptions
 @_exported import struct MongoSwift.LogicError
+@_exported import struct MongoSwift.MongoCredential
 @_exported import struct MongoSwift.MongoNamespace
 @_exported import struct MongoSwift.ObjectId
 @_exported import enum MongoSwift.OperationType

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -10,6 +10,7 @@
 
 @_exported import struct MongoSwift.Address
 @_exported import struct MongoSwift.AggregateOptions
+@_exported import enum MongoSwift.AuthMechanism
 @_exported import struct MongoSwift.AuthenticationError
 @_exported import enum MongoSwift.BSON
 @_exported import struct MongoSwift.BSONCoderOptions
@@ -42,6 +43,7 @@
 @_exported import struct MongoSwift.CountDocumentsOptions
 @_exported import struct MongoSwift.CreateCollectionOptions
 @_exported import struct MongoSwift.CreateIndexOptions
+@_exported import struct MongoSwift.Credential
 @_exported import enum MongoSwift.CursorType
 @_exported import struct MongoSwift.DBPointer
 @_exported import enum MongoSwift.DataCodingStrategy

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -10,7 +10,6 @@
 
 @_exported import struct MongoSwift.Address
 @_exported import struct MongoSwift.AggregateOptions
-@_exported import enum MongoSwift.AuthMechanism
 @_exported import struct MongoSwift.AuthenticationError
 @_exported import enum MongoSwift.BSON
 @_exported import struct MongoSwift.BSONCoderOptions

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Tests/MongoSwiftSyncTests/SyncAuthTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncAuthTests.swift
@@ -8,7 +8,7 @@ import TestsCommon
 struct TestUser {
     let username: String
     let password: String
-    let mechanisms: [AuthMechanism]
+    let mechanisms: [MongoSwift.Credential.Mechanism]
 
     /// A command to create this user.
     var createCmd: Document {
@@ -22,7 +22,7 @@ struct TestUser {
 
     func createCredential(
         authSource: String = "admin",
-        mechanism: AuthMechanism? = nil,
+        mechanism: Credential.Mechanism? = nil,
         mechanismProperties: Document? = nil
     ) -> Credential {
         Credential(
@@ -35,7 +35,7 @@ struct TestUser {
     }
 
     /// Adds this user's username and password, and an optionally provided auth mechanism, to the connection string.
-    func addToConnString(_ connStr: String, mechanism: AuthMechanism? = nil) throws -> String {
+    func addToConnString(_ connStr: String, mechanism: Credential.Mechanism? = nil) throws -> String {
         // find where the first / is.
         guard let firstSlash = connStr.firstIndex(of: "/") else {
             throw TestError(message: "expected connection string to contain slash")
@@ -118,7 +118,7 @@ final class SyncAuthTests: MongoSwiftTestCase {
             // 3. For test users that support only one mechanism, verify that explicitly specifying the other mechanism
             //    fails.
             if user.mechanisms.count == 1 {
-                let wrongMech: AuthMechanism = user.mechanisms[0] == .scramSHA1 ? .scramSHA256 : .scramSHA1
+                let wrongMech: Credential.Mechanism = user.mechanisms[0] == .scramSHA1 ? .scramSHA256 : .scramSHA1
                 let connStrWrongMech = try user.addToConnString(connString, mechanism: wrongMech)
                 let clientWrongMech = try MongoClient.makeTestClient(connStrWrongMech)
                 expect(try clientWrongMech.db("admin").runCommand(["dbstats": 1]))
@@ -144,7 +144,7 @@ final class SyncAuthTests: MongoSwiftTestCase {
             // 3. For test users that support only one mechanism, verify that explicitly specifying the other mechanism
             //    fails.
             if user.mechanisms.count == 1 {
-                let wrongMech: AuthMechanism = user.mechanisms[0] == .scramSHA1 ? .scramSHA256 : .scramSHA1
+                let wrongMech: Credential.Mechanism = user.mechanisms[0] == .scramSHA1 ? .scramSHA256 : .scramSHA1
                 let options = ClientOptions(credential: user.createCredential(mechanism: wrongMech))
                 let clientWrongMech = try MongoClient.makeTestClient(connString, options: options)
                 expect(try clientWrongMech.db("admin").runCommand(["dbstats": 1]))

--- a/Tests/MongoSwiftTests/AuthTests.swift
+++ b/Tests/MongoSwiftTests/AuthTests.swift
@@ -18,7 +18,7 @@ struct AuthTestCase: Decodable {
     let valid: Bool
     /// An authentication credential. If nil, the credential must not be considered configured for the purpose of
     /// deciding if the driver should authenticate to the topology.
-    let credential: Credential?
+    let credential: MongoCredential?
 }
 
 final class AuthTests: MongoSwiftTestCase {


### PR DESCRIPTION
I made the Credential struct public so we can share the data structure with users specifying their authentication options. Since the URI in libmongoc is the source of truth about what settings the user wishes to have when connecting to mongo I set up a function to set all the authentication properties in the URI from the user specified Credential. Added tests to cover.