### PR TITLE
SWIFT-985 Add client metadata support for wrapping libraries

### DIFF
--- a/Sources/CLibMongoC/include/CLibMongoC_bson-version.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-version.h
@@ -31,7 +31,7 @@
  *
  * BSON minor version component (e.g. 2 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MINOR_VERSION (16)
+#define BSON_MINOR_VERSION (17)
 
 
 /**
@@ -39,7 +39,7 @@
  *
  * BSON micro version component (e.g. 3 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MICRO_VERSION (0)
+#define BSON_MICRO_VERSION (4)
 
 
 /**
@@ -47,14 +47,14 @@
  *
  * BSON prerelease version component (e.g. pre if %BSON_VERSION is 1.2.3-pre)
  */
-#define BSON_PRERELEASE_VERSION (pre)
+#define BSON_PRERELEASE_VERSION ()
 
 /**
  * BSON_VERSION:
  *
  * BSON version.
  */
-#define BSON_VERSION (1.16.0-pre)
+#define BSON_VERSION (1.17.4)
 
 
 /**
@@ -63,7 +63,7 @@
  * BSON version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define BSON_VERSION_S "1.16.0-pre"
+#define BSON_VERSION_S "1.17.4"
 
 
 /**

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-version.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-version.h
@@ -31,7 +31,7 @@
  *
  * MONGOC minor version component (e.g. 2 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MINOR_VERSION (16)
+#define MONGOC_MINOR_VERSION (17)
 
 
 /**
@@ -39,7 +39,7 @@
  *
  * MONGOC micro version component (e.g. 3 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MICRO_VERSION (0)
+#define MONGOC_MICRO_VERSION (4)
 
 
 /**
@@ -47,7 +47,7 @@
  *
  * MONGOC prerelease version component (e.g. pre if %MONGOC_VERSION is 1.2.3-pre)
  */
-#define MONGOC_PRERELEASE_VERSION (pre)
+#define MONGOC_PRERELEASE_VERSION ()
 
 
 /**
@@ -55,7 +55,7 @@
  *
  * MONGOC version.
  */
-#define MONGOC_VERSION (1.16.0-pre)
+#define MONGOC_VERSION (1.17.4)
 
 
 /**
@@ -64,7 +64,7 @@
  * MONGOC version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define MONGOC_VERSION_S "1.16.0-pre"
+#define MONGOC_VERSION_S "1.17.4"
 
 
 /**

--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -14,6 +14,7 @@ public func addWrappingLibraryMetadata(name: String, version: String) {
     clientMetadataLibraryName = name
     clientMetadataLibraryVersion = version
 }
+
 private final class MongocInitializer {
     internal static let shared = MongocInitializer()
 

--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -3,12 +3,33 @@ import CLibMongoC
 /// MongoSwift only supports MongoDB 3.6+.
 internal let MIN_SUPPORTED_WIRE_VERSION = 6
 
+/// Store optionally provided metadata about a library wrapping the driver.
+private var clientMetadataLibraryName: String? 
+private var clientMetadataLibraryVersion: String?
+
+/// Adds metadata to include the in the handshake performed with the MongoDB server. This is intended for use by
+/// libraries wrapping the driver e.g. MongoDBVapor or an ORM. If used, this method should be called exactly once.
+/// This method will only have an effect if called before any `MongoClient`s are initialized.
+public func addWrappingLibraryMetadata(name: String, version: String) {
+    clientMetadataLibraryName = name
+    clientMetadataLibraryVersion = version
+}
 private final class MongocInitializer {
     internal static let shared = MongocInitializer()
 
     private init() {
         mongoc_init()
-        mongoc_handshake_data_append("MongoSwift", MongoSwiftVersionString, nil)
+        var libraryName = "MongoSwift"
+        if let additionalName = clientMetadataLibraryName {
+            libraryName += " / \(additionalName)"
+        }
+
+        var libraryVersion = MongoSwiftVersionString
+        if let additionalVersion = clientMetadataLibraryVersion {
+            libraryVersion += " / \(additionalVersion)"
+        }
+
+        mongoc_handshake_data_append(libraryName, libraryVersion, nil)
     }
 }
 

--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -4,7 +4,7 @@ import CLibMongoC
 internal let MIN_SUPPORTED_WIRE_VERSION = 6
 
 /// Store optionally provided metadata about a library wrapping the driver.
-private var clientMetadataLibraryName: String? 
+private var clientMetadataLibraryName: String?
 private var clientMetadataLibraryVersion: String?
 
 /// Adds metadata to include the in the handshake performed with the MongoDB server. This is intended for use by

--- a/Sources/MongoSwift/MongoSwift.swift
+++ b/Sources/MongoSwift/MongoSwift.swift
@@ -8,7 +8,7 @@ private var clientMetadataLibraryName: String?
 private var clientMetadataLibraryVersion: String?
 
 /// Adds metadata to include the in the handshake performed with the MongoDB server. This is intended for use by
-/// libraries wrapping the driver e.g. MongoDBVapor or an ORM. If used, this method should be called exactly once.
+/// libraries wrapping the driver e.g. MongoDBVapor or an ODM. If used, this method should be called exactly once.
 /// This method will only have an effect if called before any `MongoClient`s are initialized.
 public func addWrappingLibraryMetadata(name: String, version: String) {
     clientMetadataLibraryName = name

--- a/etc/generated_headers/bson-version.h
+++ b/etc/generated_headers/bson-version.h
@@ -31,7 +31,7 @@
  *
  * BSON minor version component (e.g. 2 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MINOR_VERSION (16)
+#define BSON_MINOR_VERSION (17)
 
 
 /**
@@ -39,7 +39,7 @@
  *
  * BSON micro version component (e.g. 3 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MICRO_VERSION (0)
+#define BSON_MICRO_VERSION (4)
 
 
 /**
@@ -47,14 +47,14 @@
  *
  * BSON prerelease version component (e.g. pre if %BSON_VERSION is 1.2.3-pre)
  */
-#define BSON_PRERELEASE_VERSION (pre)
+#define BSON_PRERELEASE_VERSION ()
 
 /**
  * BSON_VERSION:
  *
  * BSON version.
  */
-#define BSON_VERSION (1.16.0-pre)
+#define BSON_VERSION (1.17.4)
 
 
 /**
@@ -63,7 +63,7 @@
  * BSON version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define BSON_VERSION_S "1.16.0-pre"
+#define BSON_VERSION_S "1.17.4"
 
 
 /**

--- a/etc/generated_headers/mongoc-version.h
+++ b/etc/generated_headers/mongoc-version.h
@@ -31,7 +31,7 @@
  *
  * MONGOC minor version component (e.g. 2 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MINOR_VERSION (16)
+#define MONGOC_MINOR_VERSION (17)
 
 
 /**
@@ -39,7 +39,7 @@
  *
  * MONGOC micro version component (e.g. 3 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MICRO_VERSION (0)
+#define MONGOC_MICRO_VERSION (4)
 
 
 /**
@@ -47,7 +47,7 @@
  *
  * MONGOC prerelease version component (e.g. pre if %MONGOC_VERSION is 1.2.3-pre)
  */
-#define MONGOC_PRERELEASE_VERSION (pre)
+#define MONGOC_PRERELEASE_VERSION ()
 
 
 /**
@@ -55,7 +55,7 @@
  *
  * MONGOC version.
  */
-#define MONGOC_VERSION (1.16.0-pre)
+#define MONGOC_VERSION (1.17.4)
 
 
 /**
@@ -64,7 +64,7 @@
  * MONGOC version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define MONGOC_VERSION_S "1.16.0-pre"
+#define MONGOC_VERSION_S "1.17.4"
 
 
 /**


### PR DESCRIPTION
You can't really test this besides trying it out. I did so by adding `addWrappingLibraryMetadata(name: "blah", version: "x.y.z")` to the start of a test case and then only running that and looking at the mongod log. It contains:

```js
{"t":{"$date":"2021-02-18T18:17:22.206-05:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn43","msg":"client metadata","attr":{"remote":"127.0.0.1:64189","client":"conn43","doc":{"driver":{"name":"mongoc / MongoSwift / blah","version":"1.17.4 / 1.0.0 / x.y.z"},"os":{"type":"Darwin","name":"macOS","version":"20.2.0","architecture":"x86_64"},"platform":"(null)cfg=0x0001d62245 posix=200112 stdc=201112 CC=clang 12.0.0 (clang-1200.0.32.29) CFLAGS=\"\" LDFLAGS=\"\""}}}
```
