### PR TITLE
SWIFT-913 Add support for test runner and test case setup

### DIFF
--- a/Sources/TestsCommon/APMUtils.swift
+++ b/Sources/TestsCommon/APMUtils.swift
@@ -59,10 +59,10 @@ public class TestCommandMonitor: CommandEventHandler {
 }
 
 extension CommandEvent {
-    public enum EventType {
-        case commandStarted
-        case commandSucceeded
-        case commandFailed
+    public enum EventType: String, Decodable {
+        case commandStarted = "commandStartedEvent"
+        case commandSucceeded = "commandSucceededEvent"
+        case commandFailed = "commandFailedEvent"
     }
 
     /// The "type" of this event. Used for filtering events by their type.

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -417,7 +417,7 @@ extension TransactionsTests {
 extension UnifiedRunnerTests {
     static var allTests = [
         ("testSchemaVersion", testSchemaVersion),
-        ("testUnifiedTestDecoding", testUnifiedTestDecoding),
+        ("testSampleUnifiedTests", testSampleUnifiedTests),
         ("testStrictDecodableTypes", testStrictDecodableTypes),
     ]
 }

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -63,11 +63,15 @@ extension MongoClient {
         return try ServerVersion(versionString)
     }
 
-    /// Determine whether server version and topology requirements for a certain test are met
-    internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
+    internal func topologyType() throws -> TestTopologyConfiguration {
         let isMasterReply = try self.db("admin").runCommand(["isMaster": 1])
         let shards = try self.db("config").collection("shards").find().map { try $0.get() }
-        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
+        return try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
+    }
+
+    /// Determine whether server version and topology requirements for a certain test are met
+    internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
+        let topologyType = try self.topologyType()
         let serverVersion = try self.serverVersion()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
     }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
@@ -137,7 +137,7 @@ struct UnifiedTestClient {
             opts.minHeartbeatFrequencyMS = 50
             opts.heartbeatFrequencyMS = 50
         }
-        self.client = try MongoClient.makeTestClient(connStr, options: clientDescription.uriOptions)
+        self.client = try MongoClient.makeTestClient(connStr, options: opts)
         self.commandMonitor = UnifiedTestCommandMonitor(
             observeEvents: clientDescription.observeEvents,
             ignoreEvents: clientDescription.ignoreCommandMonitoringEvents
@@ -247,8 +247,7 @@ extension Array where Element == EntityDescription {
                 map[dbDesc.id] = .database(clientEntity.client.db(
                     dbDesc.databaseName,
                     options: dbDesc.databaseOptions
-                )
-                )
+                ))
             case let .collection(collDesc):
                 guard let db = try map[collDesc.database]?.asDatabase() else {
                     throw TestError(message: "No database with id \(collDesc.database) found in entity map")

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
@@ -1,5 +1,7 @@
 import Foundation
+@testable import struct MongoSwift.MongoClientOptions
 import MongoSwiftSync
+import TestsCommon
 
 /// Represents a description of an entity (client, db, etc.).
 enum EntityDescription: Decodable {
@@ -30,7 +32,7 @@ enum EntityDescription: Decodable {
 
         /// Types of events that can be observed for this client. Unspecified event types MUST be ignored by this
         /// client's event listeners.
-        let observeEvents: [String]?
+        let observeEvents: [CommandEvent.EventType]?
 
         /// Command names for which the test runner MUST ignore any observed command monitoring events. The command(s)
         /// will be ignored in addition to configureFailPoint and any commands containing sensitive information (per
@@ -113,5 +115,157 @@ enum EntityDescription: Decodable {
             let bucket = try container.decode(Bucket.self, forKey: .bucket)
             self = .bucket(bucket)
         }
+    }
+}
+
+/// Wrapper around a MongoClient used for test runner purposes.
+struct UnifiedTestClient {
+    let client: MongoClient
+
+    fileprivate let commandMonitor: UnifiedTestCommandMonitor
+
+    init(_ clientDescription: EntityDescription.Client) throws {
+        let connStr = MongoSwiftTestCase.getConnectionString(
+            singleMongos: clientDescription.useMultipleMongoses != true
+        ).toString()
+        var opts = clientDescription.uriOptions ?? MongoClientOptions()
+        // If the test might execute a configureFailPoint command, for each target client the test runner MAY
+        // specify a reduced value for heartbeatFrequencyMS (and minHeartbeatFrequencyMS if possible) to speed
+        // up SDAM recovery time and server selection after a failure; however, test runners MUST NOT do so for
+        // any client that specifies heartbeatFrequencyMS in its uriOptions.
+        if opts.heartbeatFrequencyMS == nil {
+            opts.minHeartbeatFrequencyMS = 50
+            opts.heartbeatFrequencyMS = 50
+        }
+        self.client = try MongoClient.makeTestClient(connStr, options: clientDescription.uriOptions)
+        self.commandMonitor = UnifiedTestCommandMonitor(
+            observeEvents: clientDescription.observeEvents,
+            ignoreEvents: clientDescription.ignoreCommandMonitoringEvents
+        )
+        self.client.addCommandEventHandler(self.commandMonitor)
+        try self.commandMonitor.enable()
+    }
+
+    /// Disables command monitoring for the client and returns a list of the captured events.
+    func stopCapturingEvents() throws -> [CommandEvent] {
+        try self.commandMonitor.disable()
+    }
+}
+
+/// Command observer used to collect a specified subset of events for a client.
+private class UnifiedTestCommandMonitor: CommandEventHandler {
+    private var monitoring: Bool
+    fileprivate var events: [CommandEvent]
+    private let observeEvents: [CommandEvent.EventType]
+    private let ignoreEvents: [String]
+
+    public init(observeEvents: [CommandEvent.EventType]?, ignoreEvents: [String]?) {
+        self.events = []
+        self.monitoring = false
+        self.observeEvents = observeEvents ?? []
+        self.ignoreEvents = (ignoreEvents ?? []) + ["configureFailPoint"]
+    }
+
+    public func handleCommandEvent(_ event: CommandEvent) {
+        guard self.monitoring else {
+            return
+        }
+        guard self.observeEvents.contains(event.type) else {
+            return
+        }
+        guard !self.ignoreEvents.contains(event.commandName) else {
+            return
+        }
+        self.events.append(event)
+    }
+
+    func enable() throws {
+        guard !self.monitoring else {
+            throw TestError(message: "TestCommandMonitor is already enabled")
+        }
+        self.monitoring = true
+    }
+
+    func disable() throws -> [CommandEvent] {
+        guard self.monitoring else {
+            throw TestError(message: "TestCommandMonitor is already disabled")
+        }
+        self.monitoring = false
+        defer { self.events.removeAll() }
+        return self.events
+    }
+}
+
+/// Represents an entity created at the start of a test.
+enum Entity {
+    case client(UnifiedTestClient)
+    case database(MongoDatabase)
+    case collection(MongoCollection<BSONDocument>)
+    case session(ClientSession)
+
+    func asTestClient() throws -> UnifiedTestClient {
+        guard case let .client(client) = self else {
+            throw TestError(message: "Failed to return entity \(self) as a client")
+        }
+        return client
+    }
+
+    func asDatabase() throws -> MongoDatabase {
+        guard case let .database(db) = self else {
+            throw TestError(message: "Failed to return entity \(self) as a database")
+        }
+        return db
+    }
+
+    func asCollection() throws -> MongoCollection<BSONDocument> {
+        guard case let .collection(coll) = self else {
+            throw TestError(message: "Failed to return entity \(self) as a collection")
+        }
+        return coll
+    }
+
+    func asSession() throws -> ClientSession {
+        guard case let .session(session) = self else {
+            throw TestError(message: "Failed to return entity \(self) as a session")
+        }
+        return session
+    }
+}
+
+extension Array where Element == EntityDescription {
+    /// Converts an array of entity descriptions from a test file into an entity map.
+    func toEntityMap() throws -> [String: Entity] {
+        var map = [String: Entity]()
+        for desc in self {
+            switch desc {
+            case let .client(clientDesc):
+                map[clientDesc.id] = try .client(UnifiedTestClient(clientDesc))
+            case let .database(dbDesc):
+                guard let clientEntity = try map[dbDesc.client]?.asTestClient() else {
+                    throw TestError(message: "No client with id \(dbDesc.client) found in entity map")
+                }
+                map[dbDesc.id] = .database(clientEntity.client.db(
+                    dbDesc.databaseName,
+                    options: dbDesc.databaseOptions
+                )
+                )
+            case let .collection(collDesc):
+                guard let db = try map[collDesc.database]?.asDatabase() else {
+                    throw TestError(message: "No database with id \(collDesc.database) found in entity map")
+                }
+                map[collDesc.id] = .collection(db.collection(
+                    collDesc.collectionName,
+                    options: collDesc.collectionOptions
+                ))
+            case let .session(sessionDesc):
+                guard let clientEntity = try map[sessionDesc.client]?.asTestClient() else {
+                    throw TestError(message: "No client with id \(sessionDesc.client) found in entity map")
+                }
+                map[sessionDesc.id] = .session(clientEntity.client.startSession(options: sessionDesc.sessionOptions))
+            case .bucket:
+                throw TestError(message: "Unsupported entity type bucket")
+            }
+        }
+        return map
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -25,7 +25,7 @@ struct UnifiedTestRunner {
             // The test runner MAY ignore any command failure with error Interrupted(11601) to work around
             // SERVER-38335.
             do {
-                let opts = RunCommandOptions(readPreference: .secondary)
+                let opts = RunCommandOptions(readPreference: .primary)
                 _ = try self.internalClient.db("admin").runCommand(["killAllSessions": []], options: opts)
             } catch let commandError as MongoError.CommandError where commandError.code == 11601 {}
         case .sharded, .shardedReplicaSet:

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -1,0 +1,140 @@
+import MongoSwiftSync
+import TestsCommon
+
+struct UnifiedTestRunner {
+    let internalClient: MongoClient
+    let serverVersion: ServerVersion
+    let topologyType: TestTopologyConfiguration
+
+    static let minSchemaVersion = SchemaVersion(rawValue: "1.0.0")!
+    static let maxSchemaVersion = SchemaVersion(rawValue: "1.0.0")!
+
+    init() throws {
+        let connStr = MongoSwiftTestCase.getConnectionString(singleMongos: false).toString()
+        self.internalClient = try MongoClient.makeTestClient(connStr)
+        self.serverVersion = try self.internalClient.serverVersion()
+        self.topologyType = try self.internalClient.topologyType()
+
+        // The test runner SHOULD terminate any open transactions using the internal MongoClient before executing any
+        // tests. Using the internal MongoClient, execute the killAllSessions command on either the primary or, if
+        // connected to a sharded cluster, all mongos servers.
+        switch self.topologyType {
+        case .single:
+            return
+        case .replicaSet:
+            let admin = self.internalClient.db("admin")
+            for address in MongoSwiftTestCase.getHosts() {
+                let isMaster = try admin.runCommand(["isMaster": 1], on: address)["ismaster"]!.boolValue!
+                if isMaster {
+                    // The test runner MAY ignore any command failure with error Interrupted(11601) to work around
+                    // SERVER-38335.
+                    do {
+                        _ = try admin.runCommand(["killAllSessions": []], on: address)
+                    } catch let commandError as MongoError.CommandError where commandError.code == 11601 {
+                        continue
+                    }
+                    return
+                }
+            }
+        case .sharded, .shardedReplicaSet:
+            for address in MongoSwiftTestCase.getHosts() {
+                do {
+                    _ = try self.internalClient.db("admin").runCommand(["killAllSessions": []], on: address)
+                } catch let commandError as MongoError.CommandError where commandError.code == 11601 {
+                    continue
+                }
+            }
+        }
+    }
+
+    func getUnmetRequirement(_ requirement: TestRequirement) -> UnmetRequirement? {
+        requirement.getUnmetRequirement(givenCurrent: self.serverVersion, self.topologyType)
+    }
+
+    func runFiles(_ files: [UnifiedTestFile]) throws {
+        for file in files {
+            // Upon loading a file, the test runner MUST read the schemaVersion field and determine if the test file
+            // can be processed further.
+            guard file.schemaVersion >= Self.minSchemaVersion && file.schemaVersion <= Self.maxSchemaVersion else {
+                throw TestError(
+                    message: "Test file \"\(file.description)\" has unsupported schema version \(file.schemaVersion)"
+                )
+            }
+
+            // If runOnRequirements is specified, the test runner MUST skip the test file unless one or more
+            //  runOnRequirement objects are satisfied.
+            if let requirements = file.runOnRequirements {
+                guard requirements.contains(where: { self.getUnmetRequirement($0) == nil }) else {
+                    fileLevelLog("Skipping tests from file \"\(file.description)\", deployment requirements not met.")
+                    continue
+                }
+            }
+
+            for test in file.tests {
+                // If test.skipReason is specified, the test runner MUST skip this test and MAY use the string value to
+                // log a message.
+                if let skipReason = test.skipReason {
+                    fileLevelLog(
+                        "Skipping test \"\(test.description)\" from file \"\(file.description)\": \(skipReason)."
+                    )
+                    continue
+                }
+
+                // If test.runOnRequirements is specified, the test runner MUST skip the test unless one or more
+                // runOnRequirement objects are satisfied.
+                if let requirements = test.runOnRequirements {
+                    guard requirements.contains(where: { self.getUnmetRequirement($0) == nil }) else {
+                        fileLevelLog(
+                            "Skipping test \"\(test.description)\" from file \"\(file.description)\", " +
+                                "deployment requirements not met."
+                        )
+                        continue
+                    }
+                }
+
+                fileLevelLog("Running test \"\(test.description)\" from file \"\(file.description)\"")
+
+                // If initialData is specified, for each collectionData therein the test runner MUST drop the
+                // collection and insert the specified documents (if any) using a "majority" write concern. If no
+                // documents are specified, the test runner MUST create the collection with a "majority" write concern.
+                // The test runner MUST use the internal MongoClient for these operations.
+                if let initialData = file.initialData {
+                    for collData in initialData {
+                        let db = self.internalClient.db(collData.databaseName)
+                        let coll = db.collection(collData.collectionName)
+                        try coll.drop(options: DropCollectionOptions(writeConcern: .majority))
+
+                        guard !collData.documents.isEmpty else {
+                            _ = try db.createCollection(
+                                collData.collectionName,
+                                options: CreateCollectionOptions(writeConcern: .majority)
+                            )
+                            continue
+                        }
+
+                        try coll.insertMany(collData.documents, options: InsertManyOptions(writeConcern: .majority))
+                    }
+                }
+
+                let entityMap = try file.createEntities?.toEntityMap() ?? [:]
+
+                // Workaround for SERVER-39704:  a test runners MUST execute a non-transactional distinct command on
+                // each mongos server before running any test that might execute distinct within a transaction. To ease
+                // the implementation, test runners MAY execute distinct before every test.
+                if self.topologyType == .sharded || self.topologyType == .shardedReplicaSet {
+                    let collEntities = entityMap.values.compactMap { try? $0.asCollection() }
+                    for address in MongoSwiftTestCase.getHosts() {
+                        for entity in collEntities {
+                            _ = try self.internalClient.db(entity.namespace.db).runCommand(
+                                ["distinct": .string(entity.name), "key": "_id"],
+                                on: address
+                            )
+                        }
+                    }
+                }
+
+                // TODO: execute operations here and perform assertions
+            }
+        }
+    }
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -36,14 +36,23 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
         }
     }
 
-    func testUnifiedTestDecoding() throws {
-        expect(try retrieveSpecTestFiles(
+    func testSampleUnifiedTests() throws {
+        // unsupported driver APIs
+        let skipValidPassFiles = [
+            "poc-gridfs.json",
+            "poc-transactions-convenient-api.json"
+        ]
+        let validPassTests = try retrieveSpecTestFiles(
             specName: "unified-test-format",
             subdirectory: "valid-pass",
+            excludeFiles: skipValidPassFiles,
             asType: UnifiedTestFile.self
-        )).toNot(throwError())
+        ).map { $0.1 }
 
-        let skipValidFailTests = [
+        let runner = try UnifiedTestRunner()
+        try runner.runFiles(validPassTests)
+
+        let skipValidFailFiles = [
             // Because we use an enum to represent ReturnDocument, the invalid string present in this file "Invalid"
             // gives us a decoding error, and therefore we cannot decode it. Other drivers may not report an error
             // until runtime.
@@ -53,9 +62,11 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
         expect(try retrieveSpecTestFiles(
             specName: "unified-test-format",
             subdirectory: "valid-fail",
-            excludeFiles: skipValidFailTests,
+            excludeFiles: skipValidFailFiles,
             asType: UnifiedTestFile.self
         )).toNot(throwError())
+
+        // TODO: run and assert valid fail tests fail
     }
 
     func testStrictDecodableTypes() throws {


### PR DESCRIPTION
This adds support for all of the setup code that is necessary to run before executing operations, e.g. populating entity map, running necessary commands to ensure the topology is in a good state, etc.