### PR TITLE
SWIFT-1029 Add support for EventLoop binding for MongoDatabase and MongoCollection

### DIFF
--- a/Sources/MongoSwift/EventLoopBoundMongoClient.swift
+++ b/Sources/MongoSwift/EventLoopBoundMongoClient.swift
@@ -96,4 +96,23 @@ public struct EventLoopBoundMongoClient {
             return names
         }
     }
+
+    /**
+     * Gets a `MongoDatabase` instance for the given database name that will return `EventLoopFuture`s on this
+     * `EventLoopBoundMongoClient`'s `EventLoop`. If an option is not specified in the optional `MongoDatabaseOptions`
+     * param, the database will inherit the value from this `EventLoopBoundMongoClient`'s underlying `MongoClient`
+     * or the default if the client’s option is not set.
+     * To override an option inherited from the client (e.g. a read concern) with the default value, it must be
+     * explicitly specified in the options param (e.g. ReadConcern.serverDefault, not nil).
+     *
+     * - Parameters:
+     *   - name: the name of the database to retrieve
+     *   - options: Optional `MongoDatabaseOptions` to use for the retrieved database
+     *
+     * - Returns:
+     *     A `MongoDatabase` that is bound to this `EventLoopBoundMongoClient`'s `EventLoop`.
+     */
+    public func db(_ name: String, options: MongoDatabaseOptions? = nil) -> MongoDatabase {
+        MongoDatabase(name: name, client: self.client, eventLoop: self.eventLoop, options: options)
+    }
 }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -519,7 +519,7 @@ public class MongoClient {
      * - Returns: a `MongoDatabase` corresponding to the provided database name.
      */
     public func db(_ name: String, options: MongoDatabaseOptions? = nil) -> MongoDatabase {
-        MongoDatabase(name: name, client: self, options: options)
+        MongoDatabase(name: name, client: self, eventLoop: nil, options: options)
     }
 
     /**

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -30,10 +30,18 @@ extension MongoCollection {
     ) -> EventLoopFuture<BulkWriteResult?> {
         guard !requests.isEmpty else {
             return self._client.operationExecutor
-                .makeFailedFuture(MongoError.InvalidArgumentError(message: "requests cannot be empty"))
+                .makeFailedFuture(
+                    MongoError.InvalidArgumentError(message: "requests cannot be empty"),
+                    on: self.eventLoop
+                )
         }
         let operation = BulkWriteOperation(collection: self, models: requests, options: options)
-        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
+        return self._client.operationExecutor.execute(
+            operation,
+            client: self._client,
+            on: self.eventLoop,
+            session: session
+        )
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -66,7 +66,7 @@ extension MongoCollection {
             let update = try self.encoder.encode(replacement)
             return self.findAndModify(filter: filter, update: update, options: options, session: session)
         } catch {
-            return self._client.operationExecutor.makeFailedFuture(error)
+            return self._client.operationExecutor.makeFailedFuture(error, on: self.eventLoop)
         }
     }
 
@@ -121,7 +121,12 @@ extension MongoCollection {
         session: ClientSession?
     ) -> EventLoopFuture<CollectionType?> {
         let operation = FindAndModifyOperation(collection: self, filter: filter, update: update, options: options)
-        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
+        return self._client.operationExecutor.execute(
+            operation,
+            client: self._client,
+            on: self.eventLoop,
+            session: session
+        )
     }
 }
 

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -155,7 +155,12 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<Int> {
         let operation = CountDocumentsOperation(collection: self, filter: filter, options: options)
-        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
+        return self._client.operationExecutor.execute(
+            operation,
+            client: self._client,
+            on: self.eventLoop,
+            session: session
+        )
     }
 
     /**
@@ -176,7 +181,12 @@ extension MongoCollection {
      */
     public func estimatedDocumentCount(options: EstimatedDocumentCountOptions? = nil) -> EventLoopFuture<Int> {
         let operation = EstimatedDocumentCountOperation(collection: self, options: options)
-        return self._client.operationExecutor.execute(operation, client: self._client, session: nil)
+        return self._client.operationExecutor.execute(
+            operation,
+            client: self._client,
+            on: self.eventLoop,
+            session: nil
+        )
     }
 
     /**
@@ -206,6 +216,11 @@ extension MongoCollection {
         session: ClientSession? = nil
     ) -> EventLoopFuture<[BSON]> {
         let operation = DistinctOperation(collection: self, fieldName: fieldName, filter: filter, options: options)
-        return self._client.operationExecutor.execute(operation, client: self._client, session: session)
+        return self._client.operationExecutor.execute(
+            operation,
+            client: self._client,
+            on: self.eventLoop,
+            session: session
+        )
     }
 }

--- a/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
+++ b/Sources/MongoSwift/Operations/CreateCollectionOperation.swift
@@ -135,6 +135,11 @@ internal struct CreateCollectionOperation<T: Codable>: Operation {
             uuidCodingStrategy: self.options?.uuidCodingStrategy
         )
 
-        return MongoCollection(name: self.name, database: self.database, options: collectionOptions)
+        return MongoCollection(
+            name: self.name,
+            database: self.database,
+            eventLoop: self.database.eventLoop,
+            options: collectionOptions
+        )
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -178,6 +178,18 @@ extension Document_SequenceTests {
     ]
 }
 
+extension EventLoopBoundMongoClientTests {
+    static var allTests = [
+        ("testEventLoopBoundDb", testEventLoopBoundDb),
+        ("testCollection", testCollection),
+        ("testEventLoopBoundCollection", testEventLoopBoundCollection),
+        ("testEventLoopBoundCollectionReads", testEventLoopBoundCollectionReads),
+        ("testEventLoopBoundCollectionIndexes", testEventLoopBoundCollectionIndexes),
+        ("testEventLoopBoundCollectionFindAndModify", testEventLoopBoundCollectionFindAndModify),
+        ("testEventLoopBoundCollectionBulkWrite", testEventLoopBoundCollectionBulkWrite),
+    ]
+}
+
 extension MongoClientTests {
     static var allTests = [
         ("testUsingClosedClient", testUsingClosedClient),
@@ -455,6 +467,7 @@ XCTMain([
     testCase(DocumentTests.allTests),
     testCase(Document_CollectionTests.allTests),
     testCase(Document_SequenceTests.allTests),
+    testCase(EventLoopBoundMongoClientTests.allTests),
     testCase(MongoClientTests.allTests),
     testCase(MongoCollectionTests.allTests),
     testCase(MongoCollection_BulkWriteTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -181,7 +181,6 @@ extension Document_SequenceTests {
 extension EventLoopBoundMongoClientTests {
     static var allTests = [
         ("testEventLoopBoundDb", testEventLoopBoundDb),
-        ("testCollection", testCollection),
         ("testEventLoopBoundCollection", testEventLoopBoundCollection),
         ("testEventLoopBoundCollectionReads", testEventLoopBoundCollectionReads),
         ("testEventLoopBoundCollectionIndexes", testEventLoopBoundCollectionIndexes),

--- a/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
+++ b/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
@@ -1,0 +1,140 @@
+@testable import MongoSwift
+import Nimble
+import NIO
+import TestsCommon
+
+final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
+    func testEventLoopBoundDb() throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        let expectedEventLoop = elg.next()
+
+        try self.withTestClient { client in
+            let elBoundClient = EventLoopBoundMongoClient(client: client, eventLoop: expectedEventLoop)
+            expect(elBoundClient.db(Self.testDatabase).eventLoop) === expectedEventLoop
+        }
+    }
+
+    func testCollection() throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        let expectedEventLoop = elg.next()
+
+        try self.withTestClient { client in
+            let elBoundClient = EventLoopBoundMongoClient(client: client, eventLoop: expectedEventLoop)
+
+            let db = elBoundClient.db(Self.testDatabase)
+            defer { try? db.drop().wait() }
+            expect(db.collection("test").eventLoop) === expectedEventLoop
+        }
+    }
+
+    func testEventLoopBoundCollection() throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        let expectedEventLoop = elg.next()
+
+        try self.withTestClient { client in
+            let elBoundClient = EventLoopBoundMongoClient(client: client, eventLoop: expectedEventLoop)
+
+            let db = elBoundClient.db(Self.testDatabase)
+            defer { try? db.drop().wait() }
+            let coll1 = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
+
+            // test renamed
+            let res1 = coll1.renamed(to: self.getCollectionName(suffix: "2"))
+            let coll2 = try res1.wait()
+            expect(res1.eventLoop) === expectedEventLoop
+            expect(coll2.eventLoop) === expectedEventLoop
+
+            // test drop
+            let res2 = coll2.drop()
+            expect(res2.eventLoop) === expectedEventLoop
+        }
+    }
+
+    func testEventLoopBoundCollectionReads() throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        let expectedEventLoop = elg.next()
+
+        try self.withTestClient { client in
+            let elBoundClient = EventLoopBoundMongoClient(client: client, eventLoop: expectedEventLoop)
+
+            let db = elBoundClient.db(Self.testDatabase)
+            defer { try? db.drop().wait() }
+            let coll1 = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
+
+            // test countDocuments
+            let res1 = coll1.countDocuments()
+            expect(res1.eventLoop) === expectedEventLoop
+
+            // test estimatedDocumentCount
+            let res2 = coll1.estimatedDocumentCount()
+            expect(res2.eventLoop) === expectedEventLoop
+
+            // test distinct
+            let res3 = coll1.distinct(fieldName: "foo", filter: [:])
+            expect(res3.eventLoop) === expectedEventLoop
+        }
+    }
+
+    func testEventLoopBoundCollectionIndexes() throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        let expectedEventLoop = elg.next()
+
+        try self.withTestClient { client in
+            let elBoundClient = EventLoopBoundMongoClient(client: client, eventLoop: expectedEventLoop)
+
+            let db = elBoundClient.db(Self.testDatabase)
+            defer { try? db.drop().wait() }
+            let coll = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
+
+            // test createIndex
+            expect(coll.createIndex([:]).eventLoop) === expectedEventLoop
+
+            // test createIndexes
+            expect(coll.createIndexes([IndexModel(keys: ["x": 1])]).eventLoop) === expectedEventLoop
+            // test a createIndexes that returns a failed future
+            expect(coll.createIndexes([]).eventLoop) === expectedEventLoop
+
+            // test listIndexNames
+            expect(coll.listIndexNames().eventLoop) === expectedEventLoop
+
+            // test a dropIndex that returns a failed future
+            expect(coll.dropIndex("*").eventLoop) === expectedEventLoop
+
+            // test dropIndexes
+            expect(coll.dropIndexes().eventLoop) === expectedEventLoop
+        }
+    }
+
+    func testEventLoopBoundCollectionFindAndModify() throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        let expectedEventLoop = elg.next()
+
+        try self.withTestClient { client in
+            let elBoundClient = EventLoopBoundMongoClient(client: client, eventLoop: expectedEventLoop)
+
+            let db = elBoundClient.db(Self.testDatabase)
+            defer { try? db.drop().wait() }
+            let coll = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
+
+            coll.insertOne(["x": 1])
+            expect(coll.findOneAndReplace(filter: ["x": 1], replacement: ["x": 2]).eventLoop) === expectedEventLoop
+        }
+    }
+
+    func testEventLoopBoundCollectionBulkWrite() throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        let expectedEventLoop = elg.next()
+
+        try self.withTestClient { client in
+            let elBoundClient = EventLoopBoundMongoClient(client: client, eventLoop: expectedEventLoop)
+
+            let db = elBoundClient.db(Self.testDatabase)
+            defer { try? db.drop().wait() }
+            let coll = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
+
+            expect(coll.bulkWrite([WriteModel.insertOne(["y": 1])]).eventLoop) === expectedEventLoop
+            // test a bulkWrite that returns a failed future
+            expect(coll.bulkWrite([]).eventLoop) === expectedEventLoop
+        }
+    }
+}

--- a/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
+++ b/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
@@ -15,11 +15,22 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
             expect(db.eventLoop) === expectedEventLoop
 
             // test the MongoDatabase operations return futures on the expected event loop
-            expect(db.createCollection("test").eventLoop) === expectedEventLoop
             expect(db.collection("test").eventLoop) === expectedEventLoop
-            expect(db.listMongoCollections().eventLoop) === expectedEventLoop
             expect(db.listCollectionNames().eventLoop) === expectedEventLoop
             expect(db.runCommand(["insert": "coll", "documents": [["foo": "bar"]]]).eventLoop) === expectedEventLoop
+
+            let res1 = db.createCollection("test")
+            expect(res1.eventLoop) === expectedEventLoop
+            // test the returned MongoCollection has the expected event loop
+            expect(try res1.wait().eventLoop) === expectedEventLoop
+
+            let res2 = db.listMongoCollections()
+            expect(res2.eventLoop) === expectedEventLoop
+            let collections = try res2.wait()
+            // test the returned MongoCollections have the expected event loop
+            for coll in collections {
+                expect(coll.eventLoop) === expectedEventLoop
+            }
         }
     }
 

--- a/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
+++ b/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
@@ -72,14 +72,17 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
             // test countDocuments
             let res1 = coll1.countDocuments()
             expect(res1.eventLoop) === expectedEventLoop
+            _ = try res1.wait()
 
             // test estimatedDocumentCount
             let res2 = coll1.estimatedDocumentCount()
             expect(res2.eventLoop) === expectedEventLoop
+            _ = try res2.wait()
 
             // test distinct
             let res3 = coll1.distinct(fieldName: "foo", filter: [:])
             expect(res3.eventLoop) === expectedEventLoop
+            _ = try res3.wait()
         }
     }
 
@@ -96,21 +99,34 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
             let coll = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
 
             // test createIndex
-            expect(coll.createIndex([:]).eventLoop) === expectedEventLoop
+            let res1 = coll.createIndex(IndexModel(keys: ["y": 1]))
+            expect(res1.eventLoop) === expectedEventLoop
+            _ = try res1.wait()
 
             // test createIndexes
-            expect(coll.createIndexes([IndexModel(keys: ["x": 1])]).eventLoop) === expectedEventLoop
+            let res2 = coll.createIndexes([IndexModel(keys: ["x": 1])])
+            expect(res2.eventLoop) === expectedEventLoop
+            _ = try res2.wait()
+
             // test a createIndexes that returns a failed future
-            expect(coll.createIndexes([]).eventLoop) === expectedEventLoop
+            let res3 = coll.createIndexes([])
+            expect(res3.eventLoop) === expectedEventLoop
+            expect(try res3.wait()).to(throwError())
 
             // test listIndexNames
-            expect(coll.listIndexNames().eventLoop) === expectedEventLoop
+            let res4 = coll.listIndexNames()
+            expect(res4.eventLoop) === expectedEventLoop
+            _ = try res4.wait()
 
             // test a dropIndex that returns a failed future
-            expect(coll.dropIndex("*").eventLoop) === expectedEventLoop
+            let res5 = coll.dropIndex("*")
+            expect(res5.eventLoop) === expectedEventLoop
+            expect(try res5.wait()).to(throwError())
 
             // test dropIndexes
-            expect(coll.dropIndexes().eventLoop) === expectedEventLoop
+            let res6 = coll.dropIndexes()
+            expect(res6.eventLoop) === expectedEventLoop
+            _ = try res6.wait()
         }
     }
 
@@ -125,8 +141,10 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
             defer { try? db.drop().wait() }
             let coll = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
 
-            coll.insertOne(["x": 1])
-            expect(coll.findOneAndReplace(filter: ["x": 1], replacement: ["x": 2]).eventLoop) === expectedEventLoop
+            _ = try coll.insertOne(["x": 1]).wait()
+            let res = coll.findOneAndReplace(filter: ["x": 1], replacement: ["x": 2])
+            expect(res.eventLoop) === expectedEventLoop
+            _ = try res.wait()
         }
     }
 
@@ -141,9 +159,13 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
             defer { try? db.drop().wait() }
             let coll = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
 
-            expect(coll.bulkWrite([WriteModel.insertOne(["y": 1])]).eventLoop) === expectedEventLoop
+            let res1 = coll.bulkWrite([WriteModel.insertOne(["y": 1])])
+            expect(res1.eventLoop) === expectedEventLoop
+            _ = try res1.wait()
             // test a bulkWrite that returns a failed future
-            expect(coll.bulkWrite([]).eventLoop) === expectedEventLoop
+            let res2 = coll.bulkWrite([])
+            expect(res2.eventLoop) === expectedEventLoop
+            expect(try res2.wait()).to(throwError())
         }
     }
 }

--- a/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
+++ b/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
@@ -17,17 +17,22 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
 
             // test the MongoDatabase operations return futures on the expected event loop
             expect(db.collection("test").eventLoop) === expectedEventLoop
-            expect(db.listCollectionNames().eventLoop) === expectedEventLoop
-            expect(db.runCommand(["insert": "coll", "documents": [["foo": "bar"]]]).eventLoop) === expectedEventLoop
-
-            let res1 = db.createCollection("test")
+            let res1 = db.listCollectionNames()
             expect(res1.eventLoop) === expectedEventLoop
-            // test the returned MongoCollection has the expected event loop
-            expect(try res1.wait().eventLoop) === expectedEventLoop
+            _ = try res1.wait()
 
-            let res2 = db.listMongoCollections()
+            let res2 = db.runCommand(["insert": "coll", "documents": [["foo": "bar"]]])
             expect(res2.eventLoop) === expectedEventLoop
-            let collections = try res2.wait()
+            _ = try res2.wait()
+
+            let res3 = db.createCollection("test")
+            expect(res3.eventLoop) === expectedEventLoop
+            // test the returned MongoCollection has the expected event loop
+            expect(try res3.wait().eventLoop) === expectedEventLoop
+
+            let res4 = db.listMongoCollections()
+            expect(res4.eventLoop) === expectedEventLoop
+            let collections = try res4.wait()
             // test the returned MongoCollections have the expected event loop
             for coll in collections {
                 expect(coll.eventLoop) === expectedEventLoop
@@ -47,13 +52,15 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
             let coll1 = try db.createCollection(self.getCollectionName(suffix: "1")).wait()
 
             // test renamed
-            let res = coll1.renamed(to: self.getCollectionName(suffix: "2"))
-            let coll2 = try res.wait()
-            expect(res.eventLoop) === expectedEventLoop
+            let res1 = coll1.renamed(to: self.getCollectionName(suffix: "2"))
+            let coll2 = try res1.wait()
+            expect(res1.eventLoop) === expectedEventLoop
             expect(coll2.eventLoop) === expectedEventLoop
 
             // test drop
-            expect(coll2.drop().eventLoop) === expectedEventLoop
+            let res2 = coll2.drop()
+            expect(res2.eventLoop) === expectedEventLoop
+            _ = try res2.wait()
         }
     }
 

--- a/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
+++ b/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
@@ -12,6 +12,7 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
             // TODO: SWIFT-1030 - add tests for database operations that return ChangeStream and MongoCursor
             let elBoundClient = EventLoopBoundMongoClient(client: client, eventLoop: expectedEventLoop)
             let db = elBoundClient.db(Self.testDatabase)
+            defer { try? db.drop().wait() }
             expect(db.eventLoop) === expectedEventLoop
 
             // test the MongoDatabase operations return futures on the expected event loop

--- a/mongo-swift-driver.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/mongo-swift-driver.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/mongo-swift-driver.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/mongo-swift-driver.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>


### PR DESCRIPTION
- Adds a method `EventLoopBoundMongoClient.db` that returns a bound `MongoDatabase`.
- Updates `MongoDatabase.collection` to return a bound `MongoCollection`.
- Updates the calls to `operationExecutor` to pass in the `EventLoop` (except for the ones where `MongoCursor` and `ChangeStreams` are returned, those will be modified in the next PR).
- Adds tests to verify that the futures returned by the methods are on the bound event loop.