### PR TITLE
Bump sourcery version, and ignore comments when checking Sourcery diffs going forward

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -347,9 +347,10 @@ functions:
           SWIFT_VERSION=${SWIFT_VERSION} \
             bash ${PROJECT_DIRECTORY}/.evergreen/install-tools.sh sourcery
           make linuxmain SOURCERY=${PROJECT_DIRECTORY}/opt/sourcery/bin/sourcery
-          git diff --exit-code Tests/LinuxMain.swift
+          # use regex to ignore lines starting with a /
+          git diff -G "^[^\/].*\n" --exit-code Tests/LinuxMain.swift
           make exports SOURCERY=${PROJECT_DIRECTORY}/opt/sourcery/bin/sourcery
-          git diff --exit-code Sources/MongoSwiftSync/Exports.swift
+          git diff -G "^[^\/].*\n" --exit-code Sources/MongoSwiftSync/Exports.swift
 
 pre:
   - func: "fetch source"

--- a/.evergreen/install-tools.sh
+++ b/.evergreen/install-tools.sh
@@ -45,7 +45,7 @@ then
     build_from_gh swiftformat https://github.com/nicklockwood/SwiftFormat "0.47.3"
 elif [ $1 == "sourcery" ]
 then
-    install_from_gh sourcery https://github.com/krzysztofzablocki/Sourcery/releases/download/1.0.0/Sourcery-1.0.0.zip
+    install_from_gh sourcery https://github.com/krzysztofzablocki/Sourcery/releases/download/1.3.4/Sourcery-1.3.4.zip
 else
     echo Missing/unknown install option: "$1"
 fi

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.3.4 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 
 // Re-export the BSON library
 @_exported import SwiftBSON

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.3.4 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 
 @testable import BSONTests
 @testable import MongoSwiftTests


### PR DESCRIPTION
Updates us to the latest version of Sourcery, and removes the need for us all to be on the same exact version of Sourcery going forward by ignoring any lines starting with a "/" when checking the diff.

Here's a sample patch with my first commit only, where I updated the version being used on Evergreen but did not actually regenerate the files using that version string: https://spruce.mongodb.com/version/605255a61e2d171f05624717