### PR TITLE
SWIFT-1086 Update sortedEquals impl to use equalsIgnoreKeyOrder

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/mongodb/swift-bson",
         "state": {
           "branch": "master",
-          "revision": "5389a7633fc8629c827a8db3529a8a022c670a20",
+          "revision": "4c9f3803bf0d3c6e868a111c76e77dd8ff58a37e",
           "version": null
         }
       },

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -271,15 +271,7 @@ public protocol SortedEquatable {
 
 extension BSONDocument: SortedEquatable {
     public func sortedEquals(_ other: BSONDocument) -> Bool {
-        guard self.buffer.readableBytes == other.buffer.readableBytes else {
-            return false
-        }
-        for (k, v) in self {
-            guard let otherValue = other[k], v.sortedEquals(otherValue) else {
-                return false
-            }
-        }
-        return true
+        self.equalsIgnoreKeyOrder(other)
     }
 }
 


### PR DESCRIPTION
SWIFT-1086 (driver portion)
