### PR TITLE
SWIFT-858: Duplicate pure Swift BSON breaking changes in driver

### DIFF
--- a/Sources/MongoSwift/BSON/BSON.swift
+++ b/Sources/MongoSwift/BSON/BSON.swift
@@ -306,7 +306,7 @@ extension BSON {
         BSONNull.self,
         BSONUndefined.self,
         BSONMinKey.self,
-        MaxKey.self,
+        BSONMaxKey.self,
         BSONSymbol.self,
         Double.self,
         String.self,
@@ -336,7 +336,7 @@ extension BSON {
         case .minKey:
             return BSONMinKey()
         case .maxKey:
-            return MaxKey()
+            return BSONMaxKey()
         case let .symbol(v):
             return v
         case let .double(v):

--- a/Sources/MongoSwift/BSON/BSON.swift
+++ b/Sources/MongoSwift/BSON/BSON.swift
@@ -288,11 +288,11 @@ public enum BSON {
         case let .decimal128(d):
             return d
         case let .int64(i):
-            return BSONDecimal128(String(i))
+            return try? BSONDecimal128(String(i))
         case let .int32(i):
-            return BSONDecimal128(String(i))
+            return try? BSONDecimal128(String(i))
         case let .double(d):
-            return BSONDecimal128(String(d))
+            return try? BSONDecimal128(String(d))
         default:
             return nil
         }

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -359,7 +359,10 @@ extension _BSONDecoder {
             return try Data(from: self)
         case .binary:
             let binary = try self.unboxCustom(value) { $0.binaryValue }
-            return binary.data
+            guard let data = binary.data.getBytes(at: 0, length: binary.data.writerIndex) else {
+                throw InternalError(message: "Cannot read \(binary.data.writerIndex) bytes from Binary.data")
+            }
+            return Data(data)
         case .base64:
             let base64Str = try self.unboxCustom(value) { $0.stringValue }
 

--- a/Sources/MongoSwift/BSON/BSONDocument.swift
+++ b/Sources/MongoSwift/BSON/BSONDocument.swift
@@ -329,8 +329,8 @@ extension BSONDocument {
         return String(cString: json)
     }
 
-    /// Returns a copy of the raw BSON data for this `BSONDocument`, represented as `Data`.
-    public var rawBSON: Data {
+    /// Returns a copy of the raw BSON data for this `Document`, represented as `Data`.
+    public func toData() -> Data {
         let data = self.withBSONPointer { ptr in
             // swiftlint:disable:next force_unwrapping
             bson_get_data(ptr)! // documented as always returning a value.
@@ -448,7 +448,7 @@ extension BSONDocument {
                     self = newSelf
                 }
             } catch {
-                fatalError("Failed to set the value for key \(key) to \(newValue ?? "nil"): \(error)")
+                fatalError("Failed to set the value for key \"\(key)\" to \(newValue ?? "nil"): \(error)")
             }
         }
     }

--- a/Sources/MongoSwift/BSON/BSONDocumentIterator.swift
+++ b/Sources/MongoSwift/BSON/BSONDocumentIterator.swift
@@ -79,7 +79,7 @@ public class BSONDocumentIterator: IteratorProtocol {
     /// Returns the current value's type. Assumes the iterator is in a valid position.
     internal var currentType: BSONType {
         self.withBSONIterPointer { iterPtr in
-            BSONType(rawValue: bson_iter_type(iterPtr).rawValue) ?? .invalid
+            BSONType(rawValue: UInt8(bson_iter_type(iterPtr).rawValue)) ?? .invalid
         }
     }
 

--- a/Sources/MongoSwift/BSON/BSONDocumentIterator.swift
+++ b/Sources/MongoSwift/BSON/BSONDocumentIterator.swift
@@ -219,7 +219,7 @@ public class BSONDocumentIterator: IteratorProtocol {
         .int64: Int64.self,
         .decimal128: BSONDecimal128.self,
         .minKey: BSONMinKey.self,
-        .maxKey: MaxKey.self,
+        .maxKey: BSONMaxKey.self,
         .null: BSONNull.self,
         .undefined: BSONUndefined.self
     ]

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -230,7 +230,7 @@ public struct BSONBinary: BSONValue, Equatable, Codable, Hashable {
         /// Initializes a `Subtype` with a custom value.
         /// Returns nil if rawValue within reserved range [0x07, 0x80).
         public init?(rawValue: UInt8) {
-            if rawValue > 0x06 && rawValue < 0x80 {
+            guard !(rawValue > 0x06 && rawValue < 0x80) else {
                 return nil
             }
             self.rawValue = rawValue
@@ -246,7 +246,7 @@ public struct BSONBinary: BSONValue, Equatable, Codable, Hashable {
                 throw InvalidArgumentError(message: "Cannot represent \(value) as UInt8")
             }
             guard byteValue >= 0x80 else {
-                throw InvalidArgumentError(message: "userDefined value must be greater than 0x80 got \(byteValue)")
+                throw InvalidArgumentError(message: "userDefined value must be greater than or equal to 0x80 got \(byteValue)")
             }
             guard let subtype = Subtype(rawValue: byteValue) else {
                 throw InvalidArgumentError(message: "Cannot represent \(byteValue) as Subtype")

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -228,8 +228,9 @@ public struct BSONBinary: BSONValue, Equatable, Codable, Hashable {
         private init(_ value: UInt8) { self.rawValue = value }
         internal init(_ value: bson_subtype_t) { self.rawValue = UInt8(value.rawValue) }
 
-        /// Create BSON Binary Subtype
-        /// Note: subtype 0x80-0xFF "User defined" subtype
+        /// Initializes a `Subtype` with a custom value. This value must be in the range 0x80-0xFF.
+        /// - Throws:
+        ///   - `InvalidArgumentError` if value passed is outside of the range 0x80-0xFF
         public static func userDefined(_ value: Int) throws -> Subtype {
             guard value >= 0x80 && value <= 0xFF else {
                 throw InvalidArgumentError(message: "User defined Binary Subtypes must be between 0x80 and 0xFF")

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -223,7 +223,7 @@ public struct BSONBinary: BSONValue, Equatable, Codable, Hashable {
         public static let encryptedValue = Subtype(0x06)
 
         /// Subtype indicator value
-        public var value: UInt8
+        public let value: UInt8
 
         private init(_ value: UInt8) { self.value = value }
         internal init(_ value: bson_subtype_t) { self.value = UInt8(value.rawValue) }

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -246,7 +246,9 @@ public struct BSONBinary: BSONValue, Equatable, Codable, Hashable {
                 throw InvalidArgumentError(message: "Cannot represent \(value) as UInt8")
             }
             guard byteValue >= 0x80 else {
-                throw InvalidArgumentError(message: "userDefined value must be greater than or equal to 0x80 got \(byteValue)")
+                throw InvalidArgumentError(
+                    message: "userDefined value must be greater than or equal to 0x80 got \(byteValue)"
+                )
             }
             guard let subtype = Subtype(rawValue: byteValue) else {
                 throw InvalidArgumentError(message: "Cannot represent \(byteValue) as Subtype")

--- a/Sources/MongoSwift/BSON/BSONValue.swift
+++ b/Sources/MongoSwift/BSON/BSONValue.swift
@@ -222,6 +222,7 @@ public struct BSONBinary: BSONValue, Equatable, Codable, Hashable {
         /// Encrypted BSON value
         public static let encryptedValue = Subtype(0x06)
 
+        /// Subtype indicator value
         public let rawValue: UInt8
 
         private init(_ value: UInt8) { self.rawValue = value }
@@ -229,7 +230,12 @@ public struct BSONBinary: BSONValue, Equatable, Codable, Hashable {
 
         /// Create BSON Binary Subtype
         /// Note: subtype 0x80-0xFF "User defined" subtype
-        public static func other(_ value: Int) -> Subtype { Subtype(UInt8(value)) }
+        public static func userDefined(_ value: Int) throws -> Subtype {
+            guard value >= 0x80 && value <= 0xFF else {
+                throw InvalidArgumentError(message: "User defined Binary Subtypes must be between 0x80 and 0xFF")
+            }
+            return Subtype(UInt8(value))
+        }
     }
 
     /// Initializes a `BSONBinary` instance from a `UUID`.
@@ -836,7 +842,7 @@ public struct BSONObjectID: BSONValue, Equatable, CustomStringConvertible, Codab
     /// - SeeAlso: https://github.com/mongodb/specifications/blob/master/source/objectid.rst
     public init(_ hex: String) throws {
         guard bson_oid_is_valid(hex, hex.utf8.count) else {
-            throw InternalError(message: "Cannot create ObjectId from \(hex)")
+            throw InvalidArgumentError(message: "Cannot create ObjectId from \(hex)")
         }
         var oid_t = bson_oid_t()
         bson_oid_init_from_string(&oid_t, hex)

--- a/Sources/MongoSwift/BSON/Overwritable.swift
+++ b/Sources/MongoSwift/BSON/Overwritable.swift
@@ -8,7 +8,7 @@ internal protocol Overwritable: BSONValue {
      *
      * - Throws:
      *   - `InternalError` if the `BSONValue` is an `Int` and cannot be written to BSON.
-     *   - `LogicError` if the `BSONValue` is a `Decimal128` or `BSONObjectID` and is improperly formatted.
+     *   - `LogicError` if the `BSONValue` is a `BSONDecimal128` or `BSONObjectID` and is improperly formatted.
      */
     func writeToCurrentPosition(of iter: BSONDocumentIterator) throws
 }

--- a/Tests/BSONTests/BSONCorpusTests.swift
+++ b/Tests/BSONTests/BSONCorpusTests.swift
@@ -137,8 +137,8 @@ final class BSONCorpusTests: MongoSwiftTestCase {
 
                     // for cB input:
                     // native_to_bson( bson_to_native(cB) ) = cB
-                    let docFromCB = try BSONDocument(fromBSON: cBData)
-                    expect(docFromCB.rawBSON).to(equal(cBData))
+                    let docFromCB = try Document(fromBSON: cBData)
+                    expect(docFromCB.toData()).to(equal(cBData))
 
                     // test round tripping through documents
                     // We create an array by reading every element out of the document (and therefore out of the
@@ -147,8 +147,8 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                     // -> bson_t. At the end, the new bson_t should be identical to the original one. If not, our bson_t
                     // translation layer is lossy and/or buggy.
                     let nativeFromDoc = docFromCB.toArray()
-                    let docFromNative = BSONDocument(fromArray: nativeFromDoc)
-                    expect(docFromNative.rawBSON).to(equal(cBData))
+                    let docFromNative = Document(fromArray: nativeFromDoc)
+                    expect(docFromNative.toData()).to(equal(cBData))
 
                     // native_to_canonical_extended_json( bson_to_native(cB) ) = cEJ
                     expect(docFromCB.canonicalExtendedJSON).to(cleanEqual(test.canonicalExtJSON))
@@ -165,7 +165,7 @@ final class BSONCorpusTests: MongoSwiftTestCase {
 
                     // native_to_bson( json_to_native(cEJ) ) = cB (unless lossy)
                     if !lossy {
-                        expect(try BSONDocument(fromJSON: cEJData).rawBSON).to(equal(cBData))
+                        expect(try Document(fromJSON: cEJData).toData()).to(equal(cBData))
                     }
 
                     // for dB input (if it exists):
@@ -193,7 +193,7 @@ final class BSONCorpusTests: MongoSwiftTestCase {
 
                         // native_to_bson( json_to_native(dEJ) ) = cB (unless lossy)
                         if !lossy {
-                            expect(try BSONDocument(fromJSON: dEJ).rawBSON).to(equal(cBData))
+                            expect(try Document(fromJSON: dEJ).toData()).to(equal(cBData))
                         }
                     }
 
@@ -212,13 +212,13 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                     }
                     let description = "\(testFile.description)-\(test.description)"
 
-                    switch BSONType(rawValue: UInt32(testFile.bsonType.dropFirst(2), radix: 16)!)! {
+                    switch BSONType(rawValue: UInt8(testFile.bsonType.dropFirst(2), radix: 16)!)! {
                     case .invalid: // "top level document" uses 0x00 for the bson type
                         expect(try BSONDocument(fromJSON: test.string))
                             .to(throwError(), description: description)
                     case .decimal128:
-                        expect(BSONDecimal128(test.string))
-                            .to(beNil(), description: description)
+                        expect(try BSONDecimal128(test.string))
+                            .to(throwError(), description: description)
                     default:
                         throw TestError(
                             message: "\(description): parse error tests not implemented"

--- a/Tests/BSONTests/BSONCorpusTests.swift
+++ b/Tests/BSONTests/BSONCorpusTests.swift
@@ -137,7 +137,7 @@ final class BSONCorpusTests: MongoSwiftTestCase {
 
                     // for cB input:
                     // native_to_bson( bson_to_native(cB) ) = cB
-                    let docFromCB = try Document(fromBSON: cBData)
+                    let docFromCB = try BSONDocument(fromBSON: cBData)
                     expect(docFromCB.toData()).to(equal(cBData))
 
                     // test round tripping through documents
@@ -147,7 +147,7 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                     // -> bson_t. At the end, the new bson_t should be identical to the original one. If not, our bson_t
                     // translation layer is lossy and/or buggy.
                     let nativeFromDoc = docFromCB.toArray()
-                    let docFromNative = Document(fromArray: nativeFromDoc)
+                    let docFromNative = BSONDocument(fromArray: nativeFromDoc)
                     expect(docFromNative.toData()).to(equal(cBData))
 
                     // native_to_canonical_extended_json( bson_to_native(cB) ) = cEJ
@@ -165,7 +165,7 @@ final class BSONCorpusTests: MongoSwiftTestCase {
 
                     // native_to_bson( json_to_native(cEJ) ) = cB (unless lossy)
                     if !lossy {
-                        expect(try Document(fromJSON: cEJData).toData()).to(equal(cBData))
+                        expect(try BSONDocument(fromJSON: cEJData).toData()).to(equal(cBData))
                     }
 
                     // for dB input (if it exists):
@@ -193,7 +193,7 @@ final class BSONCorpusTests: MongoSwiftTestCase {
 
                         // native_to_bson( json_to_native(dEJ) ) = cB (unless lossy)
                         if !lossy {
-                            expect(try Document(fromJSON: dEJ).toData()).to(equal(cBData))
+                            expect(try BSONDocument(fromJSON: dEJ).toData()).to(equal(cBData))
                         }
                     }
 

--- a/Tests/BSONTests/BSONValueTests.swift
+++ b/Tests/BSONTests/BSONValueTests.swift
@@ -38,7 +38,7 @@ final class BSONValueTests: MongoSwiftTestCase {
         self.checkTrueAndFalse(val: .int64(64), alternate: .int64(65))
         // Double
         self.checkTrueAndFalse(val: 1.618, alternate: 2.718)
-        // Decimal128
+        // BSONDecimal128
         self.checkTrueAndFalse(
             val: .decimal128(try BSONDecimal128("1.618")),
             alternate: .decimal128(try BSONDecimal128("2.718"))
@@ -186,7 +186,7 @@ final class BSONValueTests: MongoSwiftTestCase {
             ]
 
             candidates.compactMap { $0 }.forEach { l in
-                // Skip the Decimal128 conversions until they're implemented
+                // Skip the BSONDecimal128 conversions until they're implemented
                 // TODO: don't skip these (SWIFT-367)
                 guard l.decimal128Value == nil else {
                     return
@@ -197,7 +197,7 @@ final class BSONValueTests: MongoSwiftTestCase {
                 BSONNumberTestCase.compare(computed: l.toInt64(), expected: self.int64)
                 BSONNumberTestCase.compare(computed: l.toDouble(), expected: self.double)
 
-                // Skip double for this conversion since it generates a Decimal128(5.0) =/= Decimal128(5)
+                // Skip double for this conversion since it generates a BSONDecimal128(5.0) =/= BSONDecimal128(5)
                 if l.doubleValue == nil {
                     BSONNumberTestCase.compare(computed: l.toDecimal128(), expected: self.decimal)
                 }
@@ -213,7 +213,13 @@ final class BSONValueTests: MongoSwiftTestCase {
         expect(double.toDecimal128()).to(equal(decimal128))
 
         let cases = [
-            BSONNumberTestCase(int: 5, double: 5.0, int32: Int32(5), int64: Int64(5), decimal: try BSONDecimal128("5")),
+            BSONNumberTestCase(
+                int: 5,
+                double: 5.0,
+                int32: Int32(5),
+                int64: Int64(5),
+                decimal: try BSONDecimal128("5")
+            ),
             BSONNumberTestCase(
                 int: -5,
                 double: -5.0,
@@ -221,9 +227,27 @@ final class BSONValueTests: MongoSwiftTestCase {
                 int64: Int64(-5),
                 decimal: try BSONDecimal128("-5")
             ),
-            BSONNumberTestCase(int: 0, double: 0.0, int32: Int32(0), int64: Int64(0), decimal: try BSONDecimal128("0")),
-            BSONNumberTestCase(int: nil, double: 1.234, int32: nil, int64: nil, decimal: try BSONDecimal128("1.234")),
-            BSONNumberTestCase(int: nil, double: -31.234, int32: nil, int64: nil, decimal: try BSONDecimal128("-31.234"))
+            BSONNumberTestCase(
+                int: 0,
+                double: 0.0,
+                int32: Int32(0),
+                int64: Int64(0),
+                decimal: try BSONDecimal128("0")
+            ),
+            BSONNumberTestCase(
+                int: nil,
+                double: 1.234,
+                int32: nil,
+                int64: nil,
+                decimal: try BSONDecimal128("1.234")
+            ),
+            BSONNumberTestCase(
+                int: nil,
+                double: -31.234,
+                int32: nil,
+                int64: nil,
+                decimal: try BSONDecimal128("-31.234")
+            )
         ]
 
         cases.forEach { $0.run() }

--- a/Tests/BSONTests/BSONValueTests.swift
+++ b/Tests/BSONTests/BSONValueTests.swift
@@ -139,7 +139,7 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         // expect that we can pull the correct timestamp if
         // initialized from the original string
-        let objectIdFromString = BSONObjectID(oid)!
+        let objectIdFromString = try BSONObjectID(oid)
         expect(objectIdFromString).to(equal(objectId))
         expect(objectIdFromString.hex).to(equal(oid))
     }
@@ -231,7 +231,7 @@ final class BSONValueTests: MongoSwiftTestCase {
 
     func testBSONBinarySubtype() {
         // Check the subtype bounds are kept
-        expect(try Binary.Subtype.userDefined(0x100)).to(throwError())
-        expect(try Binary.Subtype.userDefined(0x79)).to(throwError())
+        expect(try BSONBinary.Subtype.userDefined(0x100)).to(throwError())
+        expect(try BSONBinary.Subtype.userDefined(0x79)).to(throwError())
     }
 }

--- a/Tests/BSONTests/BSONValueTests.swift
+++ b/Tests/BSONTests/BSONValueTests.swift
@@ -257,5 +257,6 @@ final class BSONValueTests: MongoSwiftTestCase {
         // Check the subtype bounds are kept
         expect(try BSONBinary.Subtype.userDefined(0x100)).to(throwError())
         expect(try BSONBinary.Subtype.userDefined(0x79)).to(throwError())
+        expect(BSONBinary.Subtype(rawValue: 0x79)).to(beNil())
     }
 }

--- a/Tests/BSONTests/BSONValueTests.swift
+++ b/Tests/BSONTests/BSONValueTests.swift
@@ -7,9 +7,9 @@ import XCTest
 
 final class BSONValueTests: MongoSwiftTestCase {
     func testInvalidDecimal128() throws {
-        expect(BSONDecimal128("hi")).to(beNil())
-        expect(BSONDecimal128("123.4.5")).to(beNil())
-        expect(BSONDecimal128("10")).toNot(beNil())
+        expect(try BSONDecimal128("hi")).to(throwError())
+        expect(try BSONDecimal128("123.4.5")).to(throwError())
+        expect(try BSONDecimal128("10")).toNot(throwError())
     }
 
     func testUUIDBytes() throws {
@@ -40,8 +40,8 @@ final class BSONValueTests: MongoSwiftTestCase {
         self.checkTrueAndFalse(val: 1.618, alternate: 2.718)
         // Decimal128
         self.checkTrueAndFalse(
-            val: .decimal128(BSONDecimal128("1.618")!),
-            alternate: .decimal128(BSONDecimal128("2.718")!)
+            val: .decimal128(try BSONDecimal128("1.618")),
+            alternate: .decimal128(try BSONDecimal128("2.718"))
         )
         // Bool
         self.checkTrueAndFalse(val: true, alternate: false)
@@ -119,14 +119,10 @@ final class BSONValueTests: MongoSwiftTestCase {
         bson_oid_to_string(&oid_t, &oid_c)
         let oid = String(cString: &oid_c)
 
-        // read the timestamp used to create the oid
-        let timestamp = UInt32(bson_oid_get_time_t(&oid_t))
-
         // initialize a new oid with the oid_t ptr
         // expect the values to be equal
         let objectId = BSONObjectID(bsonOid: oid_t)
         expect(objectId.hex).to(equal(oid))
-        expect(objectId.timestamp).to(equal(timestamp))
 
         // round trip the objectId.
         // expect the encoded oid to equal the original
@@ -140,14 +136,12 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         expect(_id).to(equal(objectId))
         expect(_id.hex).to(equal(objectId.hex))
-        expect(_id.timestamp).to(equal(objectId.timestamp))
 
         // expect that we can pull the correct timestamp if
         // initialized from the original string
         let objectIdFromString = BSONObjectID(oid)!
         expect(objectIdFromString).to(equal(objectId))
         expect(objectIdFromString.hex).to(equal(oid))
-        expect(objectIdFromString.timestamp).to(equal(timestamp))
     }
 
     func testObjectIDJSONCodable() throws {
@@ -212,24 +206,24 @@ final class BSONValueTests: MongoSwiftTestCase {
     }
 
     func testBSONNumber() throws {
-        let decimal128 = BSONDecimal128("5.5")!
+        let decimal128 = try BSONDecimal128("5.5")
         let double: BSON = 5.5
 
         expect(double.toDouble()).to(equal(5.5))
         expect(double.toDecimal128()).to(equal(decimal128))
 
         let cases = [
-            BSONNumberTestCase(int: 5, double: 5.0, int32: Int32(5), int64: Int64(5), decimal: BSONDecimal128("5")!),
+            BSONNumberTestCase(int: 5, double: 5.0, int32: Int32(5), int64: Int64(5), decimal: try BSONDecimal128("5")),
             BSONNumberTestCase(
                 int: -5,
                 double: -5.0,
                 int32: Int32(-5),
                 int64: Int64(-5),
-                decimal: BSONDecimal128("-5")!
+                decimal: try BSONDecimal128("-5")
             ),
-            BSONNumberTestCase(int: 0, double: 0.0, int32: Int32(0), int64: Int64(0), decimal: BSONDecimal128("0")!),
-            BSONNumberTestCase(int: nil, double: 1.234, int32: nil, int64: nil, decimal: BSONDecimal128("1.234")!),
-            BSONNumberTestCase(int: nil, double: -31.234, int32: nil, int64: nil, decimal: BSONDecimal128("-31.234")!)
+            BSONNumberTestCase(int: 0, double: 0.0, int32: Int32(0), int64: Int64(0), decimal: try BSONDecimal128("0")),
+            BSONNumberTestCase(int: nil, double: 1.234, int32: nil, int64: nil, decimal: try BSONDecimal128("1.234")),
+            BSONNumberTestCase(int: nil, double: -31.234, int32: nil, int64: nil, decimal: try BSONDecimal128("-31.234"))
         ]
 
         cases.forEach { $0.run() }

--- a/Tests/BSONTests/BSONValueTests.swift
+++ b/Tests/BSONTests/BSONValueTests.swift
@@ -228,4 +228,10 @@ final class BSONValueTests: MongoSwiftTestCase {
 
         cases.forEach { $0.run() }
     }
+
+    func testBSONDinarySubtype() {
+        // Check the subtype bounds are kept
+        expect(try Binary.Subtype.userDefined(0x100)).to(throwError())
+        expect(try Binary.Subtype.userDefined(0x79)).to(throwError())
+    }
 }

--- a/Tests/BSONTests/BSONValueTests.swift
+++ b/Tests/BSONTests/BSONValueTests.swift
@@ -229,7 +229,7 @@ final class BSONValueTests: MongoSwiftTestCase {
         cases.forEach { $0.run() }
     }
 
-    func testBSONDinarySubtype() {
+    func testBSONBinarySubtype() {
         // Check the subtype bounds are kept
         expect(try Binary.Subtype.userDefined(0x100)).to(throwError())
         expect(try Binary.Subtype.userDefined(0x79)).to(throwError())

--- a/Tests/BSONTests/CodecTests.swift
+++ b/Tests/BSONTests/CodecTests.swift
@@ -305,8 +305,8 @@ final class CodecTests: MongoSwiftTestCase {
                 ts: BSONTimestamp(timestamp: 1, inc: 2),
                 int32: 5,
                 int64: 6,
-                dec: BSONDecimal128("1.2E+10")!,
-                minkey: BSONMinKey(),
+                dec: try BSONDecimal128("1.2E+10"),
+                minkey: MinKey(),
                 maxkey: MaxKey(),
                 regex: BSONRegularExpression(pattern: "^abc", options: "imx"),
                 symbol: BSONSymbol("i am a symbol"),
@@ -412,7 +412,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(
             BSONDecimal128.self,
             from: "{\"$numberDecimal\": \"1.2E+10\"}"
-        )).to(equal(BSONDecimal128("1.2E+10")!))
+        )).to(equal(try BSONDecimal128("1.2E+10")))
 
         let binary = try BSONBinary(base64: "//8=", subtype: .generic)
         expect(
@@ -700,7 +700,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64.canonicalExtendedJSON).x).to(equal(int64))
 
         // decimal128
-        let decimal = BSON.decimal128(BSONDecimal128("1.2E+10")!)
+        let decimal = BSON.decimal128(try BSONDecimal128("1.2E+10"))
 
         expect(try decoder.decode(BSON.self, from: "{ \"$numberDecimal\" : \"1.2E+10\" }")).to(equal(decimal))
 

--- a/Tests/BSONTests/CodecTests.swift
+++ b/Tests/BSONTests/CodecTests.swift
@@ -297,7 +297,7 @@ final class CodecTests: MongoSwiftTestCase {
                 doc: ["x": 1],
                 arr: [.int32(1), .int32(2)],
                 binary: try BSONBinary(base64: "//8=", subtype: .generic),
-                oid: BSONObjectID("507f1f77bcf86cd799439011")!,
+                oid: try BSONObjectID("507f1f77bcf86cd799439011"),
                 bool: true,
                 date: Date(timeIntervalSinceReferenceDate: 5000),
                 code: BSONCode(code: "hi"),
@@ -311,7 +311,7 @@ final class CodecTests: MongoSwiftTestCase {
                 regex: BSONRegularExpression(pattern: "^abc", options: "imx"),
                 symbol: BSONSymbol("i am a symbol"),
                 undefined: BSONUndefined(),
-                dbpointer: BSONDBPointer(ref: "some.namespace", id: BSONObjectID("507f1f77bcf86cd799439011")!),
+                dbpointer: DBPointer(ref: "some.namespace", id: try BSONObjectID("507f1f77bcf86cd799439011")),
                 null: BSONNull()
             )
         }
@@ -398,7 +398,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(Int32.self, from: "42")).to(equal(Int32(42)))
         expect(try decoder.decode(Int32.self, from: "{\"$numberInt\": \"42\"}")).to(equal(Int32(42)))
 
-        let oid = BSONObjectID("507f1f77bcf86cd799439011")!
+        let oid = try BSONObjectID("507f1f77bcf86cd799439011")
         expect(try decoder.decode(BSONObjectID.self, from: "{\"$oid\": \"507f1f77bcf86cd799439011\"}")).to(equal(oid))
 
         expect(try decoder.decode(String.self, from: "\"somestring\"")).to(equal("somestring"))

--- a/Tests/BSONTests/CodecTests.swift
+++ b/Tests/BSONTests/CodecTests.swift
@@ -283,7 +283,7 @@ final class CodecTests: MongoSwiftTestCase {
         let int64: Int64
         let dec: BSONDecimal128
         let minkey: BSONMinKey
-        let maxkey: MaxKey
+        let maxkey: BSONMaxKey
         let regex: BSONRegularExpression
         let symbol: BSONSymbol
         let undefined: BSONUndefined
@@ -306,12 +306,12 @@ final class CodecTests: MongoSwiftTestCase {
                 int32: 5,
                 int64: 6,
                 dec: try BSONDecimal128("1.2E+10"),
-                minkey: MinKey(),
-                maxkey: MaxKey(),
+                minkey: BSONMinKey(),
+                maxkey: BSONMaxKey(),
                 regex: BSONRegularExpression(pattern: "^abc", options: "imx"),
                 symbol: BSONSymbol("i am a symbol"),
                 undefined: BSONUndefined(),
-                dbpointer: DBPointer(ref: "some.namespace", id: try BSONObjectID("507f1f77bcf86cd799439011")),
+                dbpointer: BSONDBPointer(ref: "some.namespace", id: try BSONObjectID("507f1f77bcf86cd799439011")),
                 null: BSONNull()
             )
         }
@@ -459,7 +459,7 @@ final class CodecTests: MongoSwiftTestCase {
         ).to(equal(regex))
 
         expect(try decoder.decode(BSONMinKey.self, from: "{\"$minKey\": 1}")).to(equal(BSONMinKey()))
-        expect(try decoder.decode(MaxKey.self, from: "{\"$maxKey\": 1}")).to(equal(MaxKey()))
+        expect(try decoder.decode(BSONMaxKey.self, from: "{\"$maxKey\": 1}")).to(equal(BSONMaxKey()))
 
         expect(try decoder.decode(Bool.self, from: "false")).to(beFalse())
         expect(try decoder.decode(Bool.self, from: "true")).to(beTrue())

--- a/Tests/BSONTests/Document+SequenceTests.swift
+++ b/Tests/BSONTests/Document+SequenceTests.swift
@@ -82,7 +82,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
         var expectedValues: [BSON] = [
             "test string", true, false, 25, .int32(5), .int64(123), .double(15),
             .decimal128(try BSONDecimal128("1.2E+10")), .minKey, .maxKey, .datetime(Date(timeIntervalSince1970: 5000)),
-            .timestamp(Timestamp(timestamp: 5, inc: 10))
+            .timestamp(BSONTimestamp(timestamp: 5, inc: 10))
         ]
         for (k, v) in doc {
             expect(k).to(equal(expectedKeys.removeFirst()))

--- a/Tests/BSONTests/Document+SequenceTests.swift
+++ b/Tests/BSONTests/Document+SequenceTests.swift
@@ -5,7 +5,7 @@ import TestsCommon
 import XCTest
 
 final class Document_SequenceTests: MongoSwiftTestCase {
-    func testIterator() {
+    func testIterator() throws {
         let doc: BSONDocument = [
             "string": "test string",
             "true": true,

--- a/Tests/BSONTests/Document+SequenceTests.swift
+++ b/Tests/BSONTests/Document+SequenceTests.swift
@@ -14,7 +14,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
             "int32": .int32(5),
             "int64": .int64(123),
             "double": .double(15),
-            "decimal128": .decimal128(BSONDecimal128("1.2E+10")!),
+            "decimal128": .decimal128(try BSONDecimal128("1.2E+10")),
             "minkey": .minKey,
             "maxkey": .maxKey,
             "date": .datetime(Date(timeIntervalSince1970: 5000)),
@@ -54,7 +54,7 @@ final class Document_SequenceTests: MongoSwiftTestCase {
 
         let decimalTup = iter.next()!
         expect(decimalTup.key).to(equal("decimal128"))
-        expect(decimalTup.value).to(equal(.decimal128(BSONDecimal128("1.2E+10")!)))
+        expect(decimalTup.value).to(equal(.decimal128(try BSONDecimal128("1.2E+10"))))
 
         let minTup = iter.next()!
         expect(minTup.key).to(equal("minkey"))
@@ -81,8 +81,8 @@ final class Document_SequenceTests: MongoSwiftTestCase {
         ]
         var expectedValues: [BSON] = [
             "test string", true, false, 25, .int32(5), .int64(123), .double(15),
-            .decimal128(BSONDecimal128("1.2E+10")!), .minKey, .maxKey, .datetime(Date(timeIntervalSince1970: 5000)),
-            .timestamp(BSONTimestamp(timestamp: 5, inc: 10))
+            .decimal128(try BSONDecimal128("1.2E+10")), .minKey, .maxKey, .datetime(Date(timeIntervalSince1970: 5000)),
+            .timestamp(Timestamp(timestamp: 5, inc: 10))
         ]
         for (k, v) in doc {
             expect(k).to(equal(expectedKeys.removeFirst()))

--- a/Tests/BSONTests/DocumentTests.swift
+++ b/Tests/BSONTests/DocumentTests.swift
@@ -88,7 +88,7 @@ final class DocumentTests: MongoSwiftTestCase {
         "timestamp": .timestamp(BSONTimestamp(timestamp: 5, inc: 10)),
         "nestedarray": [[1, 2], [.int32(3), .int32(4)]],
         "nesteddoc": ["a": 1, "b": 2, "c": false, "d": [3, 4]],
-        "oid": .objectID(BSONObjectID("507f1f77bcf86cd799439011")!),
+        "oid": .objectID(try! BSONObjectID("507f1f77bcf86cd799439011")),
         "regex": .regex(BSONRegularExpression(pattern: "^abc", options: "imx")),
         "array1": [1, 2],
         "array2": ["string1", "string2"],
@@ -153,7 +153,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["maxkey"]).to(equal(.maxKey))
         expect(doc["date"]).to(equal(.datetime(Date(timeIntervalSince1970: 500.004))))
         expect(doc["timestamp"]).to(equal(.timestamp(BSONTimestamp(timestamp: 5, inc: 10))))
-        expect(doc["oid"]).to(equal(.objectID(BSONObjectID("507f1f77bcf86cd799439011")!)))
+        expect(doc["oid"]).to(equal(.objectID(try BSONObjectID("507f1f77bcf86cd799439011"))))
 
         let regex = doc["regex"]?.regexValue
         expect(regex).to(equal(BSONRegularExpression(pattern: "^abc", options: "imx")))
@@ -203,7 +203,7 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(DocumentTests.testDoc.maxkey).to(equal(.maxKey))
         expect(DocumentTests.testDoc.date).to(equal(.datetime(Date(timeIntervalSince1970: 500.004))))
         expect(DocumentTests.testDoc.timestamp).to(equal(.timestamp(BSONTimestamp(timestamp: 5, inc: 10))))
-        expect(DocumentTests.testDoc.oid).to(equal(.objectID(BSONObjectID("507f1f77bcf86cd799439011")!)))
+        expect(DocumentTests.testDoc.oid).to(equal(.objectID(try BSONObjectID("507f1f77bcf86cd799439011"))))
 
         let codewscope = DocumentTests.testDoc.codewscope?.codeWithScopeValue
         expect(codewscope?.code).to(equal("console.log(x);"))
@@ -351,7 +351,7 @@ final class DocumentTests: MongoSwiftTestCase {
         "int32": .int32(32),
         "int64": .int64(Int64.max),
         "bool": false,
-        "decimal": .decimal128(try BSONDecimal128("1.2E+10")),
+        "decimal": .decimal128(try! BSONDecimal128("1.2E+10")),
         "oid": .objectID(BSONObjectID()),
         "timestamp": .timestamp(BSONTimestamp(timestamp: 1, inc: 2)),
         "datetime": .datetime(Date(msSinceEpoch: 1000))

--- a/Tests/BSONTests/DocumentTests.swift
+++ b/Tests/BSONTests/DocumentTests.swift
@@ -121,8 +121,8 @@ final class DocumentTests: MongoSwiftTestCase {
             "binary3": .binary(try BSONBinary(data: uuidData, subtype: .uuidDeprecated)),
             "binary4": .binary(try BSONBinary(data: uuidData, subtype: .uuid)),
             "binary5": .binary(try BSONBinary(data: testData, subtype: .md5)),
-            "binary6": .binary(try BSONBinary(data: testData, subtype: .userDefined(0x80))),
-            "binary7": .binary(try BSONBinary(data: testData, subtype: .userDefined(0xFF)))
+            "binary6": .binary(try BSONBinary(data: testData, subtype: try .userDefined(0x80))),
+            "binary7": .binary(try BSONBinary(data: testData, subtype: try .userDefined(0xFF)))
         ]
         try doc.merge(binaryData)
 
@@ -179,8 +179,8 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(doc["binary3"]).to(equal(.binary(try BSONBinary(data: uuidData, subtype: .uuidDeprecated))))
         expect(doc["binary4"]).to(equal(.binary(try BSONBinary(data: uuidData, subtype: .uuid))))
         expect(doc["binary5"]).to(equal(.binary(try BSONBinary(data: testData, subtype: .md5))))
-        expect(doc["binary6"]).to(equal(.binary(try BSONBinary(data: testData, subtype: .other(0x80)))))
-        expect(doc["binary7"]).to(equal(.binary(try BSONBinary(data: testData, subtype: .other(0xFF)))))
+        expect(doc["binary6"]).to(equal(.binary(try BSONBinary(data: testData, subtype: try .userDefined(0x80)))))
+        expect(doc["binary7"]).to(equal(.binary(try BSONBinary(data: testData, subtype: try .userDefined(0xFF)))))
 
         let nestedArray = doc["nestedarray"]?.arrayValue?.compactMap { $0.arrayValue?.compactMap { $0.toInt() } }
         expect(nestedArray?[0]).to(equal([1, 2]))

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -39,6 +39,7 @@ extension BSONValueTests {
         ("testObjectIDRoundTrip", testObjectIDRoundTrip),
         ("testObjectIDJSONCodable", testObjectIDJSONCodable),
         ("testBSONNumber", testBSONNumber),
+        ("testBSONBinarySubtype", testBSONBinarySubtype),
     ]
 }
 


### PR DESCRIPTION
All changes listed in ticket:
https://jira.mongodb.org/browse/SWIFT-858

Additionally changed:
- `BSONType` is `UInt8` instead of UInt32
