### PR TITLE
SWIFT-957 Fill in namespace on invalidate events

### DIFF
--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -63,7 +63,7 @@ public struct MongoDatabase {
     internal let _client: MongoClient
 
     /// The namespace for this database.
-    private let namespace: MongoNamespace
+    internal let namespace: MongoNamespace
 
     /// Encoder used by this database for BSON conversions. This encoder's options are inherited by collections derived
     /// from this database.

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -368,6 +368,7 @@ extension SyncChangeStreamTests {
         ("testChangeStreamWithFullDocumentType", testChangeStreamWithFullDocumentType),
         ("testChangeStreamOnACollectionWithCodableType", testChangeStreamOnACollectionWithCodableType),
         ("testChangeStreamLazySequence", testChangeStreamLazySequence),
+        ("testDecodingInvalidateEvents", testDecodingInvalidateEvents),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 
@@ -368,7 +368,8 @@ extension SyncChangeStreamTests {
         ("testChangeStreamWithFullDocumentType", testChangeStreamWithFullDocumentType),
         ("testChangeStreamOnACollectionWithCodableType", testChangeStreamOnACollectionWithCodableType),
         ("testChangeStreamLazySequence", testChangeStreamLazySequence),
-        ("testDecodingInvalidateEvents", testDecodingInvalidateEvents),
+        ("testDecodingInvalidateEventsOnCollection", testDecodingInvalidateEventsOnCollection),
+        ("testDecodingInvalidateEventsOnDatabase", testDecodingInvalidateEventsOnDatabase),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -1151,7 +1151,7 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
             return
         }
 
-        // invalidated changestream on a collection
+        // invalidated change stream on a collection
         try self.withTestNamespace { _, _, collection in
             let stream = try collection.watch()
 

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -1140,4 +1140,66 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
             expect(stream.isAlive()).to(beFalse())
         }
     }
+
+    /// Test that we properly manually populate the `ns` field of `ChangeStreamEvent`s for invalidate events.
+    func testDecodingInvalidateEvents() throws {
+        let unmetRequirement = try MongoClient.makeTestClient().getUnmetRequirement(
+            TestRequirement(acceptableTopologies: [.replicaSet, .sharded])
+        )
+        guard unmetRequirement == nil else {
+            printSkipMessage(testName: self.name, unmetRequirement: unmetRequirement!)
+            return
+        }
+
+        // invalidated changestream on a collection
+        try self.withTestNamespace { _, _, collection in
+            let stream = try collection.watch()
+
+            // insert to create the collection
+            try collection.insertOne(["x": 1])
+            let insertEvent = try stream.next()?.get()
+            expect(insertEvent?.operationType).to(equal(.insert))
+
+            // drop the collection to generate an invalidate event
+            try collection.drop()
+            let drop = try stream.next()?.get()
+            expect(drop?.operationType).to(equal(.drop))
+
+            let invalidate = try stream.next()?.get()
+            expect(invalidate?.operationType).to(equal(.invalidate))
+            expect(invalidate?.ns).to(equal(collection.namespace))
+        }
+
+        // invalidated change stream on a DB
+        try self.withTestNamespace { client, db, collection in
+            // DB change streams are supported as of 4.0
+            let unmetRequirement = try client.getUnmetRequirement(
+                TestRequirement(minServerVersion: ServerVersion(major: 4, minor: 0))
+            )
+            guard unmetRequirement == nil else {
+                printSkipMessage(testName: self.name, unmetRequirement: unmetRequirement!)
+                return
+            }
+
+            let stream = try db.watch()
+
+            // insert to collection to create the db
+            try collection.insertOne(["x": 1])
+            let insertEvent = try stream.next()?.get()
+            expect(insertEvent?.operationType).to(equal(.insert))
+
+            // drop the db to generate an invalidate event
+            try db.drop()
+            // first we see collection drop, then db drop
+            let dropColl = try stream.next()?.get()
+            expect(dropColl?.operationType).to(equal(.drop))
+            let dropDB = try stream.next()?.get()
+            expect(dropDB?.operationType).to(equal(.dropDatabase))
+
+            let invalidate = try stream.next()?.get()
+            expect(invalidate?.operationType).to(equal(.invalidate))
+            expect(invalidate?.ns.db).to(equal(db.name))
+            expect(invalidate?.ns.collection).to(beNil())
+        }
+    }
 }


### PR DESCRIPTION
This PR works around the fact that invalid events do not have associated namespaces by accepting a `MongoNamespace` in `ChangeStream.init`, and then storing that namespace under `ns` in the `ChangeStream'`s `BSONDecoder'`s `userInfo`.

`ChangeStreamEvent` then looks for the matching key when decoding, and falls back to it if there is no key present in the original document.

Per conversation in driver-devs it appears that as of now anyway it's impossible to encounter an invalidate event on a client.