### PR TITLE
SWIFT-423 Add transactions examples for docs

### DIFF
--- a/Examples/Docs/Sources/AsyncExamples/main.swift
+++ b/Examples/Docs/Sources/AsyncExamples/main.swift
@@ -206,12 +206,12 @@ private func transactions() throws {
         return commitFuture.flatMapError { error in
             guard
                 let labeledError = error as? LabeledError,
-                labeledError.errorLabels?.contains("UnknownTransactioncommitResult") == true
+                labeledError.errorLabels?.contains("UnknownTransactionCommitResult") == true
             else {
                 print("Error during commit...")
                 return eventLoop.makeFailedFuture(error)
             }
-            print("UnknownTransactioncommitResult, retrying commit operation...")
+            print("UnknownTransactionCommitResult, retrying commit operation...")
             return commitWithRetry(session: session)
         }
     }


### PR DESCRIPTION
[SWIFT-423](https://jira.mongodb.org/browse/SWIFT-423)

This PR adds the examples to be rendered in the official MongoDB [docs page](https://docs.mongodb.com/manual/core/transactions-in-applications/) on transactions usage in drivers.