### PR TITLE
SWIFT-742 Implement unified replica set discovery behavior

### DIFF
--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -35,7 +35,9 @@ internal class ConnectionString {
 
         // Per SDAM spec: If the ``directConnection`` option is not specified, newly developed drivers MUST behave as
         // if it was specified with the false value.
-        if !self.hasOption("directConnection") {
+        if let dc = options?.directConnection {
+            mongoc_uri_set_option_as_bool(self._uri, MONGOC_URI_DIRECTCONNECTION, dc)
+        } else if !self.hasOption("directConnection") {
             mongoc_uri_set_option_as_bool(self._uri, MONGOC_URI_DIRECTCONNECTION, false)
         }
 

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -33,6 +33,12 @@ internal class ConnectionString {
             mongoc_uri_set_option_as_bool(self._uri, MONGOC_URI_RETRYREADS, rr)
         }
 
+        // Per SDAM spec: If the ``directConnection`` option is not specified, newly developed drivers MUST behave as
+        // if it was specified with the false value.
+        if !self.hasOption("directConnection") {
+            mongoc_uri_set_option_as_bool(self._uri, MONGOC_URI_DIRECTCONNECTION, false)
+        }
+
         if let credential = options?.credential {
             try self.setMongoCredential(credential)
         }
@@ -193,6 +199,10 @@ internal class ConnectionString {
         }
 
         return hosts
+    }
+
+    private func hasOption(_ option: String) -> Bool {
+        mongoc_uri_has_option(self._uri, option)
     }
 
     /// Executes the provided closure using a pointer to the underlying `mongoc_uri_t`.

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -17,7 +17,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
     public var dateCodingStrategy: DateCodingStrategy?
 
     /// When true, the client will connect directly to a single host. When false, the client will attempt to
-    /// automatically discover all replica set members if a replica set name is provided.
+    /// automatically discover all replica set members if a replica set name is provided. Defaults to false.
     /// It is an error to set this option to `true` when used with a mongodb+srv connection string or when multiple
     /// hosts are specified in the connection string.
     public var directConnection: Bool?

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -16,6 +16,12 @@ public struct MongoClientOptions: CodingStrategyProvider {
     /// databases or collections that derive from it.
     public var dateCodingStrategy: DateCodingStrategy?
 
+    /// When true, the client will connect directly to a single host. When false, the client will attempt to
+    /// automatically discover all replica set members if a replica set name is provided.
+    /// It is an error to set this option to `true` when used with a mongodb+srv connection string or when multiple
+    /// hosts are specified in the connection string.
+    public var directConnection: Bool?
+
     /// The maximum number of connections that may be associated with a connection pool created by this client at a
     /// given time. This includes in-use and available connections. Defaults to 100.
     public var maxPoolSize: Int?
@@ -83,6 +89,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         credential: MongoCredential? = nil,
         dataCodingStrategy: DataCodingStrategy? = nil,
         dateCodingStrategy: DateCodingStrategy? = nil,
+        directConnection: Bool? = nil,
         maxPoolSize: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil,
@@ -101,6 +108,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         self.credential = credential
         self.dataCodingStrategy = dataCodingStrategy
         self.dateCodingStrategy = dateCodingStrategy
+        self.directConnection = directConnection
         self.maxPoolSize = maxPoolSize
         self.readConcern = readConcern
         self.readPreference = readPreference

--- a/Tests/BSONTests/DocumentTests.swift
+++ b/Tests/BSONTests/DocumentTests.swift
@@ -374,8 +374,6 @@ final class DocumentTests: MongoSwiftTestCase {
         // save a reference to original bson_t so we can verify it doesn't change
         let pointer = doc.pointerAddress
 
-        print("pointer is: \(pointer)")
-
         // overwrite int32 with int32
         doc["int32"] = .int32(15)
         expect(doc["int32"]).to(equal(.int32(15)))

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -319,6 +319,7 @@ extension RetryableWritesTests {
 extension SDAMTests {
     static var allTests = [
         ("testMonitoring", testMonitoring),
+        ("testInitialReplicaSetDiscovery", testInitialReplicaSetDiscovery),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/SDAMTests.swift
+++ b/Tests/MongoSwiftSyncTests/SDAMTests.swift
@@ -131,7 +131,7 @@ final class SDAMTests: MongoSwiftTestCase {
                     try collection.insertOne(["x": 1])
                 }
             } catch {
-                expect(error).to(beAnInstanceOf(CommandError.self))
+                expect(error).to(beAnInstanceOf(MongoError.CommandError.self))
                 failures += 1
             }
         }

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/direct-connection-false.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/direct-connection-false.json
@@ -1,0 +1,14 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?directConnection=false",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/direct-connection-true.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/direct-connection-true.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?directConnection=true",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because directConnection=true is incompatible with SRV URIs."
+}


### PR DESCRIPTION
This builds on my previous PR to add libmongoc support for `directConnection=true` to give us the desired discover behavior by default.

You can view a summary of the spec changes [here](https://github.com/mongodb/specifications/commit/e56f5eceed7729f8b9b43a4a1f76c7e5840db49f).

I was able to pull in the relevant initial DNS seedlist discovery tests as we implement that test runner, but the other tests use the SDAM and connection string test runners which we do not implement yet.

I did some manual local testing using SDAM monitoring and everything seems to work as expected in terms of initial topology assumptions as well as errors being reported in the right scenarios.