### PR TITLE
SWIFT-913 Make required changes to TestRequirement type for unified runner

### DIFF
--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -136,50 +136,47 @@ open class MongoSwiftTestCase: XCTestCase {
 }
 
 /// Enumerates the different topology configurations that are used throughout the tests
-public enum TestTopologyConfiguration: RawRepresentable, Decodable {
+public enum TestTopologyConfiguration: String, Decodable {
     case sharded
-    case replicaSet
+    case replicaSet = "replicaset"
+    case shardedReplicaSet = "sharded-replicaset"
     case single
 
-    public init?(rawValue: String) {
-        switch rawValue {
-        // as of MongoDB 3.6 (the lowest version this driver supports), shards must be replica sets, so for our
-        // testing purposes there is no distinction between these topology types.
-        case "sharded", "sharded-replicaset":
-            self = .sharded
-        case "replicaset":
-            self = .replicaSet
-        case "single":
-            self = .single
-        default:
-            return nil
-        }
-    }
-
-    public var rawValue: String {
-        switch self {
-        case .sharded:
-            return "sharded"
-        case .replicaSet:
-            return "replicaSet"
-        case .single:
-            return "single"
-        }
-    }
-
-    /// Determines the topologyType of a client based on the reply returned by running an isMaster command.
-    public init(isMasterReply: BSONDocument) throws {
+    /// Determines the topologyType of a client based on the reply returned by running an isMaster command and the
+    /// contents of the config.shards collection.
+    public init(isMasterReply: BSONDocument, shards: [BSONDocument]) throws {
         // Check for symptoms of different topologies
         if isMasterReply["msg"] != "isdbgrid" &&
             isMasterReply["setName"] == nil &&
             isMasterReply["isreplicaset"] != true {
             self = .single
         } else if isMasterReply["msg"] == "isdbgrid" {
-            self = .sharded
+            guard !shards.isEmpty else {
+                throw TestError(
+                    message: "isMasterReply \(isMasterReply) implies a sharded cluster, but config.shards is empty"
+                )
+            }
+            // We only check the first shard here and assume we aren't testing against sharded clusters backed by a mix
+            // of replsets and standalones.
+            let shard = shards[0]
+            guard let host = shard["host"]?.stringValue else {
+                throw TestError(message: "config.shards document \(shard) unexpectedly missing host string")
+            }
+            // If the shard is backed by a single server, this field will contain a single host (e.g. localhost:27017).
+            // If the shard is backed by a replica set, this field will contain the name of the replica followed by a
+            // forward slash and a comma-delimited list of hosts.
+            guard host.contains("/") else {
+                self = .sharded
+                return
+            }
+            self = .shardedReplicaSet
         } else if isMasterReply["ismaster"] == true && isMasterReply["setName"] != nil {
             self = .replicaSet
         } else {
-            throw TestError(message: "Invalid test topology configuration given by isMaster reply: \(isMasterReply)")
+            throw TestError(
+                message:
+                "Invalid test topology configuration given by isMaster reply: \(isMasterReply) and shards: \(shards)"
+            )
         }
     }
 }
@@ -234,6 +231,12 @@ public struct TestRequirement: Decodable {
             }
         }
         if let topologies = self.topologies {
+            // When matching a "sharded" topology, test runners MUST accept any type of sharded cluster (i.e. "sharded"
+            // implies "sharded-replicaset", but not vice versa).
+            if topology == .shardedReplicaSet && topologies.contains(.sharded) {
+                return nil
+            }
+
             guard topologies.contains(topology) else {
                 return .topology(actual: topology, required: topologies)
             }

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -160,9 +160,9 @@ public enum TestTopologyConfiguration: String, Decodable {
                 guard let host = shard["host"]?.stringValue else {
                     throw TestError(message: "config.shards document \(shard) unexpectedly missing host string")
                 }
-                // If the shard is backed by a single server, this field will contain a single host (e.g. localhost:27017).
-                // If the shard is backed by a replica set, this field will contain the name of the replica followed by a
-                // forward slash and a comma-delimited list of hosts.
+                // If the shard is backed by a single server, this field will contain a single host (e.g.
+                // localhost:27017). If the shard is backed by a replica set, this field will contain the name of the
+                // replica set followed by a forward slash and a comma-delimited list of hosts.
                 let replSetHostRegex = try NSRegularExpression(pattern: #"^.*\/.*:\d+$"#)
                 let range = NSRange(host.startIndex..<host.endIndex, in: host)
                 guard replSetHostRegex.firstMatch(in: host, range: range) != nil else {
@@ -176,7 +176,7 @@ public enum TestTopologyConfiguration: String, Decodable {
         } else {
             throw TestError(
                 message:
-                "Invalid test topology configuration given by isMaster reply: \(isMasterReply) and shars: \(shards)"
+                "Invalid test topology configuration given by isMaster reply: \(isMasterReply) and shards: \(shards)"
             )
         }
     }

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -66,8 +66,8 @@ extension MongoClient {
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
         let isMasterReply = try self.db("admin").runCommand(["isMaster": 1])
-        let firstShard = try self.db("config").collection("shards").findOne()
-        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shardDescription: firstShard)
+        let shards = try self.db("config").collection("shards").find().map { try $0.get() }
+        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
         let serverVersion = try self.serverVersion()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -65,8 +65,9 @@ extension MongoClient {
 
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
-        let reply = try self.db("admin").runCommand(["isMaster": 1])
-        let topologyType = try TestTopologyConfiguration(isMasterReply: reply)
+        let isMasterReply = try self.db("admin").runCommand(["isMaster": 1])
+        let shards = try Array(self.db("config").collection("shards").find()).map { try $0.get() }
+        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
         let serverVersion = try self.serverVersion()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -65,9 +65,8 @@ extension MongoClient {
 
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
-        let isMasterReply = try self.db("admin").runCommand(["isMaster": 1])
-        let shards = try Array(self.db("config").collection("shards").find()).map { try $0.get() }
-        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
+        let reply = try self.db("admin").runCommand(["isMaster": 1])
+        let topologyType = try TestTopologyConfiguration(isMasterReply: reply)
         let serverVersion = try self.serverVersion()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -66,8 +66,8 @@ extension MongoClient {
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
         let isMasterReply = try self.db("admin").runCommand(["isMaster": 1])
-        let shards = try Array(self.db("config").collection("shards").find()).map { try $0.get() }
-        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
+        let firstShard = try self.db("config").collection("shards").findOne()
+        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shardDescription: firstShard)
         let serverVersion = try self.serverVersion()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -41,9 +41,8 @@ extension MongoClient {
 
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
-        let isMasterReply = try self.db("admin").runCommand(["isMaster": 1]).wait()
-        let shards = try self.db("config").collection("shards").find().wait().toArray().wait()
-        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
+        let reply: BSONDocument = try self.db("admin").runCommand(["isMaster": 1]).wait()
+        let topologyType = try TestTopologyConfiguration(isMasterReply: reply)
         let serverVersion = try self.serverVersion().wait()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -42,8 +42,8 @@ extension MongoClient {
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
         let isMasterReply = try self.db("admin").runCommand(["isMaster": 1]).wait()
-        let firstShard = try self.db("config").collection("shards").findOne().wait()
-        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shardDescription: firstShard)
+        let shards = try self.db("config").collection("shards").find().wait().toArray().wait()
+        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
         let serverVersion = try self.serverVersion().wait()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -42,8 +42,8 @@ extension MongoClient {
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
         let isMasterReply = try self.db("admin").runCommand(["isMaster": 1]).wait()
-        let shards = try self.db("config").collection("shards").find().wait().toArray().wait()
-        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
+        let firstShard = try self.db("config").collection("shards").findOne().wait()
+        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shardDescription: firstShard)
         let serverVersion = try self.serverVersion().wait()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -41,8 +41,9 @@ extension MongoClient {
 
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
-        let reply: BSONDocument = try self.db("admin").runCommand(["isMaster": 1]).wait()
-        let topologyType = try TestTopologyConfiguration(isMasterReply: reply)
+        let isMasterReply = try self.db("admin").runCommand(["isMaster": 1]).wait()
+        let shards = try self.db("config").collection("shards").find().wait().toArray().wait()
+        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
         let serverVersion = try self.serverVersion().wait()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }


### PR DESCRIPTION
For readability purposes, trying to break this PR up into separate chunks when I can.

This PR introduces changes to our `TestRequirement` and `TestTopologyConfiguration` types to support usage with the new unified test format.