### PR TITLE
SWIFT-204 Suppress "ns not found" errors

### DIFF
--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -482,3 +482,13 @@ internal func wrongIterTypeError(_ iter: DocumentIterator, expected type: BSONVa
 }
 
 internal let failedToRetrieveCursorMessage = "Couldn't get cursor from the server"
+
+extension MongoError {
+    /// Determines whether this error is an "ns not found" error.
+    internal var isNsNotFound: Bool {
+        guard let commandError = self as? CommandError else {
+            return false
+        }
+        return commandError.code == 26
+    }
+}

--- a/Sources/MongoSwift/Operations/DropCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/DropCollectionOperation.swift
@@ -25,8 +25,13 @@ internal struct DropCollectionOperation<T: Codable>: Operation {
                 }
             }
         }
+
         guard success else {
-            throw extractMongoError(error: error, reply: reply)
+            let error = extractMongoError(error: error, reply: reply)
+            guard !error.isNsNotFound else {
+                return
+            }
+            throw error
         }
     }
 }

--- a/Sources/MongoSwift/Operations/DropIndexesOperation.swift
+++ b/Sources/MongoSwift/Operations/DropIndexesOperation.swift
@@ -42,7 +42,11 @@ internal struct DropIndexesOperation<T: Codable>: Operation {
             }
         }
         guard success else {
-            throw extractMongoError(error: error, reply: reply)
+            let error = extractMongoError(error: error, reply: reply)
+            guard !error.isNsNotFound else {
+                return
+            }
+            throw error
         }
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -198,6 +198,7 @@ extension MongoCollectionTests {
         ("testFindOneAndReplace", testFindOneAndReplace),
         ("testFindOneAndUpdate", testFindOneAndUpdate),
         ("testNullIds", testNullIds),
+        ("testNSNotFoundSuprression", testNSNotFoundSuppression),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -198,7 +198,7 @@ extension MongoCollectionTests {
         ("testFindOneAndReplace", testFindOneAndReplace),
         ("testFindOneAndUpdate", testFindOneAndUpdate),
         ("testNullIds", testNullIds),
-        ("testNSNotFoundSuprression", testNSNotFoundSuppression),
+        ("testNSNotFoundSuppression", testNSNotFoundSuppression),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/CrudTests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudTests.swift
@@ -50,13 +50,7 @@ final class CrudTests: MongoSwiftTestCase {
                 }
                 try test.execute(usingCollection: collection)
                 try test.verifyData(testCollection: collection, db: db)
-                do {
-                    try collection.drop()
-                } catch let commandError as CommandError where commandError.code == 26 {
-                    // ignore ns not found errors
-                } catch {
-                    throw error
-                }
+                try collection.drop()
             }
         }
         print() // for readability of results

--- a/Tests/MongoSwiftSyncTests/MongoCollection+BulkWriteTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+BulkWriteTests.swift
@@ -33,8 +33,6 @@ final class MongoCollection_BulkWriteTests: MongoSwiftTestCase {
     override func tearDown() {
         do {
             try self.coll.drop()
-        } catch let commandError as CommandError where commandError.code == 26 {
-            // ignore ns not found errors
         } catch {
             fail("encountered error when tearing down: \(error)")
         }

--- a/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
@@ -516,4 +516,12 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(result2?.insertedIds[0]).to(equal(.null))
         expect(result2?.insertedIds[1]).to(equal(20))
     }
+
+    func testNSNotFoundSuppression() throws {
+        let client = try MongoClient.makeTestClient()
+        let collection = client.db(Self.testDatabase).collection(self.getCollectionName())
+        expect(try collection.drop()).toNot(throwError())
+        expect(try collection.drop()).toNot(throwError())
+        expect(try collection.dropIndex("ljasdfjlkasdjf")).toNot(throwError())
+    }
 }


### PR DESCRIPTION
[SWIFT-204](https://jira.mongodb.org/browse/SWIFT-204)

This PR suppresses "ns not found" errors that the server returns from dropping collections and indexes on sharded clusters.
