### PR TITLE
SWIFT-913 Implement support for remaining operations and error matching

### DIFF
--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -144,10 +144,10 @@ public final class ClientSession {
     }
 
     /// The transaction state of this session.
-    internal var transactionState: TransactionState? {
+    internal var transactionState: TransactionState {
         switch self.state {
         case .notStarted, .ended:
-            return nil
+            return .none
         case let .started(session, _):
             return TransactionState(mongocTransactionState: mongoc_client_session_get_transaction_state(session))
         }
@@ -155,10 +155,7 @@ public final class ClientSession {
 
     /// Indicates whether or not the session is in a transaction.
     internal var inTransaction: Bool {
-        if let transactionState = self.transactionState {
-            return transactionState != .none
-        }
-        return false
+        self.transactionState != .none
     }
 
     /// The most recent cluster time seen by this session. This value will be nil if either of the following are true:

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -316,7 +316,7 @@ public struct BulkWriteOptions: Codable {
 }
 
 /// The result of a bulk write operation on a `MongoCollection`.
-public struct BulkWriteResult: Decodable {
+public struct BulkWriteResult: Codable {
     /// Number of documents deleted.
     public let deletedCount: Int
 

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -380,7 +380,7 @@ public struct InsertOneResult: Codable {
 }
 
 /// The result of a multi-document insert operation on a `MongoCollection`.
-public struct InsertManyResult {
+public struct InsertManyResult: Codable {
     /// Number of documents inserted.
     public let insertedCount: Int
 
@@ -395,10 +395,14 @@ public struct InsertManyResult {
         self.insertedCount = result.insertedCount
         self.insertedIDs = result.insertedIDs
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case insertedCount, insertedIDs = "insertedIds"
+    }
 }
 
 /// The result of a `delete` command on a `MongoCollection`.
-public struct DeleteResult: Decodable {
+public struct DeleteResult: Codable {
     /// The number of documents that were deleted.
     public let deletedCount: Int
 
@@ -411,7 +415,7 @@ public struct DeleteResult: Decodable {
 }
 
 /// The result of an `update` operation on a `MongoCollection`.
-public struct UpdateResult: Decodable {
+public struct UpdateResult: Codable {
     /// The number of documents that matched the filter.
     public let matchedCount: Int
 

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -458,6 +458,13 @@ extension MongoLabeledError {
     }
 }
 
+extension MongoErrorProtocol {
+    /// Returns a boolean indicating if this error occurred on the client.
+    public var isClientError: Bool {
+        self is MongoUserError || self is MongoRuntimeError
+    }
+}
+
 extension CollectionSpecificationInfo {
     public static func new(readOnly: Bool, uuid: UUID? = nil) -> CollectionSpecificationInfo {
         CollectionSpecificationInfo(readOnly: readOnly, uuid: uuid)

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Context.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Context.swift
@@ -8,7 +8,7 @@ class Context {
     /// Entities created for the test.
     var entities: EntityMap
 
-    /// Fail points enabled during test execution.
+    /// List of (fail point name, server address fail point was set on).
     var enabledFailPoints: [(String, ServerAddress?)] = []
 
     let internalClient: MongoClient

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Context.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Context.swift
@@ -8,8 +8,8 @@ class Context {
     /// Entities created for the test.
     var entities: EntityMap
 
-    /// List of (fail point name, server address fail point was set on).
-    var enabledFailPoints: [(String, ServerAddress?)] = []
+    /// Fail points that have been set during test execution and should be disabled on completion.
+    var enabledFailPoints: [FailPointGuard] = []
 
     let internalClient: MongoClient
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Context.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Context.swift
@@ -1,10 +1,22 @@
+import MongoSwiftSync
+
 /// Context passed around while executing tests.
 class Context {
     /// Path taken to get to the current state.
     var path: [String]
 
-    init(_ path: [String]) {
+    /// Entities created for the test.
+    var entities: EntityMap
+
+    /// Fail points enabled during test execution.
+    var enabledFailPoints: [(String, ServerAddress?)] = []
+
+    let internalClient: MongoClient
+
+    init(path: [String], entities: EntityMap, internalClient: MongoClient) {
         self.path = path
+        self.entities = entities
+        self.internalClient = internalClient
     }
 
     /// Executes a closure with the given path element added to the path, removing it after the closure is complete.

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/EntityDescription.swift
@@ -122,7 +122,7 @@ enum EntityDescription: Decodable {
 struct UnifiedTestClient {
     let client: MongoClient
 
-    fileprivate let commandMonitor: UnifiedTestCommandMonitor
+    let commandMonitor: UnifiedTestCommandMonitor
 
     init(_ clientDescription: EntityDescription.Client) throws {
         let connStr = MongoSwiftTestCase.getConnectionString(
@@ -153,9 +153,9 @@ struct UnifiedTestClient {
 }
 
 /// Command observer used to collect a specified subset of events for a client.
-private class UnifiedTestCommandMonitor: CommandEventHandler {
+class UnifiedTestCommandMonitor: CommandEventHandler {
     private var monitoring: Bool
-    fileprivate var events: [CommandEvent]
+    var events: [CommandEvent]
     private let observeEvents: [CommandEvent.EventType]
     private let ignoreEvents: [String]
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
@@ -22,7 +22,7 @@ struct NonMatchingError: LocalizedError {
 
 extension UnifiedOperationResult {
     /// Determines whether this result matches `expected`.
-    func matches(expected: BSON, entities: EntityMap, context: Context) throws {
+    func matches(expected: BSON, context: Context) throws {
         let actual: MatchableResult
         switch self {
         case let .bson(bson):
@@ -37,7 +37,7 @@ extension UnifiedOperationResult {
             throw NonMatchingError(expected: expected, actual: cs, context: context)
         }
 
-        try actual.matches(expected, entities: entities, context: context)
+        try actual.matches(expected, context: context)
     }
 }
 
@@ -73,11 +73,11 @@ enum MatchableResult {
     }
 
     /// Determines whether `self` matches `expected`, recursing if needed for nested documents and arrays.
-    fileprivate func matches(_ expected: BSON, entities: EntityMap, context: Context) throws {
+    fileprivate func matches(_ expected: BSON, context: Context) throws {
         switch expected {
         case let .document(expectedDoc):
             if expectedDoc.isSpecialOperator {
-                try self.matchesSpecial(expectedDoc, entities: entities, context: context)
+                try self.matchesSpecial(expectedDoc, context: context)
                 return
             }
 
@@ -86,7 +86,7 @@ enum MatchableResult {
                 for (k, v) in expectedDoc {
                     let actualValue = MatchableResult(from: actualDoc[k])
                     try context.withPushedElt(k) {
-                        try actualValue.matches(v, entities: entities, context: context)
+                        try actualValue.matches(v, context: context)
                     }
                 }
             default:
@@ -95,10 +95,12 @@ enum MatchableResult {
 
             if case let .subDocument(actualDoc) = self {
                 for k in actualDoc.keys {
-                    try context.withPushedElt(k) {
-                        guard expectedDoc.keys.contains(k) else {
-                            throw NonMatchingError(expected: nil, actual: actualDoc[k], context: context)
-                        }
+                    guard expectedDoc.keys.contains(k) else {
+                        throw NonMatchingError(
+                            expected: "doc to not have key \(k)",
+                            actual: actualDoc,
+                            context: context
+                        )
                     }
                 }
             }
@@ -121,7 +123,7 @@ enum MatchableResult {
 
             for i in 0..<actualElts.count {
                 try context.withPushedElt(String(i)) {
-                    try actualElts[i].matches(expectedArray[i], entities: entities, context: context)
+                    try actualElts[i].matches(expectedArray[i], context: context)
                 }
             }
 
@@ -150,7 +152,7 @@ enum MatchableResult {
     }
 
     /// Determines whether `self` satisfies the provided special operator.
-    private func matchesSpecial(_ specialOperator: BSONDocument, entities: EntityMap, context: Context) throws {
+    private func matchesSpecial(_ specialOperator: BSONDocument, context: Context) throws {
         let op = SpecialOperator(from: specialOperator)
         switch op {
         case let .exists(shouldExist):
@@ -167,13 +169,13 @@ enum MatchableResult {
         case let .type(expectedTypes):
             try self.matchesType(expectedTypes, context: context)
         case let .matchesEntity(id):
-            let entity = try entities.getEntity(id: id).asBSON()
-            try self.matches(entity, entities: entities, context: context)
+            let entity = try context.entities.getEntity(id: id).asBSON()
+            try self.matches(entity, context: context)
         case let .unsetOrMatches(value):
             if case .none = self {
                 return
             }
-            try self.matches(value, entities: entities, context: context)
+            try self.matches(value, context: context)
         case let .sessionLsid(id):
             guard case let .subDocument(actualDoc) = self else {
                 throw NonMatchingError(
@@ -182,7 +184,7 @@ enum MatchableResult {
                     context: context
                 )
             }
-            let session = try entities.getEntity(id: id).asSession()
+            let session = try context.entities.getEntity(id: id).asSession()
             try equals(expected: session.id, actual: actualDoc, context: context)
         }
     }
@@ -305,7 +307,7 @@ enum SpecialOperator {
 }
 
 /// Determines if the events in `actual` match the events in `expected`.
-func matchesEvents(expected: [ExpectedEvent], actual: [CommandEvent], entities: EntityMap, context: Context) throws {
+func matchesEvents(expected: [ExpectedEvent], actual: [CommandEvent], context: Context) throws {
     guard actual.count == expected.count else {
         throw NonMatchingError(expected: expected, actual: actual, context: context)
     }
@@ -326,7 +328,7 @@ func matchesEvents(expected: [ExpectedEvent], actual: [CommandEvent], entities: 
                 if let expectedCommand = expectedStarted.command {
                     let actual = MatchableResult.rootDocument(actualStarted.command)
                     try context.withPushedElt("command") {
-                        try actual.matches(.document(expectedCommand), entities: entities, context: context)
+                        try actual.matches(.document(expectedCommand), context: context)
                     }
                 }
 
@@ -345,7 +347,7 @@ func matchesEvents(expected: [ExpectedEvent], actual: [CommandEvent], entities: 
                 if let expectedReply = expectedSucceeded.reply {
                     let actual = MatchableResult.rootDocument(actualSucceeded.reply)
                     try context.withPushedElt("reply") {
-                        try actual.matches(.document(expectedReply), entities: entities, context: context)
+                        try actual.matches(.document(expectedReply), context: context)
                     }
                 }
             case let (.commandFailed(expectedFailed), .failed(actualFailed)):
@@ -356,6 +358,226 @@ func matchesEvents(expected: [ExpectedEvent], actual: [CommandEvent], entities: 
                 }
             default:
                 throw NonMatchingError(expected: expectedEvent, actual: actualEvent, context: context)
+            }
+        }
+    }
+}
+
+/// Test protocol used to indicate an error has one or more error codes and codenames. We use an array since
+/// BulkWriteErrors may have multiple failures and we need to be able to check if any of them match.
+protocol HasErrorCodes: MongoErrorProtocol {
+    var errorCodes: [MongoError.ServerErrorCode] { get }
+    var errorCodeNames: [String] { get }
+}
+
+extension MongoError.CommandError: HasErrorCodes {
+    var errorCodes: [MongoError.ServerErrorCode] { [self.code] }
+    var errorCodeNames: [String] { [self.codeName] }
+}
+
+extension MongoError.WriteError: HasErrorCodes {
+    var errorCodes: [MongoError.ServerErrorCode] {
+        if let code = self.writeFailure?.code {
+            return [code]
+        } else if let code = self.writeConcernFailure?.code {
+            return [code]
+        }
+        return []
+    }
+
+    var errorCodeNames: [String] {
+        if let codeName = self.writeFailure?.codeName {
+            return [codeName]
+        } else if let codeName = self.writeConcernFailure?.codeName {
+            return [codeName]
+        }
+        return []
+    }
+}
+
+extension MongoError.BulkWriteError: HasErrorCodes {
+    var errorCodes: [MongoError.ServerErrorCode] {
+        var codes = self.writeFailures?.map { $0.code } ?? []
+        if let wcCode = self.writeConcernFailure?.code {
+            codes.append(wcCode)
+        }
+        return codes
+    }
+
+    var errorCodeNames: [String] {
+        var codeNames = self.writeFailures?.map { $0.codeName } ?? []
+        if let wcCodeName = self.writeConcernFailure?.codeName {
+            codeNames.append(wcCodeName)
+        }
+        return codeNames
+    }
+}
+
+extension Error {
+    func matches(_ expected: ExpectedError, context: Context) throws {
+        if let isClientError = expected.isClientError {
+            let actualIsClientError = self is MongoUserError || self is MongoRuntimeError
+            try context.withPushedElt("isClientError") {
+                if isClientError {
+                    guard actualIsClientError else {
+                        throw NonMatchingError(
+                            expected: "Error to be a client error",
+                            actual: self,
+                            context: context
+                        )
+                    }
+                } else {
+                    guard !actualIsClientError else {
+                        throw NonMatchingError(
+                            expected: "Error to not be a client error",
+                            actual: self,
+                            context: context
+                        )
+                    }
+                }
+            }
+        }
+
+        if let errorContains = expected.errorContains {
+            try context.withPushedElt("errorContains") {
+                guard let mongoError = self as? MongoErrorProtocol else {
+                    throw NonMatchingError(
+                        expected: "error to conform to MongoErrorProtocol",
+                        actual: self,
+                        context: context
+                    )
+                }
+                guard mongoError.errorDescription!.lowercased().contains(errorContains.lowercased()) else {
+                    throw NonMatchingError(
+                        expected: "error message to contain \(errorContains)",
+                        actual: mongoError,
+                        context: context
+                    )
+                }
+            }
+        }
+
+        if let errorCode = expected.errorCode {
+            try context.withPushedElt("errorCode") {
+                guard let actualWithCodes = self as? HasErrorCodes else {
+                    throw NonMatchingError(
+                        expected: "error to have error code(s)",
+                        actual: self,
+                        context: context
+                    )
+                }
+
+                guard actualWithCodes.errorCodes.contains(errorCode) else {
+                    throw NonMatchingError(
+                        expected: "error to have error code \(errorCode)",
+                        actual: actualWithCodes,
+                        context: context
+                    )
+                }
+            }
+        }
+
+        if let codeName = expected.errorCodeName {
+            try context.withPushedElt("errorCodeName") {
+                guard let actualWithCodeNames = self as? HasErrorCodes else {
+                    throw NonMatchingError(
+                        expected: "error to have error code(s)",
+                        actual: self,
+                        context: context
+                    )
+                }
+                // TODO: SWIFT-1022: Due to CDRIVER-3147 many of our errors are currently missing code names, so we
+                // have to accept an empty string (i.e. unset) here as well as an actual code name.
+                let actualCodes = actualWithCodeNames.errorCodeNames
+                guard actualCodes.contains(codeName) || actualCodes.contains("") else {
+                    throw NonMatchingError(
+                        expected: "error to have codeName \"\(codeName)\" or \"\"",
+                        actual: self,
+                        context: context
+                    )
+                }
+            }
+        }
+
+        if let errorLabelsContain = expected.errorLabelsContain {
+            try context.withPushedElt("errorLabelsContain") {
+                guard let actualLabeled = self as? MongoLabeledError else {
+                    throw NonMatchingError(
+                        expected: "error to conform to MongoLabeledError",
+                        actual: self,
+                        context: context
+                    )
+                }
+
+                guard let actualLabels = actualLabeled.errorLabels else {
+                    throw NonMatchingError(
+                        expected: "error to have error labels",
+                        actual: actualLabeled,
+                        context: context
+                    )
+                }
+
+                for (i, expectedLabel) in errorLabelsContain.enumerated() {
+                    try context.withPushedElt(String(i)) {
+                        guard actualLabels.contains(expectedLabel) else {
+                            throw NonMatchingError(
+                                expected: "error to have error label \(expectedLabel)",
+                                actual: actualLabeled,
+                                context: context
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if let errorLabelsOmit = expected.errorLabelsOmit {
+            try context.withPushedElt("errorLabelsOmit") {
+                guard let actualLabeled = self as? MongoLabeledError else {
+                    throw NonMatchingError(
+                        expected: "error to conform to MongoLabeledError",
+                        actual: self,
+                        context: context
+                    )
+                }
+
+                let actualLabels = actualLabeled.errorLabels ?? []
+
+                for (i, shouldOmitLabel) in errorLabelsOmit.enumerated() {
+                    try context.withPushedElt(String(i)) {
+                        guard !actualLabels.contains(shouldOmitLabel) else {
+                            throw NonMatchingError(
+                                expected: "error to not have error label \(shouldOmitLabel)",
+                                actual: actualLabeled,
+                                context: context
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if let expectResult = expected.expectResult {
+            try context.withPushedElt("expectResult") {
+                // currently the only type of error with a nested result.
+                guard let bulkError = self as? MongoError.BulkWriteError else {
+                    throw NonMatchingError(
+                        expected: "error to be a BulkWriteError",
+                        actual: self,
+                        context: context
+                    )
+                }
+
+                guard let result = bulkError.result else {
+                    throw NonMatchingError(
+                        expected: "BulkWriteError to have a result",
+                        actual: bulkError,
+                        context: context
+                    )
+                }
+
+                let encodedResult = try BSONEncoder().encode(result)
+                try MatchableResult.rootDocument(encodedResult).matches(expectResult, context: context)
             }
         }
     }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SpecialTestOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SpecialTestOperations.swift
@@ -18,7 +18,7 @@ struct UnifiedFailPoint: UnifiedOperationProtocol {
     func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
         let testClient = try context.entities.getEntity(id: self.client).asTestClient()
         let opts = RunCommandOptions(readPreference: .primary)
-        let fpGuard = try self.failPoint.enable(using: testClient.client, options: opts)
+        let fpGuard = try self.failPoint.enableWithGuard(using: testClient.client, options: opts)
         context.enabledFailPoints.append(fpGuard)
         return .none
     }
@@ -280,7 +280,7 @@ struct UnifiedTargetedFailPoint: UnifiedOperationProtocol {
         // The test runner SHOULD use the client entity associated with the session to execute the configureFailPoint
         // command.
         let client = session.client
-        let fpGuard = try self.failPoint.enable(using: client, on: pinnedMongos)
+        let fpGuard = try self.failPoint.enableWithGuard(using: client, on: pinnedMongos)
         // add to context's list of enabled failpoints to ensure we disable it later.
         context.enabledFailPoints.append(fpGuard)
         return .none

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SpecialTestOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/SpecialTestOperations.swift
@@ -1,5 +1,8 @@
+// swiftlint:disable duplicate_imports
 @testable import class MongoSwift.ClientSession
 import MongoSwiftSync
+@testable import class MongoSwiftSync.ClientSession
+import Nimble
 
 struct UnifiedFailPoint: UnifiedOperationProtocol {
     /// The configureFailpoint command to be executed.
@@ -10,6 +13,16 @@ struct UnifiedFailPoint: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["failPoint", "client"]
+    }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let testClient = try context.entities.getEntity(id: self.client).asTestClient()
+        let opts = RunCommandOptions(readPreference: .primary)
+        try testClient.client.db("admin").runCommand(self.failPoint, options: opts)
+        // When executing this operation, the test runner MUST keep a record of the fail point so that it can be
+        // disabled after the test.
+        context.enabledFailPoints.append((failPoint["configureFailPoint"]!.stringValue!, nil))
+        return .none
     }
 }
 
@@ -23,6 +36,16 @@ struct UnifiedAssertCollectionExists: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         ["collectionName", "databaseName"]
     }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let db = context.internalClient.db(self.databaseName)
+        expect(try db.listCollectionNames()).to(
+            contain(self.collectionName),
+            description: "Expected db \(self.databaseName) to contain collection \(self.collectionName)." +
+                " Path: \(context.path)"
+        )
+        return .none
+    }
 }
 
 struct UnifiedAssertCollectionNotExists: UnifiedOperationProtocol {
@@ -34,6 +57,16 @@ struct UnifiedAssertCollectionNotExists: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["collectionName", "databaseName"]
+    }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let db = context.internalClient.db(self.databaseName)
+        expect(try db.listCollectionNames()).toNot(
+            contain(self.collectionName),
+            description: "Expected db \(self.databaseName) to not contain collection \(self.collectionName)." +
+                " Path: \(context.path)"
+        )
+        return .none
     }
 }
 
@@ -50,6 +83,16 @@ struct UnifiedAssertIndexExists: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         ["collectionName", "databaseName", "indexName"]
     }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = context.internalClient.db(self.databaseName).collection(self.collectionName)
+        expect(try collection.listIndexNames()).to(
+            contain(self.indexName),
+            description: "Expected collection \(collection.namespace) to have index \(self.indexName)."
+                + " Path: \(context.path)"
+        )
+        return .none
+    }
 }
 
 struct UnifiedAssertIndexNotExists: UnifiedOperationProtocol {
@@ -65,6 +108,16 @@ struct UnifiedAssertIndexNotExists: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         ["collectionName", "databaseName", "indexName"]
     }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = context.internalClient.db(self.databaseName).collection(self.collectionName)
+        expect(try collection.listIndexNames()).toNot(
+            contain(self.indexName),
+            description: "Expected collection \(collection.namespace) to not have index \(self.indexName)."
+                + " Path: \(context.path)"
+        )
+        return .none
+    }
 }
 
 struct AssertSessionNotDirty: UnifiedOperationProtocol {
@@ -73,6 +126,12 @@ struct AssertSessionNotDirty: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["session"]
+    }
+
+    func execute(on _: UnifiedOperation.Object, context _: Context) throws -> UnifiedOperationResult {
+        // TODO: SWIFT-1021: Actually implement this operation when we implement explicit sessions in Swift and can tell
+        // whether a session is dirty. For now it is a no-op.
+        .none
     }
 }
 
@@ -83,6 +142,12 @@ struct AssertSessionDirty: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         ["session"]
     }
+
+    func execute(on _: UnifiedOperation.Object, context _: Context) throws -> UnifiedOperationResult {
+        // TODO: SWIFT-1021: Actually implement this operation when we implement explicit sessions in Swift and can tell
+        // whether a session is dirty. For now it is a no-op.
+        .none
+    }
 }
 
 struct UnifiedAssertSessionPinned: UnifiedOperationProtocol {
@@ -91,6 +156,13 @@ struct UnifiedAssertSessionPinned: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["session"]
+    }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let session = try context.entities.getEntity(id: self.session).asSession()
+        expect(session.isPinned)
+            .to(beTrue(), description: "Session \(self.session) unexpectedly unpinned. Path: \(context.path)")
+        return .none
     }
 }
 
@@ -101,6 +173,13 @@ struct UnifiedAssertSessionUnpinned: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         ["session"]
     }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let session = try context.entities.getEntity(id: self.session).asSession()
+        expect(session.isPinned)
+            .to(beFalse(), description: "Session \(self.session) unexpectedly pinned. Path: \(context.path)")
+        return .none
+    }
 }
 
 struct UnifiedAssertSessionTransactionState: UnifiedOperationProtocol {
@@ -108,10 +187,17 @@ struct UnifiedAssertSessionTransactionState: UnifiedOperationProtocol {
     let session: String
 
     /// The expected transaction state.
-    let state: ClientSession.TransactionState
+    let state: MongoSwift.ClientSession.TransactionState
 
     static var knownArguments: Set<String> {
         ["session", "state"]
+    }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let session = try context.entities.getEntity(id: self.session).asSession()
+        let actualState = session.asyncSession.transactionState
+        expect(actualState).to(equal(self.state), description: "Session had unexpected transaction state")
+        return .none
     }
 }
 
@@ -122,6 +208,12 @@ struct AssertDifferentLsidOnLastTwoCommands: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         ["client"]
     }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let client = try context.entities.getEntity(id: self.client).asTestClient()
+        makeLsidAssertion(client: client, same: false, context: context)
+        return .none
+    }
 }
 
 struct AssertSameLsidOnLastTwoCommands: UnifiedOperationProtocol {
@@ -130,6 +222,38 @@ struct AssertSameLsidOnLastTwoCommands: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["client"]
+    }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let client = try context.entities.getEntity(id: self.client).asTestClient()
+        makeLsidAssertion(client: client, same: true, context: context)
+        return .none
+    }
+}
+
+func makeLsidAssertion(client: UnifiedTestClient, same: Bool, context: Context) {
+    let lastTwoEvents = Array(client.commandMonitor.events.compactMap { $0.commandStartedValue }.suffix(2))
+    expect(lastTwoEvents.count).to(
+        equal(2),
+        description: "Expected client to have at least two command started events. Path: \(context.path)"
+    )
+
+    let command1 = lastTwoEvents[0].command
+    let command2 = lastTwoEvents[1].command
+
+    expect(command1["lsid"]).toNot(beNil(), description: "Expected command to have lsid. Path: \(context.path)")
+    let lsid1 = command1["lsid"]!
+
+    expect(command2["lsid"]).toNot(beNil(), description: "Expected command to have lsid. Path: \(context.path)")
+    let lsid2 = command2["lsid"]!
+
+    if same {
+        expect(lsid1).to(equal(lsid2), description: "lsids for last two commands did not match. Path: \(context.path)")
+    } else {
+        expect(lsid1).toNot(
+            equal(lsid2),
+            description: "lsids for last two commands unexpectedly matched. Path: \(context.path)"
+        )
     }
 }
 
@@ -142,5 +266,24 @@ struct UnifiedTargetedFailPoint: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["failPoint", "session"]
+    }
+
+    func execute(on _: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let session = try context.entities.getEntity(id: self.session).asSession()
+        // The mongos on which to set the fail point is determined by the session argument (after resolution to a
+        // session entity). Test runners MUST error if the session is not pinned to a mongos server at the time this
+        // operation is executed.
+        expect(session.pinnedServerAddress)
+            .toNot(
+                beNil(),
+                description: "Session \(self.session) unexpectedly not pinned to a mongos. Path: \(context.path)"
+            )
+        let pinnedMongos = session.pinnedServerAddress!
+        // The test runner SHOULD use the client entity associated with the session to execute the configureFailPoint
+        // command.
+        let client = session.client
+        try client.db("admin").runCommand(self.failPoint, on: pinnedMongos)
+        context.enabledFailPoints.append((failPoint["configureFailPoint"]!.stringValue!, pinnedMongos))
+        return .none
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedClientOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedClientOperations.swift
@@ -1,3 +1,12 @@
+import MongoSwiftSync
+
 struct UnifiedListDatabases: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let testClient = try context.entities.getEntity(from: object).asTestClient()
+        let dbSpecs = try testClient.client.listDatabases()
+        let encoded = try BSONEncoder().encode(dbSpecs)
+        return .bson(.array(encoded.map { .document($0) }))
+    }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -30,6 +30,14 @@ struct UnifiedAggregate: UnifiedOperationProtocol {
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.options = try decoder.singleValueContainer().decode(AggregateOptions.self)
     }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        let cursor = try collection.aggregate(self.pipeline, options: self.options, session: session)
+        let docs = try cursor.map { try $0.get() }
+        return .rootDocumentArray(docs)
+    }
 }
 
 struct UnifiedCreateIndex: UnifiedOperationProtocol {
@@ -44,6 +52,15 @@ struct UnifiedCreateIndex: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["name", "keys", "session"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        let opts = IndexOptions(name: self.name)
+        let model = IndexModel(keys: self.keys, options: opts)
+        _ = try collection.createIndex(model, session: session)
+        return .none
     }
 }
 
@@ -75,6 +92,16 @@ struct UnifiedBulkWrite: UnifiedOperationProtocol {
         let decodedRequests = try container.decode([TestWriteModel].self, forKey: .requests)
         self.requests = decodedRequests.map { $0.toWriteModel() }
     }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        guard let result = try collection.bulkWrite(self.requests, options: self.options, session: session) else {
+            return .none
+        }
+        let encodedResult = try BSONEncoder().encode(result)
+        return .bson(.document(encodedResult))
+    }
 }
 
 struct UnifiedFind: UnifiedOperationProtocol {
@@ -103,6 +130,14 @@ struct UnifiedFind: UnifiedOperationProtocol {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.filter = try container.decode(BSONDocument.self, forKey: .filter)
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        let cursor = try collection.find(self.filter, options: self.options, session: session)
+        let docs = try cursor.map { try $0.get() }
+        return .rootDocumentArray(docs)
     }
 }
 
@@ -137,6 +172,20 @@ struct UnifiedFindOneAndReplace: UnifiedOperationProtocol {
         self.filter = try container.decode(BSONDocument.self, forKey: .filter)
         self.replacement = try container.decode(BSONDocument.self, forKey: .replacement)
     }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        guard let result = try collection.findOneAndReplace(
+            filter: filter,
+            replacement: replacement,
+            options: options,
+            session: session
+        ) else {
+            return .none
+        }
+        return .bson(.document(result))
+    }
 }
 
 struct UnifiedFindOneAndUpdate: UnifiedOperationProtocol {
@@ -170,6 +219,20 @@ struct UnifiedFindOneAndUpdate: UnifiedOperationProtocol {
         self.filter = try container.decode(BSONDocument.self, forKey: .filter)
         self.update = try container.decode(BSONDocument.self, forKey: .update)
     }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        guard let result = try collection.findOneAndUpdate(
+            filter: filter,
+            update: update,
+            options: options,
+            session: session
+        ) else {
+            return .none
+        }
+        return .rootDocument(result)
+    }
 }
 
 struct UnifiedDeleteOne: UnifiedOperationProtocol {
@@ -198,6 +261,16 @@ struct UnifiedDeleteOne: UnifiedOperationProtocol {
         self.filter = try container.decode(BSONDocument.self, forKey: .filter)
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.options = try decoder.singleValueContainer().decode(DeleteOptions.self)
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        guard let result = try collection.deleteOne(filter, options: options, session: session) else {
+            return .none
+        }
+        let encoded = try BSONEncoder().encode(result)
+        return .bson(.document(encoded))
     }
 }
 
@@ -229,9 +302,9 @@ struct UnifiedInsertOne: UnifiedOperationProtocol {
         self.options = try decoder.singleValueContainer().decode(InsertOneOptions.self)
     }
 
-    func execute(on object: UnifiedOperation.Object, entities: EntityMap) throws -> UnifiedOperationResult {
-        let collection = try entities.getEntity(from: object).asCollection()
-        let session = try entities.resolveSession(id: self.session)
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
         guard let result = try collection.insertOne(self.document, options: self.options, session: session) else {
             return .none
         }
@@ -266,6 +339,16 @@ struct UnifiedInsertMany: UnifiedOperationProtocol {
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.options = try decoder.singleValueContainer().decode(InsertManyOptions.self)
     }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        guard let result = try collection.insertMany(self.documents, options: options, session: session) else {
+            return .none
+        }
+        let encoded = try BSONEncoder().encode(result)
+        return .bson(.document(encoded))
+    }
 }
 
 struct UnifiedReplaceOne: UnifiedOperationProtocol {
@@ -298,5 +381,20 @@ struct UnifiedReplaceOne: UnifiedOperationProtocol {
         self.replacement = try container.decode(BSONDocument.self, forKey: .replacement)
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.options = try decoder.singleValueContainer().decode(ReplaceOptions.self)
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let session = try context.entities.resolveSession(id: self.session)
+        guard let result = try collection.replaceOne(
+            filter: filter,
+            replacement: replacement,
+            options: options,
+            session: session
+        ) else {
+            return .none
+        }
+        let encoded = try BSONEncoder().encode(result)
+        return .bson(.document(encoded))
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedDatabaseOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedDatabaseOperations.swift
@@ -8,6 +8,13 @@ struct UnifiedCreateCollection: UnifiedOperationProtocol {
     static var knownArguments: Set<String> {
         ["collection", "session"]
     }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let db = try context.entities.getEntity(from: object).asDatabase()
+        let session = try context.entities.resolveSession(id: self.session)
+        _ = try db.createCollection(self.collection, session: session)
+        return .none
+    }
 }
 
 struct UnifiedDropCollection: UnifiedOperationProtocol {
@@ -19,5 +26,12 @@ struct UnifiedDropCollection: UnifiedOperationProtocol {
 
     static var knownArguments: Set<String> {
         ["collection", "session"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let db = try context.entities.getEntity(from: object).asDatabase()
+        let session = try context.entities.resolveSession(id: self.session)
+        try db.collection(self.collection).drop(session: session)
+        return .none
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
@@ -106,8 +106,15 @@ struct UnifiedOperation: Decodable {
                     message: "Expected operation to succeed, but got error: \(error). Path: \(context.path)"
                 )
             }
+
+            guard let mongoError = error as? MongoErrorProtocol else {
+                throw TestError(
+                    message: "Expected operation to throw an error conforming to MongoErrorProtocol, but got \(error)"
+                )
+            }
+
             try context.withPushedElt("expectError") {
-                try error.matches(expectedError, context: context)
+                try mongoError.matches(expectedError, context: context)
             }
         }
     }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
@@ -7,15 +7,8 @@ protocol UnifiedOperationProtocol: Decodable {
     /// Set of supported arguments for the operation.
     static var knownArguments: Set<String> { get }
 
-    /// Executes this operation on the provided object, using entities from `entities`.
-    func execute(on object: UnifiedOperation.Object, entities: EntityMap) throws -> UnifiedOperationResult
-}
-
-extension UnifiedOperationProtocol {
-    // TODO: SWIFT-913: remove once this method is implemented for all operations
-    func execute(on _: UnifiedOperation.Object, entities _: EntityMap) throws -> UnifiedOperationResult {
-        throw TestError(message: "operation type \(Self.self) unimplemented")
-    }
+    /// Executes this operation on the provided object, using the provided context.
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult
 }
 
 enum UnifiedOperationResult {
@@ -87,22 +80,35 @@ struct UnifiedOperation: Decodable {
     /// Expected result of the operation.
     let expectedResult: ExpectedOperationResult?
 
-    func executeAndCheckResult(entities: inout EntityMap, context: Context) throws {
-        let actualResult = try self.operation.execute(on: self.object, entities: entities)
-        switch self.expectedResult {
-        case let .error(expectedError):
-            throw TestError(message: "I dont know how to compare errors yet")
-        case let .result(expected, saveAsEntity):
-            if let entityId = saveAsEntity {
-                entities[entityId] = try actualResult.asEntity()
-            }
-            if let expected = expected {
-                try context.withPushedElt("expectResult") {
-                    try actualResult.matches(expected: expected, entities: entities, context: context)
+    func executeAndCheckResult(context: Context) throws {
+        do {
+            let actualResult = try self.operation.execute(on: self.object, context: context)
+            switch self.expectedResult {
+            case .error:
+                throw TestError(
+                    message: "Expected operation to error, but got result: \(actualResult). Path: \(context.path)"
+                )
+            case let .result(expected, saveAsEntity):
+                if let entityId = saveAsEntity {
+                    context.entities[entityId] = try actualResult.asEntity()
                 }
+                if let expected = expected {
+                    try context.withPushedElt("expectResult") {
+                        try actualResult.matches(expected: expected, context: context)
+                    }
+                }
+            case .none:
+                return
             }
-        case .none:
-            return
+        } catch {
+            guard case let .error(expectedError) = self.expectedResult else {
+                throw TestError(
+                    message: "Expected operation to succeed, but got error: \(error). Path: \(context.path)"
+                )
+            }
+            try context.withPushedElt("expectError") {
+                try error.matches(expectedError, context: context)
+            }
         }
     }
 
@@ -218,6 +224,10 @@ struct UnifiedOperation: Decodable {
 /// Placeholder for an unsupported operation.
 struct Placeholder: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
+
+    func execute(on _: UnifiedOperation.Object, context _: Context) throws -> UnifiedOperationResult {
+        fatalError("Unexpectedly tried to execute placeholder operation")
+    }
 }
 
 /// Represents the expected result of an operation.
@@ -227,7 +237,6 @@ enum ExpectedOperationResult: Decodable {
     /// - result: A value corresponding to the expected result of the operation.
     /// - saveAsEntity: If specified, the actual result returned by the operation (if any) will be saved with this
     ///       name in the Entity Map.
-    // TODO: SWIFT-913: consider using custom type to represent results
     case result(result: BSON?, saveAsEntity: String?)
 
     private enum CodingKeys: String, CodingKey {
@@ -283,6 +292,5 @@ struct ExpectedError: Decodable {
     let errorLabelsOmit: [String]?
 
     /// This field is only used in cases where the error includes a result (e.g. bulkWrite).
-    // TODO: SWIFT-913: consider using custom type to represent results
     let expectResult: BSON?
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedSessionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedSessionOperations.swift
@@ -1,15 +1,43 @@
+import MongoSwiftSync
+// swiftlint:disable duplicate_imports
+@testable import class MongoSwiftSync.ClientSession
+
 struct EndSession: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let session = try context.entities.getEntity(from: object).asSession()
+        session.end()
+        return .none
+    }
 }
 
 struct UnifiedStartTransaction: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let session = try context.entities.getEntity(from: object).asSession()
+        try session.startTransaction()
+        return .none
+    }
 }
 
 struct UnifiedCommitTransaction: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let session = try context.entities.getEntity(from: object).asSession()
+        try session.commitTransaction()
+        return .none
+    }
 }
 
 struct UnifiedAbortTransaction: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let session = try context.entities.getEntity(from: object).asSession()
+        try session.abortTransaction()
+        return .none
+    }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -41,20 +41,22 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
     }
 
     func testSampleUnifiedTests() throws {
-        // unsupported driver APIs
-        let skipValidPassFiles = [
-            "poc-gridfs.json",
-            "poc-transactions-convenient-api.json"
-        ]
         let validPassTests = try retrieveSpecTestFiles(
             specName: "unified-test-format",
             subdirectory: "valid-pass",
-            excludeFiles: skipValidPassFiles,
             asType: UnifiedTestFile.self
-        ).map { $0.1 }.prefix(1)
+        ).map { $0.1 }
+
+        let skipRunningValid: [String: [String]] = [
+            // unsupported APIs
+            "poc-transactions-convenient-api": ["*"],
+            "poc-gridfs": ["*"],
+            // requires DB-level aggregate. TODO SWIFT-577: unskip
+            "poc-crud": ["Aggregate with $listLocalSessions"]
+        ]
 
         let runner = try UnifiedTestRunner()
-        try runner.runFiles(Array(validPassTests))
+        try runner.runFiles(validPassTests, skipTests: skipRunningValid)
 
         let skipValidFailFiles = [
             // Because we use an enum to represent ReturnDocument, the invalid string present in this file "Invalid"
@@ -63,14 +65,16 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
             "returnDocument-enum-invalid.json"
         ]
 
-        expect(try retrieveSpecTestFiles(
+        let validFailTests = try retrieveSpecTestFiles(
             specName: "unified-test-format",
             subdirectory: "valid-fail",
             excludeFiles: skipValidFailFiles,
             asType: UnifiedTestFile.self
-        )).toNot(throwError())
+        )
 
-        // TODO: run and assert valid fail tests fail
+        for (_, test) in validFailTests {
+            expect(try runner.runFiles([test])).to(throwError())
+        }
     }
 
     func testStrictDecodableTypes() throws {

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -50,9 +50,7 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
         let skipRunningValid: [String: [String]] = [
             // unsupported APIs
             "poc-transactions-convenient-api": ["*"],
-            "poc-gridfs": ["*"],
-            // requires DB-level aggregate. TODO SWIFT-577: unskip
-            "poc-crud": ["Aggregate with $listLocalSessions"]
+            "poc-gridfs": ["*"]
         ]
 
         let runner = try UnifiedTestRunner()


### PR DESCRIPTION
As I mentioned in the team channel there seem to be some sporadic failures on evg along the lines of the transactions tests ones we've been seeing lately. I'm going to investigate that now but I don't think it needs to block starting review on this.

Sorry that this is a bit larger than past PRs, but a lot of it is just operation execution boilerplate so hopefully should be easy to review.