### PR TITLE
SWIFT-974 Fix leak in Collection.findOne when encountering DecodingError

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -58,7 +58,7 @@ extension MongoCollection {
     ) -> EventLoopFuture<T?> {
         let options = options.map { FindOptions(from: $0) }
         return self.find(filter, options: options, session: session).flatMap { cursor in
-            cursor.next().afterSuccess { _ in cursor.kill() }
+            cursor.next().always { _ in _ = cursor.kill() }
         }
     }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -219,6 +219,7 @@ extension MongoCollectionTests {
         ("testFindOneAndUpdate", testFindOneAndUpdate),
         ("testNullIds", testNullIds),
         ("testNSNotFoundSuppression", testNSNotFoundSuppression),
+        ("testFindOneKillsCursor", testFindOneKillsCursor),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
@@ -550,4 +550,17 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         expect(try collection.drop()).toNot(throwError())
         expect(try collection.dropIndex("ljasdfjlkasdjf")).toNot(throwError())
     }
+
+    func testFindOneKillsCursor() throws {
+        struct Blah: Codable {
+            let ljadsflkjasdf: String // won't be present in result doc
+        }
+        try self.withTestNamespace { _, db, coll in
+            try coll.insertOne([:])
+
+            let codableColl = db.collection(coll.name, withType: Blah.self)
+            _ = try? codableColl.findOne([:])
+            // if the underlying cursor is leaked, this will crash in debug mode
+        }
+    }
 }


### PR DESCRIPTION
SWIFT-974

This PR fixes a bug in `Collection.findOne` where the cursor would get leaked if a `DecodingError` occurred while decoding the result.
