### PR TITLE
SWIFT-898 Add replicaSet option, and tests for replicaSet + appName options

### DIFF
--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -6,6 +6,7 @@ internal class ConnectionString {
     private let _uri: OpaquePointer
 
     /// Initializes a new `ConnectionString` with the provided options.
+    // swiftlint:disable:next cyclomatic_complexity
     internal init(_ connectionString: String, options: MongoClientOptions? = nil) throws {
         var error = bson_error_t()
         guard let uri = mongoc_uri_new_with_error(connectionString, &error) else {

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -48,6 +48,10 @@ internal class ConnectionString {
         if let appName = options?.appName {
             mongoc_uri_set_option_as_utf8(self._uri, MONGOC_URI_APPNAME, appName)
         }
+
+        if let replicaSet = options?.replicaSet {
+            mongoc_uri_set_option_as_utf8(self._uri, MONGOC_URI_REPLICASET, replicaSet)
+        }
     }
 
     /// Initializes a new connection string that wraps a copy of the provided URI. Does not destroy the input URI.
@@ -229,6 +233,20 @@ internal class ConnectionString {
             return nil
         }
         return BSONDocument(copying: compressors).keys
+    }
+
+    internal var replicaSet: String? {
+        guard let rs = mongoc_uri_get_replica_set(self._uri) else {
+            return nil
+        }
+        return String(cString: rs)
+    }
+
+    internal var appName: String? {
+        guard let appName = mongoc_uri_get_option_as_utf8(self._uri, MONGOC_URI_APPNAME, nil) else {
+            return nil
+        }
+        return String(cString: appName)
     }
 
     private func hasOption(_ option: String) -> Bool {

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -36,6 +36,9 @@ public struct MongoClientOptions: CodingStrategyProvider {
     /// Specifies a ReadPreference to use for the client.
     public var readPreference: ReadPreference?
 
+    /// Specifies the name of the replica set the driver should connect to.
+    public var replicaSet: String?
+
     /// Determines whether the client should retry supported read operations (on by default).
     public var retryReads: Bool?
 
@@ -98,6 +101,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         maxPoolSize: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil,
+        replicaSet: String? = nil,
         retryReads: Bool? = nil,
         retryWrites: Bool? = nil,
         threadPoolSize: Int? = nil,
@@ -118,6 +122,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         self.maxPoolSize = maxPoolSize
         self.readConcern = readConcern
         self.readPreference = readPreference
+        self.replicaSet = replicaSet
         self.retryWrites = retryWrites
         self.retryReads = retryReads
         self.threadPoolSize = threadPoolSize

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -6,7 +6,7 @@ import XCTest
 extension String {
     /// Removes the first occurrence of the specified substring from the string. If the substring is not present, has
     /// no effect.
-    fileprivate mutating func removeSubstring(_ s: String) {
+    public mutating func removeSubstring(_ s: String) {
         guard s.count <= self.count else {
             return
         }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -93,6 +93,8 @@ extension ConnectionStringTests {
     static var allTests = [
         ("testURIOptions", testURIOptions),
         ("testConnectionString", testConnectionString),
+        ("testAppNameOption", testAppNameOption),
+        ("testReplSetOption", testReplSetOption),
     ]
 }
 

--- a/Tests/MongoSwiftTests/ConnectionStringTests.swift
+++ b/Tests/MongoSwiftTests/ConnectionStringTests.swift
@@ -201,4 +201,54 @@ final class ConnectionStringTests: MongoSwiftTestCase {
     func testConnectionString() throws {
         try self.runTests("connection-string")
     }
+
+    func testAppNameOption() throws {
+        // option is set correctly from options struct
+        let opts1 = MongoClientOptions(appName: "MyApp")
+        let connStr1 = try ConnectionString("mongodb://localhost:27017", options: opts1)
+        expect(connStr1.appName).to(equal("MyApp"))
+
+        // option is parsed correctly from string
+        let connStr2 = try ConnectionString("mongodb://localhost:27017/?appName=MyApp")
+        expect(connStr2.appName).to(equal("MyApp"))
+
+        // options struct overrides string
+        let connStr3 = try ConnectionString("mongodb://localhost:27017/?appName=MyApp2", options: opts1)
+        expect(connStr3.appName).to(equal("MyApp"))
+    }
+
+    func testReplSetOption() throws {
+        // option is set correctly from options struct
+        var opts = MongoClientOptions(replicaSet: "rs0")
+        let connStr1 = try ConnectionString("mongodb://localhost:27017", options: opts)
+        expect(connStr1.replicaSet).to(equal("rs0"))
+
+        // option is parsed correctly from string
+        let connStr2 = try ConnectionString("mongodb://localhost:27017/?replicaSet=rs1")
+        expect(connStr2.replicaSet).to(equal("rs1"))
+
+        // options struct overrides string
+        let connStr3 = try ConnectionString("mongodb://localhost:27017/?replicaSet=rs1", options: opts)
+        expect(connStr3.replicaSet).to(equal("rs0"))
+
+        guard MongoSwiftTestCase.topologyType == .replicaSetWithPrimary else {
+            print("Skipping rest of test because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            return
+        }
+
+        // lower server selection timeout to speed up expected failure
+        let testConnStr = MongoSwiftTestCase.getConnectionString() + "&serverSelectionTimeoutMS=1000"
+
+        // setting actual name via client options should succeed in connecting
+        opts.replicaSet = try ConnectionString(testConnStr).replicaSet
+        try self.withTestClient(testConnStr, options: opts) { client in
+            expect(try client.listDatabases().wait()).toNot(throwError())
+        }
+
+        // setting to an incorrect repl set name via client options should fail to connect
+        opts.replicaSet! += "xyz"
+        try self.withTestClient(testConnStr, options: opts) { client in
+            expect(try client.listDatabases().wait()).to(throwError())
+        }
+    }
 }


### PR DESCRIPTION
This adds support for the replica set option and tests for it. Writing the tests made me realize I should probably at least add a simple test about options precedence for appName so I went ahead and added that too.