### PR TITLE
SWIFT-913 Add data structures for unified test schema version, test file, and test

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -414,6 +414,13 @@ extension TransactionsTests {
     ]
 }
 
+extension UnifiedRunnerTests {
+    static var allTests = [
+        ("testSchemaVersion", testSchemaVersion),
+        ("testUnifiedTestDecoding", testUnifiedTestDecoding),
+    ]
+}
+
 extension WriteConcernTests {
     static var allTests = [
         ("testWriteConcernType", testWriteConcernType),
@@ -461,5 +468,6 @@ XCTMain([
     testCase(SyncClientSessionTests.allTests),
     testCase(SyncMongoClientTests.allTests),
     testCase(TransactionsTests.allTests),
+    testCase(UnifiedRunnerTests.allTests),
     testCase(WriteConcernTests.allTests),
 ])

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SchemaVersion.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SchemaVersion.swift
@@ -1,0 +1,59 @@
+/// Represents a schemaVersion.
+struct SchemaVersion: RawRepresentable, Comparable, Decodable {
+    /// Major version.
+    let major: Int
+
+    /// Minor version.
+    let minor: Int
+
+    /// Patch version.
+    let patch: Int
+
+    public init?(rawValue: String) {
+        var components = rawValue.split(separator: ".")
+        // invalid number of components.
+        guard (1...3).contains(components.count) else {
+            return nil
+        }
+
+        guard let major = Int(components.removeFirst()) else {
+            return nil
+        }
+        self.major = major
+
+        guard !components.isEmpty else {
+            self.minor = 0
+            self.patch = 0
+            return
+        }
+
+        guard let minor = Int(components.removeFirst()) else {
+            return nil
+        }
+        self.minor = minor
+
+        guard !components.isEmpty else {
+            self.patch = 0
+            return
+        }
+
+        guard let patch = Int(components.removeFirst()) else {
+            return nil
+        }
+        self.patch = patch
+    }
+
+    public var rawValue: String {
+        "\(major).\(minor).\(patch)"
+    }
+
+    public static func < (lhs: SchemaVersion, rhs: SchemaVersion) -> Bool {
+        if lhs.major != rhs.major {
+            return lhs.major < rhs.major
+        } else if lhs.minor != rhs.minor {
+            return lhs.minor < rhs.minor
+        } else {
+            return lhs.patch < rhs.patch
+        }
+    }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SchemaVersion.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SchemaVersion.swift
@@ -44,7 +44,7 @@ struct SchemaVersion: RawRepresentable, Comparable, Decodable {
     }
 
     public var rawValue: String {
-        "\(major).\(minor).\(patch)"
+        "\(self.major).\(self.minor).\(self.patch)"
     }
 
     public static func < (lhs: SchemaVersion, rhs: SchemaVersion) -> Bool {

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
@@ -55,7 +55,7 @@ struct UnifiedTest: Decodable {
 
     /// Optional array of one or more expectedEventsForClient objects. For one or more clients, a list of events that
     /// are expected to be observed in a particular order.
-    let expectEvents: [BSONDocument]? // TODO SWIFT-913: use event types
+    let expectEvents: [BSONDocument]? // TODO: SWIFT-913: use event types
 
     /// Data that is expected to exist in collections after the test case is executed.
     let outcome: [CollectionData]?

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
@@ -1,0 +1,62 @@
+import MongoSwiftSync
+import TestsCommon
+
+/// Structure representing a test file in the unified test format.
+struct UnifiedTestFile: Decodable {
+    /// The name of the test file.
+    let description: String
+
+    /// Version of this specification with which the test file complies.
+    let schemaVersion: SchemaVersion
+
+    /// Optional array of one or more version/topology test requirements.  If no requirements are met, the test runner
+    /// MUST skip this test file.
+    let runOnRequirements: [TestRequirement]?
+
+    /// Optional array of one or more entity objects (e.g. client, collection, session objects) that SHALL be created
+    /// before each test case is executed.
+    let createEntities: [BSONDocument]? // TODO SWIFT-913: add an entity type
+
+    /// Optional array of one or more collectionData objects. Data that will exist in collections before each test case
+    /// is executed.
+    let initialData: [CollectionData]?
+
+    /// Required array of one or more test objects. List of test cases to be executed independently of each other.
+    let tests: [UnifiedTest]
+}
+
+/// List of documents corresponding to the contents of a collection.
+struct CollectionData: Decodable {
+    /// The name of a collection.
+    let collectionName: String
+
+    /// The name of a database.
+    let databaseName: String
+
+    /// List of documents corresponding to the contents of the collection. May be empty.
+    let documents: [BSONDocument]
+}
+
+/// Represents a single test in a test file.
+struct UnifiedTest: Decodable {
+    /// The name of the test.
+    let description: String
+
+    /// Optional array of one or more runOnRequirement objects. List of server version and/or topology requirements for
+    /// which this test can be run. If specified, these requirements are evaluated independently and in addition to any
+    /// top-level runOnRequirements. If no requirements in this array are met, the test runner MUST skip this test.
+    let runOnRequirements: [TestRequirement]?
+
+    /// Optional string. If set, the test will be skipped.
+    let skipReason: String?
+
+    /// Array of one or more operation objects. List of operations to be executed for the test case.
+    let operations: [BSONDocument] // TODO SWIFT-913: use operation types
+
+    /// Optional array of one or more expectedEventsForClient objects. For one or more clients, a list of events that
+    /// are expected to be observed in a particular order.
+    let expectEvents: [BSONDocument]? // // TODO SWIFT-913: use event types
+
+    /// Data that is expected to exist in collections after the test case is executed.
+    let outcome: [CollectionData]?
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
@@ -55,7 +55,7 @@ struct UnifiedTest: Decodable {
 
     /// Optional array of one or more expectedEventsForClient objects. For one or more clients, a list of events that
     /// are expected to be observed in a particular order.
-    let expectEvents: [BSONDocument]? // // TODO SWIFT-913: use event types
+    let expectEvents: [BSONDocument]? // TODO SWIFT-913: use event types
 
     /// Data that is expected to exist in collections after the test case is executed.
     let outcome: [CollectionData]?

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
@@ -15,7 +15,7 @@ struct UnifiedTestFile: Decodable {
 
     /// Optional array of one or more entity objects (e.g. client, collection, session objects) that SHALL be created
     /// before each test case is executed.
-    let createEntities: [BSONDocument]? // TODO SWIFT-913: add an entity type
+    let createEntities: [BSONDocument]? // TODO: SWIFT-913: add an entity type
 
     /// Optional array of one or more collectionData objects. Data that will exist in collections before each test case
     /// is executed.
@@ -51,7 +51,7 @@ struct UnifiedTest: Decodable {
     let skipReason: String?
 
     /// Array of one or more operation objects. List of operations to be executed for the test case.
-    let operations: [BSONDocument] // TODO SWIFT-913: use operation types
+    let operations: [BSONDocument] // TODO: SWIFT-913: use operation types
 
     /// Optional array of one or more expectedEventsForClient objects. For one or more clients, a list of events that
     /// are expected to be observed in a particular order.

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -1,0 +1,45 @@
+import Nimble
+import TestsCommon
+
+final class UnifiedRunnerTests: MongoSwiftTestCase {
+    func testSchemaVersion() {
+        let oneTwoThree = SchemaVersion(rawValue: "1.2.3")
+        expect(oneTwoThree).toNot(beNil())
+        expect(oneTwoThree?.major).to(equal(1))
+        expect(oneTwoThree?.minor).to(equal(2))
+        expect(oneTwoThree?.patch).to(equal(3))
+
+        // no patch provided
+        let oneTwo = SchemaVersion(rawValue: "1.2")
+        expect(oneTwo).toNot(beNil())
+        expect(oneTwo?.major).to(equal(1))
+        expect(oneTwo?.minor).to(equal(2))
+        expect(oneTwo?.patch).to(equal(0))
+
+        // no minor provided
+        let one = SchemaVersion(rawValue: "1")
+        expect(one).toNot(beNil())
+        expect(one?.major).to(equal(1))
+        expect(one?.minor).to(equal(0))
+        expect(one?.patch).to(equal(0))
+
+        // invalid inputs
+        let inputs = [
+            "a",
+            "1.2.3.4",
+            ""
+        ]
+
+        for input in inputs {
+            expect(SchemaVersion(rawValue: input)).to(beNil())
+        }
+    }
+
+    func testUnifiedTestDecoding() throws {
+        expect(try retrieveSpecTestFiles(
+            specName: "unified-test-format",
+            subdirectory: "valid-pass",
+            asType: UnifiedTestFile.self
+        )).toNot(throwError())
+    }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -41,5 +41,11 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
             subdirectory: "valid-pass",
             asType: UnifiedTestFile.self
         )).toNot(throwError())
+
+        expect(try retrieveSpecTestFiles(
+            specName: "unified-test-format",
+            subdirectory: "valid-fail",
+            asType: UnifiedTestFile.self
+        )).toNot(throwError())
     }
 }


### PR DESCRIPTION
Adds some new data structures to represent the contents of unified test files. For now I have left some of the sub-contents which will require their own Codable types as `BSONDocument`s; these will switch to using more specific types in future PRs. 