### PR TITLE
SWIFT-826 Make Date.init(msSinceEpoch:) internal

### DIFF
--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -356,12 +356,12 @@ extension Date: BSONValue {
 
     /// Initializes a new `Date` representing the instance `msSinceEpoch` milliseconds
     /// since the Unix epoch.
-    public init(msSinceEpoch: Int64) {
+    internal init(msSinceEpoch: Int64) {
         self.init(timeIntervalSince1970: TimeInterval(msSinceEpoch) / 1000.0)
     }
 
     /// The number of milliseconds after the Unix epoch that this `Date` occurs.
-    public var msSinceEpoch: Int64 { Int64((self.timeIntervalSince1970 * 1000.0).rounded()) }
+    internal var msSinceEpoch: Int64 { Int64((self.timeIntervalSince1970 * 1000.0).rounded()) }
 
     internal func encode(to document: inout Document, forKey key: String) throws {
         try document.withMutableBSONPointer { docPtr in

--- a/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
@@ -224,7 +224,7 @@ final class SyncMongoClientTests: MongoSwiftTestCase {
         doc = try collDoc.find(["_id": customDbCollId]).next()?.get()
 
         expect(doc).toNot(beNil())
-        expect(doc?["date"]?.int64Value).to(equal(date.msSinceEpoch))
+        expect(doc?["date"]?.int64Value).to(equal(Int64((date.timeIntervalSince1970 * 1000.0).rounded())))
         expect(doc?["uuid"]?.stringValue).to(equal(uuid.uuidString))
         expect(doc?["data"]?.stringValue).to(equal(data.base64EncodedString()))
 


### PR DESCRIPTION
I made the initializer and also the corresponding public property `internal`. Not clear to me if/how the property is really useful to users... I think we just use it for BSON encoding. so I'd rather keep it internal until someone needs it.