### PR TITLE
SWIFT-1015 Only create monitoring events if they are being consumed

### DIFF
--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -31,6 +31,7 @@ private protocol MongoSwiftEvent {
     func toPublishable() -> PublishableEventType
 }
 
+/// Indicates which type of monitoring an event is associated with.
 private enum MonitoringComponent {
     case command, sdam
 }

--- a/Tests/MongoSwiftSyncTests/SDAMTests.swift
+++ b/Tests/MongoSwiftSyncTests/SDAMTests.swift
@@ -46,23 +46,27 @@ final class SDAMTests: MongoSwiftTestCase {
             return
         }
 
-        expect(receivedEvents.count).to(equal(4))
+        expect(receivedEvents.count).to(equal(5))
         expect(receivedEvents[0].topologyOpeningValue).toNot(beNil())
-        expect(receivedEvents[1].serverOpeningValue).toNot(beNil())
-        expect(receivedEvents[2].serverDescriptionChangedValue).toNot(beNil())
-        expect(receivedEvents[3].topologyDescriptionChangedValue).toNot(beNil())
+        expect(receivedEvents[1].topologyDescriptionChangedValue).toNot(beNil())
+        expect(receivedEvents[2].serverOpeningValue).toNot(beNil())
+        expect(receivedEvents[3].serverDescriptionChangedValue).toNot(beNil())
+        expect(receivedEvents[4].topologyDescriptionChangedValue).toNot(beNil())
 
         let event0 = receivedEvents[0].topologyOpeningValue!
 
-        let event1 = receivedEvents[1].serverOpeningValue!
+        let event1 = receivedEvents[1].topologyDescriptionChangedValue!
         expect(event1.topologyID).to(equal(event0.topologyID))
-        expect(event1.serverAddress).to(equal(hostAddress))
 
-        let event2 = receivedEvents[2].serverDescriptionChangedValue!
+        let event2 = receivedEvents[2].serverOpeningValue!
         expect(event2.topologyID).to(equal(event1.topologyID))
+        expect(event2.serverAddress).to(equal(hostAddress))
 
-        let prevServer = event2.previousDescription
-        let newServer = event2.newDescription
+        let event3 = receivedEvents[3].serverDescriptionChangedValue!
+        expect(event3.topologyID).to(equal(event2.topologyID))
+
+        let prevServer = event3.previousDescription
+        let newServer = event3.newDescription
 
         expect(prevServer.address).to(equal(hostAddress))
         expect(newServer.address).to(equal(hostAddress))
@@ -73,11 +77,11 @@ final class SDAMTests: MongoSwiftTestCase {
         expect(prevServer.type).to(equal(.unknown))
         expect(newServer.type).to(equal(.standalone))
 
-        let event3 = receivedEvents[3].topologyDescriptionChangedValue!
-        expect(event3.topologyID).to(equal(event2.topologyID))
+        let event4 = receivedEvents[4].topologyDescriptionChangedValue!
+        expect(event4.topologyID).to(equal(event3.topologyID))
 
-        let prevTopology = event3.previousDescription
-        let newTopology = event3.newDescription
+        let prevTopology = event4.previousDescription
+        let newTopology = event4.newDescription
 
         expect(prevTopology.type).to(equal(.unknown))
         expect(newTopology.type).to(equal(.single))


### PR DESCRIPTION
This is a longstanding inefficiency in the driver, but only came up as a problem when using the new BSON library.

Even if the user has no handlers registered, we create a corresponding Swift event, which in the case of e.g. a command started event for a large command is quite expensive (especially now that - at least for the moment - by default we validate incoming documents.)

This PR amends that by introducing a new concept of a monitoring "component" for each event type. Depending on the component of the event to be published, we inspect the client to see if any corresponding handlers exist.

I am feeling like this file is getting a little wild, using a lot of different types and protocols, but at the same time I couldn't figure out a clean way to accomplish this without the addition of the new type. I technically could have checked if the type conformed to `CommandEventProtocol` or not and acted accordingly but that felt kind of hacky. If you have any ideas let me know.

Note that as part of this I also resolved SWIFT-524 (see inline comment about test changes).

This problem might have somewhat "gone away" if we stopped validating the command documents (which we should probably also do), but this was a very quick win that I think is worth implementing regardless.

Comparison of runtimes, in seconds:
| Benchmark                               | Old   | New Unoptimized | With this fix |
|-----------------------------------------|-------|-----------------|---------------|
| Small doc bulk insert 10k copies        | .096  | 4258.673        | 0.424         |
| Large doc bulk insert 10 copies         | 0.332 | 59.637          | 2.79          |
| small doc insertOne 10k times           | 3.258 | 8.276           | 4.481         |
| findOne by _id 10k times                | 4.07  | 229.698         | 14.597        |
| find() and empty cursor, 10k small docs | 0.468 | 10436.246       | 1.025         |
| find() and empty cursor, 10 large docs  | 0.032 | 105.365         | 3.568         |

Note that the first and second to last ones literally got 10,000 times faster...!! My spawn host was working hard last night 🙂 

I need to do some further investigation into what the remaining bottlenecks for these benchmarks are, which should be much easier now that their runtimes are significantly lower. I suspect validation continues to be a main culprit, which we still encounter via e.g. parsing reply documents and reading documents from cursors. I will probably end up writing a couple of new small benchmarks that specifically test BSON validation in order to speed up iterating on that code.
