### PR TITLE
SWIFT-897 Add appName option to MongoClientOptions

### DIFF
--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -44,6 +44,10 @@ internal class ConnectionString {
         if let credential = options?.credential {
             try self.setMongoCredential(credential)
         }
+
+        if let appName = options?.appName {
+            mongoc_uri_set_option_as_utf8(self._uri, MONGOC_URI_APPNAME, appName)
+        }
     }
 
     /// Initializes a new connection string that wraps a copy of the provided URI. Does not destroy the input URI.

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -5,6 +5,10 @@ import NIOConcurrencyHelpers
 
 /// Options to use when creating a `MongoClient`.
 public struct MongoClientOptions: CodingStrategyProvider {
+    /// Specifies a custom app name. This value is used in MongoDB logs and profiling data.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/connection-string/#urioption.appName
+    public var appName: String?
+
     /// Specifies authentication options for use with the client.
     public var credential: MongoCredential?
 
@@ -86,6 +90,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
 
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(
+        appName: String? = nil,
         credential: MongoCredential? = nil,
         dataCodingStrategy: DataCodingStrategy? = nil,
         dateCodingStrategy: DateCodingStrategy? = nil,
@@ -105,6 +110,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         uuidCodingStrategy: UUIDCodingStrategy? = nil,
         writeConcern: WriteConcern? = nil
     ) {
+        self.appName = appName
         self.credential = credential
         self.dataCodingStrategy = dataCodingStrategy
         self.dateCodingStrategy = dateCodingStrategy


### PR DESCRIPTION
Adds the appName option. I tested this works by adding an app name in a test and looking at the mongod log to see if it shows up.