### PR TITLE
SWIFT-952 Remove dependency on conditional defines in package file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,12 +24,6 @@ let package = Package(
         .target(
             name: "CLibMongoC",
             dependencies: [],
-            cSettings: [
-                .define("MONGO_SWIFT_OS_LINUX", .when(platforms: [.linux])),
-                .define("MONGO_SWIFT_OS_DARWIN", .when(platforms: [.macOS])),
-                .define("BSON_COMPILATION"),
-                .define("MONGOC_COMPILATION")
-            ],
             linkerSettings: [
                 .linkedLibrary("resolv"),
                 .linkedLibrary("ssl", .when(platforms: [.linux])),

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-config.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-config.h
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(BSON_INSIDE) && !defined(BSON_COMPILATION)
-#error "Only <bson/bson.h> can be included directly."
-#endif
-
 #ifndef BSON_CONFIG_H
 #define BSON_CONFIG_H
 

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-prelude.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-prelude.h
@@ -15,5 +15,5 @@
  */
 
 #if !defined(BSON_INSIDE) && !defined(BSON_COMPILATION)
-#error "Only <bson/bson.h> can be included directly."
+// #error "Only <bson/bson.h> can be included directly."
 #endif

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-version.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-version.h
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-
-#if !defined (BSON_INSIDE) && !defined (BSON_COMPILATION)
-#error "Only <bson/bson.h> can be included directly."
-#endif
-
-
 #ifndef BSON_VERSION_H
 #define BSON_VERSION_H
 

--- a/Sources/CLibMongoC/include/CLibMongoC_common-prelude.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_common-prelude.h
@@ -16,5 +16,5 @@
 
 #if !defined(MONGOC_INSIDE) && !defined(MONGOC_COMPILATION) && \
    !defined(BSON_COMPILATION) && !defined(BSON_INSIDE)
-#error "Only <mongoc/mongoc.h> or <bson/bson.h> can be included directly."
+// #error "Only <mongoc/mongoc.h> or <bson/bson.h> can be included directly."
 #endif

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-config.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-config.h
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(MONGOC_INSIDE) && !defined(MONGOC_COMPILATION)
-#error "Only <mongoc/mongoc.h> can be included directly."
-#endif
-
-
 #ifndef MONGOC_CONFIG_H
 #define MONGOC_CONFIG_H
 
@@ -32,7 +27,7 @@
 #define MONGOC_CC "/usr/bin/cc"
 
 /* Defines introduced by `Package.swift` */
-#ifdef MONGO_SWIFT_OS_DARWIN
+#ifdef __APPLE__
 #  define MONGOC_ENABLE_SSL_SECURE_TRANSPORT 1
 #  define MONGOC_ENABLE_CRYPTO_COMMON_CRYPTO 1
 #  define MONGOC_ENABLE_CRYPTO_LIBCRYPTO 0
@@ -44,11 +39,11 @@
 #  define MONGOC_ENABLE_SSL_SECURE_TRANSPORT 0
 #  define MONGOC_ENABLE_CRYPTO_LIBCRYPTO 1
 #  define MONGOC_ENABLE_SSL_OPENSSL 1
-#  define MONGOC_HAVE_ASN1_STRING_GET0_DATA 1
-#endif
-
-#if MONGOC_ENABLE_SSL_OPENSSL && OPENSSL_VERSION_NUMBER < 0x10100000L
-#  define MONGOC_HAVE_ASN1_STRING_GET0_DATA 0
+#  if OPENSSL_VERSION_NUMBER < 0x10100000L
+#    define MONGOC_HAVE_ASN1_STRING_GET0_DATA 0 
+#  else
+#    define MONGOC_HAVE_ASN1_STRING_GET0_DATA 1 
+#  endif
 #endif
 
 /*

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-prelude.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-prelude.h
@@ -15,5 +15,5 @@
  */
 
 #if !defined(MONGOC_INSIDE) && !defined(MONGOC_COMPILATION)
-#error "Only <mongoc/mongoc.h> can be included directly."
+// #error "Only <mongoc/mongoc.h> can be included directly."
 #endif

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-version.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-version.h
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-
-#if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
-#error "Only <mongoc/mongoc.h> can be included directly."
-#endif
-
-
 #ifndef MONGOC_VERSION_H
 #define MONGOC_VERSION_H
 

--- a/etc/generated_headers/bson-config.h
+++ b/etc/generated_headers/bson-config.h
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(BSON_INSIDE) && !defined(BSON_COMPILATION)
-#error "Only <bson/bson.h> can be included directly."
-#endif
-
 #ifndef BSON_CONFIG_H
 #define BSON_CONFIG_H
 

--- a/etc/generated_headers/bson-version.h
+++ b/etc/generated_headers/bson-version.h
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-
-#if !defined (BSON_INSIDE) && !defined (BSON_COMPILATION)
-#error "Only <bson/bson.h> can be included directly."
-#endif
-
-
 #ifndef BSON_VERSION_H
 #define BSON_VERSION_H
 

--- a/etc/generated_headers/mongoc-config.h
+++ b/etc/generated_headers/mongoc-config.h
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(MONGOC_INSIDE) && !defined(MONGOC_COMPILATION)
-#error "Only <mongoc/mongoc.h> can be included directly."
-#endif
-
-
 #ifndef MONGOC_CONFIG_H
 #define MONGOC_CONFIG_H
 
@@ -32,7 +27,7 @@
 #define MONGOC_CC "/usr/bin/cc"
 
 /* Defines introduced by `Package.swift` */
-#ifdef MONGO_SWIFT_OS_DARWIN
+#ifdef __APPLE__
 #  define MONGOC_ENABLE_SSL_SECURE_TRANSPORT 1
 #  define MONGOC_ENABLE_CRYPTO_COMMON_CRYPTO 1
 #  define MONGOC_ENABLE_CRYPTO_LIBCRYPTO 0
@@ -44,11 +39,11 @@
 #  define MONGOC_ENABLE_SSL_SECURE_TRANSPORT 0
 #  define MONGOC_ENABLE_CRYPTO_LIBCRYPTO 1
 #  define MONGOC_ENABLE_SSL_OPENSSL 1
-#  define MONGOC_HAVE_ASN1_STRING_GET0_DATA 1
-#endif
-
-#if MONGOC_ENABLE_SSL_OPENSSL && OPENSSL_VERSION_NUMBER < 0x10100000L
-#  define MONGOC_HAVE_ASN1_STRING_GET0_DATA 0
+#  if OPENSSL_VERSION_NUMBER < 0x10100000L
+#    define MONGOC_HAVE_ASN1_STRING_GET0_DATA 0 
+#  else
+#    define MONGOC_HAVE_ASN1_STRING_GET0_DATA 1 
+#  endif
 #endif
 
 /*

--- a/etc/generated_headers/mongoc-version.h
+++ b/etc/generated_headers/mongoc-version.h
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-
-#if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
-#error "Only <mongoc/mongoc.h> can be included directly."
-#endif
-
-
 #ifndef MONGOC_VERSION_H
 #define MONGOC_VERSION_H
 

--- a/etc/vendor-libmongoc.sh
+++ b/etc/vendor-libmongoc.sh
@@ -118,6 +118,11 @@ echo "RENAMING header files"
   $sed -i -e '/private/! s+include "mongoc-+include "CLibMongoC_mongoc-+' $MONGOC_PATH/mongoc-stream-gridfs-download-private.h
   $sed -i -e '/private/! s+include "mongoc-+include "CLibMongoC_mongoc-+' $MONGOC_PATH/mongoc-stream-gridfs-upload-private.h
 
+  # fix prelude define requirements, to work around xcode not supporting defines passed via SwiftPM
+  $sed -i -e 's+#error+// #error+' $CLIBMONGOC_INCLUDE_PATH/mongoc-prelude.h
+  $sed -i -e 's+#error+// #error+' $CLIBMONGOC_INCLUDE_PATH/bson-prelude.h
+  $sed -i -e 's+#error+// #error+' $CLIBMONGOC_INCLUDE_PATH/common-prelude.h
+
   pushd $CLIBMONGOC_INCLUDE_PATH
   find . -name "*.h" | $sed -e "s_./__" | xargs -I {} mv {} CLibMongoC_{}
   find . -name "*.h" | xargs $sed -i -e 's/include "bson/include "CLibMongoC_/' -e 's/include <CLibMongoC_\(.*\)>/include "CLibMongoC_\1"/'


### PR DESCRIPTION
XCode seems to have difficulty transferring SwiftPM conditional defines to generated XCode projects. This patch removes the need to depend on these definitions by hardcoding the changes directly in the source.

**NOTE:** I don't know if this fully solves the issue as we still need to convey linker flags

