### PR TITLE
SWIFT-913 Support for remaining test operations

### DIFF
--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -63,7 +63,7 @@ public struct AggregateOptions: Codable {
         self.writeConcern = writeConcern
     }
 
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
         case allowDiskUse, batchSize, bypassDocumentValidation, collation, maxTimeMS, comment, hint, readConcern,
              writeConcern
     }

--- a/Sources/TestsCommon/SpecTestUtils.swift
+++ b/Sources/TestsCommon/SpecTestUtils.swift
@@ -45,6 +45,7 @@ extension MongoDatabase {
 public func retrieveSpecTestFiles<T: Decodable>(
     specName: String,
     subdirectory: String? = nil,
+    excludeFiles: [String] = [],
     asType _: T.Type
 ) throws -> [(String, T)] {
     var path = "\(MongoSwiftTestCase.specsPath)/\(specName)/tests"
@@ -54,7 +55,10 @@ public func retrieveSpecTestFiles<T: Decodable>(
     return try FileManager.default
         .contentsOfDirectory(atPath: path)
         .filter { $0.hasSuffix(".json") }
-        .map { filename in
+        .compactMap { filename in
+            guard !excludeFiles.contains(filename) else {
+                return nil
+            }
             let url = URL(fileURLWithPath: "\(path)/\(filename)")
             var doc = try BSONDocument(fromJSONFile: url)
             doc["name"] = .string(filename)

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/CollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/CollectionOperations.swift
@@ -1,5 +1,4 @@
 import Foundation
-@testable import struct MongoSwift.FindOptions
 import MongoSwiftSync
 import TestsCommon
 
@@ -268,6 +267,10 @@ struct InsertMany: TestOperation {
 
 /// Extension of `WriteModel` adding `Decodable` conformance.
 extension WriteModel: Decodable {
+    private enum CodingKeys: CodingKey {
+        case name, arguments
+    }
+
     private enum InsertOneKeys: CodingKey {
         case document
     }
@@ -282,10 +285,6 @@ extension WriteModel: Decodable {
 
     private enum UpdateKeys: CodingKey {
         case filter, update
-    }
-
-    private enum CodingKeys: CodingKey {
-        case name, arguments
     }
 
     public init(from decoder: Decoder) throws {

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/CollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/CollectionOperations.swift
@@ -268,68 +268,52 @@ struct InsertMany: TestOperation {
 
 /// Extension of `WriteModel` adding `Decodable` conformance.
 extension WriteModel: Decodable {
-    private enum InsertOneKeys: String, CodingKey, CaseIterable {
+    private enum InsertOneKeys: CodingKey {
         case document
     }
 
-    private enum DeleteKeys: String, CodingKey, CaseIterable {
+    private enum DeleteKeys: CodingKey {
         case filter
     }
 
-    private enum ReplaceOneKeys: String, CodingKey, CaseIterable {
+    private enum ReplaceOneKeys: CodingKey {
         case filter, replacement
     }
 
-    private enum UpdateKeys: String, CodingKey, CaseIterable {
+    private enum UpdateKeys: CodingKey {
         case filter, update
     }
 
-    private enum TestKey: CodingKey {
-        case name
-    }
-
-    public init(from decoder: Decoder) throws {
-        // Unfortunately, the representation of bulk write models in older spec tests e.g. retryable writes
-        // is significantly different from the representation in the unified runner. Depending on the presence of a
-        // top-level key "name" we detect which style this file uses.
-        let container = try decoder.container(keyedBy: TestKey.self)
-        if try container.decodeIfPresent(String.self, forKey: .name) != nil {
-            self = try Self.oldDecode(from: decoder)
-        } else {
-            self = try Self.unifiedDecode(from: decoder)
-        }
-    }
-
-    private enum OldCodingKeys: CodingKey {
+    private enum CodingKeys: CodingKey {
         case name, arguments
     }
 
-    static func oldDecode(from decoder: Decoder) throws -> Self {
-        let container = try decoder.container(keyedBy: OldCodingKeys.self)
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
         let name = try container.decode(String.self, forKey: .name)
 
         switch name {
         case "insertOne":
             let args = try container.nestedContainer(keyedBy: InsertOneKeys.self, forKey: .arguments)
             let doc = try args.decode(CollectionType.self, forKey: .document)
-            return .insertOne(doc)
+            self = .insertOne(doc)
         case "deleteOne", "deleteMany":
             let options = try container.decode(DeleteModelOptions.self, forKey: .arguments)
             let args = try container.nestedContainer(keyedBy: DeleteKeys.self, forKey: .arguments)
             let filter = try args.decode(BSONDocument.self, forKey: .filter)
-            return name == "deleteOne" ? .deleteOne(filter, options: options) : .deleteMany(filter, options: options)
+            self = name == "deleteOne" ? .deleteOne(filter, options: options) : .deleteMany(filter, options: options)
         case "replaceOne":
             let options = try container.decode(ReplaceOneModelOptions.self, forKey: .arguments)
             let args = try container.nestedContainer(keyedBy: ReplaceOneKeys.self, forKey: .arguments)
             let filter = try args.decode(BSONDocument.self, forKey: .filter)
             let replacement = try args.decode(CollectionType.self, forKey: .replacement)
-            return .replaceOne(filter: filter, replacement: replacement, options: options)
+            self = .replaceOne(filter: filter, replacement: replacement, options: options)
         case "updateOne", "updateMany":
             let options = try container.decode(UpdateModelOptions.self, forKey: .arguments)
             let args = try container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .arguments)
             let filter = try args.decode(BSONDocument.self, forKey: .filter)
             let update = try args.decode(BSONDocument.self, forKey: .update)
-            return name == "updateOne" ?
+            self = name == "updateOne" ?
                 .updateOne(filter: filter, update: update, options: options) :
                 .updateMany(filter: filter, update: update, options: options)
         default:
@@ -341,78 +325,6 @@ extension WriteModel: Decodable {
                 )
             )
         }
-    }
-
-    enum NewCodingKeys: String, CodingKey {
-        // Only one of these will ever be present.
-        case insertOne, deleteOne, deleteMany, replaceOne, updateOne, updateMany
-    }
-
-    static func unifiedDecode(from decoder: Decoder) throws -> Self {
-        let container = try decoder.container(keyedBy: NewCodingKeys.self)
-
-        let model: WriteModel
-        let matchedKey: NewCodingKeys
-
-        if let nested = try? container.nestedContainer(keyedBy: InsertOneKeys.self, forKey: .insertOne) {
-            let doc = try nested.decode(CollectionType.self, forKey: .document)
-            model = .insertOne(doc)
-            matchedKey = .insertOne
-        } else if let nested = try? container.nestedContainer(keyedBy: DeleteKeys.self, forKey: .deleteOne) {
-            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
-            let options = try container.decode(DeleteModelOptions.self, forKey: .deleteOne)
-            model = .deleteOne(filter, options: options)
-            matchedKey = .deleteOne
-        } else if let nested = try? container.nestedContainer(keyedBy: DeleteKeys.self, forKey: .deleteMany) {
-            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
-            let options = try container.decode(DeleteModelOptions.self, forKey: .deleteMany)
-            model = .deleteMany(filter, options: options)
-            matchedKey = .deleteMany
-        } else if let nested = try? container.nestedContainer(keyedBy: ReplaceOneKeys.self, forKey: .replaceOne) {
-            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
-            let replacement = try nested.decode(CollectionType.self, forKey: .replacement)
-            let options = try container.decode(ReplaceOneModelOptions.self, forKey: .replaceOne)
-            model = .replaceOne(filter: filter, replacement: replacement, options: options)
-            matchedKey = .replaceOne
-        } else if let nested = try? container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .updateOne) {
-            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
-            let update = try nested.decode(BSONDocument.self, forKey: .update)
-            let options = try container.decode(UpdateModelOptions.self, forKey: .updateOne)
-            model = .updateOne(filter: filter, update: update, options: options)
-            matchedKey = .updateOne
-        } else if let nested = try? container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .updateMany) {
-            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
-            let update = try nested.decode(BSONDocument.self, forKey: .update)
-            let options = try container.decode(UpdateModelOptions.self, forKey: .updateMany)
-            model = .updateMany(filter: filter, update: update, options: options)
-            matchedKey = .updateMany
-        } else {
-            throw DecodingError.typeMismatch(
-                WriteModel.self,
-                DecodingError.Context(
-                    codingPath: decoder.codingPath,
-                    debugDescription: "Unknown write model"
-                )
-            )
-        }
-
-        let rawArgs = try container.decode(BSONDocument.self, forKey: matchedKey).keys
-        for arg in rawArgs where !Self.knownArgsForWriteModelTypes[matchedKey.rawValue]!.contains(arg) {
-            throw TestError(message: "Unsupported argument for bulkWrite \(matchedKey.rawValue): \(arg)")
-        }
-
-        return model
-    }
-
-    static var knownArgsForWriteModelTypes: [String: Set<String>] {
-        [
-            "insertOne": Set(InsertOneKeys.allCases.map { $0.stringValue }),
-            "deleteOne": Set(DeleteKeys.allCases.map { $0.stringValue } + DeleteModelOptions().propertyNames),
-            "deleteMany": Set(DeleteKeys.allCases.map { $0.stringValue } + DeleteModelOptions().propertyNames),
-            "updateOne": Set(UpdateKeys.allCases.map { $0.stringValue } + UpdateModelOptions().propertyNames),
-            "updateMany": Set(UpdateKeys.allCases.map { $0.stringValue } + UpdateModelOptions().propertyNames),
-            "replaceOne": Set(ReplaceOneKeys.allCases.map { $0.stringValue } + ReplaceOneModelOptions().propertyNames)
-        ]
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/CollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/TestOperations/CollectionOperations.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import struct MongoSwift.FindOptions
 import MongoSwiftSync
 import TestsCommon
 
@@ -267,52 +268,68 @@ struct InsertMany: TestOperation {
 
 /// Extension of `WriteModel` adding `Decodable` conformance.
 extension WriteModel: Decodable {
-    private enum CodingKeys: CodingKey {
-        case name, arguments
+    private enum InsertOneKeys: String, CodingKey, CaseIterable {
+        case document
     }
 
-    private enum InsertOneKeys: CodingKey {
-        case session, document
+    private enum DeleteKeys: String, CodingKey, CaseIterable {
+        case filter
     }
 
-    private enum DeleteKeys: CodingKey {
-        case session, filter
+    private enum ReplaceOneKeys: String, CodingKey, CaseIterable {
+        case filter, replacement
     }
 
-    private enum ReplaceOneKeys: CodingKey {
-        case session, filter, replacement
+    private enum UpdateKeys: String, CodingKey, CaseIterable {
+        case filter, update
     }
 
-    private enum UpdateKeys: CodingKey {
-        case session, filter, update
+    private enum TestKey: CodingKey {
+        case name
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Unfortunately, the representation of bulk write models in older spec tests e.g. retryable writes
+        // is significantly different from the representation in the unified runner. Depending on the presence of a
+        // top-level key "name" we detect which style this file uses.
+        let container = try decoder.container(keyedBy: TestKey.self)
+        if try container.decodeIfPresent(String.self, forKey: .name) != nil {
+            self = try Self.oldDecode(from: decoder)
+        } else {
+            self = try Self.unifiedDecode(from: decoder)
+        }
+    }
+
+    private enum OldCodingKeys: CodingKey {
+        case name, arguments
+    }
+
+    static func oldDecode(from decoder: Decoder) throws -> Self {
+        let container = try decoder.container(keyedBy: OldCodingKeys.self)
         let name = try container.decode(String.self, forKey: .name)
 
         switch name {
         case "insertOne":
             let args = try container.nestedContainer(keyedBy: InsertOneKeys.self, forKey: .arguments)
             let doc = try args.decode(CollectionType.self, forKey: .document)
-            self = .insertOne(doc)
+            return .insertOne(doc)
         case "deleteOne", "deleteMany":
             let options = try container.decode(DeleteModelOptions.self, forKey: .arguments)
             let args = try container.nestedContainer(keyedBy: DeleteKeys.self, forKey: .arguments)
             let filter = try args.decode(BSONDocument.self, forKey: .filter)
-            self = name == "deleteOne" ? .deleteOne(filter, options: options) : .deleteMany(filter, options: options)
+            return name == "deleteOne" ? .deleteOne(filter, options: options) : .deleteMany(filter, options: options)
         case "replaceOne":
             let options = try container.decode(ReplaceOneModelOptions.self, forKey: .arguments)
             let args = try container.nestedContainer(keyedBy: ReplaceOneKeys.self, forKey: .arguments)
             let filter = try args.decode(BSONDocument.self, forKey: .filter)
             let replacement = try args.decode(CollectionType.self, forKey: .replacement)
-            self = .replaceOne(filter: filter, replacement: replacement, options: options)
+            return .replaceOne(filter: filter, replacement: replacement, options: options)
         case "updateOne", "updateMany":
             let options = try container.decode(UpdateModelOptions.self, forKey: .arguments)
             let args = try container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .arguments)
             let filter = try args.decode(BSONDocument.self, forKey: .filter)
             let update = try args.decode(BSONDocument.self, forKey: .update)
-            self = name == "updateOne" ?
+            return name == "updateOne" ?
                 .updateOne(filter: filter, update: update, options: options) :
                 .updateMany(filter: filter, update: update, options: options)
         default:
@@ -324,6 +341,78 @@ extension WriteModel: Decodable {
                 )
             )
         }
+    }
+
+    enum NewCodingKeys: String, CodingKey {
+        // Only one of these will ever be present.
+        case insertOne, deleteOne, deleteMany, replaceOne, updateOne, updateMany
+    }
+
+    static func unifiedDecode(from decoder: Decoder) throws -> Self {
+        let container = try decoder.container(keyedBy: NewCodingKeys.self)
+
+        let model: WriteModel
+        let matchedKey: NewCodingKeys
+
+        if let nested = try? container.nestedContainer(keyedBy: InsertOneKeys.self, forKey: .insertOne) {
+            let doc = try nested.decode(CollectionType.self, forKey: .document)
+            model = .insertOne(doc)
+            matchedKey = .insertOne
+        } else if let nested = try? container.nestedContainer(keyedBy: DeleteKeys.self, forKey: .deleteOne) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let options = try container.decode(DeleteModelOptions.self, forKey: .deleteOne)
+            model = .deleteOne(filter, options: options)
+            matchedKey = .deleteOne
+        } else if let nested = try? container.nestedContainer(keyedBy: DeleteKeys.self, forKey: .deleteMany) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let options = try container.decode(DeleteModelOptions.self, forKey: .deleteMany)
+            model = .deleteMany(filter, options: options)
+            matchedKey = .deleteMany
+        } else if let nested = try? container.nestedContainer(keyedBy: ReplaceOneKeys.self, forKey: .replaceOne) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let replacement = try nested.decode(CollectionType.self, forKey: .replacement)
+            let options = try container.decode(ReplaceOneModelOptions.self, forKey: .replaceOne)
+            model = .replaceOne(filter: filter, replacement: replacement, options: options)
+            matchedKey = .replaceOne
+        } else if let nested = try? container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .updateOne) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let update = try nested.decode(BSONDocument.self, forKey: .update)
+            let options = try container.decode(UpdateModelOptions.self, forKey: .updateOne)
+            model = .updateOne(filter: filter, update: update, options: options)
+            matchedKey = .updateOne
+        } else if let nested = try? container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .updateMany) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let update = try nested.decode(BSONDocument.self, forKey: .update)
+            let options = try container.decode(UpdateModelOptions.self, forKey: .updateMany)
+            model = .updateMany(filter: filter, update: update, options: options)
+            matchedKey = .updateMany
+        } else {
+            throw DecodingError.typeMismatch(
+                WriteModel.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unknown write model"
+                )
+            )
+        }
+
+        let rawArgs = try container.decode(BSONDocument.self, forKey: matchedKey).keys
+        for arg in rawArgs where !Self.knownArgsForWriteModelTypes[matchedKey.rawValue]!.contains(arg) {
+            throw TestError(message: "Unsupported argument for bulkWrite \(matchedKey.rawValue): \(arg)")
+        }
+
+        return model
+    }
+
+    static var knownArgsForWriteModelTypes: [String: Set<String>] {
+        [
+            "insertOne": Set(InsertOneKeys.allCases.map { $0.stringValue }),
+            "deleteOne": Set(DeleteKeys.allCases.map { $0.stringValue } + DeleteModelOptions().propertyNames),
+            "deleteMany": Set(DeleteKeys.allCases.map { $0.stringValue } + DeleteModelOptions().propertyNames),
+            "updateOne": Set(UpdateKeys.allCases.map { $0.stringValue } + UpdateModelOptions().propertyNames),
+            "updateMany": Set(UpdateKeys.allCases.map { $0.stringValue } + UpdateModelOptions().propertyNames),
+            "replaceOne": Set(ReplaceOneKeys.allCases.map { $0.stringValue } + ReplaceOneModelOptions().propertyNames)
+        ]
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/HasListableProperties.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/HasListableProperties.swift
@@ -1,0 +1,22 @@
+import MongoSwiftSync
+
+protocol HasListableProperties {
+    var propertyNames: [String] { get }
+}
+
+extension HasListableProperties {
+    var propertyNames: [String] {
+        Mirror(reflecting: self).children.map { $0.label! }
+    }
+}
+
+extension BulkWriteOptions: HasListableProperties {}
+extension FindOneAndReplaceOptions: HasListableProperties {}
+extension FindOneAndUpdateOptions: HasListableProperties {}
+extension DeleteOptions: HasListableProperties {}
+extension ReplaceOptions: HasListableProperties {}
+extension InsertOneOptions: HasListableProperties {}
+extension DeleteModelOptions: HasListableProperties {}
+extension UpdateModelOptions: HasListableProperties {}
+extension ReplaceOneModelOptions: HasListableProperties {}
+extension ChangeStreamOptions: HasListableProperties {}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SpecialTestOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SpecialTestOperations.swift
@@ -1,3 +1,4 @@
+@testable import class MongoSwift.ClientSession
 import MongoSwiftSync
 
 struct UnifiedFailPoint: UnifiedOperationProtocol {
@@ -12,12 +13,105 @@ struct UnifiedFailPoint: UnifiedOperationProtocol {
     }
 }
 
+struct UnifiedAssertCollectionExists: UnifiedOperationProtocol {
+    /// The collection name.
+    let collectionName: String
+
+    /// The name of the database
+    let databaseName: String
+
+    static var knownArguments: Set<String> {
+        ["collectionName", "databaseName"]
+    }
+}
+
+struct UnifiedAssertCollectionNotExists: UnifiedOperationProtocol {
+    /// The collection name.
+    let collectionName: String
+
+    /// The name of the database.
+    let databaseName: String
+
+    static var knownArguments: Set<String> {
+        ["collectionName", "databaseName"]
+    }
+}
+
+struct UnifiedAssertIndexExists: UnifiedOperationProtocol {
+    /// The collection name.
+    let collectionName: String
+
+    /// The name of the database.
+    let databaseName: String
+
+    /// The name of the index.
+    let indexName: String
+
+    static var knownArguments: Set<String> {
+        ["collectionName", "databaseName", "indexName"]
+    }
+}
+
+struct UnifiedAssertIndexNotExists: UnifiedOperationProtocol {
+    /// The collection name.
+    let collectionName: String
+
+    /// The name of the database to look for the collection in.
+    let databaseName: String
+
+    /// The name of the index.
+    let indexName: String
+
+    static var knownArguments: Set<String> {
+        ["collectionName", "databaseName", "indexName"]
+    }
+}
+
 struct AssertSessionNotDirty: UnifiedOperationProtocol {
     /// The session entity to perform the assertion on.
     let session: String
 
     static var knownArguments: Set<String> {
         ["session"]
+    }
+}
+
+struct AssertSessionDirty: UnifiedOperationProtocol {
+    /// The session entity to perform the assertion on.
+    let session: String
+
+    static var knownArguments: Set<String> {
+        ["session"]
+    }
+}
+
+struct UnifiedAssertSessionPinned: UnifiedOperationProtocol {
+    /// The session entity to perform the assertion on.
+    let session: String
+
+    static var knownArguments: Set<String> {
+        ["session"]
+    }
+}
+
+struct UnifiedAssertSessionUnpinned: UnifiedOperationProtocol {
+    /// The session entity to perform the assertion on.
+    let session: String
+
+    static var knownArguments: Set<String> {
+        ["session"]
+    }
+}
+
+struct UnifiedAssertSessionTransactionState: UnifiedOperationProtocol {
+    /// The session entity to perform the assertion on.
+    let session: String
+
+    /// The expected transaction state.
+    let state: ClientSession.TransactionState
+
+    static var knownArguments: Set<String> {
+        ["session", "state"]
     }
 }
 
@@ -36,5 +130,17 @@ struct AssertSameLsidOnLastTwoCommands: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["client"]
+    }
+}
+
+struct UnifiedTargetedFailPoint: UnifiedOperationProtocol {
+    /// The configureFailPoint command to be executed.
+    let failPoint: BSONDocument
+
+    /// Identifier for the session entity with which to set the fail point.
+    let session: String
+
+    static var knownArguments: Set<String> {
+        ["failPoint", "session"]
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/TestWriteModel.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/TestWriteModel.swift
@@ -1,0 +1,117 @@
+import MongoSwiftSync
+import TestsCommon
+
+/// Intermediate representation of a bulk write model to match the test format, used for decoding purposes.
+enum TestWriteModel: Decodable {
+    case insertOne(BSONDocument)
+    case deleteOne(BSONDocument, options: DeleteModelOptions)
+    case deleteMany(BSONDocument, options: DeleteModelOptions)
+    case updateOne(filter: BSONDocument, update: BSONDocument, options: UpdateModelOptions)
+    case updateMany(filter: BSONDocument, update: BSONDocument, options: UpdateModelOptions)
+    case replaceOne(filter: BSONDocument, replacement: BSONDocument, options: ReplaceOneModelOptions)
+
+    enum CodingKeys: String, CodingKey {
+        // Only one of these will ever be present.
+        case insertOne, deleteOne, deleteMany, replaceOne, updateOne, updateMany
+    }
+
+    private enum InsertOneKeys: String, CodingKey, CaseIterable {
+        case document
+    }
+
+    private enum DeleteKeys: String, CodingKey, CaseIterable {
+        case filter
+    }
+
+    private enum ReplaceOneKeys: String, CodingKey, CaseIterable {
+        case filter, replacement
+    }
+
+    private enum UpdateKeys: String, CodingKey, CaseIterable {
+        case filter, update
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let matchedKey: CodingKeys
+
+        if let nested = try? container.nestedContainer(keyedBy: InsertOneKeys.self, forKey: .insertOne) {
+            let doc = try nested.decode(BSONDocument.self, forKey: .document)
+            self = .insertOne(doc)
+            matchedKey = .insertOne
+        } else if let nested = try? container.nestedContainer(keyedBy: DeleteKeys.self, forKey: .deleteOne) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let options = try container.decode(DeleteModelOptions.self, forKey: .deleteOne)
+            self = .deleteOne(filter, options: options)
+            matchedKey = .deleteOne
+        } else if let nested = try? container.nestedContainer(keyedBy: DeleteKeys.self, forKey: .deleteMany) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let options = try container.decode(DeleteModelOptions.self, forKey: .deleteMany)
+            self = .deleteMany(filter, options: options)
+            matchedKey = .deleteMany
+        } else if let nested = try? container.nestedContainer(keyedBy: ReplaceOneKeys.self, forKey: .replaceOne) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let replacement = try nested.decode(BSONDocument.self, forKey: .replacement)
+            let options = try container.decode(ReplaceOneModelOptions.self, forKey: .replaceOne)
+            self = .replaceOne(filter: filter, replacement: replacement, options: options)
+            matchedKey = .replaceOne
+        } else if let nested = try? container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .updateOne) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let update = try nested.decode(BSONDocument.self, forKey: .update)
+            let options = try container.decode(UpdateModelOptions.self, forKey: .updateOne)
+            self = .updateOne(filter: filter, update: update, options: options)
+            matchedKey = .updateOne
+        } else if let nested = try? container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .updateMany) {
+            let filter = try nested.decode(BSONDocument.self, forKey: .filter)
+            let update = try nested.decode(BSONDocument.self, forKey: .update)
+            let options = try container.decode(UpdateModelOptions.self, forKey: .updateMany)
+            self = .updateMany(filter: filter, update: update, options: options)
+            matchedKey = .updateMany
+        } else {
+            throw DecodingError.typeMismatch(
+                TestWriteModel.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unknown write model"
+                )
+            )
+        }
+
+        let rawArgs = try container.decode(BSONDocument.self, forKey: matchedKey).keys
+        for arg in rawArgs where !self.knownArguments.contains(arg) {
+            throw TestError(message: "Unsupported argument for bulkWrite \(matchedKey.rawValue): \(arg)")
+        }
+    }
+
+    /// Known arguments for each type of write model.
+    var knownArguments: Set<String> {
+        switch self {
+        case .insertOne:
+            return Set(InsertOneKeys.allCases.map { $0.stringValue })
+        case .deleteOne, .deleteMany:
+            return Set(DeleteKeys.allCases.map { $0.stringValue } + DeleteModelOptions().propertyNames)
+        case .updateOne, .updateMany:
+            return Set(UpdateKeys.allCases.map { $0.stringValue } + UpdateModelOptions().propertyNames)
+        case .replaceOne:
+            return Set(ReplaceOneKeys.allCases.map { $0.stringValue } + ReplaceOneModelOptions().propertyNames)
+        }
+    }
+
+    /// Converts to the WriteModel type used in the driver's public API.
+    func toWriteModel() -> WriteModel<BSONDocument> {
+        switch self {
+        case let .insertOne(doc):
+            return .insertOne(doc)
+        case let .deleteOne(filter, options):
+            return .deleteOne(filter, options: options)
+        case let .deleteMany(filter, options):
+            return .deleteMany(filter, options: options)
+        case let .updateOne(filter, update, options):
+            return .updateOne(filter: filter, update: update, options: options)
+        case let .updateMany(filter, update, options):
+            return .updateMany(filter: filter, update: update, options: options)
+        case let .replaceOne(filter, replacement, options):
+            return .replaceOne(filter: filter, replacement: replacement, options: options)
+        }
+    }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedChangeStreamOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedChangeStreamOperations.swift
@@ -18,7 +18,7 @@ struct CreateChangeStream: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         Set(
             CodingKeys.allCases.map { $0.rawValue } +
-                Mirror(reflecting: ChangeStreamOptions()).children.map { $0.label! }
+                ChangeStreamOptions().propertyNames
         )
     }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedClientOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedClientOperations.swift
@@ -1,0 +1,3 @@
+struct UnifiedListDatabases: UnifiedOperationProtocol {
+    static var knownArguments: Set<String> { [] }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -72,7 +72,8 @@ struct UnifiedBulkWrite: UnifiedOperationProtocol {
         self.options = try decoder.singleValueContainer().decode(BulkWriteOptions.self)
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
-        self.requests = try container.decode([WriteModel<BSONDocument>].self, forKey: .requests)
+        let decodedRequests = try container.decode([TestWriteModel].self, forKey: .requests)
+        self.requests = decodedRequests.map { $0.toWriteModel() }
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -1,6 +1,80 @@
 import Foundation
+@testable import struct MongoSwift.AggregateOptions
 @testable import struct MongoSwift.FindOptions
 import MongoSwiftSync
+
+struct UnifiedAggregate: UnifiedOperationProtocol {
+    /// Aggregation pipeline.
+    let pipeline: [BSONDocument]
+
+    /// Options to use for the operation.
+    let options: AggregateOptions
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case pipeline, session
+    }
+
+    static var knownArguments: Set<String> {
+        Set(
+            CodingKeys.allCases.map { $0.rawValue } +
+                AggregateOptions.CodingKeys.allCases.map { $0.rawValue }
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pipeline = try container.decode([BSONDocument].self, forKey: .pipeline)
+        self.session = try container.decodeIfPresent(String.self, forKey: .session)
+        self.options = try decoder.singleValueContainer().decode(AggregateOptions.self)
+    }
+}
+
+struct UnifiedCreateIndex: UnifiedOperationProtocol {
+    /// The name of the index to create.
+    let name: String
+
+    /// Keys for the index.
+    let keys: BSONDocument
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    static var knownArguments: Set<String> {
+        ["name", "keys", "session"]
+    }
+}
+
+struct UnifiedBulkWrite: UnifiedOperationProtocol {
+    /// Writes to perform.
+    let requests: [WriteModel<BSONDocument>]
+
+    /// Options to use for the operation.
+    let options: BulkWriteOptions
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case requests, session
+    }
+
+    static var knownArguments: Set<String> {
+        Set(
+            CodingKeys.allCases.map { $0.rawValue } +
+                BulkWriteOptions().propertyNames
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        self.options = try decoder.singleValueContainer().decode(BulkWriteOptions.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.session = try container.decodeIfPresent(String.self, forKey: .session)
+        self.requests = try container.decode([WriteModel<BSONDocument>].self, forKey: .requests)
+    }
+}
 
 struct UnifiedFind: UnifiedOperationProtocol {
     /// Filter to use for the operation.
@@ -27,7 +101,102 @@ struct UnifiedFind: UnifiedOperationProtocol {
         self.options = try decoder.singleValueContainer().decode(FindOptions.self)
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
-        self.filter = try container.decodeIfPresent(BSONDocument.self, forKey: .filter) ?? BSONDocument()
+        self.filter = try container.decode(BSONDocument.self, forKey: .filter)
+    }
+}
+
+struct UnifiedFindOneAndReplace: UnifiedOperationProtocol {
+    /// Filter to use for the operation.
+    let filter: BSONDocument
+
+    /// Replacement document.
+    let replacement: BSONDocument
+
+    /// Options to use for the operation.
+    let options: FindOneAndReplaceOptions
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case filter, replacement, session
+    }
+
+    static var knownArguments: Set<String> {
+        Set(
+            CodingKeys.allCases.map { $0.rawValue } +
+                FindOneAndReplaceOptions().propertyNames
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        self.options = try decoder.singleValueContainer().decode(FindOneAndReplaceOptions.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.session = try container.decodeIfPresent(String.self, forKey: .session)
+        self.filter = try container.decode(BSONDocument.self, forKey: .filter)
+        self.replacement = try container.decode(BSONDocument.self, forKey: .replacement)
+    }
+}
+
+struct UnifiedFindOneAndUpdate: UnifiedOperationProtocol {
+    /// Filter to use for the operation.
+    let filter: BSONDocument
+
+    /// Update to use for this operation.
+    let update: BSONDocument
+
+    /// Options to use for the operation.
+    let options: FindOneAndUpdateOptions
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case filter, update, session
+    }
+
+    static var knownArguments: Set<String> {
+        Set(
+            CodingKeys.allCases.map { $0.rawValue } +
+                FindOneAndUpdateOptions().propertyNames
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        self.options = try decoder.singleValueContainer().decode(FindOneAndUpdateOptions.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.session = try container.decodeIfPresent(String.self, forKey: .session)
+        self.filter = try container.decode(BSONDocument.self, forKey: .filter)
+        self.update = try container.decode(BSONDocument.self, forKey: .update)
+    }
+}
+
+struct UnifiedDeleteOne: UnifiedOperationProtocol {
+    /// Filter to use for the operation.
+    let filter: BSONDocument
+
+    /// Options to use for the operation.
+    let options: DeleteOptions
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case session, filter
+    }
+
+    static var knownArguments: Set<String> {
+        Set(
+            CodingKeys.allCases.map { $0.rawValue } +
+                DeleteOptions().propertyNames
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.filter = try container.decode(BSONDocument.self, forKey: .filter)
+        self.session = try container.decodeIfPresent(String.self, forKey: .session)
+        self.options = try decoder.singleValueContainer().decode(DeleteOptions.self)
     }
 }
 
@@ -48,7 +217,7 @@ struct UnifiedInsertOne: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         Set(
             CodingKeys.allCases.map { $0.rawValue } +
-                Mirror(reflecting: InsertOneOptions()).children.map { $0.label! }
+                InsertOneOptions().propertyNames
         )
     }
 
@@ -57,5 +226,67 @@ struct UnifiedInsertOne: UnifiedOperationProtocol {
         self.document = try container.decode(BSONDocument.self, forKey: .document)
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.options = try decoder.singleValueContainer().decode(InsertOneOptions.self)
+    }
+}
+
+struct UnifiedInsertMany: UnifiedOperationProtocol {
+    /// Documents to insert.
+    let documents: [BSONDocument]
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    /// Options to use while executing the operation.
+    let options: InsertManyOptions
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case documents, session
+    }
+
+    static var knownArguments: Set<String> {
+        Set(
+            CodingKeys.allCases.map { $0.rawValue } +
+                InsertManyOptions().propertyNames
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.documents = try container.decode([BSONDocument].self, forKey: .documents)
+        self.session = try container.decodeIfPresent(String.self, forKey: .session)
+        self.options = try decoder.singleValueContainer().decode(InsertManyOptions.self)
+    }
+}
+
+struct UnifiedReplaceOne: UnifiedOperationProtocol {
+    /// Filter for the query.
+    let filter: BSONDocument
+
+    /// Replacement document.
+    let replacement: BSONDocument
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    /// Options to use while executing the operation.
+    let options: ReplaceOptions
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case filter, replacement, session
+    }
+
+    static var knownArguments: Set<String> {
+        Set(
+            CodingKeys.allCases.map { $0.rawValue } +
+                ReplaceOptions().propertyNames
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.filter = try container.decode(BSONDocument.self, forKey: .filter)
+        self.replacement = try container.decode(BSONDocument.self, forKey: .replacement)
+        self.session = try container.decodeIfPresent(String.self, forKey: .session)
+        self.options = try decoder.singleValueContainer().decode(ReplaceOptions.self)
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedDatabaseOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedDatabaseOperations.swift
@@ -1,0 +1,23 @@
+struct UnifiedCreateCollection: UnifiedOperationProtocol {
+    /// The collection to create.
+    let collection: String
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    static var knownArguments: Set<String> {
+        ["collection", "session"]
+    }
+}
+
+struct UnifiedDropCollection: UnifiedOperationProtocol {
+    /// The collection to drop.
+    let collection: String
+
+    /// Optional identifier for a session entity to use.
+    let session: String?
+
+    static var knownArguments: Set<String> {
+        ["collection", "session"]
+    }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
@@ -53,27 +53,78 @@ struct UnifiedOperation: Decodable {
 
         let name = try container.decode(String.self, forKey: .name)
         switch name {
+        case "abortTransaction":
+            self.operation = UnifiedAbortTransaction()
+        case "aggregate":
+            self.operation = try container.decode(UnifiedAggregate.self, forKey: .arguments)
+        case "assertCollectionExists":
+            self.operation = try container.decode(UnifiedAssertCollectionExists.self, forKey: .arguments)
+        case "assertCollectionNotExists":
+            self.operation = try container.decode(UnifiedAssertCollectionNotExists.self, forKey: .arguments)
+        case "assertIndexExists":
+            self.operation = try container.decode(UnifiedAssertIndexExists.self, forKey: .arguments)
+        case "assertIndexNotExists":
+            self.operation = try container.decode(UnifiedAssertIndexNotExists.self, forKey: .arguments)
         case "assertDifferentLsidOnLastTwoCommands":
             self.operation = try container.decode(AssertDifferentLsidOnLastTwoCommands.self, forKey: .arguments)
         case "assertSameLsidOnLastTwoCommands":
             self.operation = try container.decode(AssertSameLsidOnLastTwoCommands.self, forKey: .arguments)
+        case "assertSessionDirty":
+            self.operation = try container.decode(AssertSessionDirty.self, forKey: .arguments)
         case "assertSessionNotDirty":
             self.operation = try container.decode(AssertSessionNotDirty.self, forKey: .arguments)
+        case "assertSessionPinned":
+            self.operation = try container.decode(UnifiedAssertSessionPinned.self, forKey: .arguments)
+        case "assertSessionUnpinned":
+            self.operation = try container.decode(UnifiedAssertSessionUnpinned.self, forKey: .arguments)
+        case "assertSessionTransactionState":
+            self.operation = try container.decode(UnifiedAssertSessionTransactionState.self, forKey: .arguments)
+        case "bulkWrite":
+            self.operation = try container.decode(UnifiedBulkWrite.self, forKey: .arguments)
+        case "commitTransaction":
+            self.operation = UnifiedCommitTransaction()
         case "createChangeStream":
             self.operation = try container.decode(CreateChangeStream.self, forKey: .arguments)
+        case "createCollection":
+            self.operation = try container.decode(UnifiedCreateCollection.self, forKey: .arguments)
+        case "createIndex":
+            self.operation = try container.decode(UnifiedCreateIndex.self, forKey: .arguments)
+        case "deleteOne":
+            self.operation = try container.decode(UnifiedDeleteOne.self, forKey: .arguments)
+        case "dropCollection":
+            self.operation = try container.decode(UnifiedDropCollection.self, forKey: .arguments)
         case "endSession":
             self.operation = EndSession()
         case "find":
             self.operation = try container.decode(UnifiedFind.self, forKey: .arguments)
+        case "findOneAndReplace":
+            self.operation = try container.decode(UnifiedFindOneAndReplace.self, forKey: .arguments)
+        case "findOneAndUpdate":
+            self.operation = try container.decode(UnifiedFindOneAndUpdate.self, forKey: .arguments)
         case "failPoint":
             self.operation = try container.decode(UnifiedFailPoint.self, forKey: .arguments)
         case "insertOne":
             self.operation = try container.decode(UnifiedInsertOne.self, forKey: .arguments)
+        case "insertMany":
+            self.operation = try container.decode(UnifiedInsertMany.self, forKey: .arguments)
         case "iterateUntilDocumentOrError":
             self.operation = IterateUntilDocumentOrError()
-        default:
-            // this is temporary so the tests compile/pass even though we don't have all the operations yet
+        case "listDatabases":
+            self.operation = UnifiedListDatabases()
+        case "replaceOne":
+            self.operation = try container.decode(UnifiedReplaceOne.self, forKey: .arguments)
+        case "startTransaction":
+            self.operation = UnifiedStartTransaction()
+        case "targetedFailPoint":
+            self.operation = try container.decode(UnifiedTargetedFailPoint.self, forKey: .arguments)
+        // GridFS ops
+        case "delete", "download", "upload":
             self.operation = Placeholder()
+        // convenient txn API
+        case "withTransaction":
+            self.operation = Placeholder()
+        default:
+            throw TestError(message: "unrecognized operation name \(name)")
         }
 
         if type(of: self.operation) != Placeholder.self,
@@ -102,6 +153,7 @@ struct UnifiedOperation: Decodable {
     }
 }
 
+/// Placeholder for an unsupported operation.
 struct Placeholder: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedSessionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedSessionOperations.swift
@@ -1,3 +1,15 @@
 struct EndSession: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
 }
+
+struct UnifiedStartTransaction: UnifiedOperationProtocol {
+    static var knownArguments: Set<String> { [] }
+}
+
+struct UnifiedCommitTransaction: UnifiedOperationProtocol {
+    static var knownArguments: Set<String> { [] }
+}
+
+struct UnifiedAbortTransaction: UnifiedOperationProtocol {
+    static var knownArguments: Set<String> { [] }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -43,9 +43,17 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
             asType: UnifiedTestFile.self
         )).toNot(throwError())
 
+        let skipValidFailTests = [
+            // Because we use an enum to represent ReturnDocument, the invalid string present in this file "Invalid"
+            // gives us a decoding error, and therefore we cannot decode it. Other drivers may not report an error
+            // until runtime.
+            "returnDocument-enum-invalid.json"
+        ]
+
         expect(try retrieveSpecTestFiles(
             specName: "unified-test-format",
             subdirectory: "valid-fail",
+            excludeFiles: skipValidFailTests,
             asType: UnifiedTestFile.self
         )).toNot(throwError())
     }


### PR DESCRIPTION
This PR is a bit larger than the past ones, but is for the most part very repetitive so hopefully is not too difficult to review. 

I'm sure we are missing some operations right now, and/or optional arguments for operations, that might be added at some point as I did not exhaustively comb through every spec, but the design of the runner here where we error on both unsupported operation names and unsupported argument names should make it very easy to identify those cases in the future.

Comments inline