### PR TITLE
SWIFT-961 Add withBSONPointer to new BSONDocument

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,10 +12,10 @@
       },
       {
         "package": "swift-bson",
-        "repositoryURL": "https://github.com/patrickfreed/swift-bson",
+        "repositoryURL": "https://github.com/mongodb/swift-bson",
         "state": {
-          "branch": "target-rename",
-          "revision": "7a140cad599134323c67418d19a61577d837e9a4",
+          "branch": "master",
+          "revision": "b8d953ae93951e7bee6cde4f7cc6774211378982",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "swift-bson",
+        "repositoryURL": "https://github.com/patrickfreed/swift-bson",
+        "state": {
+          "branch": "target-rename",
+          "revision": "7a140cad599134323c67418d19a61577d837e9a4",
+          "version": null
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")),
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.15.0")),
-        .package(url: "https://github.com/patrickfreed/swift-bson", .branch("target-rename"))
+        .package(url: "https://github.com/mongodb/swift-bson", .branch("master"))
     ],
     targets: [
         .target(name: "MongoSwift", dependencies: ["CLibMongoC", "NIO", "NIOConcurrencyHelpers", "SwiftBSON",]),

--- a/Package.swift
+++ b/Package.swift
@@ -11,10 +11,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")),
-        .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.15.0"))
+        .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.15.0")),
+        .package(url: "https://github.com/patrickfreed/swift-bson", .branch("target-rename"))
     ],
     targets: [
-        .target(name: "MongoSwift", dependencies: ["CLibMongoC", "NIO", "NIOConcurrencyHelpers"]),
+        .target(name: "MongoSwift", dependencies: ["CLibMongoC", "NIO", "NIOConcurrencyHelpers", "SwiftBSON",]),
         .target(name: "MongoSwiftSync", dependencies: ["MongoSwift", "NIO"]),
         .target(name: "AtlasConnectivity", dependencies: ["MongoSwiftSync"]),
         .target(name: "TestsCommon", dependencies: ["MongoSwift", "Nimble"]),

--- a/Sources/MongoSwift/BSON/BSONPointerUtils.swift
+++ b/Sources/MongoSwift/BSON/BSONPointerUtils.swift
@@ -1,0 +1,37 @@
+import CLibMongoC
+import Foundation
+import struct SwiftBSON.BSONDocument
+
+extension SwiftBSON.BSONDocument {
+    /// Executes the given closure with a read-only, stack-allocated pointer to a bson_t.
+    /// The pointer is only valid within the body of the closure and MUST NOT be persisted outside of it.
+    internal func withBSONPointer<T>(_ f: (BSONPointer) throws -> T) rethrows -> T {
+        var bson = bson_t()
+        return try self.buffer.withUnsafeReadableBytes { bufferPtr in
+            guard let baseAddrPtr = bufferPtr.baseAddress else {
+                fatalError("BSONDocument buffer pointer is null")
+            }
+            guard bson_init_static(&bson, baseAddrPtr.assumingMemoryBound(to: UInt8.self), bufferPtr.count) else {
+                fatalError("failed to initialize read-only bson_t from BSONDocument")
+            }
+            return try f(&bson)
+        }
+    }
+
+    /**
+     * Copies the data from the given `BSONPointer` into a new `BSONDocument`.
+     *
+     *  Throws an `MongoError.InternalError` if the bson_t isn't proper BSON.
+     */
+    internal init(copying bsonPtr: BSONPointer) throws {
+        guard let ptr = bson_get_data(bsonPtr) else {
+            fatalError("bson_t data is null")
+        }
+        let bufferPtr = UnsafeBufferPointer(start: ptr, count: Int(bsonPtr.pointee.len))
+        do {
+            try self.init(fromBSON: Data(bufferPtr))
+        } catch {
+            throw MongoError.InternalError(message: "failed initializing BSONDocument from bson_t: \(error)")
+        }
+    }
+}

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -342,7 +342,8 @@ public final class ClientSession {
         }
 
         let sessionDoc = BSONDocument(copying: bson)
-        doc["lsid"] = sessionDoc["lsid"]
+        // key that libmongoc uses to store the client session id in options documents
+        doc["sessionId"] = sessionDoc["sessionId"]
     }
 
     /**

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -331,12 +331,18 @@ public final class ClientSession {
             throw ClientSession.SessionInactiveError
         }
 
-        var error = bson_error_t()
-        try doc.withMutableBSONPointer { docPtr in
-            guard mongoc_client_session_append(session, docPtr, &error) else {
-                throw extractMongoError(error: error)
-            }
+        guard let bson = bson_new() else {
+            fatalError("failed to allocate bson_t")
         }
+        defer { bson_destroy(bson) }
+
+        var error = bson_error_t()
+        guard mongoc_client_session_append(session, bson, &error) else {
+            throw extractMongoError(error: error)
+        }
+
+        let sessionDoc = BSONDocument(copying: bson)
+        doc["lsid"] = sessionDoc["lsid"]
     }
 
     /**

--- a/Tests/BSONTests/BSONPointerUtilsTests.swift
+++ b/Tests/BSONTests/BSONPointerUtilsTests.swift
@@ -1,0 +1,40 @@
+import CLibMongoC
+import Foundation
+@testable import MongoSwift
+import Nimble
+@testable import SwiftBSON
+import TestsCommon
+import XCTest
+
+final class BSONPointerUtilsTests: MongoSwiftTestCase {
+    func testWithBSONPointer() throws {
+        let doc: SwiftBSON.BSONDocument = ["x": 1]
+        doc.withBSONPointer { bsonPtr in
+            guard let json = bson_as_relaxed_extended_json(bsonPtr, nil) else {
+                XCTFail("failed to get extjson")
+                return
+            }
+            defer { bson_free(json) }
+            expect(String(cString: json)).to(equal("{ \"x\" : 1 }"))
+        }
+        expect(doc["x"]).to(equal(1))
+    }
+
+    func testBSONPointerInitializer() throws {
+        var bson = bson_new()!
+        defer { bson_free(bson) }
+
+        guard bson_append_int32(bson, "x", Int32(1), 5) else {
+            XCTFail("append failed")
+            return
+        }
+
+        guard bson_append_int32(bson, "y", Int32(1), 5) else {
+            XCTFail("append failed")
+            return
+        }
+
+        let doc = try SwiftBSON.BSONDocument(copying: bson)
+        expect(doc).to(equal(["x": .int32(5), "y": .int32(5)]))
+    }
+}

--- a/Tests/BSONTests/DocumentTests.swift
+++ b/Tests/BSONTests/DocumentTests.swift
@@ -31,10 +31,10 @@ extension Data {
 
 struct DocElem {
     let key: String
-    let value: SwiftBSON
+    let value: SwiftBSONValue
 }
 
-enum SwiftBSON {
+enum SwiftBSONValue {
     case document([DocElem])
     case other(BSON)
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -31,6 +31,13 @@ extension BSONCorpusTests {
     ]
 }
 
+extension BSONPointerUtilsTests {
+    static var allTests = [
+        ("testWithBSONPointer", testWithBSONPointer),
+        ("testBSONPointerInitializer", testBSONPointerInitializer),
+    ]
+}
+
 extension BSONValueTests {
     static var allTests = [
         ("testInvalidDecimal128", testInvalidDecimal128),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -426,6 +426,7 @@ XCTMain([
     testCase(AsyncMongoCursorTests.allTests),
     testCase(AuthTests.allTests),
     testCase(BSONCorpusTests.allTests),
+    testCase(BSONPointerUtilsTests.allTests),
     testCase(BSONValueTests.allTests),
     testCase(ChangeStreamSpecTests.allTests),
     testCase(ChangeStreamTests.allTests),


### PR DESCRIPTION
SWIFT-961

This PR adds [`swift-bson`](https://github.com/mongodb/swift-bson) as a dependency to the driver and adds some extensions to allow interop with libbson's `bson_t`.