### PR TITLE
SWIFT-888 OCSP support testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -183,7 +183,7 @@ functions:
 
           MONGODB_URI="${MONGODB_URI}" \
           SWIFT_VERSION=${SWIFT_VERSION} \
-            ${PROJECT_DIRECTORY}/.evergreen/run-ocsp-test.sh
+            bash ${PROJECT_DIRECTORY}/.evergreen/run-ocsp-test.sh
 
   run-valid-ocsp-server:
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -13,6 +13,9 @@ command_type: system
 # That roughly accounts for variable system performance for various buildvariants
 exec_timeout_secs: 1800 # 30 minutes is the longest we'll ever run
 
+# fail a task in case fetching the source or installing Swift fails.
+pre_error_fails_task: true
+
 # What to do when evergreen hits the timeout (`post:` tasks are run automatically)
 timeout:
   - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -172,6 +172,99 @@ functions:
           ATLAS_REPL_SRV='${ATLAS_REPL_SRV}' ATLAS_SHRD_SRV='${ATLAS_SHRD_SRV}' ATLAS_FREE_SRV='${ATLAS_FREE_SRV}' ATLAS_TLS11_SRV='${ATLAS_TLS11_SRV}' ATLAS_TLS12_SRV='${ATLAS_TLS12_SRV}' \
           sh ${PROJECT_DIRECTORY}/.evergreen/run-atlas-tests.sh
 
+  "run ocsp test":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+
+          MONGODB_URI="${MONGODB_URI}" \
+          SWIFT_VERSION=${SWIFT_VERSION} \
+            ${PROJECT_DIRECTORY}/.evergreen/run-ocsp-test.sh
+
+  run-valid-ocsp-server:
+    - command: shell.exec
+      params:
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+          ${PYTHON} -m virtualenv ./venv
+          ./venv/${VENV_BIN_DIR}/python -m pip install -r mock-ocsp-responder-requirements.txt
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+
+          ./venv/${VENV_BIN_DIR}/python ocsp_mock.py \
+          --ca_file ${OCSP_ALGORITHM}/ca.pem \
+          --ocsp_responder_cert ${OCSP_ALGORITHM}/ca.crt \
+          --ocsp_responder_key ${OCSP_ALGORITHM}/ca.key \
+          -p 8100 -v
+
+  run-revoked-ocsp-server:
+    - command: shell.exec
+      params:
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+          ${PYTHON} -m virtualenv ./venv
+          ./venv/${VENV_BIN_DIR}/python -m pip install -r mock-ocsp-responder-requirements.txt
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+
+          ./venv/${VENV_BIN_DIR}/python ocsp_mock.py \
+          --ca_file ${OCSP_ALGORITHM}/ca.pem \
+          --ocsp_responder_cert ${OCSP_ALGORITHM}/ca.crt \
+          --ocsp_responder_key ${OCSP_ALGORITHM}/ca.key \
+          -p 8100 \
+          -v \
+          --fault revoked
+
+  run-valid-delegate-ocsp-server:
+    - command: shell.exec
+      params:
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+          ${PYTHON} -m virtualenv ./venv
+          ./venv/${VENV_BIN_DIR}/python -m pip install -r mock-ocsp-responder-requirements.txt
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+
+          ./venv/${VENV_BIN_DIR}/python ocsp_mock.py \
+          --ca_file ${OCSP_ALGORITHM}/ca.pem \
+          --ocsp_responder_cert ${OCSP_ALGORITHM}/ocsp-responder.crt \
+          --ocsp_responder_key ${OCSP_ALGORITHM}/ocsp-responder.key \
+          -p 8100 -v
+
+  run-revoked-delegate-ocsp-server:
+    - command: shell.exec
+      params:
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+          ${PYTHON} -m virtualenv ./venv
+          ./venv/${VENV_BIN_DIR}/python -m pip install -r mock-ocsp-responder-requirements.txt
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+
+          ./venv/${VENV_BIN_DIR}/python ocsp_mock.py \
+          --ca_file ${OCSP_ALGORITHM}/ca.pem \
+          --ocsp_responder_cert ${OCSP_ALGORITHM}/ocsp-responder.crt \
+          --ocsp_responder_key ${OCSP_ALGORITHM}/ocsp-responder.key \
+          -p 8100 \
+          -v \
+          --fault revoked
+
   "cleanup":
     - command: shell.exec
       params:
@@ -416,6 +509,330 @@ tasks:
       commands:
         - func: "run atlas tests"
 
+    - name: test-ocsp-rsa-valid-cert-server-staples
+      tags: ["ocsp", "ocsp-rsa", "ocsp-staple"]
+      commands:
+        - func: "run-valid-ocsp-server"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-rsa-invalid-cert-server-staples
+      tags: ["ocsp", "ocsp-rsa", "ocsp-staple"]
+      commands:
+        - func: run-revoked-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-rsa-valid-cert-server-does-not-staple
+      tags: ["ocsp", "ocsp-rsa"]
+      commands:
+        - func: "run-valid-ocsp-server"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-rsa-invalid-cert-server-does-not-staple
+      tags: ["ocsp", "ocsp-rsa"]
+      commands:
+        - func: run-revoked-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-rsa-soft-fail
+      tags: ["ocsp", "ocsp-rsa"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-rsa-malicious-invalid-cert-mustStaple-server-does-not-staple
+      tags: ["ocsp", "ocsp-rsa"]
+      commands:
+        - func: run-revoked-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-rsa-malicious-no-responder-mustStaple-server-does-not-staple
+      tags: ["ocsp", "ocsp-rsa"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-rsa-delegate-valid-cert-server-staples
+      tags: ["ocsp", "ocsp-rsa", "ocsp-staple"]
+      commands:
+        - func: run-valid-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-rsa-delegate-invalid-cert-server-staples
+      tags: ["ocsp", "ocsp-rsa", "ocsp-staple"]
+      commands:
+        - func: run-revoked-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple
+      tags: ["ocsp", "ocsp-rsa"]
+      commands:
+        - func: run-valid-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple
+      tags: ["ocsp", "ocsp-rsa"]
+      commands:
+        - func: run-revoked-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-rsa-delegate-malicious-invalid-cert-mustStaple-server-does-not-staple
+      tags: ["ocsp", "ocsp-rsa"]
+      commands:
+        - func: run-revoked-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "rsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "rsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-ecdsa-valid-cert-server-staples
+      tags: ["ocsp", "ocsp-ecdsa", "ocsp-staple"]
+      commands:
+        - func: run-valid-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-ecdsa-invalid-cert-server-staples
+      tags: ["ocsp", "ocsp-ecdsa", "ocsp-staple"]
+      commands:
+        - func: run-revoked-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple
+      tags: ["ocsp", "ocsp-ecdsa"]
+      commands:
+        - func: run-valid-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple
+      tags: ["ocsp", "ocsp-ecdsa"]
+      commands:
+        - func: run-revoked-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-ecdsa-soft-fail
+      tags: ["ocsp", "ocsp-ecdsa"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-ecdsa-malicious-invalid-cert-mustStaple-server-does-not-staple
+      tags: ["ocsp", "ocsp-ecdsa"]
+      commands:
+        - func: run-revoked-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-ecdsa-malicious-no-responder-mustStaple-server-does-not-staple
+      tags: ["ocsp", "ocsp-ecdsa"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples
+      tags: ["ocsp", "ocsp-ecdsa", "ocsp-staple"]
+      commands:
+        - func: run-valid-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples
+      tags: ["ocsp", "ocsp-ecdsa", "ocsp-staple"]
+      commands:
+        - func: run-revoked-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple
+      tags: ["ocsp", "ocsp-ecdsa"]
+      commands:
+        - func: run-valid-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "true"
+
+    - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple
+      tags: ["ocsp", "ocsp-ecdsa"]
+      commands:
+        - func: run-revoked-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
+    - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-mustStaple-server-does-not-staple
+      tags: ["ocsp", "ocsp-ecdsa"]
+      commands:
+        - func: run-revoked-delegate-ocsp-server
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+        - func: "run ocsp test"
+          vars:
+            OCSP_ALGORITHM: "ecdsa"
+            OCSP_TLS_SHOULD_SUCCEED: "false"
+
     - name: "check-format"
       commands:
       - func: "format"
@@ -459,14 +876,23 @@ axes:
       - id: ubuntu-18.04
         display_name: "Ubuntu 18.04"
         run_on: ubuntu1804-test
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          VENV_BIN_DIR: "bin"
 
       - id: ubuntu-16.04
         display_name: "Ubuntu 16.04"
         run_on: ubuntu1604-test
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          VENV_BIN_DIR: "bin"
 
       - id: macos-10.14
         display_name: "macOS 10.14"
         run_on: macos-1014
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          VENV_BIN_DIR: "bin"
 
   - id: topology
     display_name: Topology
@@ -551,6 +977,35 @@ buildvariants:
   tasks:
     - ".atlas-connect"
 
+- matrix_name: "ocsp"
+  matrix_spec:
+    os-fully-featured:
+      - "ubuntu-18.04"
+      - "ubuntu-16.04"
+    mongodb-version:
+      - latest
+      - 4.4
+    swift-version:
+      - 5.2
+  display_name: "OCSP ${swift-version} ${os-fully-featured} ${mongodb-version}"
+  batchtime: 20160 # 14 days
+  tasks:
+    - ".ocsp"
+
+- matrix_name: "ocsp-macos"
+  matrix_spec:
+    os-fully-featured:
+      - macos-10.14
+    swift-version:
+      - 5.2
+    mongodb-version:
+      - latest
+      - 4.4
+  display_name: "OCSP ${swift-version} ${os-fully-featured} ${mongodb-version}"
+  batchtime: 20160 # 14 days
+  tasks:
+      # macOS MongoDB servers do not staple OCSP responses and only support RSA.
+      - name: ".ocsp-rsa !.ocsp-staple"
 
 # define separate matrices for swift 5.3 that excludes macOS 10.14. unfortunately
 # as of now we cannot remove entire buildvariants via rule from the matrices above

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,13 +192,17 @@ functions:
     - command: shell.exec
       params:
         script: |
+          set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           ${PYTHON} -m virtualenv ./venv
           ./venv/${VENV_BIN_DIR}/python3 -m pip install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
+      type: setup
       params:
         background: true
         script: |
+          set -o errexit
+
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
 
           ./venv/${VENV_BIN_DIR}/python3 ocsp_mock.py \
@@ -209,15 +213,19 @@ functions:
 
   run-revoked-ocsp-server:
     - command: shell.exec
+      type: setup
       params:
         script: |
+          set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           ${PYTHON} -m virtualenv ./venv
           ./venv/${VENV_BIN_DIR}/python3 -m pip install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
+      type: setup
       params:
         background: true
         script: |
+          set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
 
           ./venv/${VENV_BIN_DIR}/python3 ocsp_mock.py \
@@ -230,15 +238,19 @@ functions:
 
   run-valid-delegate-ocsp-server:
     - command: shell.exec
+      type: setup
       params:
         script: |
+          set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           ${PYTHON} -m virtualenv ./venv
           ./venv/${VENV_BIN_DIR}/python3 -m pip install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
+      type: setup
       params:
         background: true
         script: |
+          set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
 
           ./venv/${VENV_BIN_DIR}/python3 ocsp_mock.py \
@@ -249,15 +261,20 @@ functions:
 
   run-revoked-delegate-ocsp-server:
     - command: shell.exec
+      type: setup
       params:
         script: |
+          set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           ${PYTHON} -m virtualenv ./venv
           ./venv/${VENV_BIN_DIR}/python3 -m pip install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
+      type: setup
       params:
         background: true
         script: |
+          set -o errexit
+
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
 
           ./venv/${VENV_BIN_DIR}/python3 ocsp_mock.py \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -194,14 +194,14 @@ functions:
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           ${PYTHON} -m virtualenv ./venv
-          ./venv/${VENV_BIN_DIR}/python -m pip install -r mock-ocsp-responder-requirements.txt
+          ./venv/${VENV_BIN_DIR}/python3 -m pip install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
 
-          ./venv/${VENV_BIN_DIR}/python ocsp_mock.py \
+          ./venv/${VENV_BIN_DIR}/python3 ocsp_mock.py \
           --ca_file ${OCSP_ALGORITHM}/ca.pem \
           --ocsp_responder_cert ${OCSP_ALGORITHM}/ca.crt \
           --ocsp_responder_key ${OCSP_ALGORITHM}/ca.key \
@@ -213,14 +213,14 @@ functions:
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           ${PYTHON} -m virtualenv ./venv
-          ./venv/${VENV_BIN_DIR}/python -m pip install -r mock-ocsp-responder-requirements.txt
+          ./venv/${VENV_BIN_DIR}/python3 -m pip install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
 
-          ./venv/${VENV_BIN_DIR}/python ocsp_mock.py \
+          ./venv/${VENV_BIN_DIR}/python3 ocsp_mock.py \
           --ca_file ${OCSP_ALGORITHM}/ca.pem \
           --ocsp_responder_cert ${OCSP_ALGORITHM}/ca.crt \
           --ocsp_responder_key ${OCSP_ALGORITHM}/ca.key \
@@ -234,14 +234,14 @@ functions:
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           ${PYTHON} -m virtualenv ./venv
-          ./venv/${VENV_BIN_DIR}/python -m pip install -r mock-ocsp-responder-requirements.txt
+          ./venv/${VENV_BIN_DIR}/python3 -m pip install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
 
-          ./venv/${VENV_BIN_DIR}/python ocsp_mock.py \
+          ./venv/${VENV_BIN_DIR}/python3 ocsp_mock.py \
           --ca_file ${OCSP_ALGORITHM}/ca.pem \
           --ocsp_responder_cert ${OCSP_ALGORITHM}/ocsp-responder.crt \
           --ocsp_responder_key ${OCSP_ALGORITHM}/ocsp-responder.key \
@@ -253,14 +253,14 @@ functions:
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           ${PYTHON} -m virtualenv ./venv
-          ./venv/${VENV_BIN_DIR}/python -m pip install -r mock-ocsp-responder-requirements.txt
+          ./venv/${VENV_BIN_DIR}/python3 -m pip install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
 
-          ./venv/${VENV_BIN_DIR}/python ocsp_mock.py \
+          ./venv/${VENV_BIN_DIR}/python3 ocsp_mock.py \
           --ca_file ${OCSP_ALGORITHM}/ca.pem \
           --ocsp_responder_cert ${OCSP_ALGORITHM}/ocsp-responder.crt \
           --ocsp_responder_key ${OCSP_ALGORITHM}/ocsp-responder.key \
@@ -904,21 +904,21 @@ axes:
         display_name: "Ubuntu 18.04"
         run_on: ubuntu1804-test
         variables:
-          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
 
       - id: ubuntu-16.04
         display_name: "Ubuntu 16.04"
         run_on: ubuntu1604-test
         variables:
-          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
 
       - id: macos-10.14
         display_name: "macOS 10.14"
         run_on: macos-1014
         variables:
-          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
 
   - id: topology

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -101,7 +101,8 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${MONGODB_VERSION} \
+          ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
+            MONGODB_VERSION=${MONGODB_VERSION} \
             TOPOLOGY=${TOPOLOGY} \
             SSL=${SSL} \
             AUTH=${AUTH} \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -183,6 +183,8 @@ functions:
 
           MONGODB_URI="${MONGODB_URI}" \
           SWIFT_VERSION=${SWIFT_VERSION} \
+          OCSP_TLS_SHOULD_SUCCEED="${OCSP_TLS_SHOULD_SUCCEED}" \
+          OCSP_ALGORITHM="${OCSP_ALGORITHM}" \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-ocsp-test.sh
 
   run-valid-ocsp-server:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1014,7 +1014,7 @@ buildvariants:
       - 4.4
     swift-version:
       - 5.2
-  display_name: "OCSP ${swift-version} ${os-fully-featured} ${mongodb-version}"
+  display_name: "OCSP ${swift-version} ${os-fully-featured} ${versions}"
   batchtime: 20160 # 14 days
   tasks:
     - ".ocsp"
@@ -1028,7 +1028,7 @@ buildvariants:
     versions:
       - latest
       - 4.4
-  display_name: "OCSP ${swift-version} ${os-fully-featured} ${mongodb-version}"
+  display_name: "OCSP ${swift-version} ${os-fully-featured} ${versions}"
   batchtime: 20160 # 14 days
   tasks:
       # macOS MongoDB servers do not staple OCSP responses and only support RSA.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -512,6 +512,7 @@ tasks:
     - name: test-ocsp-rsa-valid-cert-server-staples
       tags: ["ocsp", "ocsp-rsa", "ocsp-staple"]
       commands:
+        - func: "prepare resources"
         - func: "run-valid-ocsp-server"
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -526,6 +527,7 @@ tasks:
     - name: test-ocsp-rsa-invalid-cert-server-staples
       tags: ["ocsp", "ocsp-rsa", "ocsp-staple"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-ocsp-server
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -540,6 +542,7 @@ tasks:
     - name: test-ocsp-rsa-valid-cert-server-does-not-staple
       tags: ["ocsp", "ocsp-rsa"]
       commands:
+        - func: "prepare resources"
         - func: "run-valid-ocsp-server"
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -554,6 +557,7 @@ tasks:
     - name: test-ocsp-rsa-invalid-cert-server-does-not-staple
       tags: ["ocsp", "ocsp-rsa"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-ocsp-server
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -568,6 +572,7 @@ tasks:
     - name: test-ocsp-rsa-soft-fail
       tags: ["ocsp", "ocsp-rsa"]
       commands:
+        - func: "prepare resources"
         - func: "bootstrap mongo-orchestration"
           vars:
             ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-disableStapling.json"
@@ -579,6 +584,7 @@ tasks:
     - name: test-ocsp-rsa-malicious-invalid-cert-mustStaple-server-does-not-staple
       tags: ["ocsp", "ocsp-rsa"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-ocsp-server
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -593,6 +599,7 @@ tasks:
     - name: test-ocsp-rsa-malicious-no-responder-mustStaple-server-does-not-staple
       tags: ["ocsp", "ocsp-rsa"]
       commands:
+        - func: "prepare resources"
         - func: "bootstrap mongo-orchestration"
           vars:
             ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple-disableStapling.json"
@@ -604,6 +611,7 @@ tasks:
     - name: test-ocsp-rsa-delegate-valid-cert-server-staples
       tags: ["ocsp", "ocsp-rsa", "ocsp-staple"]
       commands:
+        - func: "prepare resources"
         - func: run-valid-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -618,6 +626,7 @@ tasks:
     - name: test-ocsp-rsa-delegate-invalid-cert-server-staples
       tags: ["ocsp", "ocsp-rsa", "ocsp-staple"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -632,6 +641,7 @@ tasks:
     - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple
       tags: ["ocsp", "ocsp-rsa"]
       commands:
+        - func: "prepare resources"
         - func: run-valid-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -646,6 +656,7 @@ tasks:
     - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple
       tags: ["ocsp", "ocsp-rsa"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -660,6 +671,7 @@ tasks:
     - name: test-ocsp-rsa-delegate-malicious-invalid-cert-mustStaple-server-does-not-staple
       tags: ["ocsp", "ocsp-rsa"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "rsa"
@@ -674,6 +686,7 @@ tasks:
     - name: test-ocsp-ecdsa-valid-cert-server-staples
       tags: ["ocsp", "ocsp-ecdsa", "ocsp-staple"]
       commands:
+        - func: "prepare resources"
         - func: run-valid-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -688,6 +701,7 @@ tasks:
     - name: test-ocsp-ecdsa-invalid-cert-server-staples
       tags: ["ocsp", "ocsp-ecdsa", "ocsp-staple"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -702,6 +716,7 @@ tasks:
     - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple
       tags: ["ocsp", "ocsp-ecdsa"]
       commands:
+        - func: "prepare resources"
         - func: run-valid-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -716,6 +731,7 @@ tasks:
     - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple
       tags: ["ocsp", "ocsp-ecdsa"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -730,6 +746,7 @@ tasks:
     - name: test-ocsp-ecdsa-soft-fail
       tags: ["ocsp", "ocsp-ecdsa"]
       commands:
+        - func: "prepare resources"
         - func: "bootstrap mongo-orchestration"
           vars:
             ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
@@ -741,6 +758,7 @@ tasks:
     - name: test-ocsp-ecdsa-malicious-invalid-cert-mustStaple-server-does-not-staple
       tags: ["ocsp", "ocsp-ecdsa"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -755,6 +773,7 @@ tasks:
     - name: test-ocsp-ecdsa-malicious-no-responder-mustStaple-server-does-not-staple
       tags: ["ocsp", "ocsp-ecdsa"]
       commands:
+        - func: "prepare resources"
         - func: "bootstrap mongo-orchestration"
           vars:
             ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json"
@@ -766,6 +785,7 @@ tasks:
     - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples
       tags: ["ocsp", "ocsp-ecdsa", "ocsp-staple"]
       commands:
+        - func: "prepare resources"
         - func: run-valid-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -780,6 +800,7 @@ tasks:
     - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples
       tags: ["ocsp", "ocsp-ecdsa", "ocsp-staple"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -794,6 +815,7 @@ tasks:
     - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple
       tags: ["ocsp", "ocsp-ecdsa"]
       commands:
+        - func: "prepare resources"
         - func: run-valid-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -808,6 +830,7 @@ tasks:
     - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple
       tags: ["ocsp", "ocsp-ecdsa"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"
@@ -822,6 +845,7 @@ tasks:
     - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-mustStaple-server-does-not-staple
       tags: ["ocsp", "ocsp-ecdsa"]
       commands:
+        - func: "prepare resources"
         - func: run-revoked-delegate-ocsp-server
           vars:
             OCSP_ALGORITHM: "ecdsa"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -982,7 +982,7 @@ buildvariants:
     os-fully-featured:
       - "ubuntu-18.04"
       - "ubuntu-16.04"
-    mongodb-version:
+    versions:
       - latest
       - 4.4
     swift-version:
@@ -998,7 +998,7 @@ buildvariants:
       - macos-10.14
     swift-version:
       - 5.2
-    mongodb-version:
+    versions:
       - latest
       - 4.4
   display_name: "OCSP ${swift-version} ${os-fully-featured} ${mongodb-version}"

--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -26,7 +26,6 @@ PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
 SWIFT_VERSION=${SWIFT_VERSION:-5.2.5}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-EXTRA_FLAGS="-Xlinker -rpath -Xlinker ${INSTALL_DIR}/lib"
 
 # enable swiftenv
 export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
@@ -42,10 +41,10 @@ fi
 swiftenv local $SWIFT_VERSION
 
 # build the driver
-swift build $EXTRA_FLAGS
+swift build
 
 # test the driver
 set +o errexit # even if tests fail we want to parse the results, so disable errexit
 set -o pipefail # propagate error codes in the following pipes
 
-swift test --filter=OCSP $EXTRA_FLAGS
+swift test --filter=OCSP

--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -o xtrace
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Required environment variables:
+# MONGODB_URI
+# OCSP_TLS_SHOULD_SUCCEED    Whether the connection attempt should succeed or not with
+#                            the given configuration.
+# OCSP_ALGORITHM             Specify the cyptographic algorithm used to sign the server's
+#                            certificate. Must be either "rsa" or "ecdsa".
+
+echo "Running OCSP test"
+
+# show test output
+set -x
+
+# variables
+export MONGODB_URI=${MONGODB_URI:-"NO_URI_PROVIDED"}
+export SSL=ssl
+export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem"
+PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
+SWIFT_VERSION=${SWIFT_VERSION:-5.2.5}
+INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+EXTRA_FLAGS="-Xlinker -rpath -Xlinker ${INSTALL_DIR}/lib"
+RAW_TEST_RESULTS="${PROJECT_DIRECTORY}/rawTestResults"
+XML_TEST_RESULTS="${PROJECT_DIRECTORY}/testResults.xml"
+
+# enable swiftenv
+export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
+export PATH="${SWIFTENV_ROOT}/bin:$PATH"
+eval "$(swiftenv init -)"
+
+# select the latest Xcode for Swift 5.1 support on MacOS
+if [ "$OS" == "darwin" ]; then
+    sudo xcode-select -s /Applications/Xcode11.3.app
+fi
+
+# switch swift version, and run tests
+swiftenv local $SWIFT_VERSION
+
+# build the driver
+swift build $EXTRA_FLAGS
+
+# test the driver
+set +o errexit # even if tests fail we want to parse the results, so disable errexit
+set -o pipefail # propagate error codes in the following pipes
+
+MONGODB_OCSP_TESTING=1 MONGODB_URI=$MONGODB_URI swift test --filter=OCSP $EXTRA_FLAGS 2>&1 | tee ${RAW_TEST_RESULTS}
+
+# save tests exit code
+EXIT_CODE=$?
+
+# convert tests to XML
+cat ${RAW_TEST_RESULTS} | swift "${PROJECT_DIRECTORY}/etc/convert-test-results.swift" > ${XML_TEST_RESULTS}
+
+# exit with exit code for running the tests
+exit $EXIT_CODE

--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -19,13 +19,14 @@ set -x
 export MONGODB_URI=${MONGODB_URI:-"NO_URI_PROVIDED"}
 export SSL=ssl
 export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem"
+export MONGODB_OCSP_TESTING=1
+export OCSP_ALGORITHM=${OCSP_ALGORITHM}
+export OCSP_TLS_SHOULD_SUCCEED=${OCSP_TLS_SHOULD_SUCCEED}
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
 SWIFT_VERSION=${SWIFT_VERSION:-5.2.5}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 EXTRA_FLAGS="-Xlinker -rpath -Xlinker ${INSTALL_DIR}/lib"
-RAW_TEST_RESULTS="${PROJECT_DIRECTORY}/rawTestResults"
-XML_TEST_RESULTS="${PROJECT_DIRECTORY}/testResults.xml"
 
 # enable swiftenv
 export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
@@ -47,13 +48,4 @@ swift build $EXTRA_FLAGS
 set +o errexit # even if tests fail we want to parse the results, so disable errexit
 set -o pipefail # propagate error codes in the following pipes
 
-MONGODB_OCSP_TESTING=1 MONGODB_URI=$MONGODB_URI swift test --filter=OCSP $EXTRA_FLAGS 2>&1 | tee ${RAW_TEST_RESULTS}
-
-# save tests exit code
-EXIT_CODE=$?
-
-# convert tests to XML
-cat ${RAW_TEST_RESULTS} | swift "${PROJECT_DIRECTORY}/etc/convert-test-results.swift" > ${XML_TEST_RESULTS}
-
-# exit with exit code for running the tests
-exit $EXIT_CODE
+swift test --filter=OCSP $EXTRA_FLAGS

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -9,7 +9,6 @@ SWIFT_VERSION=${SWIFT_VERSION:-5.2.5}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 TOPOLOGY=${TOPOLOGY:-single}
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-EXTRA_FLAGS="-Xlinker -rpath -Xlinker ${INSTALL_DIR}/lib"
 RAW_TEST_RESULTS="${PROJECT_DIRECTORY}/rawTestResults"
 XML_TEST_RESULTS="${PROJECT_DIRECTORY}/testResults.xml"
 INSTALL_DEPS=${INSTALL_DEPS:-"false"}
@@ -42,13 +41,13 @@ fi
 swiftenv local $SWIFT_VERSION
 
 # build the driver
-swift build $EXTRA_FLAGS
+swift build
 
 # test the driver
 set +o errexit # even if tests fail we want to parse the results, so disable errexit
 set -o pipefail # propagate error codes in the following pipes
 
-MONGODB_TOPOLOGY=${TOPOLOGY} MONGODB_URI=$MONGODB_URI swift test $EXTRA_FLAGS 2>&1 | tee ${RAW_TEST_RESULTS}
+MONGODB_TOPOLOGY=${TOPOLOGY} MONGODB_URI=$MONGODB_URI swift test 2>&1 | tee ${RAW_TEST_RESULTS}
 
 # save tests exit code
 EXIT_CODE=$?

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -116,6 +116,7 @@ extension MongoClientTests {
         ("testBound", testBound),
         ("testResubmittingToThreadPool", testResubmittingToThreadPool),
         ("testConnectionPoolClose", testConnectionPoolClose),
+        ("testOCSP", testOCSP),
     ]
 }
 

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -13,10 +13,10 @@ extension MongoClient {
         var opts = options ?? MongoClientOptions()
         // if SSL is on and custom TLS options were not provided, enable them
         if MongoSwiftTestCase.ssl && opts.tlsCAFile == nil && opts.tlsCertificateKeyFile == nil {
-            if let caPath = MongoSwiftTestCase.sslCAFilePath  {
+            if let caPath = MongoSwiftTestCase.sslCAFilePath {
                 opts.tlsCAFile = URL(string: caPath)
             }
-            if let keyPath = MongoSwiftTestCase.sslPEMKeyFilePath  {
+            if let keyPath = MongoSwiftTestCase.sslPEMKeyFilePath {
                 opts.tlsCertificateKeyFile = URL(string: keyPath)
             }
         }

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -13,8 +13,12 @@ extension MongoClient {
         var opts = options ?? MongoClientOptions()
         // if SSL is on and custom TLS options were not provided, enable them
         if MongoSwiftTestCase.ssl && opts.tlsCAFile == nil && opts.tlsCertificateKeyFile == nil {
-            opts.tlsCAFile = URL(string: MongoSwiftTestCase.sslCAFilePath ?? "")
-            opts.tlsCertificateKeyFile = URL(string: MongoSwiftTestCase.sslPEMKeyFilePath ?? "")
+            if let caPath = MongoSwiftTestCase.sslCAFilePath  {
+                opts.tlsCAFile = URL(string: caPath)
+            }
+            if let keyPath = MongoSwiftTestCase.sslPEMKeyFilePath  {
+                opts.tlsCertificateKeyFile = URL(string: keyPath)
+            }
         }
         return try MongoClient(uri, using: eventLoopGroup, options: opts)
     }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -196,5 +196,11 @@ final class MongoClientTests: MongoSwiftTestCase {
         try self.withTestClient(options: options) { invalidCertClient in
             expect(try invalidCertClient.db("admin").runCommand(["ping": 1]).wait()).toNot(throwError())
         }
+
+        options.tlsAllowInvalidHostnames = nil
+        options.tlsInsecure = true
+        try self.withTestClient(options: options) { invalidTLSClient in
+            expect(try invalidTLSClient.db("admin").runCommand(["ping": 1]).wait()).toNot(throwError())
+        }
     }
 }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -173,7 +173,9 @@ final class MongoClientTests: MongoSwiftTestCase {
             return
         }
 
-        guard let shouldSucceed = ProcessInfo.processInfo.environment["OCSP_TLS_SHOULD_SUCCEED"].flatMap(Bool.init) else {
+        guard
+            let shouldSucceed = ProcessInfo.processInfo.environment["OCSP_TLS_SHOULD_SUCCEED"].flatMap(Bool.init)
+        else {
             throw MongoError.InternalError(message: "OCSP_TLS_SHOULD_SUCCEED not set or has invalid value")
         }
 

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import MongoSwift
 import Nimble
 import NIO
@@ -164,5 +165,34 @@ final class MongoClientTests: MongoSwiftTestCase {
 
         // wait to ensure all resource cleanup happens correctly
         try closeFuture.wait()
+    }
+
+    func testOCSP() throws {
+        guard ProcessInfo.processInfo.environment["MONGODB_OCSP_TESTING"] != nil else {
+            printSkipMessage(testName: "testOCSP", reason: "MONGODB_OCSP_TESTING environment variable not set")
+            return
+        }
+
+        guard let shouldSucceed = ProcessInfo.processInfo.environment["OCSP_TLS_SHOULD_SUCCEED"].flatMap(Bool.init) else {
+            throw MongoError.InternalError(message: "OCSP_TLS_SHOULD_SUCCEED not set or has invalid value")
+        }
+
+        var options = MongoClientOptions(serverSelectionTimeoutMS: 200)
+        try self.withTestClient(options: options) { client in
+            let response = Result {
+                try client.db("admin").runCommand(["ping": 1]).wait()
+            }
+
+            if shouldSucceed {
+                expect(try response.get()).toNot(throwError())
+            } else {
+                expect(try response.get()).to(throwError())
+            }
+        }
+
+        options.tlsAllowInvalidCertificates = true
+        try self.withTestClient(options: options) { invalidCertClient in
+            expect(try invalidCertClient.db("admin").runCommand(["ping": 1]).wait()).toNot(throwError())
+        }
     }
 }

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -188,7 +188,7 @@ final class MongoClientTests: MongoSwiftTestCase {
             if shouldSucceed {
                 expect(try response.get()).toNot(throwError())
             } else {
-                expect(try response.get()).to(throwError())
+                expect(try response.get()).to(throwError(errorType: MongoError.ServerSelectionError.self))
             }
         }
 

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -197,7 +197,7 @@ final class MongoClientTests: MongoSwiftTestCase {
             expect(try invalidCertClient.db("admin").runCommand(["ping": 1]).wait()).toNot(throwError())
         }
 
-        options.tlsAllowInvalidHostnames = nil
+        options.tlsAllowInvalidCertificates = nil
         options.tlsInsecure = true
         try self.withTestClient(options: options) { invalidTLSClient in
             expect(try invalidTLSClient.db("admin").runCommand(["ping": 1]).wait()).toNot(throwError())


### PR DESCRIPTION
SWIFT-888

This PR adds tests for OCSP support to the evergreen matrix as required in the specification. Note, due to CDRIVER-3759, the "soft fail" test may occasionally fail on macOS. I filed DRIVERS-1574 to cover the work for fixing that.

This PR does not introduce any new functionality to the driver, nor does it test the options parsing behavior. That will be completed in a subsequent PR for SWIFT-787.

patch with OCSP tests: https://evergreen.mongodb.com/version/60303e863627e04ae9e0061d
There are a few failures on Ubuntu 18.04 + latest, and they seem to be consistent with libmongoc's [OCSP testing](https://evergreen.mongodb.com/build/mongo_c_driver_r1.17_ocsp_264fc940df5a2d86d83c51b9523073a5d007a55f_21_02_02_16_10_14). I asked in `#driver-devs` to see if anyone else is experiencing something similar.

Update: I think this may be a libmongoc bug. Jira is having issues right now and won't let me file a ticket, so I'll try again on Monday.

2nd update: https://jira.mongodb.org/browse/CDRIVER-3912