### PR TITLE
SWIFT-912 Error if minPoolSize is specified

### DIFF
--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -80,6 +80,14 @@ internal class ConnectionString {
             }
         }
 
+        // the way libmongoc has implemented this option is not in line with the way users would expect a minPoolSize
+        // option to behave. throw an error if we detect it to prevent users from inadvertently using it.
+        // once we own our own connection pool we will implement this option correctly.
+        // see: http://mongoc.org/libmongoc/current/mongoc_client_pool_min_size.html
+        if self.hasOption(MONGOC_URI_MINPOOLSIZE) {
+            throw MongoError.InvalidArgumentError(message: "Unsupported connection string option minPoolSize")
+        }
+
         if let rc = options?.readConcern {
             self.readConcern = rc
         }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -100,6 +100,7 @@ extension ConnectionStringTests {
         ("testServerSelectionTimeoutMS", testServerSelectionTimeoutMS),
         ("testServerSelectionTimeoutMSWithCommand", testServerSelectionTimeoutMSWithCommand),
         ("testLocalThresholdMSOption", testLocalThresholdMSOption),
+        ("testMinPoolSizeErrors", testMinPoolSizeErrors),
     ]
 }
 

--- a/Tests/MongoSwiftTests/ConnectionStringTests.swift
+++ b/Tests/MongoSwiftTests/ConnectionStringTests.swift
@@ -441,4 +441,8 @@ final class ConnectionStringTests: MongoSwiftTestCase {
             options: MongoClientOptions(localThresholdMS: tooLarge)
         )).to(throwError(errorType: MongoError.InvalidArgumentError.self))
     }
+
+    func testMinPoolSizeErrors() throws {
+        expect(try ConnectionString("mongodb://localhost:27017/?minPoolSize=10")).to(throwError())
+    }
 }


### PR DESCRIPTION
Throw an error if users provide this option, due to problematic libmongoc implementation. It feels a little weird to throw on this option but not any other unsupported options, but I don't really know what else we can do.