### PR TITLE
SWIFT-519 Make startAfter public

### DIFF
--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -110,9 +110,10 @@ public class ChangeStream<T: Codable>: CursorProtocol {
         self.decoder = BSONDecoder(copies: decoder, options: nil)
         self.decoder.userInfo[changeStreamNamespaceKey] = namespace
 
-        // TODO: SWIFT-519 - Starting 4.2, update resumeToken to startAfter (if set).
         // startAfter takes precedence over resumeAfter.
-        if let resumeAfter = options?.resumeAfter {
+        if let startAfter = options?.startAfter {
+            self.resumeToken = startAfter
+        } else if let resumeAfter = options?.resumeAfter {
             self.resumeToken = resumeAfter
         }
     }

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -55,8 +55,7 @@ public struct ChangeStreamOptions: Codable {
      * - Note: The server will report an error if `startAfter` and `resumeAfter` are both specified.
      * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
      */
-    // TODO: SWIFT-519 - Make this public when support is added for 4.2 change stream features.
-    // internal var startAfter: ResumeToken?
+    public var startAfter: ResumeToken?
 
     /// The change stream will only provide changes that occurred at or after the specified timestamp.
     /// Any command run against the server will return an operation time that can be used here.
@@ -70,6 +69,7 @@ public struct ChangeStreamOptions: Codable {
         fullDocument: FullDocument? = nil,
         maxAwaitTimeMS: Int? = nil,
         resumeAfter: ResumeToken? = nil,
+        startAfter: ResumeToken? = nil,
         startAtOperationTime: BSONTimestamp? = nil
     ) {
         self.batchSize = batchSize
@@ -77,6 +77,7 @@ public struct ChangeStreamOptions: Codable {
         self.fullDocument = fullDocument
         self.maxAwaitTimeMS = maxAwaitTimeMS
         self.resumeAfter = resumeAfter
+        self.startAfter = startAfter
         self.startAtOperationTime = startAtOperationTime
     }
 }

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -957,6 +957,17 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
 
         // expect this change stream to have more events after resuming
         expect(try changeStream2.nextWithTimeout()).toNot(beNil())
+
+        // test with startAfter
+        let newColl = try coll.renamed(to: self.getCollectionName(suffix: "2"))
+
+        _ = try changeStream2.nextWithTimeout()
+        expect(try changeStream2.nextWithTimeout()?.operationType).to(equal(.invalidate))
+
+        let opts = ChangeStreamOptions(startAfter: changeStream2.resumeToken)
+
+        // resuming (with startAfter) after an invalidate event should work
+        expect(try newColl.watch(options: opts)).toNot(throwError())
     }
 
     struct MyFullDocumentType: Codable, Equatable {

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -958,6 +958,11 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
         // expect this change stream to have more events after resuming
         expect(try changeStream2.nextWithTimeout()).toNot(beNil())
 
+        guard try client.serverVersion() >= ServerVersion(major: 4, minor: 2) else {
+            print("Skipping test case for server version \(try client.serverVersion())")
+            return
+        }
+
         // test with startAfter
         let newColl = try coll.renamed(to: self.getCollectionName(suffix: "2"))
 

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -964,7 +964,7 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
         }
 
         // test with startAfter
-        let newColl = try coll.renamed(to: self.getCollectionName(suffix: "2"))
+        _ = try coll.renamed(to: self.getCollectionName(suffix: "2"))
 
         _ = try changeStream2.nextWithTimeout()
         expect(try changeStream2.nextWithTimeout()?.operationType).to(equal(.invalidate))
@@ -972,7 +972,12 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
         let opts = ChangeStreamOptions(startAfter: changeStream2.resumeToken)
 
         // resuming (with startAfter) after an invalidate event should work
-        expect(try newColl.watch(options: opts)).toNot(throwError())
+        expect(try coll.watch(options: opts)).toNot(throwError())
+        let changeStream3 = try coll.watch(options: opts)
+
+        try coll.insertOne(["kitty": "cat"])
+
+        expect(try changeStream3.nextWithTimeout()?.operationType).to(equal(.insert))
     }
 
     struct MyFullDocumentType: Codable, Equatable {

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -972,7 +972,6 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
         let opts = ChangeStreamOptions(startAfter: changeStream2.resumeToken)
 
         // resuming (with startAfter) after an invalidate event should work
-        expect(try coll.watch(options: opts)).toNot(throwError())
         let changeStream3 = try coll.watch(options: opts)
 
         try coll.insertOne(["kitty": "cat"])


### PR DESCRIPTION
Makes `startAfter` public now that libmongoc 4.2 change streams has been released.