### PR TITLE
SWIFT-592 Move format/lint/sourcery check to Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -188,19 +188,56 @@ functions:
             perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $filename
           done
 
-  "install dependencies":
+  "install swift":
     - command: shell.exec
       params:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-
           SWIFT_VERSION=${SWIFT_VERSION} \
-            sh ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
+            sh ${PROJECT_DIRECTORY}/.evergreen/install-swift.sh
+  
+  "format":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          SWIFT_VERSION=${SWIFT_VERSION} \
+            bash ${PROJECT_DIRECTORY}/.evergreen/install-tools.sh swiftformat
+          SWIFT_VERSION=${SWIFT_VERSION} \
+          ${PROJECT_DIRECTORY}/opt/swiftformat/.build/release/swiftformat --verbose --lint .
+  
+  "lint":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          SWIFT_VERSION=${SWIFT_VERSION} \
+            bash ${PROJECT_DIRECTORY}/.evergreen/install-tools.sh swiftlint
+          LINUX_SOURCEKIT_LIB_PATH=${PROJECT_DIRECTORY}/opt/swiftenv/versions/${SWIFT_VERSION}/usr/lib \
+            ${PROJECT_DIRECTORY}/opt/swiftlint/.build/release/swiftlint --strict --quiet
+  
+  "sourcery":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          SWIFT_VERSION=${SWIFT_VERSION} \
+            bash ${PROJECT_DIRECTORY}/.evergreen/install-tools.sh sourcery
+          make linuxmain SOURCERY=${PROJECT_DIRECTORY}/opt/sourcery/bin/sourcery
+          git diff --exit-code Tests/LinuxMain.swift
+          make exports SOURCERY=${PROJECT_DIRECTORY}/opt/sourcery/bin/sourcery
+          git diff --exit-code Sources/MongoSwiftSync/Exports.swift
 
 pre:
   - func: "fetch source"
-  - func: "install dependencies"
+  - func: "install swift"
 
 post:
   - func: "stop mongo-orchestration"
@@ -379,6 +416,18 @@ tasks:
       commands:
         - func: "run atlas tests"
 
+    - name: "check-format"
+      commands:
+      - func: "format"
+
+    - name: "check-lint"
+      commands:
+        - func: "lint"
+    
+    - name: "check-sourcery"
+      commands:
+        - func: "sourcery"
+
 axes:
   - id: versions
     display_name: MongoDB Version
@@ -541,3 +590,20 @@ buildvariants:
   display_name: "Atlas Connectivity ${swift-version} ${os-fully-featured}"
   tasks:
     - ".atlas-connect"
+
+- matrix_name: "format-lint"
+  display_name: "Format and Lint"
+  matrix_spec:
+    os-fully-featured: "ubuntu-18.04"
+    swift-version: "5.3"
+  tasks:
+    - name: "check-format"
+    - name: "check-lint"
+
+- matrix_name: "check-sourcery"
+  display_name: "Check Sourcery"
+  matrix_spec:
+    os-fully-featured: "macos-10.14"
+    swift-version: "5.2"
+  tasks:
+    - name: "check-sourcery"

--- a/.evergreen/install-swift.sh
+++ b/.evergreen/install-swift.sh
@@ -4,13 +4,11 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 # variables
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
-SWIFT_VERSION=${SWIFT_VERSION:-5.0.3}
+SWIFT_VERSION=${SWIFT_VERSION:-5.1.5}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
-BUILD_DIR="${PROJECT_DIRECTORY}/libmongoc-build"
-EVG_DIR=$(dirname $0)
 
 export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
-export PATH=/opt/cmake/bin:${SWIFTENV_ROOT}/bin:$PATH
+export PATH="${SWIFTENV_ROOT}/bin:$PATH"
 
 # install swiftenv
 git clone --depth 1 -b "osx-install-path" https://github.com/mbroadst/swiftenv.git "${SWIFTENV_ROOT}"

--- a/.evergreen/install-tools.sh
+++ b/.evergreen/install-tools.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Script for installing various tool dependencies.
+
+# variables
+PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
+SWIFT_VERSION=${SWIFT_VERSION:-5.2.4}
+INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
+
+export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
+export PATH="${SWIFTENV_ROOT}/bin:$PATH"
+
+# usage: build_from_gh [name] [url] [tag]
+build_from_gh () {
+    NAME=$1
+    URL=$2
+    TAG=$3
+
+    git clone ${URL} --depth 1 --branch ${TAG} ${INSTALL_DIR}/${NAME}
+    cd ${INSTALL_DIR}/${NAME}
+    swift build -c release
+    cd -
+}
+
+# usage: install_from_gh [name] [url]
+install_from_gh () {
+    NAME=$1
+    URL=$2
+    mkdir ${INSTALL_DIR}/${NAME}
+    curl -L ${URL} -o ${INSTALL_DIR}/${NAME}/${NAME}.zip
+    unzip ${INSTALL_DIR}/${NAME}/${NAME}.zip -d ${INSTALL_DIR}/${NAME}
+}
+
+# enable swiftenv
+eval "$(swiftenv init -)"
+swiftenv local $SWIFT_VERSION
+
+if [ $1 == "swiftlint" ]
+then
+    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.41.0"
+elif [ $1 == "swiftformat" ]
+then
+    build_from_gh swiftformat https://github.com/nicklockwood/SwiftFormat "0.47.3"
+elif [ $1 == "sourcery" ]
+then
+    install_from_gh sourcery https://github.com/krzysztofzablocki/Sourcery/releases/download/1.0.0/Sourcery-1.0.0.zip
+else
+    echo Missing/unknown install option: "$1"
+fi

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,7 @@
 --exclude Sources/MongoSwift/MongoSwiftVersion.swift,Sources/MongoSwiftSync/Exports.swift
 --exclude **/.build
 --exclude etc
+--exclude opt
 
 # unnecessary
 --disable andOperator

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,8 +57,7 @@ excluded:
   - Tests/LinuxMain.swift
   - Sources/MongoSwiftSync/Exports.swift
   - Sources/MongoSwift/MongoSwiftVersion.swift
-  - etc/swiftlint
-  - etc/SwiftFormat
+  - opt
 
 trailing_whitespace:
   ignores_comments: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,34 +7,6 @@ env:
 
 jobs:
   include:
-    - stage: pre-tests
-      name: verify Sourcery has been run
-      os: osx
-      install: ./etc/install_dependencies.sh sourcery
-      before_script: skip
-      script:
-        - make linuxmain SOURCERY=${PWD}/sourcery/bin/sourcery
-        - git diff --exit-code Tests/LinuxMain.swift
-        - make exports SOURCERY=${PWD}/sourcery/bin/sourcery
-        - git diff --exit-code Sources/MongoSwiftSync/Exports.swift
-
-    - stage: pre-tests
-      name: lint
-      os: osx
-      osx_image: xcode11.3
-      install: pushd etc && ./install_dependencies.sh swiftlint && ./install_dependencies.sh swiftformat && popd
-      before_script: skip
-      script: ./etc/swiftlint/swiftlint --strict && ./etc/SwiftFormat/CommandLineTool/swiftformat --verbose --lint .
-
-    - stage: tests
-      os: osx
-      osx_image: xcode11.3
-      env: SWIFT_VERSION=5.2
-
-    - stage: tests
-      os: linux
-      env: SWIFT_VERSION=5.2
-
     - stage: post-tests
       name: code coverage
       os: osx
@@ -51,7 +23,3 @@ before_script:
   - MONGODIR=${PWD}/mongodb-${MONGODB_VERSION}
   - mkdir ${MONGODIR}/data
   - ${MONGODIR}/bin/mongod --dbpath ${MONGODIR}/data --logpath ${MONGODIR}/mongodb.log --fork
-
-script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make test-pretty; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test; fi


### PR DESCRIPTION
My branch name was a bit premature as code coverage is still being generated through Travis, but this moves everything else over and stops running tests on Travis altogether. 

It would be good to move code coverage too, though I think that will be a bit more complicated so I've opened another ticket to handle that separately at a later time: SWIFT-1019. The coverage isn't very accurate at this point because it only tests against a standalone on 3.6. We should be generating a number of reports across different Evergreen runs and merging them together. I don't think we really rely much on code coverage feedback in PRs anyway so it seems less essential to get timely feedback on.

Sample successful patch: https://spruce.mongodb.com/version/5faf1bc09ccd4e21e67cd68d/tasks

Sample patch where I intentionally broke formatting/linting/sourcery: https://spruce.mongodb.com/version/5faf1e443e8e8655c850e2ea/tasks