### PR TITLE
SWIFT-903, SWIFT-909: Add compression options to MongoClientOptions

### DIFF
--- a/Sources/MongoSwift/Compressor.swift
+++ b/Sources/MongoSwift/Compressor.swift
@@ -1,32 +1,38 @@
 /// Specifies a library to use for network compression.
-public struct Compressor {
+public struct Compressor: CustomStringConvertible {
+    internal enum _Compressor {
+        case zlib(level: Int32? = nil)
+    }
+
+    /// The compressor to use.
+    internal let _compressor: _Compressor
+
+    private init(_ compressor: _Compressor) {
+        self._compressor = compressor
+    }
+
     /// Use zlib for data compression.
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/glossary/#term-zlib
-    public static let zlib = Compressor("zlib")
+    public static let zlib = Compressor(.zlib())
 
     /// Use zlib for data compression, with the specified compression level.
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/connection-string/#urioption.zlibCompressionLevel
     public static func zlib(level: Int) throws -> Compressor {
-        try Compressor("zlib", level: level)
-    }
-
-    /// Compressor name.
-    internal let name: String
-
-    internal let zLibLevel: Int32?
-
-    private init(_ compressor: String) {
-        self.name = compressor
-        self.zLibLevel = nil
-    }
-
-    private init(_ compressor: String, level: Int) throws {
         guard (-1...9).contains(level) else {
             throw MongoError.InvalidArgumentError(
                 message: "Invalid zlib compression level \(level): must be between -1 and 9"
             )
         }
-        self.name = compressor
-        self.zLibLevel = Int32(level)
+        return Compressor(.zlib(level: Int32(level)))
+    }
+
+    public var description: String {
+        switch self._compressor {
+        case let .zlib(level):
+            guard let level = level else {
+                return "zlib"
+            }
+            return "zlib(level:\(level))"
+        }
     }
 }

--- a/Sources/MongoSwift/Compressor.swift
+++ b/Sources/MongoSwift/Compressor.swift
@@ -1,0 +1,32 @@
+/// Specifies a library to use for network compression.
+public struct Compressor {
+    /// Use zlib for data compression.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/glossary/#term-zlib
+    public static let zlib = Compressor("zlib")
+
+    /// Use zlib for data compression, with the specified compression level.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/connection-string/#urioption.zlibCompressionLevel
+    public static func zlib(level: Int) throws -> Compressor {
+        try Compressor("zlib", level: level)
+    }
+
+    /// Compressor name.
+    internal let name: String
+
+    internal let zLibLevel: Int32?
+
+    private init(_ compressor: String) {
+        self.name = compressor
+        self.zLibLevel = nil
+    }
+
+    private init(_ compressor: String, level: Int) throws {
+        guard (-1...9).contains(level) else {
+            throw MongoError.InvalidArgumentError(
+                message: "Invalid zlib compression level \(level): must be between -1 and 9"
+            )
+        }
+        self.name = compressor
+        self.zLibLevel = Int32(level)
+    }
+}

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -33,25 +33,24 @@ internal class ConnectionString {
                 return
             }
 
-            // otherwise, the only valid inputs are a length 1 array containing either zlib or zlib with a level.
-            let nonZlib = compressors.filter { $0.name != "zlib" }
-            guard nonZlib.isEmpty else {
-                throw MongoError.InvalidArgumentError(message: "Unsupported compressor \(nonZlib[0].name)")
-            }
-
+            // otherwise, the only valid inputs is a length 1 array containing either zlib or zlib with a level.
             guard compressors.count == 1 else {
                 throw MongoError.InvalidArgumentError(message: "zlib compressor provided multiple times")
             }
 
-            guard mongoc_uri_set_compressors(self._uri, "zlib") else {
-                throw MongoError.InvalidArgumentError(message: "Failed to set compressor to zlib")
-            }
+            let compressor = compressors[0]
+            switch compressor._compressor {
+            case let .zlib(level):
+                guard mongoc_uri_set_compressors(self._uri, "zlib") else {
+                    throw MongoError.InvalidArgumentError(message: "Failed to set compressor to zlib")
+                }
 
-            if let level = compressors[0].zLibLevel {
-                guard mongoc_uri_set_option_as_int32(self._uri, MONGOC_URI_ZLIBCOMPRESSIONLEVEL, level) else {
-                    throw MongoError.InvalidArgumentError(message:
-                        "Failed to set zLibCompressionLevel to \(level)"
-                    )
+                if let level = level {
+                    guard mongoc_uri_set_option_as_int32(self._uri, MONGOC_URI_ZLIBCOMPRESSIONLEVEL, level) else {
+                        throw MongoError.InvalidArgumentError(message:
+                            "Failed to set zLibCompressionLevel to \(level)"
+                        )
+                    }
                 }
             }
         }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -9,6 +9,11 @@ public struct MongoClientOptions: CodingStrategyProvider {
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/connection-string/#urioption.appName
     public var appName: String?
 
+    /// Specifies one or more compressors to use for network compression for communication between this client and
+    /// mongod/mongos instances. Currently, the driver only supports compression via zlib.
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/connection-string/#urioption.compressors
+    public var compressors: [Compressor]?
+
     /// Specifies authentication options for use with the client.
     public var credential: MongoCredential?
 
@@ -107,6 +112,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
     /// Convenience initializer allowing any/all parameters to be omitted or optional.
     public init(
         appName: String? = nil,
+        compressors: [Compressor]? = nil,
         credential: MongoCredential? = nil,
         dataCodingStrategy: DataCodingStrategy? = nil,
         dateCodingStrategy: DateCodingStrategy? = nil,
@@ -131,6 +137,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         writeConcern: WriteConcern? = nil
     ) {
         self.appName = appName
+        self.compressors = compressors
         self.credential = credential
         self.dataCodingStrategy = dataCodingStrategy
         self.dateCodingStrategy = dateCodingStrategy

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -39,6 +39,7 @@
 @_exported import struct MongoSwift.CommandFailedEvent
 @_exported import struct MongoSwift.CommandStartedEvent
 @_exported import struct MongoSwift.CommandSucceededEvent
+@_exported import struct MongoSwift.Compressor
 @_exported import struct MongoSwift.CountDocumentsOptions
 @_exported import struct MongoSwift.CreateCollectionOptions
 @_exported import struct MongoSwift.CreateIndexOptions

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -100,6 +100,8 @@ extension ConnectionStringTests {
         ("testServerSelectionTimeoutMS", testServerSelectionTimeoutMS),
         ("testServerSelectionTimeoutMSWithCommand", testServerSelectionTimeoutMSWithCommand),
         ("testLocalThresholdMSOption", testLocalThresholdMSOption),
+        ("testMinPoolSizeErrors", testMinPoolSizeErrors),
+        ("testCompressionOptions", testCompressionOptions),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -100,7 +100,6 @@ extension ConnectionStringTests {
         ("testServerSelectionTimeoutMS", testServerSelectionTimeoutMS),
         ("testServerSelectionTimeoutMSWithCommand", testServerSelectionTimeoutMSWithCommand),
         ("testLocalThresholdMSOption", testLocalThresholdMSOption),
-        ("testMinPoolSizeErrors", testMinPoolSizeErrors),
     ]
 }
 


### PR DESCRIPTION
This ended up having some API-related concerns so adding @mbroadst as well.

This adds support for specifying compressors (currently only zlib is supported), as well as an optional level to use for zlib compression, via `MongoClientOptions`.