### PR TITLE
SWIFT-928 Consolidate setting of client options

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -251,7 +251,7 @@ public class MongoClient {
         initializeMongoc()
 
         let connString = try ConnectionString(connectionString, options: options)
-        self.connectionPool = try ConnectionPool(from: connString, options: options)
+        self.connectionPool = try ConnectionPool(from: connString)
         self.operationExecutor = OperationExecutor(
             eventLoopGroup: eventLoopGroup,
             threadPoolSize: options?.threadPoolSize ?? MongoClient.defaultThreadPoolSize

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -47,12 +47,8 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
     // Note: the file txt-record-with-overridden-uri-option.json causes a mongoc warning. This is expected.
     // swiftlint:disable:next cyclomatic_complexity
     func testInitialDNSSeedlistDiscovery() throws {
-        guard MongoSwiftTestCase.ssl else {
-            print("Skipping test, requires SSL")
-            return
-        }
         guard MongoSwiftTestCase.topologyType == .replicaSetWithPrimary else {
-            print("Skipping test case because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
+            print("Skipping test because of unsupported topology type \(MongoSwiftTestCase.topologyType)")
             return
         }
 
@@ -61,31 +57,33 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
             asType: DNSSeedlistTestCase.self
         )
         for (fileName, testCase) in tests {
-            let topologyWatcher = TopologyDescriptionWatcher()
-
             // TODO: DRIVERS-796 or DRIVERS-990: unskip this test
             guard fileName != "txt-record-with-overridden-uri-option.json" else {
                 continue
             }
 
+            // this particular test case requires SSL is disabled. see DRIVERS-1324.
+            let requiresTLS = fileName != "txt-record-with-overridden-ssl-option.json"
+
+            // TLS requirement for this test case is not met.
+            guard (requiresTLS && MongoSwiftTestCase.ssl) || (!requiresTLS && !MongoSwiftTestCase.ssl) else {
+                continue
+            }
+
+            let topologyWatcher = TopologyDescriptionWatcher()
+
             // Enclose all of the potentially throwing code in `doTest`. Sometimes the expected errors come when
             // parsing the URI, and other times they are not until we try to select a server.
             func doTest() throws -> ConnectionString {
-                var opts = MongoClientOptions(
-                    tlsAllowInvalidCertificates: true,
-                    tlsCAFile: URL(string: MongoSwiftTestCase.sslCAFilePath ?? ""),
-                    tlsCertificateKeyFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? "")
-                )
-
-                // NOTE: since we have to connect to the replica set and attempt server selection to get the SRV
-                // records resolved and the URI updated accordingly, we override cases where ssl=false by always
-                // setting `tls: true` in the opts struct. thus the value in the final URI after server selection
-                // selection is always true.
-                // here we assert that ssl=false is at least correctly parsed from the URI.
-                if testCase.uri.contains("ssl=false") {
-                    let tempConnStr = try ConnectionString(testCase.uri)
-                    expect(tempConnStr.options?["tls"]?.boolValue).to(beFalse())
-                    opts.tls = true
+                let opts: MongoClientOptions?
+                if requiresTLS {
+                    opts = MongoClientOptions(
+                        tlsAllowInvalidCertificates: true,
+                        tlsCAFile: URL(string: MongoSwiftTestCase.sslCAFilePath ?? ""),
+                        tlsCertificateKeyFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? "")
+                    )
+                } else {
+                    opts = nil
                 }
 
                 return try self.withTestClient(testCase.uri, options: opts) { client in
@@ -122,10 +120,6 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                 switch k {
                 // the test files still use SSL, but libmongoc uses TLS
                 case "ssl":
-                    // see note above for why we skip asserting here.
-                    guard v.boolValue == true else {
-                        continue
-                    }
                     expect(connStrOptions["tls"]).to(equal(v))
                 // these values are not returned as part of the options doc
                 case "authSource", "auth_database":

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -57,8 +57,9 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
             asType: DNSSeedlistTestCase.self
         )
         for (fileName, testCase) in tests {
-            // TODO: DRIVERS-796 or DRIVERS-990: unskip this test
+            // TODO: SWIFT-910: unskip this test
             guard fileName != "txt-record-with-overridden-uri-option.json" else {
+                print("Skipping test file \(fileName); see SWIFT-910")
                 continue
             }
 
@@ -67,8 +68,11 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
 
             // TLS requirement for this test case is not met.
             guard (requiresTLS && MongoSwiftTestCase.ssl) || (!requiresTLS && !MongoSwiftTestCase.ssl) else {
+                print("Skipping test file \(fileName); TLS requirement not met")
                 continue
             }
+
+            print("Running test file \(fileName)...")
 
             let topologyWatcher = TopologyDescriptionWatcher()
 
@@ -78,9 +82,7 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                 let opts: MongoClientOptions?
                 if requiresTLS {
                     opts = MongoClientOptions(
-                        tlsAllowInvalidCertificates: true,
-                        tlsCAFile: URL(string: MongoSwiftTestCase.sslCAFilePath ?? ""),
-                        tlsCertificateKeyFile: URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? "")
+                        tlsAllowInvalidCertificates: true
                     )
                 } else {
                     opts = nil


### PR DESCRIPTION
This consolidates all of our options settings for clients into a single place, making it easier to reason about and laying the groundwork for doing our own validation of options in a future PR (see [SWIFT-929](https://jira.mongodb.org/browse/SWIFT-929)).

Previously, we set TLS options and the pool size option directly on the pool rather than on the `mongoc_uri_t`.