### PR TITLE
SWIFT-855 Add minimum macOS version and document OS support policy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "mongo-swift-driver",
     platforms: [
-       .macOS(.v10_14)
+        .macOS(.v10_14)
     ],
     products: [
         .library(name: "MongoSwift", targets: ["MongoSwift"]),

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,9 @@
 import PackageDescription
 let package = Package(
     name: "mongo-swift-driver",
+    platforms: [
+       .macOS(.v10_14)
+    ],
     products: [
         .library(name: "MongoSwift", targets: ["MongoSwift"]),
         .library(name: "MongoSwiftSync", targets: ["MongoSwiftSync"])

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Bug reports in JIRA for all driver projects (i.e. NODE, PYTHON, CSHARP, JAVA) an
 Core Server (i.e. SERVER) project are **public**.
 
 ## Installation
-The driver supports use with Swift 5.1+ on MacOS and Linux.
+The driver supports use with Swift 5.1+. It is tested in continuous integration against macOS 10.14, Ubuntu 16.04, and Ubuntu 18.04.
 
 Installation is supported via [Swift Package Manager](https://swift.org/package-manager/).
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Bug reports in JIRA for all driver projects (i.e. NODE, PYTHON, CSHARP, JAVA) an
 Core Server (i.e. SERVER) project are **public**.
 
 ## Installation
-The driver supports use with Swift 5.1+. It is tested in continuous integration against macOS 10.14, Ubuntu 16.04, and Ubuntu 18.04.
+The driver supports use with Swift 5.1+. The minimum macOS version required to build the driver is 10.14. The driver is tested in continuous integration against macOS 10.14, Ubuntu 16.04, and Ubuntu 18.04.
 
 Installation is supported via [Swift Package Manager](https://swift.org/package-manager/).
 

--- a/Sources/MongoSwift/BSON/BSONDecoder.swift
+++ b/Sources/MongoSwift/BSON/BSONDecoder.swift
@@ -396,9 +396,6 @@ extension _BSONDecoder {
             let seconds = try unboxNumber(value, as: Double.self)
             return Date(timeIntervalSince1970: seconds)
         case .iso8601:
-            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
-            }
             let isoString = try self.unboxCustom(value) { $0.stringValue }
             guard let date = BSONDecoder.iso8601Formatter.date(from: isoString) else {
                 throw DecodingError.dataCorrupted(

--- a/Sources/MongoSwift/BSON/BSONEncoder.swift
+++ b/Sources/MongoSwift/BSON/BSONEncoder.swift
@@ -438,9 +438,6 @@ extension _BSONEncoder {
         case let .formatted(formatter):
             return formatter.string(from: date)
         case .iso8601:
-            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
-            }
             return BSONDecoder.iso8601Formatter.string(from: date)
         case let .custom(f):
             return try self.handleCustomStrategy(encodeFunc: f, forValue: date)

--- a/Sources/MongoSwift/BSON/CodingStrategies.swift
+++ b/Sources/MongoSwift/BSON/CodingStrategies.swift
@@ -82,9 +82,6 @@ public enum DateCodingStrategy: RawRepresentable {
         case (.secondsSince1970, .secondsSince1970):
             self = .secondsSince1970
         case (.iso8601, .iso8601):
-            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
-            }
             self = .iso8601
         case let (.formatted(encodingFormatter), .formatted(decodingFormatter)):
             guard encodingFormatter == decodingFormatter else {
@@ -109,9 +106,6 @@ public enum DateCodingStrategy: RawRepresentable {
         case .secondsSince1970:
             return (.secondsSince1970, .secondsSince1970)
         case .iso8601:
-            guard #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
-            }
             return (.iso8601, .iso8601)
         case let .formatted(formatter):
             return (.formatted(formatter), .formatted(formatter))

--- a/Tests/BSONTests/DocumentTests.swift
+++ b/Tests/BSONTests/DocumentTests.swift
@@ -711,11 +711,9 @@ final class DocumentTests: MongoSwiftTestCase {
         let millisecondsSince1970 = try encoder.encode(dateStruct)
         expect(millisecondsSince1970["date"]).to(equal(.int64(date.msSinceEpoch)))
 
-        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-            encoder.dateEncodingStrategy = .iso8601
-            let iso = try encoder.encode(dateStruct)
-            expect(iso["date"]).to(equal(.string(BSONDecoder.iso8601Formatter.string(from: date))))
-        }
+        encoder.dateEncodingStrategy = .iso8601
+        let iso = try encoder.encode(dateStruct)
+        expect(iso["date"]).to(equal(.string(BSONDecoder.iso8601Formatter.string(from: date))))
 
         let formatter = DateFormatter()
         formatter.timeStyle = .full
@@ -819,15 +817,13 @@ final class DocumentTests: MongoSwiftTestCase {
         expect(try decoder.decode(DateWrapper.self, from: badlyFormatted)).to(throwError(CodecTests.dataCorruptedErr))
         expect(try decoder.decode(DateWrapper.self, from: sDouble)).to(throwError(CodecTests.typeMismatchErr))
 
-        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-            decoder.dateDecodingStrategy = .iso8601
-            let isoDoc: BSONDocument = ["date": .string(BSONDecoder.iso8601Formatter.string(from: date))]
-            let isoStruct = try decoder.decode(DateWrapper.self, from: isoDoc)
-            expect(isoStruct.date).to(equal(date))
-            expect(try decoder.decode(DateWrapper.self, from: formatted)).to(throwError(CodecTests.dataCorruptedErr))
-            expect(try decoder.decode(DateWrapper.self, from: badlyFormatted))
-                .to(throwError(CodecTests.dataCorruptedErr))
-        }
+        decoder.dateDecodingStrategy = .iso8601
+        let isoDoc: BSONDocument = ["date": .string(BSONDecoder.iso8601Formatter.string(from: date))]
+        let isoStruct = try decoder.decode(DateWrapper.self, from: isoDoc)
+        expect(isoStruct.date).to(equal(date))
+        expect(try decoder.decode(DateWrapper.self, from: formatted)).to(throwError(CodecTests.dataCorruptedErr))
+        expect(try decoder.decode(DateWrapper.self, from: badlyFormatted))
+            .to(throwError(CodecTests.dataCorruptedErr))
 
         decoder.dateDecodingStrategy = .custom({ decode in try Date(from: decode) })
         let customDoc: BSONDocument = ["date": .double(date.timeIntervalSinceReferenceDate)]


### PR DESCRIPTION
This adds a minimum macOS version to our package manifest, and clarifies supported / tested platforms in our README.
This also lets us remove the availability checks for 10.12+ we had to use for the date formatter.