### PR TITLE
SWIFT-787 Add OCSP configuration options

### DIFF
--- a/Guides/TLS-Guide.md
+++ b/Guides/TLS-Guide.md
@@ -81,15 +81,21 @@ let client = try MongoClient(
 
 ## Server Certificate Validation
 
-The driver will automatically verify the validity of the server certificate, such as issued by configured Certificate
-Authority, hostname validation, and expiration.
+The driver will automatically verify the validity of the server certificate by ensuring that it was issued by the
+configured Certificate Authority, its SAN or CN match the hostname provided in the connection string, and it has not
+expired.
 
-To overwrite this behavior, it is possible to disable hostname validation, OCSP endpoint revocation checking, and revocation
-checking entirely, and allow invalid certificates.
+To override this behavior, it is possible to disable parts or all of it via the following options in the
+`MongoClientOptions` or connection string used to create the `MongoClient`:
+- `tlsAllowInvalidHostnames`: disables hostname validation
+- `tlsDisableOCSPEndpointCheck`: disables OCSP endpoint revocation checking. This does not disable verifying OCSP
+responses stapled to a server's certificate 
+- `tlsDisableCertificateRevocationCheck`: disables revocation checking entirely, including via OCSP stapled responses or
+CRLs.
+- `tlsAllowInvalidCertificates`: completely disables server certificate verification and allows any certificate to be
+used.
 
-This behavior is controlled using the `tlsAllowInvalidHostnames`, `tlsDisableOCSPEndpointCheck`,
-`tlsDisableCertificateRevocationCheck`, and `tlsAllowInvalidCertificates` options respectively. By default, all are set
-to false.
+By default, all of these options are set to false.
 
 It is not recommended to change these defaults as it exposes the client to Man In The Middle attacks (when
 `tlsAllowInvalidHostnames` is set), invalid certificates (when `tlsAllowInvalidCertificates` is set), or potentially

--- a/Guides/TLS-Guide.md
+++ b/Guides/TLS-Guide.md
@@ -84,7 +84,7 @@ let client = try MongoClient(
 The driver will automatically verify the validity of the server certificate, such as issued by configured Certificate
 Authority, hostname validation, and expiration.
 
-To overwrite this behavior, it is possible to disable hostname validation, OCSP endpoint revocation checking, revocation
+To overwrite this behavior, it is possible to disable hostname validation, OCSP endpoint revocation checking, and revocation
 checking entirely, and allow invalid certificates.
 
 This behavior is controlled using the `tlsAllowInvalidHostnames`, `tlsDisableOCSPEndpointCheck`,

--- a/Guides/TLS-Guide.md
+++ b/Guides/TLS-Guide.md
@@ -79,3 +79,35 @@ let client = try MongoClient(
 ```
 **Note**: In both cases, if both a client certificate and a client private key are needed, the files should be concatenated into a single file which is specified by `tlsCertificateKeyFile`.
 
+## Server Certificate Validation
+
+The driver will automatically verify the validity of the server certificate, such as issued by configured Certificate
+Authority, hostname validation, and expiration.
+
+To overwrite this behavior, it is possible to disable hostname validation, OCSP endpoint revocation checking, revocation
+checking entirely, and allow invalid certificates.
+
+This behavior is controlled using the `tlsAllowInvalidHostnames`, `tlsDisableOCSPEndpointCheck`,
+`tlsDisableCertificateRevocationCheck`, and `tlsAllowInvalidCertificates` options respectively. By default, all are set
+to false.
+
+It is not recommended to change these defaults as it exposes the client to Man In The Middle attacks (when
+`tlsAllowInvalidHostnames` is set), invalid certificates (when `tlsAllowInvalidCertificates` is set), or potentially
+revoked certificates (when `tlsDisableOCSPEndpointCheck` or `tlsDisableCertificateRevocationCheck` are set).
+
+Note that `tlsDisableCertificateRevocationCheck` and `tlsDisableOCSPEndpointCheck` have no effect on macOS.
+
+### OCSP on Linux/OpenSSL
+The Online Certificate Status Protocol (OCSP) (see [RFC 6960](https://tools.ietf.org/html/rfc6960)) is fully supported
+when using OpenSSL 1.0.1+
+
+### OCSP on macOS
+The Online Certificate Status Protocol (OCSP) (see [RFC 6960](https://tools.ietf.org/html/rfc6960)) is partially
+supported with the following notes:
+
+- The Must-Staple extension (see [RFC 7633](https://tools.ietf.org/html/rfc7633)) is ignored. Connection may continue if
+  a Must-Staple certificate is presented with no stapled response (unless the client receives a revoked response from an
+  OCSP responder).
+
+- Connection will continue if a Must-Staple certificate is presented without a stapled response and the OCSP responder
+  is down.

--- a/Guides/TLS-Guide.md
+++ b/Guides/TLS-Guide.md
@@ -99,7 +99,7 @@ Note that `tlsDisableCertificateRevocationCheck` and `tlsDisableOCSPEndpointChec
 
 ### OCSP on Linux/OpenSSL
 The Online Certificate Status Protocol (OCSP) (see [RFC 6960](https://tools.ietf.org/html/rfc6960)) is fully supported
-when using OpenSSL 1.0.1+
+when using OpenSSL 1.0.1+.
 
 ### OCSP on macOS
 The Online Certificate Status Protocol (OCSP) (see [RFC 6960](https://tools.ietf.org/html/rfc6960)) is partially

--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -2,6 +2,35 @@ import CLibMongoC
 
 /// Class representing a connection string for connecting to MongoDB.
 internal class ConnectionString {
+    /// Type defining the relationship between a field on MongoClientOptions and a URI option.
+    private struct Option {
+        /// The key path into `MongoClientOptions` of the option.
+        let path: KeyPath<MongoClientOptions, Bool?>
+
+        /// The associated URI option.
+        let uriOption: String
+    }
+
+    // A few select options that we define to test for incompatibilities between each other.
+
+    private static let TLS_INSECURE = Option(path: \.tlsInsecure, uriOption: "tlsInsecure")
+    private static let TLS_ALLOW_INVALID_HOSTNAMES = Option(
+        path: \.tlsAllowInvalidHostnames,
+        uriOption: "tlsAllowInvalidHostnames"
+    )
+    private static let TLS_ALLOW_INVALID_CERTIFICATES = Option(
+        path: \.tlsAllowInvalidCertificates,
+        uriOption: "tlsAllowInvalidCertificates"
+    )
+    private static let TLS_DISABLE_OCSP_ENDPOINT_CHECK = Option(
+        path: \.tlsDisableOCSPEndpointCheck,
+        uriOption: "tlsDisableOCSPEndpointCheck"
+    )
+    private static let TLS_DISABLE_CERTIFICATE_REVOCATION_CHECK = Option(
+        path: \.tlsDisableCertificateRevocationCheck,
+        uriOption: "tlsDisableCertificateRevocationCheck"
+    )
+
     /// Pointer to the underlying `mongoc_uri_t`.
     private let _uri: OpaquePointer
     /// Tracks whether we have already destroyed the above pointer.
@@ -133,6 +162,26 @@ internal class ConnectionString {
         )
     }
 
+    private func checkIncompatibility(
+        between optionA: Option,
+        and incompatibilities: [Option],
+        options: MongoClientOptions?
+    ) throws {
+        guard options?[keyPath: optionA.path] != nil || self.hasOption(optionA.uriOption) else {
+            return
+        }
+        for incompatibleOption in incompatibilities {
+            guard
+                options?[keyPath: incompatibleOption.path] == nil,
+                !self.hasOption(incompatibleOption.uriOption)
+            else {
+                throw MongoError.InvalidArgumentError(
+                    message: "\(incompatibleOption.uriOption) and \(optionA.uriOption) options cannot both be specified"
+                )
+            }
+        }
+    }
+
     /// Sets and validates TLS-related on the underlying `mongoc_uri_t`.
     private func applyAndValidateTLSOptions(_ options: MongoClientOptions?) throws {
         if let tls = options?.tls {
@@ -142,24 +191,33 @@ internal class ConnectionString {
             try self.setBoolOption(MONGOC_URI_TLS, to: tls)
         }
 
-        if options?.tlsInsecure != nil || self.hasOption(MONGOC_URI_TLSINSECURE) {
-            let errString = "and \(MONGOC_URI_TLSINSECURE) options cannot both be specified"
+        try self.checkIncompatibility(
+            between: Self.TLS_INSECURE,
+            and: [
+                Self.TLS_ALLOW_INVALID_CERTIFICATES,
+                Self.TLS_ALLOW_INVALID_HOSTNAMES,
+                Self.TLS_DISABLE_OCSP_ENDPOINT_CHECK,
+                Self.TLS_DISABLE_CERTIFICATE_REVOCATION_CHECK
+            ],
+            options: options
+        )
 
-            // per URI options spec, we must raise an error if `tlsInsecure` is provided along with either of
-            // `tlsAllowInvalidCertificates` or `tlsAllowInvalidHostnames`. if such a combination is provided in the
-            // input connection string, libmongoc will error.
-            if options?.tlsAllowInvalidCertificates != nil || self.hasOption(MONGOC_URI_TLSALLOWINVALIDCERTIFICATES) {
-                throw MongoError.InvalidArgumentError(
-                    message: "\(MONGOC_URI_TLSALLOWINVALIDCERTIFICATES) \(errString)"
-                )
-            }
+        try self.checkIncompatibility(
+            between: Self.TLS_ALLOW_INVALID_CERTIFICATES,
+            and: [
+                Self.TLS_DISABLE_OCSP_ENDPOINT_CHECK,
+                Self.TLS_DISABLE_CERTIFICATE_REVOCATION_CHECK
+            ],
+            options: options
+        )
 
-            if options?.tlsAllowInvalidHostnames != nil || self.hasOption(MONGOC_URI_TLSALLOWINVALIDHOSTNAMES) {
-                throw MongoError.InvalidArgumentError(
-                    message: "\(MONGOC_URI_TLSALLOWINVALIDHOSTNAMES) \(errString)"
-                )
-            }
-        }
+        try self.checkIncompatibility(
+            between: Self.TLS_DISABLE_CERTIFICATE_REVOCATION_CHECK,
+            and: [
+                Self.TLS_DISABLE_OCSP_ENDPOINT_CHECK
+            ],
+            options: options
+        )
 
         if let tlsInsecure = options?.tlsInsecure {
             try self.setBoolOption(MONGOC_URI_TLSINSECURE, to: tlsInsecure)

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -99,10 +99,23 @@ public struct MongoClientOptions: CodingStrategyProvider {
     /// Specifies the password to de-crypt the `tlsCertificateKeyFile`.
     public var tlsCertificateKeyFilePassword: String?
 
+    /// Indicates if revocation checking (CRL / OCSP) should be disabled.
+    /// On macOS, this setting has no effect.
+    /// By default this is set to false.
+    /// It is an error to specify both this option and `tlsDisableOCSPEndpointCheck`, either via this options struct,
+    /// connection string, or a combination of both.
+    public var tlsDisableCertificateRevocationCheck: Bool?
+
+    /// Indicates if OCSP responder endpoints should not be requested when an OCSP response is not stapled.
+    /// On macOS, this setting has no effect.
+    /// By default this is set to false.
+    public var tlsDisableOCSPEndpointCheck: Bool?
+
     /// When specified, TLS constraints will be relaxed as much as possible. Currently, setting this option to `true`
-    /// is equivalent to setting both `tlsAllowInvalidCertificates` and `tlsAllowInvalidHostnames` to `true`.
-    /// It is an error to specify both this option and either of `tlsAllowInvalidCertificates` or
-    /// `tlsAllowInvalidHostnames`, either via this options struct, connection string, or a combination of both.
+    /// is equivalent to setting `tlsAllowInvalidCertificates`, `tlsAllowInvalidHostnames`, and
+    /// `tlsDisableCertificateRevocationCheck` to `true`.
+    /// It is an error to specify both this option and any of the options enabled by it, either via this options struct,
+    /// connection string, or a combination of both.
     public var tlsInsecure: Bool?
 
     /// Specifies the `UUIDCodingStrategy` to use for BSON encoding/decoding operations performed by this client and any

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -342,6 +342,7 @@ extension SyncMongoClientTests {
         ("testCodingStrategies", testCodingStrategies),
         ("testClientLifetimeManagement", testClientLifetimeManagement),
         ("testAPMCallbacks", testAPMCallbacks),
+        ("testCertificateVerificationOptions", testCertificateVerificationOptions),
     ]
 }
 

--- a/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
@@ -288,4 +288,36 @@ final class SyncMongoClientTests: MongoSwiftTestCase {
         expect(commandEvents).toEventually(haveCount(2)) // wait for started and succeeded / failed
         expect(sdamEvents.isEmpty).toEventually(beFalse())
     }
+
+    func testCertificateVerificationOptions() throws {
+        var options = MongoClientOptions()
+        options.tlsInsecure = true
+        options.tlsDisableOCSPEndpointCheck = false
+        expect(try MongoClient("mongodb://localhost:12345", options: options))
+            .to(throwError(errorType: MongoError.InvalidArgumentError.self))
+
+        options = MongoClientOptions()
+        options.tlsInsecure = true
+        options.tlsDisableCertificateRevocationCheck = true
+        expect(try MongoClient("mongodb://localhost:12345", options: options))
+            .to(throwError(errorType: MongoError.InvalidArgumentError.self))
+
+        options = MongoClientOptions()
+        options.tlsAllowInvalidCertificates = true
+        options.tlsDisableOCSPEndpointCheck = false
+        expect(try MongoClient("mongodb://localhost:12345", options: options))
+            .to(throwError(errorType: MongoError.InvalidArgumentError.self))
+
+        options = MongoClientOptions()
+        options.tlsAllowInvalidCertificates = true
+        options.tlsDisableCertificateRevocationCheck = false
+        expect(try MongoClient("mongodb://localhost:12345", options: options))
+            .to(throwError(errorType: MongoError.InvalidArgumentError.self))
+
+        options = MongoClientOptions()
+        options.tlsDisableCertificateRevocationCheck = false
+        options.tlsDisableOCSPEndpointCheck = true
+        expect(try MongoClient("mongodb://localhost:12345", options: options))
+            .to(throwError(errorType: MongoError.InvalidArgumentError.self))
+    }
 }

--- a/Tests/MongoSwiftTests/ConnectionStringTests.swift
+++ b/Tests/MongoSwiftTests/ConnectionStringTests.swift
@@ -128,12 +128,6 @@ func shouldSkip(file: String, test: String) -> Bool {
         return true
     }
 
-    // check for these separately rather than putting them in the skip list since there are a lot of them.
-    // TODO: SWIFT-787: unskip
-    if test.contains("tlsDisableCertificateRevocationCheck") || test.contains("tlsDisableOCSPEndpointCheck") {
-        return true
-    }
-
     return false
 }
 


### PR DESCRIPTION
SWIFT-787

This PR adds OCSP configuration options to `MongoClientOptions` and enables the associated tests. It also adds some one-off prose tests as mentioned in the specification and updates the TLS guide to describe them.