### PR TITLE
SWIFT-774 Implement sharded transactions tests

### DIFF
--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -38,6 +38,12 @@ public struct Address: Equatable {
     }
 }
 
+extension Address: CustomStringConvertible {
+    public var description: String {
+        "\(self.host):\(self.port)"
+    }
+}
+
 private struct IsMasterResponse: Decodable {
     fileprivate struct LastWrite: Decodable {
         public let lastWriteDate: Date?

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -31,9 +31,7 @@ open class MongoSwiftTestCase: XCTestCase {
     /// will return a default of "mongodb://127.0.0.1/". If singleMongos is true and this is a sharded topology, will
     /// edit $MONGODB_URI as needed so that it only contains a single host.
     public static func getConnectionString(singleMongos: Bool = true) -> String {
-        guard let uri = ProcessInfo.processInfo.environment["MONGODB_URI"] else {
-            return "mongodb://127.0.0.1/"
-        }
+        let uri = Self.uri
 
         // we only need to manipulate the URI if singleMongos is requested and the topology is sharded.
         guard singleMongos && MongoSwiftTestCase.topologyType == .sharded else {
@@ -74,6 +72,13 @@ open class MongoSwiftTestCase: XCTestCase {
             return .single
         }
         return TopologyDescription.TopologyType(from: topology)
+    }
+
+    public static var uri: String {
+        guard let uri = ProcessInfo.processInfo.environment["MONGODB_URI"] else {
+            return "mongodb://127.0.0.1/"
+        }
+        return uri
     }
 
     /// Indicates that we are running the tests with SSL enabled, determined by the environment variable $SSL.

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -50,6 +50,26 @@ open class MongoSwiftTestCase: XCTestCase {
         return output
     }
 
+    /// Get a connection string for the specified host only.
+    public static func getConnectionString(forHost serverAddress: Address) -> String {
+        Self.getConnectionStringPerHost().first { $0.contains(String(describing: serverAddress)) }!
+    }
+
+    /// Returns a different connection string per host specified in MONGODB_URI.
+    public static func getConnectionStringPerHost() -> [String] {
+        let uri = Self.uri
+
+        let regex = try! NSRegularExpression(pattern: #"mongodb:\/\/(?:.*@)?([^\/]+)(?:\/|$)"#)
+        let range = NSRange(uri.startIndex..<uri.endIndex, in: uri)
+        let match = regex.firstMatch(in: uri, range: range)!
+
+        let hostsRange = Range(match.range(at: 1), in: uri)!
+
+        return try! ConnectionString(uri).hosts!.map { host in
+            uri.replacingCharacters(in: hostsRange, with: host)
+        }
+    }
+
     // indicates whether we are running on a 32-bit platform
     public static let is32Bit = MemoryLayout<Int>.size == 4
 

--- a/Tests/MongoSwiftSyncTests/RetryableReadsTests.swift
+++ b/Tests/MongoSwiftSyncTests/RetryableReadsTests.swift
@@ -40,7 +40,7 @@ private struct RetryableReadsTestFile: Decodable, SpecTestFile {
 
     let tests: [RetryableReadsTest]
 
-    let skippedTestFileNameKeywords = [
+    static let skippedTestFileNameKeywords = [
         "changeStream", // TODO: SWIFT-648: Unskip this test
         "gridfs",
         "count.",

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/FailPoint.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/FailPoint.swift
@@ -64,7 +64,7 @@ internal struct FailPoint: Decodable {
             }
         }
         if let serverAddress = serverAddress {
-            let connectionString = "mongodb://\(serverAddress)"
+            let connectionString = MongoSwiftTestCase.getConnectionString(forHost: serverAddress)
             let client = try MongoClient.makeTestClient(connectionString)
             try client.db("admin").runCommand(commandDoc)
         } else {

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -245,8 +245,8 @@ extension SpecTestFile {
             // Due to strange behavior in mongos, a "distinct" command needs to be run against each mongos
             // before the tests run to prevent certain errors from ocurring. (SERVER-39704)
             if MongoSwiftTestCase.topologyType == .sharded, let collName = self.collectionName {
-                for host in try ConnectionString(MongoSwiftTestCase.uri).hosts! {
-                    let client = try MongoClient("mongodb://\(host)")
+                for connStr in MongoSwiftTestCase.getConnectionStringPerHost() {
+                    let client = try MongoClient(connStr)
                     _ = try client.db(self.databaseName).collection(collName).distinct(fieldName: "_id")
                 }
             }

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -218,8 +218,8 @@ extension SpecTestFile {
     /// Run all the tests specified in this file, optionally specifying keywords that, if included in a test's
     /// description, will cause certain tests to be skipped.
     internal func runTests() throws {
-        guard !Self.skippedTestFileNameKeywords.contains(where: { self.name.contains($0) }) else {
-            fileLevelLog("Skipping tests from file \(self.name), matched skipped keyword.")
+        if let keyword = Self.skippedTestFileNameKeywords.first(where: { self.name.contains($0) }) {
+            fileLevelLog("Skipping tests from file \(self.name), matched skipped keyword \"\(keyword)\".")
             return
         }
 
@@ -235,8 +235,8 @@ extension SpecTestFile {
 
         fileLevelLog("Executing tests from file \(self.name)...")
         for var test in self.tests {
-            guard !Self.TestType.skippedTestKeywords.contains(where: { test.description.contains($0) }) else {
-                print("Skipping test \(test.description)")
+            if let keyword = Self.TestType.skippedTestKeywords.first(where: { test.description.contains($0) }) {
+                print("Skipping test \(test.description) due to matched keyword \"\(keyword)\".")
                 continue
             }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -246,7 +246,7 @@ extension SpecTestFile {
             // before the tests run to prevent certain errors from ocurring. (SERVER-39704)
             if MongoSwiftTestCase.topologyType == .sharded, let collName = self.collectionName {
                 for connStr in MongoSwiftTestCase.getConnectionStringPerHost() {
-                    let client = try MongoClient(connStr)
+                    let client = try MongoClient.makeTestClient(connStr)
                     _ = try client.db(self.databaseName).collection(collName).distinct(fieldName: "_id")
                 }
             }

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -1,5 +1,4 @@
 import Foundation
-@testable import MongoSwift
 @testable import struct MongoSwift.ReadPreference
 import MongoSwiftSync
 import Nimble

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestOperation.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestOperation.swift
@@ -181,6 +181,7 @@ struct TestOperationDescription: Decodable {
             }
         }
     }
+
     // swiftlint:enable cyclomatic_complexity
 }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestOperation.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestOperation.swift
@@ -131,6 +131,9 @@ struct TestOperationDescription: Decodable {
     // swiftlint:disable cyclomatic_complexity
 
     /// Runs the operation and asserts its results meet the expectation.
+    ///
+    /// The operation may be mutated over the course of this execution (e.g. by enabling a failpoint), so it
+    /// must be passed as an `inout` parameter.
     func validateExecution<T: SpecTest>(
         test: inout T,
         client: MongoClient,

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestOperation.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestOperation.swift
@@ -16,9 +16,6 @@ protocol TestOperation: Decodable {
     func execute(on session: ClientSession) throws -> TestOperationResult?
 
     func execute<T: SpecTest>(on runner: inout T, sessions: [String: ClientSession]) throws -> TestOperationResult?
-
-    /// The name of the session this operation should execute against, if any.
-    var session: String? { get }
 }
 
 extension TestOperation {
@@ -43,20 +40,6 @@ extension TestOperation {
 
     func execute<T: SpecTest>(on _: inout T, sessions _: [String: ClientSession]) throws -> TestOperationResult? {
         throw TestError(message: "\(type(of: self)) cannot execute on a test runner")
-    }
-
-    var session: String? { nil }
-
-    func getSession(from sessions: [String: ClientSession]) throws -> ClientSession? {
-        guard let sessionName = self.session else {
-            return nil
-        }
-
-        guard let session = sessions[sessionName] else {
-            throw TestError(message: "\(sessionName) not included in sessions map \(sessions)")
-        }
-
-        return session
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestOperationResult.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestOperationResult.swift
@@ -223,16 +223,12 @@ struct ErrorResult: Equatable, Decodable {
     }
 
     internal func checkErrorLabels(_ error: Error) throws {
-        // `configureFailPoint` command correctly handles error labels in MongoDB v4.3.1+ (see SERVER-43941).
-        // Do not check the "RetryableWriteError" error label until the spec test requirements are updated.
-        let skippedErrorLabels = ["RetryableWriteError"]
-
         if let errorLabelsContain = self.errorLabelsContain {
             guard let labeledError = error as? LabeledError else {
                 XCTFail("\(error) does not contain errorLabels")
                 return
             }
-            for label in errorLabelsContain where !skippedErrorLabels.contains(label) {
+            for label in errorLabelsContain {
                 expect(labeledError.errorLabels).to(contain(label))
             }
         }

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestRunnerOperations.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/TestRunnerOperations.swift
@@ -77,11 +77,11 @@ struct AssertSessionUnpinned: TestOperation {
 }
 
 struct AssertSessionTransactionState: TestOperation {
-    let session: String?
+    let session: String
     let state: ClientSession.TransactionState
 
     func execute<T: SpecTest>(on _: inout T, sessions: [String: ClientSession]) throws -> TestOperationResult? {
-        guard let transactionState = sessions[self.session ?? ""]?.transactionState else {
+        guard let transactionState = sessions[self.session]?.transactionState else {
             throw TestError(message: "active session not provided to assertSessionTransactionState")
         }
         expect(transactionState).to(equal(self.state))

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -197,9 +197,11 @@ extension MongoSwiftSync.ClientSession {
 
     internal var id: Document? { self.asyncSession.id }
 
-    internal var serverId: UInt32? { self.asyncSession.serverId }
+    internal var pinnedServerAddress: Address? { self.asyncSession.pinnedServerAddress }
 
     internal typealias TransactionState = MongoSwift.ClientSession.TransactionState
 
     internal var transactionState: TransactionState? { self.asyncSession.transactionState }
+
+    internal var isPinned: Bool { self.pinnedServerAddress != nil }
 }

--- a/Tests/MongoSwiftSyncTests/TransactionsTests.swift
+++ b/Tests/MongoSwiftSyncTests/TransactionsTests.swift
@@ -29,7 +29,7 @@ private struct TransactionsTest: SpecTest {
 
     static let skippedTestKeywords: [String] = [
         // TODO: SWIFT-762 the following 3 require libmongoc v1.17
-        "add RetryableWriteError",
+        "RetryableWriteError",
         "commitTransaction fails after two errors",
         "commitTransaction applies majority write concern on retries"
     ]


### PR DESCRIPTION
[SWIFT-774](https://jira.mongodb.org/browse/SWIFT-774)

This PR adds support in the spec test runner for sharded transactions tests. It also refactors the runner to make skipping tests a little easier, repurposes the `FailPointConfigured` protocol to be more generally useful (it's now a requirement of the `SpecTest` protocol), and splits up `TestOperation.swift` into a subdirectory of different operations for easier code discovery.

The changes to `FailPointConfigured` will close out [SWIFT-755](https://jira.mongodb.org/browse/SWIFT-755) as part of this work.