### PR TITLE
SWIFT-815: More convenient API for ReadConcern/WriteConcern creation

### DIFF
--- a/Examples/Docs/Sources/AsyncExamples/main.swift
+++ b/Examples/Docs/Sources/AsyncExamples/main.swift
@@ -19,7 +19,7 @@ private func causalConsistency() throws {
     let currentDate = Date()
     var dbOptions = DatabaseOptions(
         readConcern: .majority,
-        writeConcern: try WriteConcern(w: .majority, wtimeoutMS: 1000)
+        writeConcern: try WriteConcern.majority(wtimeoutMS: 1000)
     )
     let items = client1.db("test", options: dbOptions).collection("items")
     let result1 = items.updateOne(

--- a/Examples/Docs/Sources/AsyncExamples/main.swift
+++ b/Examples/Docs/Sources/AsyncExamples/main.swift
@@ -19,7 +19,7 @@ private func causalConsistency() throws {
     let currentDate = Date()
     var dbOptions = DatabaseOptions(
         readConcern: .majority,
-        writeConcern: try WriteConcern.majority(wtimeoutMS: 1000)
+        writeConcern: try .majority(wtimeoutMS: 1000)
     )
     let items = client1.db("test", options: dbOptions).collection("items")
     let result1 = items.updateOne(

--- a/Examples/Docs/Sources/AsyncExamples/main.swift
+++ b/Examples/Docs/Sources/AsyncExamples/main.swift
@@ -18,7 +18,7 @@ private func causalConsistency() throws {
     let s1 = client1.startSession(options: ClientSessionOptions(causalConsistency: true))
     let currentDate = Date()
     var dbOptions = DatabaseOptions(
-        readConcern: ReadConcern.majority,
+        readConcern: .majority,
         writeConcern: try WriteConcern(w: .majority, wtimeoutMS: 1000)
     )
     let items = client1.db("test", options: dbOptions).collection("items")

--- a/Examples/Docs/Sources/AsyncExamples/main.swift
+++ b/Examples/Docs/Sources/AsyncExamples/main.swift
@@ -18,7 +18,7 @@ private func causalConsistency() throws {
     let s1 = client1.startSession(options: ClientSessionOptions(causalConsistency: true))
     let currentDate = Date()
     var dbOptions = DatabaseOptions(
-        readConcern: ReadConcern(.majority),
+        readConcern: ReadConcern.majority,
         writeConcern: try WriteConcern(w: .majority, wtimeoutMS: 1000)
     )
     let items = client1.db("test", options: dbOptions).collection("items")

--- a/Examples/Docs/Sources/SyncExamples/main.swift
+++ b/Examples/Docs/Sources/SyncExamples/main.swift
@@ -12,7 +12,7 @@ private func causalConsistency() throws {
     let s1 = client1.startSession(options: ClientSessionOptions(causalConsistency: true))
     let currentDate = Date()
     var dbOptions = DatabaseOptions(
-        readConcern: ReadConcern.majority,
+        readConcern: .majority,
         writeConcern: try WriteConcern(w: .majority, wtimeoutMS: 1000)
     )
     let items = client1.db("test", options: dbOptions).collection("items")

--- a/Examples/Docs/Sources/SyncExamples/main.swift
+++ b/Examples/Docs/Sources/SyncExamples/main.swift
@@ -13,7 +13,7 @@ private func causalConsistency() throws {
     let currentDate = Date()
     var dbOptions = DatabaseOptions(
         readConcern: .majority,
-        writeConcern: try WriteConcern(w: .majority, wtimeoutMS: 1000)
+        writeConcern: try WriteConcern.majority(wtimeoutMS: 1000)
     )
     let items = client1.db("test", options: dbOptions).collection("items")
     try items.updateOne(

--- a/Examples/Docs/Sources/SyncExamples/main.swift
+++ b/Examples/Docs/Sources/SyncExamples/main.swift
@@ -13,7 +13,7 @@ private func causalConsistency() throws {
     let currentDate = Date()
     var dbOptions = DatabaseOptions(
         readConcern: .majority,
-        writeConcern: try WriteConcern.majority(wtimeoutMS: 1000)
+        writeConcern: try .majority(wtimeoutMS: 1000)
     )
     let items = client1.db("test", options: dbOptions).collection("items")
     try items.updateOne(

--- a/Examples/Docs/Sources/SyncExamples/main.swift
+++ b/Examples/Docs/Sources/SyncExamples/main.swift
@@ -12,7 +12,7 @@ private func causalConsistency() throws {
     let s1 = client1.startSession(options: ClientSessionOptions(causalConsistency: true))
     let currentDate = Date()
     var dbOptions = DatabaseOptions(
-        readConcern: ReadConcern(.majority),
+        readConcern: ReadConcern.majority,
         writeConcern: try WriteConcern(w: .majority, wtimeoutMS: 1000)
     )
     let items = client1.db("test", options: dbOptions).collection("items")

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -15,7 +15,7 @@ import NIO
  *
  * e.g.
  *   ```
- *   let opts = CollectionOptions(readConcern: ReadConcern(.majority), writeConcern: try WriteConcern(w: .majority))
+ *   let opts = CollectionOptions(readConcern: ReadConcern.majority, writeConcern: WriteConcern.majority)
  *   let collection = database.collection("mycoll", options: opts)
  *   let futureCount = client.withSession { session in
  *       collection.insertOne(["x": 1], session: session).flatMap { _ in

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -15,7 +15,7 @@ import NIO
  *
  * e.g.
  *   ```
- *   let opts = CollectionOptions(readConcern: ReadConcern.majority, writeConcern: WriteConcern.majority)
+ *   let opts = CollectionOptions(readConcern: .majority, writeConcern: .majority)
  *   let collection = database.collection("mycoll", options: opts)
  *   let futureCount = client.withSession { session in
  *       collection.insertOne(["x": 1], session: session).flatMap { _ in

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -449,7 +449,7 @@ public class MongoClient {
      * Gets a `MongoDatabase` instance for the given database name. If an option is not specified in the optional
      * `DatabaseOptions` param, the database will inherit the value from the parent client or the default if
      * the client’s option is not set. To override an option inherited from the client (e.g. a read concern) with the
-     * default value, it must be explicitly specified in the options param (e.g. ReadConcern(), not nil).
+     * default value, it must be explicitly specified in the options param (e.g. ReadConcern.empty, not nil).
      *
      * - Parameters:
      *   - name: the name of the database to retrieve

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -449,7 +449,7 @@ public class MongoClient {
      * Gets a `MongoDatabase` instance for the given database name. If an option is not specified in the optional
      * `DatabaseOptions` param, the database will inherit the value from the parent client or the default if
      * the client’s option is not set. To override an option inherited from the client (e.g. a read concern) with the
-     * default value, it must be explicitly specified in the options param (e.g. ReadConcern.empty, not nil).
+     * default value, it must be explicitly specified in the options param (e.g. ReadConcern.serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the database to retrieve

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -124,16 +124,18 @@ public struct MongoCollection<T: Codable> {
             // client. If this `MongoCollection`'s value for any of those settings is different than the parent, we
             //  need to explicitly set it here.
 
-        if self.readConcern != self._client.readConcern {
-            // a nil value for self.readConcern corresponds to the empty read concern.
-            (self.readConcern ?? .serverDefault).withMongocReadConcern { rcPtr in
-                mongoc_collection_set_read_concern(collection, rcPtr)
+            if self.readConcern != self._client.readConcern {
+                // a nil value for self.readConcern corresponds to the empty read concern.
+                (self.readConcern ?? .serverDefault).withMongocReadConcern { rcPtr in
+                    mongoc_collection_set_read_concern(collection, rcPtr)
+                }
             }
 
-        if self.writeConcern != self._client.writeConcern {
-            // a nil value for self.writeConcern corresponds to the empty write concern.
-            (self.writeConcern ?? .serverDefault).withMongocWriteConcern { wcPtr in
-                mongoc_collection_set_write_concern(collection, wcPtr)
+            if self.writeConcern != self._client.writeConcern {
+                // a nil value for self.writeConcern corresponds to the empty write concern.
+                (self.writeConcern ?? .serverDefault).withMongocWriteConcern { wcPtr in
+                    mongoc_collection_set_write_concern(collection, wcPtr)
+                }
             }
 
             if self.readPreference != self._client.readPreference {

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -124,11 +124,10 @@ public struct MongoCollection<T: Codable> {
             // client. If this `MongoCollection`'s value for any of those settings is different than the parent, we
             //  need to explicitly set it here.
 
-            if self.readConcern != self._client.readConcern {
-                // a nil value for self.readConcern corresponds to the empty read concern.
-                (self.readConcern ?? ReadConcern()).withMongocReadConcern { rcPtr in
-                    mongoc_collection_set_read_concern(collection, rcPtr)
-                }
+        if self.readConcern != self._client.readConcern {
+            // a nil value for self.readConcern corresponds to the empty read concern.
+            (self.readConcern ?? ReadConcern.empty).withMongocReadConcern { rcPtr in
+                mongoc_collection_set_read_concern(collection, rcPtr)
             }
 
             if self.writeConcern != self._client.writeConcern {

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -126,15 +126,14 @@ public struct MongoCollection<T: Codable> {
 
         if self.readConcern != self._client.readConcern {
             // a nil value for self.readConcern corresponds to the empty read concern.
-            (self.readConcern ?? .empty).withMongocReadConcern { rcPtr in
+            (self.readConcern ?? .serverDefault).withMongocReadConcern { rcPtr in
                 mongoc_collection_set_read_concern(collection, rcPtr)
             }
 
-            if self.writeConcern != self._client.writeConcern {
-                // a nil value for self.writeConcern corresponds to the empty write concern.
-                (self.writeConcern ?? WriteConcern()).withMongocWriteConcern { wcPtr in
-                    mongoc_collection_set_write_concern(collection, wcPtr)
-                }
+        if self.writeConcern != self._client.writeConcern {
+            // a nil value for self.writeConcern corresponds to the empty write concern.
+            (self.writeConcern ?? .serverDefault).withMongocWriteConcern { wcPtr in
+                mongoc_collection_set_write_concern(collection, wcPtr)
             }
 
             if self.readPreference != self._client.readPreference {

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -126,7 +126,7 @@ public struct MongoCollection<T: Codable> {
 
         if self.readConcern != self._client.readConcern {
             // a nil value for self.readConcern corresponds to the empty read concern.
-            (self.readConcern ?? ReadConcern.empty).withMongocReadConcern { rcPtr in
+            (self.readConcern ?? .empty).withMongocReadConcern { rcPtr in
                 mongoc_collection_set_read_concern(collection, rcPtr)
             }
 

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -135,7 +135,7 @@ public struct MongoDatabase {
      * Access a collection within this database. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern.empty, not nil).
+     * specified in the options param (e.g. ReadConcern.serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get
@@ -153,7 +153,7 @@ public struct MongoDatabase {
      * `MongoCollection` instance. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern.empty, not nil).
+     * specified in the options param (e.g. ReadConcern.serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -135,7 +135,7 @@ public struct MongoDatabase {
      * Access a collection within this database. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern.serverDefault, not nil).
+     * specified in the options param (e.g. .serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get
@@ -153,7 +153,7 @@ public struct MongoDatabase {
      * `MongoCollection` instance. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern.serverDefault, not nil).
+     * specified in the options param (e.g. .serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get
@@ -476,16 +476,18 @@ public struct MongoDatabase {
             // If this database's value for any of those settings is different than the parent, we need to explicitly
             // set it here.
 
-        if self.readConcern != self._client.readConcern {
-            // a nil value for self.readConcern corresponds to the empty read concern.
-            (self.readConcern ?? .serverDefault).withMongocReadConcern { rcPtr in
-                mongoc_database_set_read_concern(db, rcPtr)
+            if self.readConcern != self._client.readConcern {
+                // a nil value for self.readConcern corresponds to the empty read concern.
+                (self.readConcern ?? .serverDefault).withMongocReadConcern { rcPtr in
+                    mongoc_database_set_read_concern(db, rcPtr)
+                }
             }
 
-        if self.writeConcern != self._client.writeConcern {
-            // a nil value for self.writeConcern corresponds to the empty write concern.
-            (self.writeConcern ?? .serverDefault).withMongocWriteConcern { wcPtr in
-                mongoc_database_set_write_concern(db, wcPtr)
+            if self.writeConcern != self._client.writeConcern {
+                // a nil value for self.writeConcern corresponds to the empty write concern.
+                (self.writeConcern ?? WriteConcern()).withMongocWriteConcern { wcPtr in
+                    mongoc_database_set_write_concern(db, wcPtr)
+                }
             }
 
             if self.readPreference != self._client.readPreference {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -478,7 +478,7 @@ public struct MongoDatabase {
 
         if self.readConcern != self._client.readConcern {
             // a nil value for self.readConcern corresponds to the empty read concern.
-            (self.readConcern ?? ReadConcern.empty).withMongocReadConcern { rcPtr in
+            (self.readConcern ?? .empty).withMongocReadConcern { rcPtr in
                 mongoc_database_set_read_concern(db, rcPtr)
             }
 

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -478,15 +478,14 @@ public struct MongoDatabase {
 
         if self.readConcern != self._client.readConcern {
             // a nil value for self.readConcern corresponds to the empty read concern.
-            (self.readConcern ?? .empty).withMongocReadConcern { rcPtr in
+            (self.readConcern ?? .serverDefault).withMongocReadConcern { rcPtr in
                 mongoc_database_set_read_concern(db, rcPtr)
             }
 
-            if self.writeConcern != self._client.writeConcern {
-                // a nil value for self.writeConcern corresponds to the empty write concern.
-                (self.writeConcern ?? WriteConcern()).withMongocWriteConcern { wcPtr in
-                    mongoc_database_set_write_concern(db, wcPtr)
-                }
+        if self.writeConcern != self._client.writeConcern {
+            // a nil value for self.writeConcern corresponds to the empty write concern.
+            (self.writeConcern ?? .serverDefault).withMongocWriteConcern { wcPtr in
+                mongoc_database_set_write_concern(db, wcPtr)
             }
 
             if self.readPreference != self._client.readPreference {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -135,7 +135,7 @@ public struct MongoDatabase {
      * Access a collection within this database. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern(), not nil).
+     * specified in the options param (e.g. ReadConcern.empty, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get
@@ -153,7 +153,7 @@ public struct MongoDatabase {
      * `MongoCollection` instance. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern(), not nil).
+     * specified in the options param (e.g. ReadConcern.empty, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get
@@ -476,11 +476,10 @@ public struct MongoDatabase {
             // If this database's value for any of those settings is different than the parent, we need to explicitly
             // set it here.
 
-            if self.readConcern != self._client.readConcern {
-                // a nil value for self.readConcern corresponds to the empty read concern.
-                (self.readConcern ?? ReadConcern()).withMongocReadConcern { rcPtr in
-                    mongoc_database_set_read_concern(db, rcPtr)
-                }
+        if self.readConcern != self._client.readConcern {
+            // a nil value for self.readConcern corresponds to the empty read concern.
+            (self.readConcern ?? ReadConcern.empty).withMongocReadConcern { rcPtr in
+                mongoc_database_set_read_concern(db, rcPtr)
             }
 
             if self.writeConcern != self._client.writeConcern {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -135,7 +135,7 @@ public struct MongoDatabase {
      * Access a collection within this database. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. .serverDefault, not nil).
+     * specified in the options param (e.g. ReadConcern.serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get
@@ -153,7 +153,7 @@ public struct MongoDatabase {
      * `MongoCollection` instance. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. .serverDefault, not nil).
+     * specified in the options param (e.g. ReadConcern.serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -2,74 +2,37 @@ import CLibMongoC
 
 /// A struct to represent a MongoDB read concern.
 public struct ReadConcern: Codable {
-    /// Local ReadConcern, see https://docs.mongodb.com/manual/reference/read-concern-local/.
-    public static let local = ReadConcern(.local)
+    /// Local ReadConcern.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/read-concern-local/
+    public static let local = ReadConcern("local")
 
-    /// Available ReadConcern, see https://docs.mongodb.com/manual/reference/read-concern-available/.
-    public static let available = ReadConcern(.available)
+    /// Available ReadConcern.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/read-concern-available/
+    public static let available = ReadConcern("available")
 
-    /// Linearizable ReadConcern, see https://docs.mongodb.com/manual/reference/read-concern-majority/.
-    public static let linearizable = ReadConcern(.linearizable)
+    /// Linearizable ReadConcern.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/read-concern-majority/
+    public static let linearizable = ReadConcern("linearizable")
 
-    /// Majority ReadConcern, see https://docs.mongodb.com/manual/reference/read-concern-linearizable/.
-    public static let majority = ReadConcern(.majority)
+    /// Majority ReadConcern.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/read-concern-linearizable/
+    public static let majority = ReadConcern("majority")
 
-    /// Snapshot ReadConcern, see https://docs.mongodb.com/master/reference/read-concern-snapshot/.
-    public static let snapshot = ReadConcern(.snapshot)
+    /// Snapshot ReadConcern.
+    /// - SeeAlso: https://docs.mongodb.com/master/reference/read-concern-snapshot/
+    public static let snapshot = ReadConcern("snapshot")
 
     /// Server default ReadConcern.
     public static let serverDefault = ReadConcern(nil)
 
-    public static func other(_ level: Level) -> ReadConcern {
+    /// For an unknown ReadConcern.
+    /// For forwards compatibility, no error will be thrown when an unknown value is provided.
+    public static func other(_ level: String) -> ReadConcern {
         ReadConcern(level)
     }
 
-    public static func other(_ level: String) -> ReadConcern {
-        ReadConcern(Level(level))
-    }
-
-    /// An enumeration of possible ReadConcern levels.
-    public struct Level: Codable, Equatable, LosslessStringConvertible {
-        /// See https://docs.mongodb.com/manual/reference/read-concern-local/
-        public static let local = Level("local")
-
-        /// See https://docs.mongodb.com/manual/reference/read-concern-available/
-        public static let available = Level("available")
-
-        /// See https://docs.mongodb.com/manual/reference/read-concern-majority/
-        public static let majority = Level("majority")
-
-        /// See https://docs.mongodb.com/manual/reference/read-concern-linearizable/
-        public static let linearizable = Level("linearizable")
-
-        /// See https://docs.mongodb.com/master/reference/read-concern-snapshot/
-        public static let snapshot = Level("snapshot")
-
-        private var name: String
-
-        /// Returns the string value of the Level for convenient conversion.
-        public var description: String { "\(self.name)" }
-
-        /// Initialize a new `Level` from `String`
-        /// This initializer allows any `String` for forward compatabilty.
-        public init(_ name: String) {
-            self.name = name
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.singleValueContainer()
-            let string = try container.decode(String.self)
-            self.name = string
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.singleValueContainer()
-            try container.encode(self.name)
-        }
-    }
-
     /// The level of this `ReadConcern`, or `nil` if the level is not set.
-    public var level: Level?
+    internal var level: String?
 
     /// Indicates whether this `ReadConcern` is the server default.
     public var isDefault: Bool {
@@ -80,12 +43,12 @@ public struct ReadConcern: Codable {
     // The caller is responsible for freeing the original `mongoc_read_concern_t`.
     internal init(copying readConcern: OpaquePointer) {
         if let level = mongoc_read_concern_get_level(readConcern) {
-            self.level = Level(String(cString: level))
+            self.level = String(cString: level)
         }
     }
 
-    /// Initialize a new `ReadConcern` with a `Level`.
-    fileprivate init(_ level: Level?) {
+    /// Initialize a new `ReadConcern` with a `String`.
+    fileprivate init(_ level: String?) {
         self.level = level
     }
 
@@ -97,7 +60,7 @@ public struct ReadConcern: Codable {
         let readConcern: OpaquePointer = mongoc_read_concern_new()
         defer { mongoc_read_concern_destroy(readConcern) }
         if let level = self.level {
-            mongoc_read_concern_set_level(readConcern, String(level))
+            mongoc_read_concern_set_level(readConcern, level)
         }
         return try body(readConcern)
     }

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -4,16 +4,21 @@ import CLibMongoC
 public struct ReadConcern: Codable {
     /// Local ReadConcern, see https://docs.mongodb.com/manual/reference/read-concern-local/.
     public static let local = ReadConcern(.local)
+
     /// Available ReadConcern, see https://docs.mongodb.com/manual/reference/read-concern-available/.
     public static let available = ReadConcern(.available)
+
     /// Linearizable ReadConcern, see https://docs.mongodb.com/manual/reference/read-concern-majority/.
     public static let linearizable = ReadConcern(.linearizable)
+
     /// Majority ReadConcern, see https://docs.mongodb.com/manual/reference/read-concern-linearizable/.
     public static let majority = ReadConcern(.majority)
+
     /// Snapshot ReadConcern, see https://docs.mongodb.com/master/reference/read-concern-snapshot/.
     public static let snapshot = ReadConcern(.snapshot)
-    /// Empty ReadConcern.
-    public static let empty = ReadConcern(nil)
+
+    /// Server default ReadConcern.
+    public static let serverDefault = ReadConcern(nil)
 
     public static func other(_ level: Level) -> ReadConcern {
         ReadConcern(level)
@@ -24,20 +29,29 @@ public struct ReadConcern: Codable {
     }
 
     /// An enumeration of possible ReadConcern levels.
-    public struct Level: Codable, Equatable {
+    public struct Level: Codable, Equatable, LosslessStringConvertible {
         /// See https://docs.mongodb.com/manual/reference/read-concern-local/
         public static let local = Level("local")
+
         /// See https://docs.mongodb.com/manual/reference/read-concern-available/
         public static let available = Level("available")
+
         /// See https://docs.mongodb.com/manual/reference/read-concern-majority/
         public static let majority = Level("majority")
+
         /// See https://docs.mongodb.com/manual/reference/read-concern-linearizable/
         public static let linearizable = Level("linearizable")
+
         /// See https://docs.mongodb.com/master/reference/read-concern-snapshot/
         public static let snapshot = Level("snapshot")
 
-        public var name: String
+        private var name: String
 
+        /// Returns the string value of the Level for convenient conversion.
+        public var description: String { "\(self.name)" }
+
+        /// Initialize a new `Level` from `String`
+        /// This initializer allows any `String` for forward compatabilty.
         public init(_ name: String) {
             self.name = name
         }
@@ -83,7 +97,7 @@ public struct ReadConcern: Codable {
         let readConcern: OpaquePointer = mongoc_read_concern_new()
         defer { mongoc_read_concern_destroy(readConcern) }
         if let level = self.level {
-            mongoc_read_concern_set_level(readConcern, level.name)
+            mongoc_read_concern_set_level(readConcern, String(level))
         }
         return try body(readConcern)
     }

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -12,6 +12,12 @@ public struct ReadConcern: Codable {
     public static let majority = ReadConcern(.majority)
     /// Snapshot ReadConcern.
     public static let snapshot = ReadConcern(.snapshot)
+    /// Empty ReadConcern.
+    public static let empty = ReadConcern(nil)
+
+    public static func other(_ level: String) -> ReadConcern {
+        ReadConcern(level)
+    }
 
     /// An enumeration of possible ReadConcern levels.
     public enum Level: RawRepresentable, Codable, Equatable {
@@ -80,18 +86,13 @@ public struct ReadConcern: Codable {
     }
 
     /// Initialize a new `ReadConcern` with a `Level`.
-    public init(_ level: Level) {
+    fileprivate init(_ level: Level?) {
         self.level = level
     }
 
     /// Initialize a new `ReadConcern` from a `String` corresponding to a read concern level.
-    public init(_ level: String) {
+    fileprivate init(_ level: String) {
         self.level = Level(rawValue: level)
-    }
-
-    /// Initialize a new empty `ReadConcern`.
-    public init() {
-        self.level = nil
     }
 
     /**

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -2,6 +2,17 @@ import CLibMongoC
 
 /// A struct to represent a MongoDB read concern.
 public struct ReadConcern: Codable {
+    /// Local ReadConcern.
+    public static let local = ReadConcern(.local)
+    /// Available ReadConcern.
+    public static let available = ReadConcern(.available)
+    /// Linearizable ReadConcern.
+    public static let linearizable = ReadConcern(.linearizable)
+    /// Majority ReadConcern.
+    public static let majority = ReadConcern(.majority)
+    /// Snapshot ReadConcern.
+    public static let snapshot = ReadConcern(.snapshot)
+
     /// An enumeration of possible ReadConcern levels.
     public enum Level: RawRepresentable, Codable, Equatable {
         /// See https://docs.mongodb.com/manual/reference/read-concern-local/

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -3,18 +3,19 @@ import Foundation
 
 /// A class to represent a MongoDB write concern.
 public struct WriteConcern: Codable {
-    /// Majority WriteConcern
+    /// Majority WriteConcern with journal and wtimeoutMS unset.
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/write-concern/#writeconcern._dq_majority_dq_
-    // swiftlint:disable force_try
     public static let majority = try! WriteConcern(w: .majority)
-    // swiftlint:enable force_try
+    // swiftlint:disable:previous force_try
+    // lint disabled since the force try will throw during testing given its static
 
     /**
      * Returns a customized Majority WriteConcern.
      *
      * - Parameters:
-     *   - wtimeoutMS: This option specifies a time limit, in milliseconds, for the write concern.
-     *   - journal: requests acknowledgment that the mongod instances, have written to the on-disk journal.
+     *   - wtimeoutMS: The maximum amount of time, in milliseconds, that the primary will wait for the write concern
+     *   to be satisfied before returning a WriteConcernError.
+     *   - journal: requests acknowledgment that the mongod instances have written to the on-disk journal.
      *
      * - SeeAlso: https://docs.mongodb.com/manual/reference/write-concern/#writeconcern._dq_majority_dq_
      */

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -3,8 +3,14 @@ import Foundation
 
 /// A class to represent a MongoDB write concern.
 public struct WriteConcern: Codable {
-    /// Majority WriteConcern.
-    public static let majority = WriteConcern(journal: nil, w: .majority, wtimeoutMS: nil)
+    /// Majority WriteConcern,
+    /// see https://docs.mongodb.com/manual/reference/write-concern/#writeconcern._dq_majority_dq_.
+    // swiftlint:disable force_try
+    public static let majority = try! WriteConcern(w: .majority)
+    // swiftlint:enable force_try
+
+    /// Server default WriteConcern.
+    public static let serverDefault = WriteConcern()
 
     /// An option to request acknowledgement that the write operation has propagated to specified mongod instances.
     public enum W: Codable, Equatable {
@@ -114,13 +120,6 @@ public struct WriteConcern: Codable {
                 "Invalid combination of options: journal=\(journalStr), w=\(wStr), wtimeoutMS=\(timeoutStr)"
             )
         }
-    }
-
-    /// Initializes a new `WriteConcern` without throwing any errors.
-    fileprivate init(journal: Bool?, w: W, wtimeoutMS: Int?) {
-        self.journal = journal
-        self.w = w
-        self.wtimeoutMS = wtimeoutMS
     }
 
     /// Initializes a new `WriteConcern` with the same values as the provided `mongoc_write_concern_t`.

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -3,11 +3,17 @@ import Foundation
 
 /// A class to represent a MongoDB write concern.
 public struct WriteConcern: Codable {
-    /// Majority WriteConcern,
-    /// see https://docs.mongodb.com/manual/reference/write-concern/#writeconcern._dq_majority_dq_.
+    /// Majority WriteConcern
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/write-concern/#writeconcern._dq_majority_dq_
     // swiftlint:disable force_try
     public static let majority = try! WriteConcern(w: .majority)
     // swiftlint:enable force_try
+
+    /// Returns Majority WriteConcern.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/write-concern/#writeconcern._dq_majority_dq_
+    public static func majority(wtimeoutMS: Int? = nil, journal: Bool? = nil) throws -> WriteConcern {
+        try WriteConcern(journal: journal, w: .majority, wtimeoutMS: wtimeoutMS)
+    }
 
     /// Server default WriteConcern.
     public static let serverDefault = WriteConcern()

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -9,8 +9,15 @@ public struct WriteConcern: Codable {
     public static let majority = try! WriteConcern(w: .majority)
     // swiftlint:enable force_try
 
-    /// Returns Majority WriteConcern.
-    /// - SeeAlso: https://docs.mongodb.com/manual/reference/write-concern/#writeconcern._dq_majority_dq_
+    /**
+     * Returns a customized Majority WriteConcern.
+     *
+     * - Parameters:
+     *   - wtimeoutMS: This option specifies a time limit, in milliseconds, for the write concern.
+     *   - journal: requests acknowledgment that the mongod instances, have written to the on-disk journal.
+     *
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/write-concern/#writeconcern._dq_majority_dq_
+     */
     public static func majority(wtimeoutMS: Int? = nil, journal: Bool? = nil) throws -> WriteConcern {
         try WriteConcern(journal: journal, w: .majority, wtimeoutMS: wtimeoutMS)
     }

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -3,6 +3,9 @@ import Foundation
 
 /// A class to represent a MongoDB write concern.
 public struct WriteConcern: Codable {
+    /// Majority WriteConcern.
+    public static let majority = WriteConcern(journal: false, w: W.majority, wtimeoutMS: 0)
+
     /// An option to request acknowledgement that the write operation has propagated to specified mongod instances.
     public enum W: Codable, Equatable {
         /// Specifies the number of nodes that should acknowledge the write. MUST be greater than or equal to 0.
@@ -111,6 +114,13 @@ public struct WriteConcern: Codable {
                 "Invalid combination of options: journal=\(journalStr), w=\(wStr), wtimeoutMS=\(timeoutStr)"
             )
         }
+    }
+
+    /// Initializes a new `WriteConcern` without throwing any errors.
+    fileprivate init(journal: Bool, w: W, wtimeoutMS: Int) {
+        self.journal = journal
+        self.w = w
+        self.wtimeoutMS = wtimeoutMS
     }
 
     /// Initializes a new `WriteConcern` with the same values as the provided `mongoc_write_concern_t`.

--- a/Sources/MongoSwift/WriteConcern.swift
+++ b/Sources/MongoSwift/WriteConcern.swift
@@ -4,7 +4,7 @@ import Foundation
 /// A class to represent a MongoDB write concern.
 public struct WriteConcern: Codable {
     /// Majority WriteConcern.
-    public static let majority = WriteConcern(journal: false, w: W.majority, wtimeoutMS: 0)
+    public static let majority = WriteConcern(journal: nil, w: .majority, wtimeoutMS: nil)
 
     /// An option to request acknowledgement that the write operation has propagated to specified mongod instances.
     public enum W: Codable, Equatable {
@@ -117,7 +117,7 @@ public struct WriteConcern: Codable {
     }
 
     /// Initializes a new `WriteConcern` without throwing any errors.
-    fileprivate init(journal: Bool, w: W, wtimeoutMS: Int) {
+    fileprivate init(journal: Bool?, w: W, wtimeoutMS: Int?) {
         self.journal = journal
         self.w = w
         self.wtimeoutMS = wtimeoutMS

--- a/Sources/MongoSwiftSync/ClientSession.swift
+++ b/Sources/MongoSwiftSync/ClientSession.swift
@@ -13,7 +13,7 @@ import MongoSwift
  *
  * e.g.
  *   ```
- *   let opts = CollectionOptions(readConcern: ReadConcern(.majority), writeConcern: try WriteConcern(w: .majority))
+ *   let opts = CollectionOptions(readConcern: ReadConcern.majority, writeConcern: WriteConcern.majority)
  *   let collection = database.collection("mycoll", options: opts)
  *   try client.withSession { session in
  *       try collection.insertOne(["x": 1], session: session)

--- a/Sources/MongoSwiftSync/ClientSession.swift
+++ b/Sources/MongoSwiftSync/ClientSession.swift
@@ -13,7 +13,7 @@ import MongoSwift
  *
  * e.g.
  *   ```
- *   let opts = CollectionOptions(readConcern: ReadConcern.majority, writeConcern: WriteConcern.majority)
+ *   let opts = CollectionOptions(readConcern: .majority, writeConcern: WriteConcern.majority)
  *   let collection = database.collection("mycoll", options: opts)
  *   try client.withSession { session in
  *       try collection.insertOne(["x": 1], session: session)

--- a/Sources/MongoSwiftSync/ClientSession.swift
+++ b/Sources/MongoSwiftSync/ClientSession.swift
@@ -13,7 +13,7 @@ import MongoSwift
  *
  * e.g.
  *   ```
- *   let opts = CollectionOptions(readConcern: .majority, writeConcern: WriteConcern.majority)
+ *   let opts = CollectionOptions(readConcern: .majority, writeConcern: .majority)
  *   let collection = database.collection("mycoll", options: opts)
  *   try client.withSession { session in
  *       try collection.insertOne(["x": 1], session: session)

--- a/Sources/MongoSwiftSync/MongoClient.swift
+++ b/Sources/MongoSwiftSync/MongoClient.swift
@@ -160,7 +160,7 @@ public class MongoClient {
      * Gets a `MongoDatabase` instance for the given database name. If an option is not specified in the optional
      * `DatabaseOptions` param, the database will inherit the value from the parent client or the default if
      * the client’s option is not set. To override an option inherited from the client (e.g. a read concern) with the
-     * default value, it must be explicitly specified in the options param (e.g. ReadConcern.empty, not nil).
+     * default value, it must be explicitly specified in the options param (e.g. ReadConcern.serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the database to retrieve

--- a/Sources/MongoSwiftSync/MongoClient.swift
+++ b/Sources/MongoSwiftSync/MongoClient.swift
@@ -160,7 +160,7 @@ public class MongoClient {
      * Gets a `MongoDatabase` instance for the given database name. If an option is not specified in the optional
      * `DatabaseOptions` param, the database will inherit the value from the parent client or the default if
      * the client’s option is not set. To override an option inherited from the client (e.g. a read concern) with the
-     * default value, it must be explicitly specified in the options param (e.g. ReadConcern(), not nil).
+     * default value, it must be explicitly specified in the options param (e.g. ReadConcern.empty, not nil).
      *
      * - Parameters:
      *   - name: the name of the database to retrieve

--- a/Sources/MongoSwiftSync/MongoDatabase.swift
+++ b/Sources/MongoSwiftSync/MongoDatabase.swift
@@ -51,7 +51,7 @@ public struct MongoDatabase {
      * Access a collection within this database. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern(), not nil).
+     * specified in the options param (e.g. ReadConcern.empty, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get
@@ -69,7 +69,7 @@ public struct MongoDatabase {
      * `MongoCollection` instance. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern(), not nil).
+     * specified in the options param (e.g. ReadConcern.empty, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get

--- a/Sources/MongoSwiftSync/MongoDatabase.swift
+++ b/Sources/MongoSwiftSync/MongoDatabase.swift
@@ -51,7 +51,7 @@ public struct MongoDatabase {
      * Access a collection within this database. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern.empty, not nil).
+     * specified in the options param (e.g. ReadConcern.serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get
@@ -69,7 +69,7 @@ public struct MongoDatabase {
      * `MongoCollection` instance. If an option is not specified in the `CollectionOptions` param, the
      * collection will inherit the value from the parent database or the default if the db's option is not set.
      * To override an option inherited from the db (e.g. a read concern) with the default value, it must be explicitly
-     * specified in the options param (e.g. ReadConcern.empty, not nil).
+     * specified in the options param (e.g. ReadConcern.serverDefault, not nil).
      *
      * - Parameters:
      *   - name: the name of the collection to get

--- a/Tests/BSONTests/CodecTests.swift
+++ b/Tests/BSONTests/CodecTests.swift
@@ -775,7 +775,7 @@ final class CodecTests: MongoSwiftTestCase {
     func testOptionsEncoding() throws {
         let encoder = BSONEncoder()
 
-        let rc = ReadConcern(.majority)
+        let rc = ReadConcern.majority
         let wc = try WriteConcern(wtimeoutMS: 123)
         let rp = ReadPreference.primary
 

--- a/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
@@ -417,7 +417,7 @@ final class SyncClientSessionTests: MongoSwiftTestCase {
         try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
             let collection1 = db.collection(
                 self.getCollectionName(),
-                options: CollectionOptions(readConcern: ReadConcern(.local))
+                options: CollectionOptions(readConcern: ReadConcern.local)
             )
             _ = try collection1.countDocuments(session: session)
             let opTime = session.operationTime

--- a/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
@@ -417,7 +417,7 @@ final class SyncClientSessionTests: MongoSwiftTestCase {
         try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
             let collection1 = db.collection(
                 self.getCollectionName(),
-                options: CollectionOptions(readConcern: ReadConcern.local)
+                options: CollectionOptions(readConcern: .local)
             )
             _ = try collection1.countDocuments(session: session)
             let opTime = session.operationTime

--- a/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
@@ -410,7 +410,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.countDocuments()).to(equal(1))
 
         // test using a write concern
-        let opts2 = FindOneAndDeleteOptions(writeConcern: WriteConcern.majority)
+        let opts2 = FindOneAndDeleteOptions(writeConcern: .majority)
         let result2 = try self.coll.findOneAndDelete([:], options: opts2)
         expect(result2).to(equal(self.doc1))
         expect(try self.coll.countDocuments()).to(equal(0))
@@ -446,7 +446,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.countDocuments()).to(equal(2))
 
         // test using a write concern
-        let opts3 = FindOneAndReplaceOptions(writeConcern: WriteConcern.majority)
+        let opts3 = FindOneAndReplaceOptions(writeConcern: .majority)
         let result3 = try self.coll.findOneAndReplace(
             filter: ["cat": "blah"],
             replacement: ["cat": "cat"],
@@ -486,7 +486,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.countDocuments()).to(equal(2))
 
         // test using a write concern
-        let opts3 = FindOneAndUpdateOptions(writeConcern: WriteConcern.majority)
+        let opts3 = FindOneAndUpdateOptions(writeConcern: .majority)
         let result3 = try self.coll.findOneAndUpdate(
             filter: ["cat": "blah"],
             update: ["$set": ["cat": "cat"]],

--- a/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
@@ -410,7 +410,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.countDocuments()).to(equal(1))
 
         // test using a write concern
-        let opts2 = FindOneAndDeleteOptions(writeConcern: try WriteConcern(w: .majority))
+        let opts2 = FindOneAndDeleteOptions(writeConcern: WriteConcern.majority)
         let result2 = try self.coll.findOneAndDelete([:], options: opts2)
         expect(result2).to(equal(self.doc1))
         expect(try self.coll.countDocuments()).to(equal(0))
@@ -446,7 +446,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.countDocuments()).to(equal(2))
 
         // test using a write concern
-        let opts3 = FindOneAndReplaceOptions(writeConcern: try WriteConcern(w: .majority))
+        let opts3 = FindOneAndReplaceOptions(writeConcern: WriteConcern.majority)
         let result3 = try self.coll.findOneAndReplace(
             filter: ["cat": "blah"],
             replacement: ["cat": "cat"],
@@ -486,7 +486,7 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try self.coll.countDocuments()).to(equal(2))
 
         // test using a write concern
-        let opts3 = FindOneAndUpdateOptions(writeConcern: try WriteConcern(w: .majority))
+        let opts3 = FindOneAndUpdateOptions(writeConcern: WriteConcern.majority)
         let result3 = try self.coll.findOneAndUpdate(
             filter: ["cat": "blah"],
             update: ["$set": ["cat": "cat"]],

--- a/Tests/MongoSwiftSyncTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoDatabaseTests.swift
@@ -94,7 +94,7 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
             validationAction: "warn",
             validationLevel: "moderate",
             validator: ["phone": ["$type": "string"]],
-            writeConcern: try WriteConcern(w: .majority)
+            writeConcern: WriteConcern.majority
         )
         expect(try db.createCollection("foo", options: fooOptions)).toNot(throwError())
 

--- a/Tests/MongoSwiftSyncTests/MongoDatabaseTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoDatabaseTests.swift
@@ -94,7 +94,7 @@ final class MongoDatabaseTests: MongoSwiftTestCase {
             validationAction: "warn",
             validationLevel: "moderate",
             validator: ["phone": ["$type": "string"]],
-            writeConcern: WriteConcern.majority
+            writeConcern: .majority
         )
         expect(try db.createCollection("foo", options: fooOptions)).toNot(throwError())
 

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -18,17 +18,17 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
         let command: Document = ["count": .string(coll.name)]
 
         // run command with a valid readConcern
-        let options1 = RunCommandOptions(readConcern: ReadConcern(.local))
+        let options1 = RunCommandOptions(readConcern: ReadConcern.local)
         let res1 = try db.runCommand(command, options: options1)
         expect(res1["ok"]?.asDouble()).to(equal(1.0))
 
         // run command with an empty readConcern
-        let options2 = RunCommandOptions(readConcern: ReadConcern())
+        let options2 = RunCommandOptions(readConcern: ReadConcern.empty)
         let res2 = try db.runCommand(command, options: options2)
         expect(res2["ok"]?.asDouble()).to(equal(1.0))
 
         // running command with an invalid RC level should throw
-        let options3 = RunCommandOptions(readConcern: ReadConcern("blah"))
+        let options3 = RunCommandOptions(readConcern: ReadConcern.other("blah"))
         // error code 9: FailedToParse
         expect(try db.runCommand(command, options: options3))
             .to(throwError(CommandError(
@@ -39,25 +39,25 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
             )))
 
         // try various command + read concern pairs to make sure they work
-        expect(try coll.find(options: FindOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
-        expect(try coll.findOne(options: FindOneOptions(readConcern: ReadConcern(.local)))).toNot(throwError())
+        expect(try coll.find(options: FindOptions(readConcern: ReadConcern.local))).toNot(throwError())
+        expect(try coll.findOne(options: FindOneOptions(readConcern: ReadConcern.local))).toNot(throwError())
 
         expect(try coll.aggregate(
             [["$project": ["a": 1]]],
-            options: AggregateOptions(readConcern: ReadConcern(.majority))
+            options: AggregateOptions(readConcern: ReadConcern.majority)
         )).toNot(throwError())
 
-        expect(try coll.countDocuments(options: CountDocumentsOptions(readConcern: ReadConcern(.majority))))
+        expect(try coll.countDocuments(options: CountDocumentsOptions(readConcern: ReadConcern.majority)))
             .toNot(throwError())
 
         expect(try coll.estimatedDocumentCount(
             options:
-            EstimatedDocumentCountOptions(readConcern: ReadConcern(.majority))
+            EstimatedDocumentCountOptions(readConcern: ReadConcern.majority)
         )).toNot(throwError())
 
         expect(try coll.distinct(
             fieldName: "a",
-            options: DistinctOptions(readConcern: ReadConcern(.local))
+            options: DistinctOptions(readConcern: ReadConcern.local)
         )).toNot(throwError())
     }
 

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -23,7 +23,7 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
         expect(res1["ok"]?.asDouble()).to(equal(1.0))
 
         // run command with an empty readConcern
-        let options2 = RunCommandOptions(readConcern: .empty)
+        let options2 = RunCommandOptions(readConcern: .serverDefault)
         let res2 = try db.runCommand(command, options: options2)
         expect(res2["ok"]?.asDouble()).to(equal(1.0))
 
@@ -109,7 +109,7 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
 
         let coll = try db.createCollection(self.getCollectionName())
         let wc1 = try WriteConcern(w: .number(1))
-        let wc2 = WriteConcern()
+        let wc2 = WriteConcern.serverDefault
         let wc3 = try WriteConcern(journal: true)
 
         let command: Document = ["insert": .string(coll.name), "documents": [.document(nextDoc())]]

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -18,17 +18,17 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
         let command: Document = ["count": .string(coll.name)]
 
         // run command with a valid readConcern
-        let options1 = RunCommandOptions(readConcern: ReadConcern.local)
+        let options1 = RunCommandOptions(readConcern: .local)
         let res1 = try db.runCommand(command, options: options1)
         expect(res1["ok"]?.asDouble()).to(equal(1.0))
 
         // run command with an empty readConcern
-        let options2 = RunCommandOptions(readConcern: ReadConcern.empty)
+        let options2 = RunCommandOptions(readConcern: .empty)
         let res2 = try db.runCommand(command, options: options2)
         expect(res2["ok"]?.asDouble()).to(equal(1.0))
 
         // running command with an invalid RC level should throw
-        let options3 = RunCommandOptions(readConcern: ReadConcern.other("blah"))
+        let options3 = RunCommandOptions(readConcern: .other("blah"))
         // error code 9: FailedToParse
         expect(try db.runCommand(command, options: options3))
             .to(throwError(CommandError(
@@ -39,25 +39,25 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
             )))
 
         // try various command + read concern pairs to make sure they work
-        expect(try coll.find(options: FindOptions(readConcern: ReadConcern.local))).toNot(throwError())
-        expect(try coll.findOne(options: FindOneOptions(readConcern: ReadConcern.local))).toNot(throwError())
+        expect(try coll.find(options: FindOptions(readConcern: .local))).toNot(throwError())
+        expect(try coll.findOne(options: FindOneOptions(readConcern: .local))).toNot(throwError())
 
         expect(try coll.aggregate(
             [["$project": ["a": 1]]],
-            options: AggregateOptions(readConcern: ReadConcern.majority)
+            options: AggregateOptions(readConcern: .majority)
         )).toNot(throwError())
 
-        expect(try coll.countDocuments(options: CountDocumentsOptions(readConcern: ReadConcern.majority)))
+        expect(try coll.countDocuments(options: CountDocumentsOptions(readConcern: .majority)))
             .toNot(throwError())
 
         expect(try coll.estimatedDocumentCount(
             options:
-            EstimatedDocumentCountOptions(readConcern: ReadConcern.majority)
+            EstimatedDocumentCountOptions(readConcern: .majority)
         )).toNot(throwError())
 
         expect(try coll.distinct(
             fieldName: "a",
-            options: DistinctOptions(readConcern: ReadConcern.local)
+            options: DistinctOptions(readConcern: .local)
         )).toNot(throwError())
     }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/CodableExtensions.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/CodableExtensions.swift
@@ -85,7 +85,7 @@ extension ClientOptions: Decodable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let readConcern = try? ReadConcern(container.decode(String.self, forKey: .readConcernLevel))
+        let readConcern = try? ReadConcern.other(container.decode(String.self, forKey: .readConcernLevel))
         let readPreference = try? ReadPreference(container.decode(ReadPreference.Mode.self, forKey: .mode))
         let retryReads = try container.decodeIfPresent(Bool.self, forKey: .retryReads)
         let retryWrites = try container.decodeIfPresent(Bool.self, forKey: .retryWrites)

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -185,7 +185,7 @@ extension SpecTestFile {
 
         // Majority write concern ensures that initial data is propagated to all nodes in a replica set or sharded
         // cluster.
-        let collectionOptions = CollectionOptions(writeConcern: try WriteConcern(w: .majority))
+        let collectionOptions = CollectionOptions(writeConcern: WriteConcern.majority)
 
         try? database.drop()
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -185,7 +185,7 @@ extension SpecTestFile {
 
         // Majority write concern ensures that initial data is propagated to all nodes in a replica set or sharded
         // cluster.
-        let collectionOptions = CollectionOptions(writeConcern: WriteConcern.majority)
+        let collectionOptions = CollectionOptions(writeConcern: .majority)
 
         try? database.drop()
 

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -31,11 +31,11 @@ private func checkReadConcern<T: ReadConcernable>(
 final class ReadConcernTests: MongoSwiftTestCase {
     func testReadConcernType() throws {
         // check level var works as expected
-        let rc = ReadConcern(.majority)
+        let rc = ReadConcern.majority
         expect(rc.level).to(equal(.majority))
 
         // test empty init
-        let rc2 = ReadConcern()
+        let rc2 = ReadConcern.empty
         expect(rc2.level).to(beNil())
         expect(rc2.isDefault).to(beTrue())
 
@@ -44,19 +44,19 @@ final class ReadConcernTests: MongoSwiftTestCase {
         expect(rc3.level).to(equal(.majority))
 
         // test string init
-        let rc4 = ReadConcern("majority")
+        let rc4 = ReadConcern.other("majority")
         expect(rc4.level).to(equal(.majority))
 
         // test init with unknown level
-        let rc5 = ReadConcern("blah")
+        let rc5 = ReadConcern.other("blah")
         expect(rc5.level).to(equal(.other(level: "blah")))
     }
 
     func testClientReadConcern() throws {
-        let empty = ReadConcern()
-        let majority = ReadConcern(.majority)
-        let majorityString = ReadConcern("majority")
-        let local = ReadConcern(.local)
+        let empty = ReadConcern.empty
+        let majority = ReadConcern.majority
+        let majorityString = ReadConcern.other("majority")
+        let local = ReadConcern.local
 
         // test behavior of a client with initialized with no RC
         try self.withTestClient { client in
@@ -92,7 +92,7 @@ final class ReadConcernTests: MongoSwiftTestCase {
             try checkReadConcern(db3, majority, "db created with majority string RC from \(clientDesc)")
 
             // test with unknown level
-            let unknown = ReadConcern("blah")
+            let unknown = ReadConcern.other("blah")
             let db4 = client.db(Self.testDatabase, options: DatabaseOptions(readConcern: unknown))
             try checkReadConcern(db4, unknown, "db created with unknown RC from \(clientDesc)")
         }
@@ -114,11 +114,11 @@ final class ReadConcernTests: MongoSwiftTestCase {
     }
 
     func testDatabaseReadConcern() throws {
-        let empty = ReadConcern()
-        let local = ReadConcern(.local)
-        let localString = ReadConcern("local")
-        let unknown = ReadConcern("blah")
-        let majority = ReadConcern(.majority)
+        let empty = ReadConcern.empty
+        let local = ReadConcern.local
+        let localString = ReadConcern.other("local")
+        let unknown = ReadConcern.other("blah")
+        let majority = ReadConcern.majority
 
         try self.withTestClient { client in
             let db1 = client.db(Self.testDatabase)
@@ -180,13 +180,13 @@ final class ReadConcernTests: MongoSwiftTestCase {
 
     func testRoundTripThroughLibmongoc() throws {
         let rcs: [ReadConcern] = [
-            ReadConcern(),
-            ReadConcern(.local),
-            ReadConcern(.available),
-            ReadConcern(.majority),
-            ReadConcern(.linearizable),
-            ReadConcern(.snapshot),
-            ReadConcern(.other(level: "a"))
+            ReadConcern.empty,
+            ReadConcern.local,
+            ReadConcern.available,
+            ReadConcern.majority,
+            ReadConcern.linearizable,
+            ReadConcern.snapshot,
+            ReadConcern.other("a")
         ]
 
         for original in rcs {

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -32,7 +32,7 @@ final class ReadConcernTests: MongoSwiftTestCase {
     func testReadConcernType() throws {
         // check level var works as expected
         let rc = ReadConcern.majority
-        expect(rc.level).to(equal(.majority))
+        expect(rc).to(equal(.majority))
 
         // test empty init
         let rc2 = ReadConcern.serverDefault
@@ -41,15 +41,15 @@ final class ReadConcernTests: MongoSwiftTestCase {
 
         // test init from doc
         let rc3 = try BSONDecoder().decode(ReadConcern.self, from: ["level": "majority"])
-        expect(rc3.level).to(equal(.majority))
+        expect(rc3).to(equal(.majority))
 
         // test string init
         let rc4 = ReadConcern.other("majority")
-        expect(rc4.level).to(equal(.majority))
+        expect(rc4).to(equal(.majority))
 
         // test init with unknown level
         let rc5 = ReadConcern.other("blah")
-        expect(rc5.level).to(equal(ReadConcern.other("blah").level))
+        expect(rc5).to(equal(ReadConcern.other("blah")))
     }
 
     func testClientReadConcern() throws {

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -180,13 +180,13 @@ final class ReadConcernTests: MongoSwiftTestCase {
 
     func testRoundTripThroughLibmongoc() throws {
         let rcs: [ReadConcern] = [
-            ReadConcern.empty,
-            ReadConcern.local,
-            ReadConcern.available,
-            ReadConcern.majority,
-            ReadConcern.linearizable,
-            ReadConcern.snapshot,
-            ReadConcern.other("a")
+            .empty,
+            .local,
+            .available,
+            .majority,
+            .linearizable,
+            .snapshot,
+            .other("a")
         ]
 
         for original in rcs {

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -35,7 +35,7 @@ final class ReadConcernTests: MongoSwiftTestCase {
         expect(rc.level).to(equal(.majority))
 
         // test empty init
-        let rc2 = ReadConcern.empty
+        let rc2 = ReadConcern.serverDefault
         expect(rc2.level).to(beNil())
         expect(rc2.isDefault).to(beTrue())
 
@@ -53,7 +53,7 @@ final class ReadConcernTests: MongoSwiftTestCase {
     }
 
     func testClientReadConcern() throws {
-        let empty = ReadConcern.empty
+        let empty = ReadConcern.serverDefault
         let majority = ReadConcern.majority
         let majorityString = ReadConcern.other("majority")
         let local = ReadConcern.local
@@ -114,7 +114,7 @@ final class ReadConcernTests: MongoSwiftTestCase {
     }
 
     func testDatabaseReadConcern() throws {
-        let empty = ReadConcern.empty
+        let empty = ReadConcern.serverDefault
         let local = ReadConcern.local
         let localString = ReadConcern.other("local")
         let unknown = ReadConcern.other("blah")
@@ -180,7 +180,7 @@ final class ReadConcernTests: MongoSwiftTestCase {
 
     func testRoundTripThroughLibmongoc() throws {
         let rcs: [ReadConcern] = [
-            .empty,
+            .serverDefault,
             .local,
             .available,
             .majority,

--- a/Tests/MongoSwiftTests/ReadConcernTests.swift
+++ b/Tests/MongoSwiftTests/ReadConcernTests.swift
@@ -49,7 +49,7 @@ final class ReadConcernTests: MongoSwiftTestCase {
 
         // test init with unknown level
         let rc5 = ReadConcern.other("blah")
-        expect(rc5.level).to(equal(.other(level: "blah")))
+        expect(rc5.level).to(equal(ReadConcern.other("blah").level))
     }
 
     func testClientReadConcern() throws {

--- a/Tests/MongoSwiftTests/WriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/WriteConcernTests.swift
@@ -148,7 +148,7 @@ final class WriteConcernTests: MongoSwiftTestCase {
             WriteConcern(),
             try WriteConcern(w: .number(2)),
             try WriteConcern(w: .tag("hi")),
-            try WriteConcern(w: .majority),
+            WriteConcern.majority,
             try WriteConcern(journal: true),
             try WriteConcern(wtimeoutMS: 200)
         ]

--- a/Tests/MongoSwiftTests/WriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/WriteConcernTests.swift
@@ -52,7 +52,7 @@ final class WriteConcernTests: MongoSwiftTestCase {
     func testClientWriteConcern() throws {
         let w1 = try WriteConcern(w: .number(1))
         let w2 = try WriteConcern(w: .number(2))
-        let empty = WriteConcern()
+        let empty = WriteConcern.serverDefault
 
         // test behavior of a client with initialized with no WC
         try self.withTestClient { client in
@@ -99,7 +99,7 @@ final class WriteConcernTests: MongoSwiftTestCase {
     }
 
     func testDatabaseWriteConcern() throws {
-        let empty = WriteConcern()
+        let empty = WriteConcern.serverDefault
         let w1 = try WriteConcern(w: .number(1))
         let w2 = try WriteConcern(w: .number(2))
 
@@ -145,10 +145,10 @@ final class WriteConcernTests: MongoSwiftTestCase {
 
     func testRoundTripThroughLibmongoc() throws {
         let wcs: [WriteConcern] = [
-            WriteConcern(),
+            .serverDefault,
             try WriteConcern(w: .number(2)),
             try WriteConcern(w: .tag("hi")),
-            WriteConcern.majority,
+            .majority,
             try WriteConcern(journal: true),
             try WriteConcern(wtimeoutMS: 200)
         ]


### PR DESCRIPTION
Added convenience properties to ReadConcern and WriteConcern.
Some notes:
- ReadConcern no longer has a public constructor, users can rely on the static other method to make unsupported ReadConcerns.
- WriteConcern now has a `fileprivate init` this was done because we needed a non-throwing constructor to add the `static let majority: WriteConcern` property.
- We now make use the convenience API internally so the changes are being tested.