### PR TITLE
SWIFT-885 Implement connection string spec tests

### DIFF
--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -45,7 +45,7 @@ open class MongoSwiftTestCase: XCTestCase {
         var output = uri
         // remove all but the first host so we connect to a single mongos.
         for host in hosts[1...] {
-            output.removeSubstring(",\(host)")
+            output.removeSubstring(",\(host.description)")
         }
         return output
     }
@@ -66,7 +66,7 @@ open class MongoSwiftTestCase: XCTestCase {
         let hostsRange = Range(match.range(at: 1), in: uri)!
 
         return try! ConnectionString(uri).hosts!.map { host in
-            uri.replacingCharacters(in: hostsRange, with: host)
+            uri.replacingCharacters(in: hostsRange, with: host.description)
         }
     }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -92,6 +92,7 @@ extension CommandMonitoringTests {
 extension ConnectionStringTests {
     static var allTests = [
         ("testURIOptions", testURIOptions),
+        ("testConnectionString", testConnectionString),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/SDAMTests.swift
+++ b/Tests/MongoSwiftSyncTests/SDAMTests.swift
@@ -41,11 +41,10 @@ final class SDAMTests: MongoSwiftTestCase {
 
         let connString = try ConnectionString(MongoSwiftTestCase.getConnectionString())
 
-        guard let host = connString.hosts?[0] else {
+        guard let hostAddress = connString.hosts?[0] else {
             XCTFail("Could not get hosts for uri: \(MongoSwiftTestCase.getConnectionString())")
             return
         }
-        let hostAddress = try ServerAddress(host)
 
         expect(receivedEvents.count).to(equal(4))
         expect(receivedEvents[0].topologyOpeningValue).toNot(beNil())


### PR DESCRIPTION
(You should review SWIFT-573 first)

This contains additions to the URI options test runner to support running the connection string spec tests as well.