### PR TITLE
SWIFT-779 Safe access to connection pointer

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -623,7 +623,9 @@ public class MongoClient {
     /// and is for testing purposes only**.
     internal func getMongocReadConcern() throws -> ReadConcern? {
         try self.connectionPool.withConnection { conn in
-            ReadConcern(copying: mongoc_client_get_read_concern(conn.clientHandle))
+            conn.withMongocConnection { connPtr in
+                ReadConcern(copying: mongoc_client_get_read_concern(connPtr))
+            }
         }
     }
 
@@ -631,7 +633,9 @@ public class MongoClient {
     /// and is for testing purposes only**.
     internal func getMongocReadPreference() throws -> ReadPreference {
         try self.connectionPool.withConnection { conn in
-            ReadPreference(copying: mongoc_client_get_read_prefs(conn.clientHandle))
+            conn.withMongocConnection { connPtr in
+                ReadPreference(copying: mongoc_client_get_read_prefs(connPtr))
+            }
         }
     }
 
@@ -639,7 +643,9 @@ public class MongoClient {
     /// and is for testing purposes only**.
     internal func getMongocWriteConcern() throws -> WriteConcern? {
         try self.connectionPool.withConnection { conn in
-            WriteConcern(copying: mongoc_client_get_write_concern(conn.clientHandle))
+            conn.withMongocConnection { connPtr in
+                WriteConcern(copying: mongoc_client_get_write_concern(connPtr))
+            }
         }
     }
 }

--- a/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
+++ b/Sources/MongoSwift/Operations/ListDatabasesOperation.swift
@@ -73,19 +73,21 @@ internal struct ListDatabasesOperation: Operation {
         var reply = Document()
         var error = bson_error_t()
 
-        let success = cmd.withBSONPointer { cmdPtr in
-            readPref.withMongocReadPreference { rpPtr in
-                withOptionalBSONPointer(to: opts) { optsPtr in
-                    reply.withMutableBSONPointer { replyPtr in
-                        mongoc_client_read_command_with_opts(
-                            connection.clientHandle,
-                            "admin",
-                            cmdPtr,
-                            rpPtr,
-                            optsPtr,
-                            replyPtr,
-                            &error
-                        )
+        let success = connection.withMongocConnection { connPtr in
+            cmd.withBSONPointer { cmdPtr in
+                readPref.withMongocReadPreference { rpPtr in
+                    withOptionalBSONPointer(to: opts) { optsPtr in
+                        reply.withMutableBSONPointer { replyPtr in
+                            mongoc_client_read_command_with_opts(
+                                connPtr,
+                                "admin",
+                                cmdPtr,
+                                rpPtr,
+                                optsPtr,
+                                replyPtr,
+                                &error
+                            )
+                        }
                     }
                 }
             }

--- a/Sources/MongoSwift/Operations/StartSessionOperation.swift
+++ b/Sources/MongoSwift/Operations/StartSessionOperation.swift
@@ -56,10 +56,12 @@ internal struct StartSessionOperation: Operation {
 
         let sessionPtr: OpaquePointer = try withSessionOpts(wrapping: self.session.options) { opts in
             var error = bson_error_t()
-            guard let sessionPtr = mongoc_client_start_session(connection.clientHandle, opts, &error) else {
-                throw extractMongoError(error: error)
+            return try connection.withMongocConnection { connPtr in
+                guard let sessionPtr = mongoc_client_start_session(connPtr, opts, &error) else {
+                    throw extractMongoError(error: error)
+                }
+                return sessionPtr
             }
-            return sessionPtr
         }
         self.session.state = .started(session: sessionPtr, connection: connection)
         // if we cached opTime or clusterTime, set them now

--- a/Sources/MongoSwift/Operations/WatchOperation.swift
+++ b/Sources/MongoSwift/Operations/WatchOperation.swift
@@ -45,7 +45,10 @@ internal struct WatchOperation<CollectionType: Codable, ChangeStreamType: Codabl
                 case let .client(c):
                     client = c
                     decoder = c.decoder
-                    changeStreamPtr = mongoc_client_watch(connection.clientHandle, pipelinePtr, optsPtr)
+                    changeStreamPtr = connection.withMongocConnection { connPtr in
+                        mongoc_client_watch(connPtr, pipelinePtr, optsPtr)
+                    }
+
                 case let .database(db):
                     client = db._client
                     decoder = db.decoder


### PR DESCRIPTION
Trying to finish up this ticket finally. This makes the `clientHandle` pointer underlying a `Connection` private, restricting access to a `withMongocConnection` method. Fortunately since we use `withMongocCollection` and `withMongocDatabase` in most places there wasn't a lot that needed to change here. 