### PR TITLE
SWIFT-815: More convenient API for ReadConcern/WriteConcern creation

### DIFF
--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -2,6 +2,17 @@ import CLibMongoC
 
 /// A struct to represent a MongoDB read concern.
 public struct ReadConcern: Codable {
+    /// Local ReadConcern.
+    public static let local = ReadConcern(.local)
+    /// Available ReadConcern.
+    public static let available = ReadConcern(.available)
+    /// Linearizable ReadConcern.
+    public static let linearizable = ReadConcern(.linearizable)
+    /// Majority ReadConcern.
+    public static let majority = ReadConcern(.majority)
+    /// Snapshot ReadConcern.
+    public static let snapshot = ReadConcern(.snapshot)
+
     /// An enumeration of possible ReadConcern levels.
     public enum Level: RawRepresentable, Codable, Equatable {
         /// See https://docs.mongodb.com/manual/reference/read-concern-local/

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -3,6 +3,9 @@ import Foundation
 
 /// A class to represent a MongoDB write concern.
 public struct WriteConcern: Codable {
+    /// Majority WriteConcern.
+    public static let majority = WriteConcern(journal: false, w: W.majority, wtimeoutMS: 0)
+
     /// An option to request acknowledgement that the write operation has propagated to specified mongod instances.
     public enum W: Codable, Equatable {
         /// Specifies the number of nodes that should acknowledge the write. MUST be greater than or equal to 0.
@@ -111,6 +114,13 @@ public struct WriteConcern: Codable {
                 "Invalid combination of options: journal=\(journalStr), w=\(wStr), wtimeoutMS=\(timeoutStr)"
             )
         }
+    }
+
+    /// Initializes a new `WriteConcern` without throwing any errors.
+    fileprivate init(journal: Bool, w: W, wtimeoutMS: Int) {
+        self.journal = journal
+        self.w = w
+        self.wtimeoutMS = wtimeoutMS
     }
 
     /// Initializes a new `WriteConcern` with the same values as the provided `mongoc_write_concern_t`.


### PR DESCRIPTION
Added the convenience properties, documentation is sparse but maybe that's acceptable for this case. Let me know if we should put links in to the mongodb manual.