### PR TITLE
SWIFT-1072 Improve result parsing performance

### DIFF
--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -419,7 +419,10 @@ public struct BulkWriteResult: Codable {
         var upsertedCount: Int?
         var upsertedIDs = [Int: BSON]()
 
-        var seenKey = true
+        // To improve the performance of this initializer, we perform only a single walk over the entire document and
+        // record the values as they are encountered instead of doing repeated random lookups, since each lookup
+        // would result in a traversal of the document.
+        var seenKey = false
         for (k, v) in reply {
             guard let key = MongocKeys(rawValue: k) else {
                 continue


### PR DESCRIPTION
SWIFT-1072

This PR contains the driver-side changes of SWIFT-1072. This also is the only change required for the find performance improvements as well, making this the last PR of SWIFT-993.

Benchmark results (insertion ones copied from PR on `swift-bson`):
| benchmark                       | libbson based median time | target time (1.25x) | unoptimized swift-bson | post-optimizations |
|---------------------------------|---------------------------|---------------------|------------------------|--------------------|
| small doc bulk insert           | 0.096                     | 0.12                | 4258.673               | 0.117              |
| large doc bulk insert           | 0.332                     | 0.415               | 59.637                 | 0.454              |
| small doc insertOne             | 3.258                     | 4.0725              | 8.276                  | 3.412              |
| large doc insertOne             | 0.327                     | 0.409               | 28.742                 | 0.456              |
| findOne by _id                  | 4.07                      | 5.088               | 229.7                  | 3.837              |
| find and empty cursor small doc | 0.468                     | 0.585               | 10436.246              | 0.498              |
| find and empty cursor large doc | 0.032                     | 0.040               | 105.365                | 0.043              |
