### PR TITLE
SWIFT-882 Convert extJSON properties to methods

### DIFF
--- a/Sources/MongoSwift/BSON/BSONDocument.swift
+++ b/Sources/MongoSwift/BSON/BSONDocument.swift
@@ -300,7 +300,7 @@ extension BSONDocument {
 
     /// Returns the relaxed extended JSON representation of this `BSONDocument`.
     /// On error, an empty string will be returned.
-    public var extendedJSON: String {
+    public func toExtendedJSON() -> String {
         let result = self.withBSONPointer { ptr in
             bson_as_relaxed_extended_json(ptr, nil)
         }
@@ -314,7 +314,7 @@ extension BSONDocument {
 
     /// Returns the canonical extended JSON representation of this `BSONDocument`.
     /// On error, an empty string will be returned.
-    public var canonicalExtendedJSON: String {
+    public func toCanonicalExtendedJSON() -> String {
         let result = self.withBSONPointer { ptr in
             bson_as_canonical_extended_json(ptr, nil)
         }
@@ -541,7 +541,7 @@ extension BSONDocument: CustomStringConvertible {
     /// Returns the relaxed extended JSON representation of this `BSONDocument`.
     /// On error, an empty string will be returned.
     public var description: String {
-        self.extendedJSON
+        self.toExtendedJSON()
     }
 }
 

--- a/Sources/MongoSwift/BSON/BSONDocument.swift
+++ b/Sources/MongoSwift/BSON/BSONDocument.swift
@@ -300,7 +300,7 @@ extension BSONDocument {
 
     /// Returns the relaxed extended JSON representation of this `BSONDocument`.
     /// On error, an empty string will be returned.
-    public func toExtendedJSON() -> String {
+    public func toExtendedJSONString() -> String {
         let result = self.withBSONPointer { ptr in
             bson_as_relaxed_extended_json(ptr, nil)
         }
@@ -314,7 +314,7 @@ extension BSONDocument {
 
     /// Returns the canonical extended JSON representation of this `BSONDocument`.
     /// On error, an empty string will be returned.
-    public func toCanonicalExtendedJSON() -> String {
+    public func toCanonicalExtendedJSONString() -> String {
         let result = self.withBSONPointer { ptr in
             bson_as_canonical_extended_json(ptr, nil)
         }
@@ -541,7 +541,7 @@ extension BSONDocument: CustomStringConvertible {
     /// Returns the relaxed extended JSON representation of this `BSONDocument`.
     /// On error, an empty string will be returned.
     public var description: String {
-        self.toExtendedJSON()
+        self.toExtendedJSONString()
     }
 }
 

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -167,7 +167,7 @@ private func clean(json: String?) -> String {
     }
     do {
         let doc = try BSONDocument(fromJSON: str.data(using: .utf8)!)
-        return doc.toExtendedJSON()
+        return doc.toExtendedJSONString()
     } catch {
         print("Failed to clean string: \(str)")
         return String()

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -167,7 +167,7 @@ private func clean(json: String?) -> String {
     }
     do {
         let doc = try BSONDocument(fromJSON: str.data(using: .utf8)!)
-        return doc.extendedJSON
+        return doc.toExtendedJSON()
     } catch {
         print("Failed to clean string: \(str)")
         return String()

--- a/Tests/BSONTests/BSONCorpusTests.swift
+++ b/Tests/BSONTests/BSONCorpusTests.swift
@@ -151,16 +151,16 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                     expect(docFromNative.toData()).to(equal(cBData))
 
                     // native_to_canonical_extended_json( bson_to_native(cB) ) = cEJ
-                    expect(docFromCB.toCanonicalExtendedJSON()).to(cleanEqual(test.canonicalExtJSON))
+                    expect(docFromCB.toCanonicalExtendedJSONString()).to(cleanEqual(test.canonicalExtJSON))
 
                     // native_to_relaxed_extended_json( bson_to_native(cB) ) = rEJ (if rEJ exists)
                     if let rEJ = test.relaxedExtJSON {
-                        expect(try BSONDocument(fromBSON: cBData).toExtendedJSON()).to(cleanEqual(rEJ))
+                        expect(try BSONDocument(fromBSON: cBData).toExtendedJSONString()).to(cleanEqual(rEJ))
                     }
 
                     // for cEJ input:
                     // native_to_canonical_extended_json( json_to_native(cEJ) ) = cEJ
-                    expect(try BSONDocument(fromJSON: cEJData).toCanonicalExtendedJSON())
+                    expect(try BSONDocument(fromJSON: cEJData).toCanonicalExtendedJSONString())
                         .to(cleanEqual(test.canonicalExtJSON))
 
                     // native_to_bson( json_to_native(cEJ) ) = cB (unless lossy)
@@ -176,19 +176,19 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                         }
 
                         // bson_to_canonical_extended_json(dB) = cEJ
-                        expect(try BSONDocument(fromBSON: dBData).toCanonicalExtendedJSON())
+                        expect(try BSONDocument(fromBSON: dBData).toCanonicalExtendedJSONString())
                             .to(cleanEqual(test.canonicalExtJSON))
 
                         // bson_to_relaxed_extended_json(dB) = rEJ (if rEJ exists)
                         if let rEJ = test.relaxedExtJSON {
-                            expect(try BSONDocument(fromBSON: dBData).toExtendedJSON()).to(cleanEqual(rEJ))
+                            expect(try BSONDocument(fromBSON: dBData).toExtendedJSONString()).to(cleanEqual(rEJ))
                         }
                     }
 
                     // for dEJ input (if it exists):
                     if let dEJ = test.degenerateExtJSON {
                         // native_to_canonical_extended_json( json_to_native(dEJ) ) = cEJ
-                        expect(try BSONDocument(fromJSON: dEJ).toCanonicalExtendedJSON())
+                        expect(try BSONDocument(fromJSON: dEJ).toCanonicalExtendedJSONString())
                             .to(cleanEqual(test.canonicalExtJSON))
 
                         // native_to_bson( json_to_native(dEJ) ) = cB (unless lossy)
@@ -200,7 +200,7 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                     // for rEJ input (if it exists):
                     if let rEJ = test.relaxedExtJSON {
                         // native_to_relaxed_extended_json( json_to_native(rEJ) ) = rEJ
-                        expect(try BSONDocument(fromJSON: rEJ).toExtendedJSON()).to(cleanEqual(rEJ))
+                        expect(try BSONDocument(fromJSON: rEJ).toExtendedJSONString()).to(cleanEqual(rEJ))
                     }
                 }
             }

--- a/Tests/BSONTests/BSONCorpusTests.swift
+++ b/Tests/BSONTests/BSONCorpusTests.swift
@@ -151,16 +151,16 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                     expect(docFromNative.toData()).to(equal(cBData))
 
                     // native_to_canonical_extended_json( bson_to_native(cB) ) = cEJ
-                    expect(docFromCB.canonicalExtendedJSON).to(cleanEqual(test.canonicalExtJSON))
+                    expect(docFromCB.toCanonicalExtendedJSON()).to(cleanEqual(test.canonicalExtJSON))
 
                     // native_to_relaxed_extended_json( bson_to_native(cB) ) = rEJ (if rEJ exists)
                     if let rEJ = test.relaxedExtJSON {
-                        expect(try BSONDocument(fromBSON: cBData).extendedJSON).to(cleanEqual(rEJ))
+                        expect(try BSONDocument(fromBSON: cBData).toExtendedJSON()).to(cleanEqual(rEJ))
                     }
 
                     // for cEJ input:
                     // native_to_canonical_extended_json( json_to_native(cEJ) ) = cEJ
-                    expect(try BSONDocument(fromJSON: cEJData).canonicalExtendedJSON)
+                    expect(try BSONDocument(fromJSON: cEJData).toCanonicalExtendedJSON())
                         .to(cleanEqual(test.canonicalExtJSON))
 
                     // native_to_bson( json_to_native(cEJ) ) = cB (unless lossy)
@@ -176,19 +176,19 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                         }
 
                         // bson_to_canonical_extended_json(dB) = cEJ
-                        expect(try BSONDocument(fromBSON: dBData).canonicalExtendedJSON)
+                        expect(try BSONDocument(fromBSON: dBData).toCanonicalExtendedJSON())
                             .to(cleanEqual(test.canonicalExtJSON))
 
                         // bson_to_relaxed_extended_json(dB) = rEJ (if rEJ exists)
                         if let rEJ = test.relaxedExtJSON {
-                            expect(try BSONDocument(fromBSON: dBData).extendedJSON).to(cleanEqual(rEJ))
+                            expect(try BSONDocument(fromBSON: dBData).toExtendedJSON()).to(cleanEqual(rEJ))
                         }
                     }
 
                     // for dEJ input (if it exists):
                     if let dEJ = test.degenerateExtJSON {
                         // native_to_canonical_extended_json( json_to_native(dEJ) ) = cEJ
-                        expect(try BSONDocument(fromJSON: dEJ).canonicalExtendedJSON)
+                        expect(try BSONDocument(fromJSON: dEJ).toCanonicalExtendedJSON())
                             .to(cleanEqual(test.canonicalExtJSON))
 
                         // native_to_bson( json_to_native(dEJ) ) = cB (unless lossy)
@@ -200,7 +200,7 @@ final class BSONCorpusTests: MongoSwiftTestCase {
                     // for rEJ input (if it exists):
                     if let rEJ = test.relaxedExtJSON {
                         // native_to_relaxed_extended_json( json_to_native(rEJ) ) = rEJ
-                        expect(try BSONDocument(fromJSON: rEJ).extendedJSON).to(cleanEqual(rEJ))
+                        expect(try BSONDocument(fromJSON: rEJ).toExtendedJSON()).to(cleanEqual(rEJ))
                     }
                 }
             }

--- a/Tests/BSONTests/CodecTests.swift
+++ b/Tests/BSONTests/CodecTests.swift
@@ -533,7 +533,7 @@ final class CodecTests: MongoSwiftTestCase {
         let bsonDoc = BSON.document(doc)
         expect(try encoder.encode(bsonDoc)).to(equal(doc))
         expect(try decoder.decode(BSON.self, from: doc)).to(equal(bsonDoc))
-        expect(try decoder.decode(BSON.self, from: doc.canonicalExtendedJSON)).to(equal(bsonDoc))
+        expect(try decoder.decode(BSON.self, from: doc.toCanonicalExtendedJSON())).to(equal(bsonDoc))
         // doc wrapped in a struct
 
         let wrappedDoc: BSONDocument = ["x": bsonDoc]
@@ -541,7 +541,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDoc).x).to(equal(bsonDoc))
         expect(try decoder.decode(
             AnyBSONStruct.self,
-            from: wrappedDoc.canonicalExtendedJSON
+            from: wrappedDoc.toCanonicalExtendedJSON()
         ).x).to(equal(bsonDoc))
 
         // values wrapped in an `AnyBSONStruct`
@@ -551,7 +551,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedDouble: BSONDocument = ["x": double]
         expect(try encoder.encode(AnyBSONStruct(double))).to(equal(wrappedDouble))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDouble).x).to(equal(double))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDouble.canonicalExtendedJSON).x).to(equal(double))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDouble.toCanonicalExtendedJSON()).x)
+          .to(equal(double))
 
         // string
         let string: BSON = "hi"
@@ -560,7 +561,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedString: BSONDocument = ["x": string]
         expect(try encoder.encode(AnyBSONStruct(string))).to(equal(wrappedString))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedString).x).to(equal(string))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedString.canonicalExtendedJSON).x).to(equal(string))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedString.toCanonicalExtendedJSON()).x).to(equal(string))
 
         // array
         let array: BSON = [1, 2, "hello"]
@@ -596,7 +597,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBinary).x).to(equal(binary))
         expect(try decoder.decode(
             AnyBSONStruct.self,
-            from: wrappedBinary.canonicalExtendedJSON
+            from: wrappedBinary.toCanonicalExtendedJSON()
         ).x).to(equal(binary))
 
         // BSONObjectID
@@ -608,7 +609,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedOid: BSONDocument = ["x": bsonOid]
         expect(try encoder.encode(AnyBSONStruct(bsonOid))).to(equal(wrappedOid))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedOid).x).to(equal(bsonOid))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedOid.canonicalExtendedJSON).x).to(equal(bsonOid))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedOid.toCanonicalExtendedJSON()).x).to(equal(bsonOid))
 
         // bool
         let bool: BSON = true
@@ -618,7 +619,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedBool: BSONDocument = ["x": bool]
         expect(try encoder.encode(AnyBSONStruct(bool))).to(equal(wrappedBool))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBool).x).to(equal(bool))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBool.canonicalExtendedJSON).x).to(equal(bool))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBool.toCanonicalExtendedJSON()).x).to(equal(bool))
 
         // date
         let date = BSON.datetime(Date(timeIntervalSince1970: 5000))
@@ -628,7 +629,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedDate: BSONDocument = ["x": date]
         expect(try encoder.encode(AnyBSONStruct(date))).to(equal(wrappedDate))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDate).x).to(equal(date))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDate.canonicalExtendedJSON).x).to(equal(date))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDate.toCanonicalExtendedJSON()).x).to(equal(date))
 
         let dateEncoder = BSONEncoder()
         dateEncoder.dateEncodingStrategy = .millisecondsSince1970
@@ -650,7 +651,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedRegex: BSONDocument = ["x": regex]
         expect(try encoder.encode(AnyBSONStruct(regex))).to(equal(wrappedRegex))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedRegex).x).to(equal(regex))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedRegex.canonicalExtendedJSON).x).to(equal(regex))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedRegex.toCanonicalExtendedJSON()).x).to(equal(regex))
 
         // codewithscope
         let code = BSON.codeWithScope(BSONCodeWithScope(code: "console.log(x);", scope: ["x": 1]))
@@ -666,7 +667,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedCode: BSONDocument = ["x": code]
         expect(try encoder.encode(AnyBSONStruct(code))).to(equal(wrappedCode))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedCode).x).to(equal(code))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedCode.canonicalExtendedJSON).x).to(equal(code))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedCode.toCanonicalExtendedJSON()).x).to(equal(code))
 
         // int32
         let int32 = BSON.int32(5)
@@ -676,7 +677,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedInt32: BSONDocument = ["x": int32]
         expect(try encoder.encode(AnyBSONStruct(int32))).to(equal(wrappedInt32))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt32).x).to(equal(int32))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt32.canonicalExtendedJSON).x).to(equal(int32)
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt32.toCanonicalExtendedJSON()).x).to(equal(int32)
         )
 
         // int
@@ -687,7 +688,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedInt: BSONDocument = ["x": int]
         expect(try encoder.encode(AnyBSONStruct(int))).to(equal(wrappedInt))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt).x).to(equal(int))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt.canonicalExtendedJSON).x).to(equal(int))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt.toCanonicalExtendedJSON()).x).to(equal(int))
 
         // int64
         let int64 = BSON.int64(5)
@@ -697,7 +698,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedInt64: BSONDocument = ["x": int64]
         expect(try encoder.encode(AnyBSONStruct(int64))).to(equal(wrappedInt64))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64).x).to(equal(int64))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64.canonicalExtendedJSON).x).to(equal(int64))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64.toCanonicalExtendedJSON()).x).to(equal(int64))
 
         // decimal128
         let decimal = BSON.decimal128(try BSONDecimal128("1.2E+10"))
@@ -707,7 +708,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedDecimal: BSONDocument = ["x": decimal]
         expect(try encoder.encode(AnyBSONStruct(decimal))).to(equal(wrappedDecimal))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDecimal).x).to(equal(decimal))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDecimal.canonicalExtendedJSON).x).to(equal(decimal))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDecimal.toCanonicalExtendedJSON()).x).to(equal(decimal))
 
         // maxkey
         let maxKey = BSON.maxKey
@@ -717,7 +718,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedMaxKey: BSONDocument = ["x": maxKey]
         expect(try encoder.encode(AnyBSONStruct(maxKey))).to(equal(wrappedMaxKey))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMaxKey).x).to(equal(maxKey))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMaxKey.canonicalExtendedJSON).x).to(equal(maxKey))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMaxKey.toCanonicalExtendedJSON()).x).to(equal(maxKey))
 
         // minkey
         let minKey = BSON.minKey
@@ -727,7 +728,7 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedMinKey: BSONDocument = ["x": minKey]
         expect(try encoder.encode(AnyBSONStruct(minKey))).to(equal(wrappedMinKey))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMinKey).x).to(equal(minKey))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMinKey.canonicalExtendedJSON).x).to(equal(minKey))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMinKey.toCanonicalExtendedJSON()).x).to(equal(minKey))
 
         // BSONNull
         expect(try decoder.decode(AnyBSONStruct.self, from: ["x": .null]).x).to(equal(BSON.null))

--- a/Tests/BSONTests/CodecTests.swift
+++ b/Tests/BSONTests/CodecTests.swift
@@ -533,7 +533,7 @@ final class CodecTests: MongoSwiftTestCase {
         let bsonDoc = BSON.document(doc)
         expect(try encoder.encode(bsonDoc)).to(equal(doc))
         expect(try decoder.decode(BSON.self, from: doc)).to(equal(bsonDoc))
-        expect(try decoder.decode(BSON.self, from: doc.toCanonicalExtendedJSON())).to(equal(bsonDoc))
+        expect(try decoder.decode(BSON.self, from: doc.toCanonicalExtendedJSONString())).to(equal(bsonDoc))
         // doc wrapped in a struct
 
         let wrappedDoc: BSONDocument = ["x": bsonDoc]
@@ -541,7 +541,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDoc).x).to(equal(bsonDoc))
         expect(try decoder.decode(
             AnyBSONStruct.self,
-            from: wrappedDoc.toCanonicalExtendedJSON()
+            from: wrappedDoc.toCanonicalExtendedJSONString()
         ).x).to(equal(bsonDoc))
 
         // values wrapped in an `AnyBSONStruct`
@@ -551,8 +551,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedDouble: BSONDocument = ["x": double]
         expect(try encoder.encode(AnyBSONStruct(double))).to(equal(wrappedDouble))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDouble).x).to(equal(double))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDouble.toCanonicalExtendedJSON()).x)
-          .to(equal(double))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDouble.toCanonicalExtendedJSONString()).x)
+            .to(equal(double))
 
         // string
         let string: BSON = "hi"
@@ -561,7 +561,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedString: BSONDocument = ["x": string]
         expect(try encoder.encode(AnyBSONStruct(string))).to(equal(wrappedString))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedString).x).to(equal(string))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedString.toCanonicalExtendedJSON()).x).to(equal(string))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedString.toCanonicalExtendedJSONString()).x)
+            .to(equal(string))
 
         // array
         let array: BSON = [1, 2, "hello"]
@@ -597,7 +598,7 @@ final class CodecTests: MongoSwiftTestCase {
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBinary).x).to(equal(binary))
         expect(try decoder.decode(
             AnyBSONStruct.self,
-            from: wrappedBinary.toCanonicalExtendedJSON()
+            from: wrappedBinary.toCanonicalExtendedJSONString()
         ).x).to(equal(binary))
 
         // BSONObjectID
@@ -609,7 +610,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedOid: BSONDocument = ["x": bsonOid]
         expect(try encoder.encode(AnyBSONStruct(bsonOid))).to(equal(wrappedOid))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedOid).x).to(equal(bsonOid))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedOid.toCanonicalExtendedJSON()).x).to(equal(bsonOid))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedOid.toCanonicalExtendedJSONString()).x)
+            .to(equal(bsonOid))
 
         // bool
         let bool: BSON = true
@@ -619,7 +621,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedBool: BSONDocument = ["x": bool]
         expect(try encoder.encode(AnyBSONStruct(bool))).to(equal(wrappedBool))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBool).x).to(equal(bool))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBool.toCanonicalExtendedJSON()).x).to(equal(bool))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedBool.toCanonicalExtendedJSONString()).x)
+            .to(equal(bool))
 
         // date
         let date = BSON.datetime(Date(timeIntervalSince1970: 5000))
@@ -629,7 +632,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedDate: BSONDocument = ["x": date]
         expect(try encoder.encode(AnyBSONStruct(date))).to(equal(wrappedDate))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDate).x).to(equal(date))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDate.toCanonicalExtendedJSON()).x).to(equal(date))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDate.toCanonicalExtendedJSONString()).x)
+            .to(equal(date))
 
         let dateEncoder = BSONEncoder()
         dateEncoder.dateEncodingStrategy = .millisecondsSince1970
@@ -651,7 +655,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedRegex: BSONDocument = ["x": regex]
         expect(try encoder.encode(AnyBSONStruct(regex))).to(equal(wrappedRegex))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedRegex).x).to(equal(regex))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedRegex.toCanonicalExtendedJSON()).x).to(equal(regex))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedRegex.toCanonicalExtendedJSONString()).x)
+            .to(equal(regex))
 
         // codewithscope
         let code = BSON.codeWithScope(BSONCodeWithScope(code: "console.log(x);", scope: ["x": 1]))
@@ -667,7 +672,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedCode: BSONDocument = ["x": code]
         expect(try encoder.encode(AnyBSONStruct(code))).to(equal(wrappedCode))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedCode).x).to(equal(code))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedCode.toCanonicalExtendedJSON()).x).to(equal(code))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedCode.toCanonicalExtendedJSONString()).x)
+            .to(equal(code))
 
         // int32
         let int32 = BSON.int32(5)
@@ -677,8 +683,9 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedInt32: BSONDocument = ["x": int32]
         expect(try encoder.encode(AnyBSONStruct(int32))).to(equal(wrappedInt32))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt32).x).to(equal(int32))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt32.toCanonicalExtendedJSON()).x).to(equal(int32)
-        )
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt32.toCanonicalExtendedJSONString()).x)
+            .to(equal(int32)
+            )
 
         // int
         let int: BSON = 5
@@ -688,7 +695,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedInt: BSONDocument = ["x": int]
         expect(try encoder.encode(AnyBSONStruct(int))).to(equal(wrappedInt))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt).x).to(equal(int))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt.toCanonicalExtendedJSON()).x).to(equal(int))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt.toCanonicalExtendedJSONString()).x)
+            .to(equal(int))
 
         // int64
         let int64 = BSON.int64(5)
@@ -698,7 +706,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedInt64: BSONDocument = ["x": int64]
         expect(try encoder.encode(AnyBSONStruct(int64))).to(equal(wrappedInt64))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64).x).to(equal(int64))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64.toCanonicalExtendedJSON()).x).to(equal(int64))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedInt64.toCanonicalExtendedJSONString()).x)
+            .to(equal(int64))
 
         // decimal128
         let decimal = BSON.decimal128(try BSONDecimal128("1.2E+10"))
@@ -708,7 +717,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedDecimal: BSONDocument = ["x": decimal]
         expect(try encoder.encode(AnyBSONStruct(decimal))).to(equal(wrappedDecimal))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDecimal).x).to(equal(decimal))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDecimal.toCanonicalExtendedJSON()).x).to(equal(decimal))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedDecimal.toCanonicalExtendedJSONString()).x)
+            .to(equal(decimal))
 
         // maxkey
         let maxKey = BSON.maxKey
@@ -718,7 +728,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedMaxKey: BSONDocument = ["x": maxKey]
         expect(try encoder.encode(AnyBSONStruct(maxKey))).to(equal(wrappedMaxKey))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMaxKey).x).to(equal(maxKey))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMaxKey.toCanonicalExtendedJSON()).x).to(equal(maxKey))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMaxKey.toCanonicalExtendedJSONString()).x)
+            .to(equal(maxKey))
 
         // minkey
         let minKey = BSON.minKey
@@ -728,7 +739,8 @@ final class CodecTests: MongoSwiftTestCase {
         let wrappedMinKey: BSONDocument = ["x": minKey]
         expect(try encoder.encode(AnyBSONStruct(minKey))).to(equal(wrappedMinKey))
         expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMinKey).x).to(equal(minKey))
-        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMinKey.toCanonicalExtendedJSON()).x).to(equal(minKey))
+        expect(try decoder.decode(AnyBSONStruct.self, from: wrappedMinKey.toCanonicalExtendedJSONString()).x)
+            .to(equal(minKey))
 
         // BSONNull
         expect(try decoder.decode(AnyBSONStruct.self, from: ["x": .null]).x).to(equal(BSON.null))


### PR DESCRIPTION
[SWIFT-882](https://jira.mongodb.org/browse/SWIFT-882)

This PR converts the extJSON computed properties to methods, since they may be computationally expensive. @mbroadst noted that they would be superseded by `ExtendedJSONEncoder`, and that we would probably deprecate them once that was introduced. Since these produce `String`s, they could perhaps be useful as conveniences over invoking the encoder, so I also added "String" as a suffix to their method names.

These changes are not release blockers, but if we do want to make them we need to do so today, so I just put up the PR now to get the discussion rolling.
