### PR TITLE
SWIFT-913 Add EntityDescription and ExpectedEventsForClient types for unified test runner

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -418,6 +418,7 @@ extension UnifiedRunnerTests {
     static var allTests = [
         ("testSchemaVersion", testSchemaVersion),
         ("testUnifiedTestDecoding", testUnifiedTestDecoding),
+        ("testStrictDecodableTypes", testStrictDecodableTypes),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
@@ -50,7 +50,7 @@ enum EntityDescription: Decodable {
         let databaseName: String
 
         /// Options to use for this database.
-        let options: MongoDatabaseOptions?
+        let databaseOptions: MongoDatabaseOptions?
     }
 
     /// Describes a Collection entity. (named Coll because Collection clashes with the stdlib's Collection protocol.)
@@ -65,7 +65,7 @@ enum EntityDescription: Decodable {
         let collectionName: String
 
         /// Options to use for this collection.
-        let options: MongoCollectionOptions?
+        let collectionOptions: MongoCollectionOptions?
     }
 
     /// Describes a ClientSession entity.
@@ -77,7 +77,7 @@ enum EntityDescription: Decodable {
         let client: String
 
         /// Options to use for this session.
-        let options: ClientSessionOptions?
+        let sessionOptions: ClientSessionOptions?
     }
 
     /// Defines a GridFS bucket entity.

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
@@ -1,0 +1,117 @@
+import Foundation
+import MongoSwiftSync
+
+/// Represents a description of an entity (client, db, etc.).
+enum EntityDescription: Decodable {
+    case client(Client)
+    case database(Database)
+    case collection(Coll)
+    case session(Session)
+    case bucket(Bucket)
+
+    /// Describes a Client entity.
+    struct Client: Decodable {
+        /// Unique name for this entity.
+        let id: String
+
+        /// Additional URI options to apply to the test suite's connection string that is used to create this client.
+        let uriOptions: MongoClientOptions?
+
+        /**
+         * If true and the topology is a sharded cluster, the test runner MUST assert that this MongoClient connects
+         * to multiple mongos hosts (e.g. by inspecting the connection string). If false and the topology is a sharded
+         * cluster, the test runner MUST ensure that this MongoClient connects to only a single mongos host (e.g. by
+         * modifying the connection string).
+         * If this option is not specified and the topology is a sharded cluster, the test runner MUST NOT enforce any
+         * limit on the number of mongos hosts in the connection string. This option has no effect for non-sharded
+         * topologies.
+         */
+        let useMultipleMongoses: Bool?
+
+        /// Types of events that can be observed for this client. Unspecified event types MUST be ignored by this
+        /// client's event listeners.
+        let observeEvents: [String]?
+
+        /// Command names for which the test runner MUST ignore any observed command monitoring events. The command(s)
+        /// will be ignored in addition to configureFailPoint and any commands containing sensitive information (per
+        /// the Command Monitoring spec).
+        let ignoreCommandMonitoringEvents: [String]?
+    }
+
+    /// Describes a Database entity.
+    struct Database: Decodable {
+        /// Unique name for this entity.
+        let id: String
+
+        /// Client entity from which this database will be created.
+        let client: String
+
+        /// Database name.
+        let databaseName: String
+
+        /// Options to use for this database.
+        let options: MongoDatabaseOptions?
+    }
+
+    /// Describes a Collection entity. (named Coll because Collection clashes with the stdlib's Collection protocol.)
+    struct Coll: Decodable {
+        /// Unique name for this entity.
+        let id: String
+
+        /// Database entity from which this collection will be created.
+        let database: String
+
+        /// Collection name.
+        let collectionName: String
+
+        /// Options to use for this collection.
+        let options: MongoCollectionOptions?
+    }
+
+    /// Describes a ClientSession entity.
+    struct Session: Decodable {
+        /// Unique name for this entity.
+        let id: String
+
+        /// Client entity from which this session will be created.
+        let client: String
+
+        /// Options to use for this session.
+        let options: ClientSessionOptions?
+    }
+
+    /// Defines a GridFS bucket entity.
+    struct Bucket: Decodable {
+        /// Unique name for this entity.
+        let id: String
+
+        /// Database entity from which this bucket will be created.
+        let database: String
+
+        /// Options to use for this bucket. Eventually this would be GridFSOptions rather than just a document, if we
+        /// ever add GridFS support.
+        let bucketOptions: BSONDocument?
+    }
+
+    /// All of the possible keys. Only one will ever be present.
+    private enum CodingKeys: String, CodingKey {
+        case client, database, collection, session, bucket
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let client = try container.decodeIfPresent(Client.self, forKey: .client) {
+            self = .client(client)
+        } else if let db = try container.decodeIfPresent(Database.self, forKey: .database) {
+            self = .database(db)
+        } else if let coll = try container.decodeIfPresent(Coll.self, forKey: .collection) {
+            self = .collection(coll)
+        } else if let session = try container.decodeIfPresent(Session.self, forKey: .session) {
+            self = .session(session)
+        } else {
+            let bucket = try container.decode(Bucket.self, forKey: .bucket)
+            self = .bucket(bucket)
+        }
+    }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MongoSwiftSync
+
+/// Represents the events expected for the specified client.
+struct ExpectedEventsForClient: Decodable {
+    /// Client entity on which the events are expected to be observed.
+    let client: String
+
+    /// List of events, which are expected to be observed (in this order) on the corresponding client while executing
+    /// operations. If the array is empty, the test runner MUST assert that no events were observed on the client
+    /// (excluding ignored events).
+    let events: [ExpectedEvent]
+}
+
+/// Describes expected events.
+enum ExpectedEvent: Decodable {
+    case commandStarted(CommandStartedExpectation)
+
+    case commandSucceeded(CommandSucceededExpectation)
+
+    case commandFailed(CommandFailedExpectation)
+
+    private enum CodingKeys: String, CodingKey {
+        case commandStartedEvent, commandSucceededEvent, commandFailedEvent
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let started = try container.decodeIfPresent(CommandStartedExpectation.self, forKey: .commandStartedEvent) {
+            self = .commandStarted(started)
+        } else if let succeeded = try container.decodeIfPresent(
+            CommandSucceededExpectation.self,
+            forKey: .commandSucceededEvent
+        ) {
+            self = .commandSucceeded(succeeded)
+        } else {
+            let failed = try container.decode(CommandFailedExpectation.self, forKey: .commandFailedEvent)
+            self = .commandFailed(failed)
+        }
+    }
+
+    /// We use the below types rather than the driver's event types directly as we only care about making assertions
+    /// for a subset of fields.
+    /// Represents expectations for a CommandStartedEvent.
+    struct CommandStartedExpectation: Decodable {
+        ///  A value corresponding to the expected command document.
+        let command: BSONDocument?
+
+        /// Name of the command.
+        let commandName: String?
+
+        /// Name of the database the command is run against.
+        let databaseName: String?
+    }
+
+    /// Represents expectations for a CommandSucceededEvent.
+    struct CommandSucceededExpectation: Decodable {
+        /// A value corresponding to the expected reply document.
+        let reply: BSONDocument?
+
+        /// Name of the command.
+        let commandName: String?
+    }
+
+    /// Represents expectations for a CommandStartedEvent.
+    struct CommandFailedExpectation: Decodable {
+        /// Name of the command.
+        let commandName: String?
+    }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestFile.swift
@@ -15,7 +15,7 @@ struct UnifiedTestFile: Decodable {
 
     /// Optional array of one or more entity objects (e.g. client, collection, session objects) that SHALL be created
     /// before each test case is executed.
-    let createEntities: [BSONDocument]? // TODO: SWIFT-913: add an entity type
+    let createEntities: [EntityDescription]?
 
     /// Optional array of one or more collectionData objects. Data that will exist in collections before each test case
     /// is executed.
@@ -55,7 +55,7 @@ struct UnifiedTest: Decodable {
 
     /// Optional array of one or more expectedEventsForClient objects. For one or more clients, a list of events that
     /// are expected to be observed in a particular order.
-    let expectEvents: [BSONDocument]? // TODO: SWIFT-913: use event types
+    let expectEvents: [ExpectedEventsForClient]?
 
     /// Data that is expected to exist in collections after the test case is executed.
     let outcome: [CollectionData]?

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -1,3 +1,4 @@
+import MongoSwiftSync
 import Nimble
 import TestsCommon
 
@@ -47,5 +48,45 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
             subdirectory: "valid-fail",
             asType: UnifiedTestFile.self
         )).toNot(throwError())
+    }
+
+    func testStrictDecodableTypes() throws {
+        // Test decoding a valid key. Conveniently, this options is supported by 4 of the 5 StrictDecodable types.
+        let validOptsRaw: BSONDocument = [
+            "readPreference": "primary"
+        ]
+
+        expect(try BSONDecoder().decode(MongoDatabaseOptions.self, from: validOptsRaw)).toNot(throwError())
+        expect(try BSONDecoder().decode(MongoCollectionOptions.self, from: validOptsRaw)).toNot(throwError())
+        expect(try BSONDecoder().decode(MongoClientOptions.self, from: validOptsRaw)).toNot(throwError())
+        expect(try BSONDecoder().decode(TransactionOptions.self, from: validOptsRaw)).toNot(throwError())
+
+        let validSessionOptsRaw: BSONDocument = [
+            "causalConsistency": true,
+            "defaultTransactionOptions": .document(validOptsRaw)
+        ]
+        expect(try BSONDecoder().decode(ClientSessionOptions.self, from: validSessionOptsRaw)).toNot(throwError())
+
+        // Test decoding from a document with an unsupported key errors.
+        let invalidOptsRaw: BSONDocument = [
+            "blah": "hi"
+        ]
+        expect(try BSONDecoder().decode(MongoDatabaseOptions.self, from: invalidOptsRaw))
+            .to(throwError(errorType: TestError.self))
+        expect(try BSONDecoder().decode(MongoCollectionOptions.self, from: invalidOptsRaw))
+            .to(throwError(errorType: TestError.self))
+        expect(try BSONDecoder().decode(MongoClientOptions.self, from: invalidOptsRaw))
+            .to(throwError(errorType: TestError.self))
+        expect(try BSONDecoder().decode(ClientSessionOptions.self, from: invalidOptsRaw))
+            .to(throwError(errorType: TestError.self))
+        expect(try BSONDecoder().decode(TransactionOptions.self, from: invalidOptsRaw))
+            .to(throwError(errorType: TestError.self))
+
+        // Test that we error when the invalid key is in a nested field (whose type also conforms to StrictDecodable).
+        let invalidNestedOptsRaw: BSONDocument = [
+            "defaultTransactionOptions": .document(invalidOptsRaw)
+        ]
+        expect(try BSONDecoder().decode(ClientSessionOptions.self, from: invalidNestedOptsRaw))
+            .to(throwError(errorType: TestError.self))
     }
 }


### PR DESCRIPTION
Adding some more data structures and support for (at least some types) for verifying only expected options are present. I'll add some commentary inline.