### PR TITLE
SWIFT-827: Rewrite enums with ".other" case as structs

### DIFF
--- a/Examples/Docs/Sources/AsyncExamples/main.swift
+++ b/Examples/Docs/Sources/AsyncExamples/main.swift
@@ -86,7 +86,7 @@ private func changeStreams() throws {
         let inventory = db.collection("inventory")
 
         // Option 1: use next() to iterate
-        let next = inventory.watch(options: ChangeStreamOptions(fullDocument: .other("blah")))
+        let next = inventory.watch(options: ChangeStreamOptions(fullDocument: .updateLookup))
             .flatMap { changeStream in
                 changeStream.next()
             }

--- a/Examples/Docs/Sources/AsyncExamples/main.swift
+++ b/Examples/Docs/Sources/AsyncExamples/main.swift
@@ -86,7 +86,7 @@ private func changeStreams() throws {
         let inventory = db.collection("inventory")
 
         // Option 1: use next() to iterate
-        let next = inventory.watch(options: ChangeStreamOptions(fullDocument: .updateLookup))
+        let next = inventory.watch(options: ChangeStreamOptions(fullDocument: .other("blah")))
             .flatMap { changeStream in
                 changeStream.next()
             }

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -11,6 +11,7 @@ public struct FullDocument: RawRepresentable, Codable {
 
     public var rawValue: String
 
+    /// Creates a `FullDocument`. Never returns nil.
     public init?(rawValue: String) { self.rawValue = rawValue }
     internal init(_ value: String) { self.rawValue = value }
 }

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -1,29 +1,18 @@
 /// Describes the modes for configuring the fullDocument field of a change stream document.
-public enum FullDocument: RawRepresentable, Codable {
+public struct FullDocument: RawRepresentable, Codable {
     /// Specifies that the `fullDocument` field of an update event will contain a copy of the entire document that
     /// was changed from some time after the change occurred. If the document was deleted since the updated happened,
     /// it will be nil.
-    case updateLookup
+    public static let updateLookup = FullDocument("updateLookup")
     /// For an unknown value. For forwards compatibility, no error will be thrown when an unknown value is provided.
-    case other(String)
-
-    public var rawValue: String {
-        switch self {
-        case .updateLookup:
-            return "updateLookup"
-        case let .other(v):
-            return v
-        }
+    public static func other(_ value: String) -> FullDocument {
+        FullDocument(value)
     }
 
-    public init?(rawValue: String) {
-        switch rawValue {
-        case "updateLookup":
-            self = .updateLookup
-        default:
-            self = .other(rawValue)
-        }
-    }
+    public var rawValue: String
+
+    public init?(rawValue: String) { self.rawValue = rawValue }
+    internal init(_ value: String) { self.rawValue = value }
 }
 
 /// Options to use when creating a `ChangeStream`.

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 
@@ -63,7 +63,7 @@
 @_exported import struct MongoSwift.FindOneAndUpdateOptions
 @_exported import struct MongoSwift.FindOneOptions
 @_exported import struct MongoSwift.FindOptions
-@_exported import enum MongoSwift.FullDocument
+@_exported import struct MongoSwift.FullDocument
 @_exported import enum MongoSwift.IndexHint
 @_exported import struct MongoSwift.IndexModel
 @_exported import struct MongoSwift.IndexOptions

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/SWIFT-827

`CollectionType` is out of scope (we discussed that since it's an administrative api we can leave it as is)
That only leaves `FullDocument` which is now a RawRepresentable struct with a public static other function