### PR TITLE
SWIFT-779 Safe access to ConnectionString._uri

### DIFF
--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -72,8 +72,11 @@ internal class ConnectionPool {
 
     /// Initializes the pool using the provided `ConnectionString` and options.
     internal init(from connString: ConnectionString, options: ClientOptions?) throws {
-        guard let pool = mongoc_client_pool_new(connString._uri) else {
-            throw InternalError(message: "Failed to initialize libmongoc client pool")
+        let pool: OpaquePointer = try connString.withMongocURI { uriPtr in
+            guard let pool = mongoc_client_pool_new(uriPtr) else {
+                throw InternalError(message: "Failed to initialize libmongoc client pool")
+            }
+            return pool
         }
 
         guard mongoc_client_pool_set_error_api(pool, MONGOC_ERROR_API_VERSION_2) else {

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -3,7 +3,7 @@ import CLibMongoC
 /// Class representing a connection string for connecting to MongoDB.
 internal class ConnectionString {
     /// Pointer to the underlying `mongoc_uri_t`.
-    internal let _uri: OpaquePointer
+    private let _uri: OpaquePointer
 
     /// Initializes a new `ConnectionString` with the provided options.
     internal init(_ connectionString: String, options: ClientOptions? = nil) throws {
@@ -189,5 +189,10 @@ internal class ConnectionString {
         }
 
         return hosts
+    }
+
+    /// Executes the provided closure using a pointer to the underlying `mongoc_uri_t`.
+    internal func withMongocURI<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {
+        try body(self._uri)
     }
 }


### PR DESCRIPTION
Guards access to `ConnectionString._uri` through a helper.