### PR TITLE
minor: ignore MongoSwiftVersion.swift in swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,6 +53,7 @@ excluded:
   - Examples/*/Package.swift
   - Tests/LinuxMain.swift
   - Sources/MongoSwiftSync/Exports.swift
+  - Sources/MongoSwift/MongoSwiftVersion.swift
   - SwiftFormat # this is the path we download SwiftFormat to on travis
 
 trailing_whitespace:


### PR DESCRIPTION
`swiftlint autocorrect` now ignores `MongoSwiftVersion.swift`