### PR TITLE
SWIFT-992 Update references to master branch

### DIFF
--- a/Examples/ComplexVaporExample/README.md
+++ b/Examples/ComplexVaporExample/README.md
@@ -46,7 +46,7 @@ Therefore, we must always `hop` when we are done calling a driver API. Please se
 ### Codable Usage
 Throughout the application, we frequently use [`Codable`](https://developer.apple.com/documentation/swift/codable) Swift types. These are very useful as they allow us to convert seamlessly from BSON, the format MongoDB stores data in, to Swift types used in the server, to JSON to send to the client. The same is true for the opposite direction.
 
-Note that Vapor's[`Content`](https://api.vapor.codes/vapor/master/Vapor/Protocols/Content.html) protocol, which specifies types that can be initialized from HTTP requests and serialized to HTTP responses, inherits from `Codable`.
+Note that Vapor's [`Content`](https://api.vapor.codes/vapor/master/Vapor/Content/) protocol, which specifies types that can be initialized from HTTP requests and serialized to HTTP responses, inherits from `Codable`.
 
 When creating a `MongoCollection` object in the driver, you can pass in the name of a `Codable` type:
 ```swift

--- a/Examples/Docs/Package.swift
+++ b/Examples/Docs/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .macOS(.v10_14)
     ],
     dependencies: [
-        .package(url: "https://github.com/mongodb/mongo-swift-driver", .branch("master")),
+        .package(url: "https://github.com/mongodb/mongo-swift-driver", .branch("main")),
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Guides/BSON-Guide.md
+++ b/Guides/BSON-Guide.md
@@ -101,7 +101,7 @@ let uuid = try myBSONBinary.toUUID() // new
 Previously, `Document`/`BSONDocument` had computed properties, `extendedJSON` and `canonicalExtendedJSON`, to support converting to those formats. To better signify that these methods involve a non-constant time conversion, we've converted these properties to methods named `toExtendedJSONString()` and `toCanonicalExtendedJSONString()`, respectively.
 
 #### Errors
-Previously, the BSON library used the same types of errors as the driver. As of 1.0.0, the BSON library has its own set of errors. Please see the [error handling guide](https://github.com/mongodb/mongo-swift-driver/blob/master/Guides/Error-Handling.md) for more details.
+Previously, the BSON library used the same types of errors as the driver. As of 1.0.0, the BSON library has its own set of errors. Please see the [error handling guide](https://github.com/mongodb/mongo-swift-driver/blob/main/Guides/Error-Handling.md) for more details.
 
 ### Migrating from the 0.0.1-0.1.3 API to the 0.2.0 BSON API
 In version 0.2.0 of `MongoSwift`, the public API for using BSON values was changed dramatically. This section will describe the process for migrating from the old API (BSON API v1) to this new one (BSON API v2).

--- a/Guides/Development.md
+++ b/Guides/Development.md
@@ -56,7 +56,7 @@ To filter tests by regular expression:
 
 ### Diagnosing Backtraces on Linux
 
-[SWIFT-755](https://bugs.swift.org/browse/SR-755) documents an outstanding problem on Linux where backtraces do not contain debug symbols. As discussed in [this Stack Overflow thread](https://stackoverflow.com/a/44956167/162228), a [`symbolicate-linux-fatal`](https://github.com/apple/swift/blob/master/utils/symbolicate-linux-fatal) script may be used to add symbols to an existing backtrace. Consider the following:
+[SWIFT-755](https://bugs.swift.org/browse/SR-755) documents an outstanding problem on Linux where backtraces do not contain debug symbols. As discussed in [this Stack Overflow thread](https://stackoverflow.com/a/44956167/162228), a [`symbolicate-linux-fatal`](https://github.com/apple/swift/blob/main/utils/symbolicate-linux-fatal) script may be used to add symbols to an existing backtrace. Consider the following:
 
 ```
 $ swift test --filter CrashingTest &> crash.log
@@ -120,10 +120,10 @@ If you have a setup for developing the driver in an editor other than the ones l
 1. Ensure your code passes both the linter and the formatter.
 1. Make sure your code builds and passes all tests on:
     - [Travis](https://travis-ci.org/mongodb/mongo-swift-driver). Every time you push to GitHub or open a pull request, it will trigger a new build, which includes running the linter, formatter, and basic tests.
-    - (If you work at MongoDB) [Evergreen](https://evergreen.mongodb.com/waterfall/mongo-swift-driver) - Our Evergreen matrix tests a variety of MongoDB configurations, operating systems, and Swift language versions, and provides a way to more robustly test the driver. A new Evergreen build is automatically triggered for every commit to master, but for more complex pull requests it's a good idea to run patches on Evergreen before merging.
-1. Open a pull request on the repository. Make sure you have rebased your branch onto the latest commits on `master`.
+    - (If you work at MongoDB) [Evergreen](https://evergreen.mongodb.com/waterfall/mongo-swift-driver) - Our Evergreen matrix tests a variety of MongoDB configurations, operating systems, and Swift language versions, and provides a way to more robustly test the driver. A new Evergreen build is automatically triggered for every commit to `main`, but for more complex pull requests it's a good idea to run patches on Evergreen before merging.
+1. Open a pull request on the repository. Make sure you have rebased your branch onto the latest commits on `main`.
 1. Go through code review to get the team's approval on your changes. (See the next section on [Code Review](#code-review) for more details on this process.) Once you get the required approvals and your code passes all tests:
-1. Rebase on master again if needed.
+1. Rebase on `main` again if needed.
 1. Rerun tests.
 1. Squash all commits into a single, descriptive commit method, formatted as: `TICKET-NUMBER: Description of changes`. For example, `SWIFT-30: Implement WriteConcern type`.
 1. Merge it, or if you don't have permissions, ask someone to merge it for you.

--- a/Guides/Multithreaded-Usage.md
+++ b/Guides/Multithreaded-Usage.md
@@ -16,4 +16,4 @@ Each `MongoClient` uses its own background thread to monitor the MongoDB topolog
 **In order to share the connection pool across threads and minimize the number of background monitoring threads, we recommend sharing `MongoClient`s across threads.**
 
 ## Usage With Server-side Swift Frameworks
-See the [`Examples/`](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples) directory in the driver GitHub repository for examples of how to integrate the driver in multithreaded frameworks.
+See the [`Examples/`](https://github.com/mongodb/mongo-swift-driver/tree/main/Examples) directory in the driver GitHub repository for examples of how to integrate the driver in multithreaded frameworks.

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
         "package": "swift-bson",
         "repositoryURL": "https://github.com/mongodb/swift-bson",
         "state": {
-          "branch": "master",
-          "revision": "4c9f3803bf0d3c6e868a111c76e77dd8ff58a37e",
+          "branch": "main",
+          "revision": "e2b2dc0bd8e6435cc7fd3d5f3ebf1bc407dc0d40",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")),
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.15.0")),
-        .package(url: "https://github.com/mongodb/swift-bson", .branch("master"))
+        .package(url: "https://github.com/mongodb/swift-bson", .branch("main"))
     ],
     targets: [
         .target(name: "MongoSwift", dependencies: ["CLibMongoC", "NIO", "NIOConcurrencyHelpers", "SwiftBSON",]),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Build Status](https://travis-ci.org/mongodb/mongo-swift-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-swift-driver)
-[![Code Coverage](https://codecov.io/gh/mongodb/mongo-swift-driver/branch/master/graph/badge.svg)](https://codecov.io/gh/mongodb/mongo-swift-driver/branch/master)
-[![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level)
+[![Code Coverage](https://codecov.io/gh/mongodb/mongo-swift-driver/branch/main/graph/badge.svg)](https://codecov.io/gh/mongodb/mongo-swift-driver/branch/main)
+[![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/main/process/incubation.md#sandbox-level)
 
 # MongoSwift
 The official [MongoDB](https://www.mongodb.com/) driver for Swift applications on macOS and Linux.
@@ -191,11 +190,11 @@ all available. However, runtime guarantees are not yet met for many of these
 methods.
 
 ### Usage With Kitura, Vapor, and Perfect
-The `Examples/` directory contains sample projects that use the driver with [Kitura](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/KituraExample), [Vapor](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/ComplexVaporExample), and [Perfect](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/PerfectExample).
+The `Examples/` directory contains sample projects that use the driver with [Kitura](https://github.com/mongodb/mongo-swift-driver/tree/main/Examples/KituraExample), [Vapor](https://github.com/mongodb/mongo-swift-driver/tree/main/Examples/ComplexVaporExample), and [Perfect](https://github.com/mongodb/mongo-swift-driver/tree/main/Examples/PerfectExample).
 
 Please note that the driver is built using SwiftNIO 2, and therefore is incompatible with frameworks built upon SwiftNIO 1. SwiftNIO 2 is used as of Vapor 4.0 and Kitura 2.5.
 
 ## Development Instructions
 
-See our [development guide](https://github.com/mongodb/mongo-swift-driver/blob/master/Guides/Development.md) for instructions for building and testing the driver.
+See our [development guide](https://github.com/mongodb/mongo-swift-driver/blob/main/Guides/Development.md) for instructions for building and testing the driver.
 

--- a/Sources/MongoSwift/ChangeStreamOptions.swift
+++ b/Sources/MongoSwift/ChangeStreamOptions.swift
@@ -53,7 +53,7 @@ public struct ChangeStreamOptions: Codable {
      * to receive notifications even after an invalidate event (e.g. it will allow watching a collection that has
      * been dropped and recreated).
      * - Note: The server will report an error if `startAfter` and `resumeAfter` are both specified.
-     * - SeeAlso: https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
+     * - SeeAlso: https://docs.mongodb.com/manual/changeStreams/#change-stream-start-after
      */
     public var startAfter: ResumeToken?
 

--- a/Sources/MongoSwift/ReadConcern.swift
+++ b/Sources/MongoSwift/ReadConcern.swift
@@ -19,7 +19,7 @@ public struct ReadConcern: Codable {
     public static let majority = ReadConcern("majority")
 
     /// Snapshot ReadConcern.
-    /// - SeeAlso: https://docs.mongodb.com/master/reference/read-concern-snapshot/
+    /// - SeeAlso: https://docs.mongodb.com/manual/reference/read-concern-snapshot/
     public static let snapshot = ReadConcern("snapshot")
 
     /// Server default ReadConcern.

--- a/etc/build-examples.sh
+++ b/etc/build-examples.sh
@@ -8,8 +8,8 @@ for example_project in ${examples[@]}; do
     echo "Building $example_project"
     example_dir="Examples/${example_project}"
 
-    # replace version string with master
-    etc/sed.sh -i 's/swift-driver", .upToNextMajor[^)]*)/swift-driver", .branch("master")/' "${example_dir}/Package.swift"
+    # replace version string with main
+    etc/sed.sh -i 's/swift-driver", .upToNextMajor[^)]*)/swift-driver", .branch("main")/' "${example_dir}/Package.swift"
 
     pushd "${example_dir}"
 


### PR DESCRIPTION
SWIFT-992

In preparation for renaming the default branch of this repository from `master` to `main`, this PR updates any existing references to the `master` branch accordingly.