### PR TITLE
SWIFT-958 Ensure nil is returned from next() before ClosedCursorError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
 before_script:
   - MONGODIR=${PWD}/mongodb-${MONGODB_VERSION}
   - mkdir ${MONGODIR}/data
-  - ${MONGODIR}/bin/mongod --dbpath ${MONGODIR}/data --logpath ${MONGODIR}/mongodb.log --fork --setParameter enableTestCommands=1
+  - ${MONGODIR}/bin/mongod --dbpath ${MONGODIR}/data --logpath ${MONGODIR}/mongodb.log --fork
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make test-pretty; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
 before_script:
   - MONGODIR=${PWD}/mongodb-${MONGODB_VERSION}
   - mkdir ${MONGODIR}/data
-  - ${MONGODIR}/bin/mongod --dbpath ${MONGODIR}/data --logpath ${MONGODIR}/mongodb.log --fork
+  - ${MONGODIR}/bin/mongod --dbpath ${MONGODIR}/data --logpath ${MONGODIR}/mongodb.log --fork --setParameter enableTestCommands=1
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make test-pretty; fi

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -158,6 +158,17 @@ public struct TestRequirement: Decodable {
     private let maxServerVersion: ServerVersion?
     private let topology: [TestTopologyConfiguration]?
 
+    public static let failCommandSupport: [TestRequirement] = [
+        TestRequirement(
+            minServerVersion: ServerVersion.mongodFailCommandSupport,
+            acceptableTopologies: [.single, .replicaSet]
+        ),
+        TestRequirement(
+            minServerVersion: ServerVersion.mongosFailCommandSupport,
+            acceptableTopologies: [.sharded]
+        )
+    ]
+
     public init(
         minServerVersion: ServerVersion? = nil,
         maxServerVersion: ServerVersion? = nil,
@@ -284,23 +295,25 @@ public func sortedEqual(_ expectedValue: BSONDocument?) -> Predicate<BSONDocumen
     }
 }
 
+public func printSkipMessage(testName: String, reason: String) {
+    print("Skipping test case \"\(testName)\": \(reason)")
+}
+
 /// Prints a message if a server version or topology requirement is not met and a test is skipped
 public func printSkipMessage(
     testName: String,
     unmetRequirement: UnmetRequirement
 ) {
+    let reason: String
     switch unmetRequirement {
     case let .minServerVersion(actual, required):
-        print("Skipping test case \"\(testName)\": minimum required server " +
-            "version \(required) not met by current server version \(actual)")
-
+        reason = "minimum required server version \(required) not met by current server version \(actual)"
     case let .maxServerVersion(actual, required):
-        print("Skipping test case \"\(testName)\": maximum required server " +
-            "version \(required) not met by current server version \(actual)")
-
+        reason = "maximum required server version \(required) not met by current server version \(actual)"
     case let .topology(actual, required):
-        print("Skipping \(testName) due to unsupported topology type \(actual), supported topologies are: \(required)")
+        reason = "unsupported topology type \(actual), supported topologies are: \(required)"
     }
+    printSkipMessage(testName: testName, reason: reason)
 }
 
 public func unsupportedTopologyMessage(

--- a/Sources/TestsCommon/ServerVersion.swift
+++ b/Sources/TestsCommon/ServerVersion.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// A struct representing a server version.
 public struct ServerVersion: Comparable, Decodable, CustomStringConvertible {
+    public static let mongodFailCommandSupport = ServerVersion(major: 4, minor: 0)
+    public static let mongosFailCommandSupport = ServerVersion(major: 4, minor: 1, patch: 5)
+
     let major: Int
     let minor: Int
     let patch: Int

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -263,6 +263,8 @@ extension MongoCursorTests {
         ("testKill", testKill),
         ("testKillTailable", testKillTailable),
         ("testLazySequence", testLazySequence),
+        ("testCursorTerminatesOnError", testCursorTerminatesOnError),
+        ("testCursorClosedError", testCursorClosedError),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCursorTests.swift
@@ -241,7 +241,12 @@ final class MongoCursorTests: MongoSwiftTestCase {
     }
 
     func testCursorTerminatesOnError() throws {
-        try self.withTestNamespace { _, _, coll in
+        try self.withTestNamespace { client, _, coll in
+            guard try client.supportsFailCommand() else {
+                printSkipMessage(testName: self.name, reason: "failCommand not supported")
+                return
+            }
+
             try coll.insertOne([:])
             try coll.insertOne([:])
 

--- a/Tests/MongoSwiftSyncTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCursorTests.swift
@@ -106,6 +106,7 @@ final class MongoCursorTests: MongoSwiftTestCase {
             expect(try cursor.next()?.get()).to(throwError(expectedError))
             // cursor should be closed now that it errored
             expect(cursor.isAlive()).to(beFalse())
+            expect(cursor.next()).to(beNil())
 
             // iterating dead cursor should error
             expect(try cursor.next()?.get()).to(throwError(errorType: MongoError.LogicError.self))

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -71,6 +71,12 @@ extension MongoClient {
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }
 
+    internal func meetsAnyRequirement(in requirements: [TestRequirement]) throws -> Bool {
+        try requirements.contains {
+            try self.getUnmetRequirement($0) == nil
+        }
+    }
+
     /// Get the max wire version of the primary.
     internal func maxWireVersion() throws -> Int {
         let options = RunCommandOptions(readPreference: .primary)
@@ -114,13 +120,7 @@ extension MongoClient {
     }
 
     internal func supportsFailCommand() throws -> Bool {
-        let version = try self.serverVersion()
-        switch MongoSwiftTestCase.topologyType {
-        case .sharded:
-            return version >= ServerVersion(major: 4, minor: 1, patch: 5)
-        default:
-            return version >= ServerVersion(major: 4, minor: 0)
-        }
+        try self.meetsAnyRequirement(in: TestRequirement.failCommandSupport)
     }
 }
 

--- a/Tests/MongoSwiftTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftTests/MongoCursorTests.swift
@@ -129,6 +129,7 @@ final class AsyncMongoCursorTests: MongoSwiftTestCase {
             expect(try cursor.next().wait()).to(throwError(expectedError))
             // cursor should be closed now that it errored
             expect(try cursor.isAlive().wait()).to(beFalse())
+            expect(try cursor.next().wait()).to(beNil())
 
             // iterating dead cursor should error
             expect(try cursor.next().wait()).to(throwError(errorType: MongoError.LogicError.self))


### PR DESCRIPTION
SWIFT-958

This fixes a bug where cursors would iterate forever after encountering a non-`DecodingError` by ensuring `next` returns `nil` once after the error. This does not apply to `tryNext` or `toArray`, since those are `throws`. Also, in the case of `tryNext`, `nil` doesn't necessarily imply that the cursor is dead.