### PR TITLE
SWIFT-828 Add support for hidden indexes

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -59,6 +59,10 @@ public struct IndexOptions: Codable {
     /// Optionally specifies the length in time, in seconds, for documents to remain in a collection.
     public var expireAfterSeconds: Int?
 
+    /// Optionally specifies that the index should exist on the target collection but should not be used by the query
+    /// planner when executing operations. This option is only supported by servers >= 4.4.
+    public var hidden: Bool?
+
     /// Optionally specifies the field in the document to override the language.
     public var languageOverride: String?
 
@@ -114,6 +118,7 @@ public struct IndexOptions: Codable {
         bucketSize: Int? = nil,
         collation: BSONDocument? = nil,
         defaultLanguage: String? = nil,
+        hidden: Bool? = nil,
         expireAfterSeconds: Int? = nil,
         languageOverride: String? = nil,
         max: Double? = nil,
@@ -134,6 +139,7 @@ public struct IndexOptions: Codable {
         self.collation = collation
         self.defaultLanguage = defaultLanguage
         self.expireAfterSeconds = expireAfterSeconds
+        self.hidden = hidden
         self.languageOverride = languageOverride
         self.max = max
         self.min = min
@@ -149,7 +155,7 @@ public struct IndexOptions: Codable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case background, expireAfterSeconds, name, sparse, storageEngine, unique, version = "v",
+        case background, expireAfterSeconds, hidden, name, sparse, storageEngine, unique, version = "v",
              defaultLanguage = "default_language", languageOverride = "language_override", textIndexVersion, weights,
              sphereIndexVersion = "2dsphereIndexVersion", bits, max, min, bucketSize, partialFilterExpression,
              collation

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -96,6 +96,10 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             options.bucketSize = 10
         }
 
+        if try _client!.serverVersion() >= ServerVersion(major: 4, minor: 4, patch: 0) {
+            options.hidden = false
+        }
+
         let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)
         expect(try self.coll.createIndex(model)).to(equal("testOptions"))
 
@@ -259,6 +263,7 @@ extension IndexOptions: Equatable {
             lhs.unique == rhs.unique &&
             lhs.version == rhs.version &&
             lhs.defaultLanguage == rhs.defaultLanguage &&
+            lhs.hidden == rhs.hidden &&
             lhs.languageOverride == rhs.languageOverride &&
             lhs.textIndexVersion == rhs.textIndexVersion &&
             lhs.weights == rhs.weights &&

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -97,7 +97,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         }
 
         if try _client!.serverVersion() >= ServerVersion(major: 4, minor: 4, patch: 0) {
-            options.hidden = false
+            options.hidden = true
         }
 
         let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)


### PR DESCRIPTION
Adds support for hidden indexes. [JIRA](https://jira.mongodb.org/browse/SWIFT-828)