### PR TITLE
minor: bump SwiftFormat version to 0.44.16

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,5 +1,6 @@
 --exclude Sources/MongoSwift/MongoSwiftVersion.swift,Sources/MongoSwiftSync/Exports.swift
 --exclude **/.build
+--exclude etc
 
 # unnecessary
 --disable andOperator

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,5 +1,5 @@
 --exclude Sources/MongoSwift/MongoSwiftVersion.swift,Sources/MongoSwiftSync/Exports.swift
---exclude .build/*
+--exclude **/.build
 
 # unnecessary
 --disable andOperator
@@ -11,7 +11,7 @@
 --indent 4
 
 # 0..<3 vs 0 ..< 3
---ranges "no-space"
+--nospaceoperators ...,..<
 
 # always want explicit acl
 --disable redundantExtensionACL

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -54,7 +54,7 @@ excluded:
   - Tests/LinuxMain.swift
   - Sources/MongoSwiftSync/Exports.swift
   - Sources/MongoSwift/MongoSwiftVersion.swift
-  - SwiftFormat # this is the path we download SwiftFormat to on travis
+  - etc
 
 trailing_whitespace:
   ignores_comments: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ jobs:
       name: lint
       os: osx
       osx_image: xcode11.3
-      install: ./etc/install_dependencies.sh swiftlint && ./etc/install_dependencies.sh swiftformat
+      install: pushd etc && ./install_dependencies.sh swiftlint && ./install_dependencies.sh swiftformat && popd
       before_script: skip
-      script: ${PWD}/swiftlint/swiftlint --strict && ${PWD}/SwiftFormat/CommandLineTool/swiftformat --verbose --lint .
+      script: ./etc/swiftlint/swiftlint --strict && ./etc/SwiftFormat/CommandLineTool/swiftformat --verbose --lint .
 
     - stage: tests
       os: osx

--- a/etc/install_dependencies.sh
+++ b/etc/install_dependencies.sh
@@ -33,7 +33,7 @@ then
 
 elif [[ $1 = "swiftformat" ]]
 then
-  git clone https://github.com/nicklockwood/SwiftFormat --branch="0.40.13"
+  git clone https://github.com/nicklockwood/SwiftFormat --branch="0.44.16"
   pushd SwiftFormat
   swift build -c release
   popd


### PR DESCRIPTION
The SwiftFormat version we're using is a bit out of date, so we're seeing discrepancies between what travis formats and our local formatters in #503. To fix that, I bumped SwiftFormat to its latest version. As part of this, I also made SwiftFormat ignore any `.build` directories in any subfolder of the driver (e.g. including `Examples`). Also, I moved the installation stuff into `etc` so that we don't have to specifically skip each tool we install as part of the formatting process.