### PR TITLE
SWIFT-768 Add custom localizedDescription to all errors

### DIFF
--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -80,6 +80,10 @@ public struct BulkWriteError: ServerError {
             descriptions.append("Write concern error: \(message)")
         }
 
+        if let otherError = self.otherError {
+            descriptions.append("Other error: \(otherError.localizedDescription)")
+        }
+
         return descriptions.joined(separator: ", ")
     }
 }
@@ -323,9 +327,9 @@ internal func extractMongoError(error bsonError: bson_error_t, reply: Document? 
     // if the reply is nil or writeErrors or writeConcernErrors aren't present, use the mongoc error to determine
     // what to throw.
     guard let serverReply: Document = reply,
-        !(serverReply["writeErrors"]?.arrayValue ?? []).isEmpty ||
-        !(serverReply["writeConcernError"]?.documentValue?.keys ?? []).isEmpty ||
-        !(serverReply["writeConcernErrors"]?.arrayValue ?? []).isEmpty else {
+        serverReply["writeErrors"] != nil ||
+        serverReply["writeConcernError"] != nil ||
+        serverReply["writeConcernErrors"] != nil else {
         return parseMongocError(bsonError, reply: reply)
     }
 
@@ -366,9 +370,9 @@ internal func extractBulkWriteError<T: Codable>(
 ) -> Error {
     // if the reply is nil or writeErrors or writeConcernErrors aren't present, use the mongoc error to determine
     // what to throw.
-    guard !(reply["writeErrors"]?.arrayValue ?? []).isEmpty ||
-        !(reply["writeConcernError"]?.documentValue?.keys ?? []).isEmpty ||
-        !(reply["writeConcernErrors"]?.arrayValue ?? []).isEmpty else {
+    guard reply["writeErrors"] != nil ||
+        reply["writeConcernError"] != nil ||
+        reply["writeConcernErrors"] != nil else {
         return parseMongocError(error, reply: reply)
     }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperationResult.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperationResult.swift
@@ -189,41 +189,11 @@ struct ErrorResult: Equatable, Decodable {
         try self.checkErrorLabels(error)
     }
 
-    // swiftlint:disable cyclomatic_complexity
-
     internal func checkErrorContains(_ error: Error) throws {
         if let errorContains = self.errorContains?.lowercased() {
-            if let commandError = error as? CommandError {
-                expect(commandError.message.lowercased()).to(contain(errorContains))
-            } else if let writeError = error as? WriteError {
-                if let writeFailure = writeError.writeFailure {
-                    expect(writeFailure.message.lowercased()).to(contain(errorContains))
-                }
-                if let writeConcernFailure = writeError.writeConcernFailure {
-                    expect(writeConcernFailure.message.lowercased()).to(contain(errorContains))
-                }
-            } else if let bulkWriteError = error as? BulkWriteError {
-                if let writeFailures = bulkWriteError.writeFailures {
-                    for writeFailure in writeFailures {
-                        expect(writeFailure.message.lowercased()).to(contain(errorContains))
-                    }
-                }
-                if let writeConcernFailure = bulkWriteError.writeConcernFailure {
-                    expect(writeConcernFailure.message.lowercased()).to(contain(errorContains))
-                }
-            } else if let logicError = error as? LogicError {
-                expect(logicError.errorDescription.lowercased()).to(contain(errorContains))
-            } else if let invalidArgumentError = error as? InvalidArgumentError {
-                expect(invalidArgumentError.errorDescription.lowercased()).to(contain(errorContains))
-            } else if let connectionError = error as? ConnectionError {
-                expect(connectionError.message.lowercased()).to(contain(errorContains))
-            } else {
-                XCTFail("\(error) does not contain message")
-            }
+            expect(error.localizedDescription.lowercased()).to(contain(errorContains))
         }
     }
-
-    // swiftlint:enable cyclomatic_complexity
 
     internal func checkCodeName(_ error: Error) throws {
         // TODO: can remove `equal("")` references once SERVER-36755 is resolved


### PR DESCRIPTION
[SWIFT-768](https://jira.mongodb.org/browse/SWIFT-768)

This PR ensures all of our error types have a custom `localizedDescription`. This allows errors to provide a concise description of themselves that can be accessed without casting to a concrete type.