### PR TITLE
SWIFT-734 Update scripts to maintain multiple versions of the documentation

### DIFF
--- a/etc/docs-main.md
+++ b/etc/docs-main.md
@@ -5,4 +5,6 @@ The MongoDB Swift driver contains two modules:
 - [MongoSwift](../MongoSwift/index.html), containing an asynchronous API and a BSON library
 - [MongoSwiftSync](../MongoSwiftSync/index.html), containing a synchronous wrapper of the API in `MongoSwift`
 
+See [here](https://mongodb.github.io/mongo-swift-driver/docs) for documentation of other versions of the driver.
+
 The driver relies on our [official Swift BSON library](https://github.com/mongodb/swift-bson), with API documentation available [here](https://mongodb.github.io/swift-bson).

--- a/etc/generate-docs.sh
+++ b/etc/generate-docs.sh
@@ -23,14 +23,15 @@ jazzy_args=(--clean
             --module-version "${version}")
 
 # Generate MongoSwift docs
+sourcekitten doc --spm --module-name MongoSwift > mongoswift-docs.json
 args=("${jazzy_args[@]}"  --output "docs-temp/MongoSwift" --module "MongoSwift" --config ".jazzy.yml" 
+        --sourcekitten-sourcefile mongoswift-docs.json
         --root-url "https://mongodb.github.io/mongo-swift-driver/docs/MongoSwift/")
 jazzy "${args[@]}"
 
 # Generate MongoSwiftSync docs
 
 # we have to do some extra work to get re-exported symbols to show up
-sourcekitten doc --spm --module-name MongoSwift > mongoswift-docs.json
 python3 etc/filter_sourcekitten_output.py
 
 sourcekitten doc --spm --module-name MongoSwiftSync > mongoswiftsync-docs.json

--- a/etc/release.sh
+++ b/etc/release.sh
@@ -18,9 +18,12 @@ version=${1}
 # commit/push docs to the gh-pages branch
 git checkout gh-pages
 
-rm -rf docs/*
-mv docs-temp/* docs/
-rm -d docs-temp
+rm -r docs/current
+cp -r docs-temp docs/current
+mv docs-temp docs/${version}
+
+# build up documentation index
+python3 ./etc/update-index.py
 
 git add docs/
 git commit -m "${version} docs"

--- a/etc/update-index.py
+++ b/etc/update-index.py
@@ -1,0 +1,17 @@
+import os
+
+first=True
+with open('./docs/index.md', 'w') as f:
+    f.write('# MongoSwift Documentation Index\n')
+
+    for dir in sorted(os.listdir('./docs'), reverse=True):
+        if not dir[0].isdigit():
+            continue
+
+        version_str = dir
+        if first:
+            version_str += ' (current)'
+            dir = 'current'
+            first = False
+
+        f.write('- [{}]({}/MongoSwift/index.html)\n'.format(version_str, dir))


### PR DESCRIPTION
SWIFT-734

This PR updates the release and documentation scripts to generate the docs in a way that works for multiple versions of the driver, based on [SwiftNIO's setup](https://github.com/apple/swift-nio/tree/gh-pages). See #600 for the changes it makes to the `gh-pages` branch (or rather, [check out the branch of my fork](https://github.com/patrickfreed/mongo-swift-driver/tree/SWIFT-734/gh-pages-update), since that diff is crazy).