### PR TITLE
SWIFT-863 Rename WriteConcern tag case to custom

### DIFF
--- a/Tests/MongoSwiftTests/ReadWriteConcernSpecTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernSpecTests.swift
@@ -11,8 +11,8 @@ extension WriteConcern {
         let j = doc["journal"]?.boolValue
 
         var w: W?
-        if let wtag = doc["w"]?.stringValue {
-            w = wtag == "majority" ? .majority : .tag(wtag)
+        if let str = doc["w"]?.stringValue {
+            w = str == "majority" ? .majority : .custom(str)
         } else if let wInt = doc["w"]?.toInt() {
             w = .number(wInt)
         }

--- a/Tests/MongoSwiftTests/WriteConcernTests.swift
+++ b/Tests/MongoSwiftTests/WriteConcernTests.swift
@@ -35,7 +35,7 @@ final class WriteConcernTests: MongoSwiftTestCase {
         expect(try WriteConcern(w: .number(3))).toNot(throwError())
         expect(try WriteConcern(journal: true, w: .number(1))).toNot(throwError())
         expect(try WriteConcern(w: .number(0), wtimeoutMS: 1000)).toNot(throwError())
-        expect(try WriteConcern(w: .tag("hi"))).toNot(throwError())
+        expect(try WriteConcern(w: .custom("hi"))).toNot(throwError())
         expect(try WriteConcern(w: .majority)).toNot(throwError())
 
         // verify that this combination is considered invalid
@@ -147,7 +147,7 @@ final class WriteConcernTests: MongoSwiftTestCase {
         let wcs: [WriteConcern] = [
             .serverDefault,
             try WriteConcern(w: .number(2)),
-            try WriteConcern(w: .tag("hi")),
+            try WriteConcern(w: .custom("hi")),
             .majority,
             try WriteConcern(journal: true),
             try WriteConcern(wtimeoutMS: 200)


### PR DESCRIPTION
Renames this case to be more in line with what we're calling it in MongoDB docs now.