### PR TITLE
Fix txn tests

### DIFF
--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -137,10 +137,19 @@ open class MongoSwiftTestCase: XCTestCase {
 
 /// Enumerates the different topology configurations that are used throughout the tests
 public enum TestTopologyConfiguration: String, Decodable {
+    /// A sharded topology where each shard is a standalone.
     case sharded
+    /// A replica set.
     case replicaSet = "replicaset"
+    /// A sharded topology where each shard is a replica set.
     case shardedReplicaSet = "sharded-replicaset"
+    /// A standalone server.
     case single
+
+    /// Returns a Bool indicating whether this topology is either sharded configuration.
+    public var isSharded: Bool {
+        self == .sharded || self == .shardedReplicaSet
+    }
 
     /// Determines the topologyType of a client based on the reply returned by running an isMaster command and the
     /// first document in the config.shards collection.

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -182,7 +182,10 @@ extension SpecTestFile {
         }
     }
 
-    func terminateOpenTransactions(using client: MongoSwiftSync.MongoClient, mongosClients: [MongoSwiftSync.MongoClient]?) throws {
+    func terminateOpenTransactions(
+        using client: MongoSwiftSync.MongoClient,
+        mongosClients: [MongoSwiftSync.MongoClient]?
+    ) throws {
         // if connected to a replica set, use the provided client to execute killAllSessions on the primary.
         // if connected to a sharded cluster, use the per-mongos clients to execute killAllSessions on each mongos.
         switch try client.topologyType() {
@@ -199,7 +202,7 @@ extension SpecTestFile {
             for mongosClient in mongosClients! {
                 do {
                     _ = try mongosClient.db("admin").runCommand(["killAllSessions": []])
-                break
+                    break
                 } catch let commandError as MongoError.CommandError where commandError.code == 11601 {}
             }
         }
@@ -222,7 +225,7 @@ extension SpecTestFile {
         let setupClient = try MongoClient.makeTestClient(connString, options: setupClientOptions)
         let topologyType = try setupClient.topologyType()
 
-        var mongosClients: [MongoClient]? = nil
+        var mongosClients: [MongoClient]?
         switch topologyType {
         case .sharded, .shardedReplicaSet:
             var opts = setupClientOptions
@@ -256,7 +259,7 @@ extension SpecTestFile {
                test.description.contains("distinct")
             {
                 for client in mongosClients! {
-                     _ = try client.db(self.databaseName).runCommand(["distinct": .string(collName), "key": "_id"])
+                    _ = try client.db(self.databaseName).runCommand(["distinct": .string(collName), "key": "_id"])
                 }
             }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -182,9 +182,9 @@ extension SpecTestFile {
         }
     }
 
-    func terminateOpenTransactions(using client: MongoSwiftSync.MongoClient) throws {
-        // Using the provided MongoClient, execute the killAllSessions command on either the primary or, if
-        // connected to a sharded cluster, all mongos servers.
+    func terminateOpenTransactions(using client: MongoSwiftSync.MongoClient, mongosClients: [MongoSwiftSync.MongoClient]?) throws {
+        // if connected to a replica set, use the provided client to execute killAllSessions on the primary.
+        // if connected to a sharded cluster, use the per-mongos clients to execute killAllSessions on each mongos.
         switch try client.topologyType() {
         case .single:
             return
@@ -196,12 +196,11 @@ extension SpecTestFile {
                 _ = try client.db("admin").runCommand(["killAllSessions": []], options: opts)
             } catch let commandError as MongoError.CommandError where commandError.code == 11601 {}
         case .sharded, .shardedReplicaSet:
-            for address in MongoSwiftTestCase.getHosts() {
+            for mongosClient in mongosClients! {
                 do {
-                    _ = try client.db("admin").runCommand(["killAllSessions": []], on: address)
-                } catch let commandError as MongoError.CommandError where commandError.code == 11601 {
-                    continue
-                }
+                    _ = try mongosClient.db("admin").runCommand(["killAllSessions": []])
+                break
+                } catch let commandError as MongoError.CommandError where commandError.code == 11601 {}
             }
         }
     }
@@ -221,6 +220,18 @@ extension SpecTestFile {
         setupClientOptions.minHeartbeatFrequencyMS = 50
         setupClientOptions.heartbeatFrequencyMS = 50
         let setupClient = try MongoClient.makeTestClient(connString, options: setupClientOptions)
+        let topologyType = try setupClient.topologyType()
+
+        var mongosClients: [MongoClient]? = nil
+        switch topologyType {
+        case .sharded, .shardedReplicaSet:
+            var opts = setupClientOptions
+            opts.directConnection = true // connect directly to mongoses
+            mongosClients = try MongoSwiftTestCase.getConnectionStringPerHost()
+                .map { try MongoClient.makeTestClient($0.toString(), options: opts) }
+        default:
+            break
+        }
 
         if let requirements = self.runOn {
             guard try requirements.contains(where: { try setupClient.getUnmetRequirement($0) == nil }) else {
@@ -235,19 +246,17 @@ extension SpecTestFile {
                 print("Skipping test \(test.description) due to matched keyword \"\(keyword)\".")
                 continue
             }
-
-            try self.terminateOpenTransactions(using: setupClient)
+            try self.terminateOpenTransactions(using: setupClient, mongosClients: mongosClients)
             try self.populateData(using: setupClient)
 
             // Due to strange behavior in mongos, a "distinct" command needs to be run against each mongos
             // before the tests run to prevent certain errors from ocurring. (SERVER-39704)
-            if MongoSwiftTestCase.topologyType == .sharded,
+            if [.sharded, .shardedReplicaSet].contains(topologyType),
                let collName = self.collectionName,
                test.description.contains("distinct")
             {
-                for address in MongoSwiftTestCase.getHosts() {
-                    _ = try setupClient.db(self.databaseName)
-                        .runCommand(["distinct": .string(collName), "key": "_id"], on: address)
+                for client in mongosClients! {
+                     _ = try client.db(self.databaseName).runCommand(["distinct": .string(collName), "key": "_id"])
                 }
             }
 

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -223,6 +223,14 @@ extension SpecTestFile {
         setupClientOptions.minHeartbeatFrequencyMS = 50
         setupClientOptions.heartbeatFrequencyMS = 50
         let setupClient = try MongoClient.makeTestClient(connString, options: setupClientOptions)
+
+        if let requirements = self.runOn {
+            guard try requirements.contains(where: { try setupClient.getUnmetRequirement($0) == nil }) else {
+                fileLevelLog("Skipping tests from file \(self.name), deployment requirements not met.")
+                return
+            }
+        }
+
         let topologyType = try setupClient.topologyType()
 
         var mongosClients: [MongoClient]?
@@ -236,12 +244,6 @@ extension SpecTestFile {
             break
         }
 
-        if let requirements = self.runOn {
-            guard try requirements.contains(where: { try setupClient.getUnmetRequirement($0) == nil }) else {
-                fileLevelLog("Skipping tests from file \(self.name), deployment requirements not met.")
-                return
-            }
-        }
 
         fileLevelLog("Executing tests from file \(self.name)...")
         for var test in self.tests {

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -244,7 +244,6 @@ extension SpecTestFile {
             break
         }
 
-
         fileLevelLog("Executing tests from file \(self.name)...")
         for var test in self.tests {
             if let keyword = Self.TestType.skippedTestKeywords.first(where: { test.description.contains($0) }) {

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -152,7 +152,7 @@ struct UnifiedTestRunner {
                 // Workaround for SERVER-39704:  a test runners MUST execute a non-transactional distinct command on
                 // each mongos server before running any test that might execute distinct within a transaction. To ease
                 // the implementation, test runners MAY execute distinct before every test.
-                if self.topologyType == .sharded || self.topologyType == .shardedReplicaSet {
+                if self.topologyType.isSharded {
                     let collEntities = context.entities.values.compactMap { try? $0.asCollection() }
                     for address in MongoSwiftTestCase.getHosts() {
                         for entity in collEntities {


### PR DESCRIPTION
Fixes the transactions test failures by using separate clients for running specific commands against each mongos. As discussed in #driver-devs, this accounts for cases where the setup client has not yet reconnected to one of the mongoses after a test.

I thought about porting this over to the unified runner, but that one is fairly specific that the internal client should be used for terminating open transactions and doesn't appear to be suffering from this issue on its own. It may become necessary in the future if any similarly racy tests start using that runner.

Evg patch against all sharded variants (realized those < 4.2 were useless too late): https://evergreen.mongodb.com/version/601c817c850e612ab835c3c9

no macOS results in yet but as you can see this has fixed all the Ubuntu failures anyway. 