### PR TITLE
SWIFT-901, SWIFT-929 Add tlsInsecure option, validate options

### DIFF
--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -200,7 +200,12 @@ internal class ConnectionString {
     private func applyAndValidateConnectionPoolOptions(_ options: MongoClientOptions?) throws {
         if let maxPoolSize = options?.maxPoolSize {
             guard let value = Int32(exactly: maxPoolSize), value > 0 else {
-                throw self.int32OutOfRangeError(option: MONGOC_URI_MAXPOOLSIZE, value: maxPoolSize, min: 1, max: Int32.max)
+                throw self.int32OutOfRangeError(
+                    option: MONGOC_URI_MAXPOOLSIZE,
+                    value: maxPoolSize,
+                    min: 1,
+                    max: Int32.max
+                )
             }
 
             try self.setInt32Option(MONGOC_URI_MAXPOOLSIZE, to: value)

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -96,6 +96,12 @@ public struct MongoClientOptions: CodingStrategyProvider {
     /// Specifies the password to de-crypt the `tlsCertificateKeyFile`.
     public var tlsCertificateKeyFilePassword: String?
 
+    /// When specified, TLS constraints will be relaxed as much as possible. Currently, setting this option to `true`
+    /// is equivalent to setting both `tlsAllowInvalidCertificates` and `tlsAllowInvalidHostnames` to `true`.
+    /// It is an error to specify both this option and either of `tlsAllowInvalidCertificates` or
+    /// `tlsAllowInvalidHostnames`, either via this options struct, connection string, or a combination of both.
+    public var tlsInsecure: Bool?
+
     /// Specifies the `UUIDCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any
     /// databases or collections that derive from it.
     public var uuidCodingStrategy: UUIDCodingStrategy?
@@ -133,6 +139,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         tlsCAFile: URL? = nil,
         tlsCertificateKeyFile: URL? = nil,
         tlsCertificateKeyFilePassword: String? = nil,
+        tlsInsecure: Bool? = nil,
         uuidCodingStrategy: UUIDCodingStrategy? = nil,
         writeConcern: WriteConcern? = nil
     ) {
@@ -158,6 +165,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         self.tlsCAFile = tlsCAFile
         self.tlsCertificateKeyFile = tlsCertificateKeyFile
         self.tlsCertificateKeyFilePassword = tlsCertificateKeyFilePassword
+        self.tlsInsecure = tlsInsecure
         self.uuidCodingStrategy = uuidCodingStrategy
         self.writeConcern = writeConcern
     }

--- a/Sources/MongoSwift/ReadPreference.swift
+++ b/Sources/MongoSwift/ReadPreference.swift
@@ -197,8 +197,8 @@ public struct ReadPreference: Equatable {
         if let maxStaleness = maxStalenessSeconds {
             guard maxStaleness >= MONGOC_SMALLEST_MAX_STALENESS_SECONDS else {
                 throw MongoError.InvalidArgumentError(
-                    message: "Expected maxStalenessSeconds to be >= " +
-                        " \(MONGOC_SMALLEST_MAX_STALENESS_SECONDS), \(maxStaleness) given"
+                    message: "Invalid \(MONGOC_URI_MAXSTALENESSSECONDS) \(maxStaleness): " +
+                        "must be at least \(MONGOC_SMALLEST_MAX_STALENESS_SECONDS)"
                 )
             }
         }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -100,8 +100,9 @@ extension ConnectionStringTests {
         ("testServerSelectionTimeoutMS", testServerSelectionTimeoutMS),
         ("testServerSelectionTimeoutMSWithCommand", testServerSelectionTimeoutMSWithCommand),
         ("testLocalThresholdMSOption", testLocalThresholdMSOption),
-        ("testMinPoolSizeErrors", testMinPoolSizeErrors),
+        ("testUnsupportedOptions", testUnsupportedOptions),
         ("testCompressionOptions", testCompressionOptions),
+        ("testInvalidOptionsCombinations", testInvalidOptionsCombinations),
     ]
 }
 


### PR DESCRIPTION
This PR does the following: 

1. Added `tlsInsecure` option to client options.

2. Adds validation for various combinations of options / usages of options that are invalid, as specified in the URI options spec (see [this section](https://github.com/mongodb/specifications/blob/master/source/uri-options/uri-options.rst#conflicting-tls-options) and the two following it.) When these situations are present in the initial string, libmongoc handles validating them for us, but when we override any of the involved options after the `mongoc_uri_t` is created we do not necessarily get validation. See [CDRIVER-3723](https://jira.mongodb.org/browse/CDRIVER-3723) for details.

3. I also realized that the "lack of libmongoc errors on invalid timeouts in the input string" issue (mentioned in [CDRIVER-3167](https://jira.mongodb.org/browse/CDRIVER-3167)) encountered when adding `serverSelectionTimeoutMS` and `localThresholdMS` was relevant for the options we've decided to only support via connection string. It seemed like we should at least be consistent and error on invalid values for these, too. It also applies to `maxStalenessSeconds` when specified via connection string.

4. I noticed that libmongoc does not support any of maxIdleTimeMS, waitQueueMultiple, and waitQueueTimeoutMS. Since these do show up in the connection string docs and other drivers support them, it seemed like it might make sense to error when they are provided. Though on the other hand, maybe we should treat them like any other unrecognized option and just do nothing. (libmongoc does at least log on other unrecognized options but does not for these. I am trying to open a CDRIVER ticket about that right now but Jira seems to be on the verge of a crash so I guess I'll wait until later.)