### PR TITLE
SWIFT-913 Start adding support for operations; support non-error result and event matching

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -359,7 +359,7 @@ public struct DeleteOptions: Codable, BulkWriteOptionsConvertible {
 // Write command results structs
 
 /// The result of an `insertOne` command on a `MongoCollection`.
-public struct InsertOneResult: Decodable {
+public struct InsertOneResult: Codable {
     /// The identifier that was inserted. If the document doesn't have an identifier, this value
     /// will be generated and added to the document before insertion.
     public let insertedID: BSON

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
@@ -299,22 +299,6 @@ extension EntityMap {
         return entity
     }
 
-    func getEntityAsCollection(from object: UnifiedOperation.Object) throws -> MongoCollection<BSONDocument> {
-        try self.getEntity(from: object).asCollection()
-    }
-
-    func getEntityAsChangeStream(from object: UnifiedOperation.Object) throws -> ChangeStream<BSONDocument> {
-        try self.getEntity(from: object).asChangeStream()
-    }
-
-    func getEntityAsBSON(from object: UnifiedOperation.Object) throws -> BSON {
-        try self.getEntity(from: object).asBSON()
-    }
-
-    func getEntityAsSession(from object: UnifiedOperation.Object) throws -> ClientSession {
-        try self.getEntity(from: object).asSession()
-    }
-
     func resolveSession(id: String?) throws -> ClientSession? {
         guard let id = id else {
             return nil

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
@@ -118,6 +118,7 @@ enum MatchableResult {
         }
     }
 
+    /// Determines whether `self` matches the provided BSON number.
     /// When comparing numeric types (excluding Decimal128), test runners MUST consider 32-bit, 64-bit, and floating
     /// point numbers to be equal if their values are numerically equivalent.
     private func matchesNumber(_ expected: BSON) -> Bool {
@@ -132,7 +133,7 @@ enum MatchableResult {
         return abs(actualDouble - expected.toDouble()!) < 0.0001
     }
 
-    /// Determines whether `self` satisfies the special matching operator in the provided `operatorDoc`.
+    /// Determines whether `self` satisfies the provided special operator.
     private func matchesSpecial(_ specialOperator: BSONDocument, entities: EntityMap) throws -> Bool {
         let op = SpecialOperator(from: specialOperator)
         switch op {

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
@@ -85,7 +85,7 @@ func matchesInner(
 
         return true
     case .int32, .int64, .double:
-        return matchNumbers(expected: expected, actual: actual)
+        return matchesNumber(expected: expected, actual: actual)
     default:
         return actual == expected
     }
@@ -93,7 +93,7 @@ func matchesInner(
 
 /// When comparing numeric types (excluding Decimal128), test runners MUST consider 32-bit, 64-bit, and floating point
 /// numbers to be equal if their values are numerically equivalent.
-func matchNumbers(expected: BSON, actual: BSON?) -> Bool {
+func matchesNumber(expected: BSON, actual: BSON?) -> Bool {
     guard let actualDouble = actual?.toDouble() else {
         return false
     }
@@ -114,7 +114,7 @@ func matchesSpecial(operatorDoc: BSONDocument, actual: BSON?, entities: EntityMa
     case "$$exists":
         return value.boolValue! == (actual != nil)
     case "$$type":
-        return try typeMatches(expectedType: value, actual: actual)
+        return try matchesType(expectedType: value, actual: actual)
     case "$$matchesEntity":
         guard let id = value.stringValue else {
             throw TestError(
@@ -141,7 +141,7 @@ func matchesSpecial(operatorDoc: BSONDocument, actual: BSON?, entities: EntityMa
 }
 
 /// Determines whether `actual` satisfies the $$type operator value `expectedType`.
-func typeMatches(expectedType: BSON, actual: BSON?) throws -> Bool {
+func matchesType(expectedType: BSON, actual: BSON?) throws -> Bool {
     guard let actual = actual else {
         return false
     }
@@ -200,7 +200,7 @@ func typeMatches(expectedType: BSON, actual: BSON?) throws -> Bool {
 }
 
 /// Determiens the events in `actual` match the events in `expected`.
-func eventsMatch(expected: [ExpectedEvent], actual: [CommandEvent], entities: EntityMap) throws -> Bool {
+func matchesEvents(expected: [ExpectedEvent], actual: [CommandEvent], entities: EntityMap) throws -> Bool {
     guard actual.count == expected.count else {
         return false
     }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
@@ -1,0 +1,263 @@
+import MongoSwiftSync
+import TestsCommon
+
+extension UnifiedOperationResult {
+    /// Determines whether this result matches `expected`. `opReturnsRootDocs` should be set to `true` if this result
+    /// was obtained from an operation that returns root documents.
+    func matches(expected: BSON, entities: EntityMap, opReturnsRootDocs: Bool) throws -> Bool {
+        let actual: BSON?
+        switch self {
+        case let .bson(bson):
+            actual = bson
+        case .none:
+            actual = nil
+        default:
+            return false
+        }
+
+        return try matchesInner(
+            expected: expected,
+            actual: actual,
+            entities: entities,
+            isRoot: true,
+            containsRootDocs: opReturnsRootDocs
+        )
+    }
+}
+
+/// Determines whether `actual` matches `expected`, recursing if needed for nested documents and arrays. `isRoot`
+/// should be set to `true` if `expected` is a root document per the spec. `containsRootDocs` should be set to true if
+/// `expected` is a top-level array which contains root documents.
+func matchesInner(
+    expected: BSON,
+    actual: BSON?,
+    entities: EntityMap,
+    isRoot: Bool = false,
+    containsRootDocs: Bool = false
+) throws -> Bool {
+    switch expected {
+    case let .document(expectedDoc):
+        if expectedDoc.isSpecialOperator {
+            return try matchesSpecial(operatorDoc: expectedDoc, actual: actual, entities: entities)
+        }
+
+        // The only case in which nil is an acceptable value is if the expected document is a special operator;
+        // otherwise, the two documents do not match.
+        guard let actualDoc = actual?.documentValue else {
+            return false
+        }
+
+        for (k, v) in expectedDoc {
+            guard try matchesInner(expected: v, actual: actualDoc[k], entities: entities) else {
+                return false
+            }
+        }
+
+        // Documents that are not the root-level document should not contain extra keys.
+        if !isRoot {
+            for k in actualDoc.keys {
+                guard expectedDoc.keys.contains(k) else {
+                    return false
+                }
+            }
+        }
+
+        return true
+    case let .array(expectedArray):
+        guard let actualArray = actual?.arrayValue else {
+            return false
+        }
+
+        guard actualArray.count == expectedArray.count else {
+            return false
+        }
+
+        for (actualElt, expectedElt) in zip(actualArray, expectedArray) {
+            guard try matchesInner(
+                expected: expectedElt,
+                actual: actualElt,
+                entities: entities,
+                isRoot: containsRootDocs
+            ) else {
+                return false
+            }
+        }
+
+        return true
+    case .int32, .int64, .double:
+        return matchNumbers(expected: expected, actual: actual)
+    default:
+        return actual == expected
+    }
+}
+
+/// When comparing numeric types (excluding Decimal128), test runners MUST consider 32-bit, 64-bit, and floating point
+/// numbers to be equal if their values are numerically equivalent.
+func matchNumbers(expected: BSON, actual: BSON?) -> Bool {
+    guard let actualDouble = actual?.toDouble() else {
+        return false
+    }
+    return actualDouble == expected.toDouble()!
+}
+
+extension BSONDocument {
+    /// Returns whether this document is a special matching operator.
+    var isSpecialOperator: Bool {
+        self.count == 1 && self.keys[0].starts(with: "$$")
+    }
+}
+
+/// Determines whether `actual` satisfies the special matching operator in the provided `operatorDoc`.
+func matchesSpecial(operatorDoc: BSONDocument, actual: BSON?, entities: EntityMap) throws -> Bool {
+    let (op, value) = operatorDoc.first!
+    switch op {
+    case "$$exists":
+        return value.boolValue! == (actual != nil)
+    case "$$type":
+        return try typeMatches(expectedType: value, actual: actual)
+    case "$$matchesEntity":
+        guard let id = value.stringValue else {
+            throw TestError(
+                message: "Expected $$matchesEntity to be a string, got \(value) with type \(type(of: value))"
+            )
+        }
+        let entity = try entities.getEntity(id: id).asBSON()
+        return try matchesInner(expected: entity, actual: actual, entities: entities)
+    case "$$matchesHexBytes":
+        throw TestError(message: "Unsupported special operator $$matchesHexBytes")
+    case "$$unsetOrMatches":
+        return try actual == nil || matchesInner(expected: value, actual: actual, entities: entities)
+    case "$$sessionLsid":
+        guard let id = value.stringValue else {
+            throw TestError(
+                message: "Expected $$sessionLsid to be a string, got \(value) with type \(type(of: value))"
+            )
+        }
+        let session = try entities.getEntity(id: id).asSession()
+        return actual?.documentValue == session.id
+    default:
+        throw TestError(message: "Unrecognized special operator \(op)")
+    }
+}
+
+/// Determines whether `actual` satisfies the $$type operator value `expectedType`.
+func typeMatches(expectedType: BSON, actual: BSON?) throws -> Bool {
+    guard let actual = actual else {
+        return false
+    }
+    guard let typeString = expectedType.stringValue else {
+        throw TestError(
+            message: "Expected $$type to be a string, got \(expectedType) with type \(type(of: expectedType))"
+        )
+    }
+    // aliases from https://docs.mongodb.com/manual/reference/operator/query/type/#available-types
+    switch typeString {
+    case "double":
+        return actual.type == .double
+    case "string":
+        return actual.type == .string
+    case "object":
+        return actual.type == .document
+    case "array":
+        return actual.type == .array
+    case "binData":
+        return actual.type == .binary
+    case "undefined":
+        return actual.type == .undefined
+    case "objectId":
+        return actual.type == .objectID
+    case "bool":
+        return actual.type == .bool
+    case "date":
+        return actual.type == .datetime
+    case "null":
+        return actual.type == .null
+    case "regex":
+        return actual.type == .regex
+    case "dbPointer":
+        return actual.type == .dbPointer
+    case "javascript":
+        return actual.type == .code
+    case "symbol":
+        return actual.type == .symbol
+    case "javascriptWithScope":
+        return actual.type == .codeWithScope
+    case "int":
+        return actual.type == .int32
+    case "timestamp":
+        return actual.type == .timestamp
+    case "long":
+        return actual.type == .int64
+    case "decimal":
+        return actual.type == .decimal128
+    case "minKey":
+        return actual.type == .minKey
+    case "maxKey":
+        return actual.type == .maxKey
+    default:
+        throw TestError(message: "Unrecognized $$typeMatches value \(typeString)")
+    }
+}
+
+/// Determiens the events in `actual` match the events in `expected`.
+func eventsMatch(expected: [ExpectedEvent], actual: [CommandEvent], entities: EntityMap) throws -> Bool {
+    guard actual.count == expected.count else {
+        return false
+    }
+
+    for (expectedEvent, actualEvent) in zip(expected, actual) {
+        switch (expectedEvent, actualEvent) {
+        case let (.commandStarted(expectedStarted), .started(actualStarted)):
+            if let expectedName = expectedStarted.commandName {
+                guard actualStarted.commandName == expectedName else {
+                    return false
+                }
+            }
+
+            if let expectedCommand = expectedStarted.command {
+                guard try matchesInner(
+                    expected: .document(expectedCommand),
+                    actual: .document(actualStarted.command),
+                    entities: entities,
+                    isRoot: true
+                ) else {
+                    return false
+                }
+            }
+
+            if let expectedDb = expectedStarted.databaseName {
+                guard actualStarted.databaseName == expectedDb else {
+                    return false
+                }
+            }
+        case let (.commandSucceeded(expectedSucceeded), .succeeded(actualSucceeded)):
+            if let expectedName = expectedSucceeded.commandName {
+                guard actualSucceeded.commandName == expectedName else {
+                    return false
+                }
+            }
+
+            if let expectedReply = expectedSucceeded.reply {
+                guard try matchesInner(
+                    expected: .document(expectedReply),
+                    actual: .document(actualSucceeded.reply),
+                    entities: entities,
+                    isRoot: true
+                ) else {
+                    return false
+                }
+            }
+        case let (.commandFailed(expectedFailed), .failed(actualFailed)):
+            if let expectedName = expectedFailed.commandName {
+                guard actualFailed.commandName == expectedName else {
+                    return false
+                }
+            }
+        default:
+            // event types don't match
+            return false
+        }
+    }
+
+    return true
+}

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedChangeStreamOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedChangeStreamOperations.swift
@@ -52,10 +52,10 @@ struct IterateUntilDocumentOrError: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
 
     func execute(on object: UnifiedOperation.Object, entities: EntityMap) throws -> UnifiedOperationResult {
-        let cs = try entities.getEntityAsChangeStream(from: object)
+        let cs = try entities.getEntity(from: object).asChangeStream()
         guard let next = cs.next() else {
             throw TestError(message: "Change stream unexpectedly exhausted")
         }
-        return .bson(.document(try next.get()))
+        return .rootDocument(try next.get())
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedChangeStreamOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedChangeStreamOperations.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MongoSwiftSync
+import TestsCommon
 
 struct CreateChangeStream: UnifiedOperationProtocol {
     /// Pipeline for the change stream.
@@ -28,8 +29,33 @@ struct CreateChangeStream: UnifiedOperationProtocol {
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.options = try decoder.singleValueContainer().decode(ChangeStreamOptions.self)
     }
+
+    func execute(on object: UnifiedOperation.Object, entities: EntityMap) throws -> UnifiedOperationResult {
+        let entity = try entities.getEntity(from: object)
+        let session = try entities.resolveSession(id: self.session)
+        switch entity {
+        case let .client(testClient):
+            let changeStream = try testClient.client.watch(
+                self.pipeline,
+                options: self.options,
+                session: session,
+                withEventType: BSONDocument.self
+            )
+            return .changeStream(changeStream)
+        default:
+            throw TestError(message: "Unsupported entity type \(entity) for createChangeStream operation")
+        }
+    }
 }
 
 struct IterateUntilDocumentOrError: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
+
+    func execute(on object: UnifiedOperation.Object, entities: EntityMap) throws -> UnifiedOperationResult {
+        let cs = try entities.getEntityAsChangeStream(from: object)
+        guard let next = cs.next() else {
+            throw TestError(message: "Change stream unexpectedly exhausted")
+        }
+        return .bson(.document(try next.get()))
+    }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -230,7 +230,7 @@ struct UnifiedInsertOne: UnifiedOperationProtocol {
     }
 
     func execute(on object: UnifiedOperation.Object, entities: EntityMap) throws -> UnifiedOperationResult {
-        let collection = try entities.getEntityAsCollection(from: object)
+        let collection = try entities.getEntity(from: object).asCollection()
         let session = try entities.resolveSession(id: self.session)
         guard let result = try collection.insertOne(self.document, options: self.options, session: session) else {
             return .none

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -228,6 +228,15 @@ struct UnifiedInsertOne: UnifiedOperationProtocol {
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.options = try decoder.singleValueContainer().decode(InsertOneOptions.self)
     }
+
+    func execute(on object: UnifiedOperation.Object, entities: EntityMap) throws -> UnifiedOperationResult {
+        let collection = try entities.getEntityAsCollection(from: object)
+        let session = try entities.resolveSession(id: self.session)
+        guard let result = try collection.insertOne(self.document, options: self.options, session: session) else {
+            return .none
+        }
+        return .bson(.document(try BSONEncoder().encode(result)))
+    }
 }
 
 struct UnifiedInsertMany: UnifiedOperationProtocol {

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
@@ -6,6 +6,39 @@ import TestsCommon
 protocol UnifiedOperationProtocol: Decodable {
     /// Set of supported arguments for the operation.
     static var knownArguments: Set<String> { get }
+
+    /// Indicates whether this operation returns an array of root documents. This is used when determining how to match
+    /// against the operation's expected result.
+    static var returnsRootDocuments: Bool { get }
+
+    /// Executes this operation on the provided object, using entities from `entities`.
+    func execute(on object: UnifiedOperation.Object, entities: EntityMap) throws -> UnifiedOperationResult
+}
+
+extension UnifiedOperationProtocol {
+    static var returnsRootDocuments: Bool { false }
+
+    // TODO: SWIFT-913: remove once this method is implemented for all operations
+    func execute(on _: UnifiedOperation.Object, entities _: EntityMap) throws -> UnifiedOperationResult {
+        throw TestError(message: "operation type \(Self.self) unimplemented")
+    }
+}
+
+enum UnifiedOperationResult {
+    case changeStream(ChangeStream<BSONDocument>)
+    case bson(BSON)
+    case none
+
+    func asEntity() throws -> Entity {
+        switch self {
+        case let .changeStream(cs):
+            return .changeStream(cs)
+        case let .bson(bson):
+            return .bson(bson)
+        case .none:
+            throw TestError(message: "Cannot convert result type .none to an entity")
+        }
+    }
 }
 
 struct UnifiedOperation: Decodable {
@@ -33,6 +66,13 @@ struct UnifiedOperation: Decodable {
                 self = .entity(rawValue)
             }
         }
+
+        func asEntityId() throws -> String {
+            guard case let .entity(id) = self else {
+                throw TestError(message: "Expected object to be an entity, but got testRunner")
+            }
+            return id
+        }
     }
 
     /// Object on which to perform the operation.
@@ -42,7 +82,30 @@ struct UnifiedOperation: Decodable {
     let operation: UnifiedOperationProtocol
 
     /// Expected result of the operation.
-    let result: UnifiedOperationResult?
+    let expectedResult: ExpectedOperationResult?
+
+    func executeAndCheckResult(entities: inout EntityMap) throws {
+        let actualResult = try self.operation.execute(on: self.object, entities: entities)
+        switch self.expectedResult {
+        case let .error(expectedError):
+            throw TestError(message: "I dont know how to compare errors yet")
+        case let .result(expected, saveAsEntity):
+            if let entityId = saveAsEntity {
+                entities[entityId] = try actualResult.asEntity()
+            }
+            if let expected = expected {
+                guard try actualResult.matches(
+                    expected: expected,
+                    entities: entities,
+                    opReturnsRootDocs: type(of: self.operation).returnsRootDocuments
+                ) else {
+                    throw TestError(message: "Results did not match. Actual: \(actualResult), expected: \(expected)")
+                }
+            }
+        case .none:
+            return
+        }
+    }
 
     private enum CodingKeys: String, CodingKey {
         case name, object, arguments
@@ -143,13 +206,13 @@ struct UnifiedOperation: Decodable {
         self.object = try container.decode(Object.self, forKey: .object)
 
         let singleContainer = try decoder.singleValueContainer()
-        let result = try singleContainer.decode(UnifiedOperationResult.self)
+        let result = try singleContainer.decode(ExpectedOperationResult.self)
         guard !result.isEmpty else {
-            self.result = nil
+            self.expectedResult = nil
             return
         }
 
-        self.result = result
+        self.expectedResult = result
     }
 }
 
@@ -159,7 +222,7 @@ struct Placeholder: UnifiedOperationProtocol {
 }
 
 /// Represents the expected result of an operation.
-enum UnifiedOperationResult: Decodable {
+enum ExpectedOperationResult: Decodable {
     /// One or more assertions for an error expected to be raised by the operation.
     case error(ExpectedError)
     /// - result: A value corresponding to the expected result of the operation.

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -147,7 +147,7 @@ struct UnifiedTestRunner {
                             throw TestError(message: "No client entity found with id \(clientId)")
                         }
 
-                        guard try eventsMatch(
+                        guard try matchesEvents(
                             expected: expectedEventList.events,
                             actual: actualEvents,
                             entities: entityMap

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -3,6 +3,10 @@ import Nimble
 import TestsCommon
 
 final class UnifiedRunnerTests: MongoSwiftTestCase {
+    override func setUp() {
+        self.continueAfterFailure = false
+    }
+
     func testSchemaVersion() {
         let oneTwoThree = SchemaVersion(rawValue: "1.2.3")
         expect(oneTwoThree).toNot(beNil())
@@ -47,10 +51,10 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
             subdirectory: "valid-pass",
             excludeFiles: skipValidPassFiles,
             asType: UnifiedTestFile.self
-        ).map { $0.1 }
+        ).map { $0.1 }.prefix(1)
 
         let runner = try UnifiedTestRunner()
-        try runner.runFiles(validPassTests)
+        try runner.runFiles(Array(validPassTests))
 
         let skipValidFailFiles = [
             // Because we use an enum to represent ReturnDocument, the invalid string present in this file "Invalid"


### PR DESCRIPTION
This adds support for everything that is needed to execute the [first test in the first file](https://github.com/mongodb/mongo-swift-driver/blob/8bd6f978d56a69a54dfb4c9ce74d8b8fdd78d828/Tests/Specs/unified-test-format/tests/valid-pass/poc-change-streams.json#L92) and perform the required assertions on the result:

- Extends `UnifiedOperationProtocol` to add an `execute` method and adds a general `executeAndCheckResult` method to `UnifiedOperation`
- Implements the `execute` method for operations used in this test (`createChangeStream`, `insertOne`, `iterateUntilDocumentOrError`)
- Matching (non-error) results
- Saving results as entities
- Matching observed events

The code is temporarily modified, for now, to only execute that test.... I could have kept going but I wanted to get your feedback first on what I have so far before this gets to be too massive of a diff 🙂

