### PR TITLE
SWIFT-1054 Add public API for versioned API

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ disabled_rules:
   - inclusive_language # disabled until we complete work for the "remove offensive terminology" project.
   - cyclomatic_complexity
   - opening_brace # conflicts with SwiftFormat wrapMultilineStatementBraces
+  - nesting
 
 opt_in_rules:
   - array_init

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -152,7 +152,7 @@ public struct MongoClientOptions: CodingStrategyProvider {
         replicaSet: String? = nil,
         retryReads: Bool? = nil,
         retryWrites: Bool? = nil,
-        serverAPI: ServerAPI? = nil,
+        serverAPI: MongoServerAPI? = nil,
         serverSelectionTimeoutMS: Int? = nil,
         threadPoolSize: Int? = nil,
         tls: Bool? = nil,

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -66,76 +66,9 @@ public struct MongoClientOptions: CodingStrategyProvider {
     /// Determines whether the client should retry supported write operations (on by default).
     public var retryWrites: Bool?
 
-    /// A type containing options for specifying a MongoDB server API version and related behavior.
-    public struct ServerAPI: Codable {
-        /// Represents a server API version.
-        public struct Version: Codable, Equatable, LosslessStringConvertible {
-            /// MongoDB API version 1.
-            public static let v1 = Version(.v1)
-
-            private enum _Version: String {
-                case v1 = "1"
-            }
-
-            private let _version: _Version
-
-            private init(_ version: _Version) {
-                self._version = version
-            }
-
-            /// `LosslessStringConvertible` conformance
-
-            public init?(_ description: String) {
-                guard let _version = _Version(rawValue: description) else {
-                    return nil
-                }
-                self.init(_version)
-            }
-
-            public var description: String {
-                self._version.rawValue
-            }
-
-            /// `Codable` conformance
-
-            public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
-                try container.encode(self._version.rawValue)
-            }
-
-            public init(from decoder: Decoder) throws {
-                let container = try decoder.singleValueContainer()
-                let stringValue = try container.decode(String.self)
-
-                guard let version = _Version(rawValue: stringValue) else {
-                    throw DecodingError.dataCorruptedError(
-                        in: container,
-                        debugDescription: "Invalid API version string \(stringValue)"
-                    )
-                }
-                self = Version(version)
-            }
-        }
-
-        /// Specifies the API version to use.
-        public var version: Version
-
-        /// Specifies whether the server should return errors for features that are not part of the API version.
-        public var strict: Bool?
-
-        /// Specifies whether the server should return errors for deprecated features.
-        public var deprecationErrors: Bool?
-
-        /// Convenience initializer allowing optional parameters to be optional or omitted.
-        public init(version: Version, strict: Bool? = nil, deprecationErrors: Bool? = nil) {
-            self.version = version
-            self.strict = strict
-            self.deprecationErrors = deprecationErrors
-        }
-    }
-
+    // TODO: SWIFT-1159: add versioned API docs link.
     /// Specifies a MongoDB server API version and related options.
-    public var serverAPI: ServerAPI?
+    public var serverAPI: MongoServerAPI?
 
     /// Specifies how long the driver should attempt to select a server for before throwing an error. Defaults to 30
     /// seconds (30000 ms).

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -357,6 +357,9 @@ public struct MongoDatabase {
      *    - `MongoError.WriteError` if any error occurs while the command was performing a write.
      *    - `MongoError.CommandError` if an error occurs that prevents the command from being performed.
      *    - `EncodingError` if an error occurs while encoding the options to BSON.
+     *
+     * - Note: Attempting to specify an API version in this command is considered undefined behavior. API version may
+     *         only be configured at the `MongoClient` level.
      */
     public func runCommand(
         _ command: BSONDocument,

--- a/Sources/MongoSwift/MongoServerAPI.swift
+++ b/Sources/MongoSwift/MongoServerAPI.swift
@@ -1,0 +1,68 @@
+// TODO: SWIFT-1159: add versioned API docs link.
+/// A type containing options for specifying a MongoDB server API version and related behavior.
+public struct MongoServerAPI: Codable {
+    /// Represents a server API version.
+    public struct Version: Codable, Equatable, LosslessStringConvertible {
+        /// MongoDB API version 1.
+        public static let v1 = Version(.v1)
+
+        private enum _Version: String {
+            case v1 = "1"
+        }
+
+        private let _version: _Version
+
+        private init(_ version: _Version) {
+            self._version = version
+        }
+
+        /// `LosslessStringConvertible` conformance
+
+        public init?(_ description: String) {
+            guard let _version = _Version(rawValue: description) else {
+                return nil
+            }
+            self.init(_version)
+        }
+
+        public var description: String {
+            self._version.rawValue
+        }
+
+        /// `Codable` conformance
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(self._version.rawValue)
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let stringValue = try container.decode(String.self)
+
+            guard let version = _Version(rawValue: stringValue) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid API version string \(stringValue)"
+                )
+            }
+            self = Version(version)
+        }
+    }
+
+    /// Specifies the API version to use.
+    public var version: Version
+
+    /// Specifies whether the server should return errors for features that are not part of the API version.
+    public var strict: Bool?
+
+    /// Specifies whether the server should return errors for deprecated features.
+    public var deprecationErrors: Bool?
+
+    /// Convenience initializer allowing optional parameters to be optional or omitted.
+    public init(version: Version, strict: Bool? = nil, deprecationErrors: Bool? = nil) {
+        self.version = version
+        self.strict = strict
+        self.deprecationErrors = deprecationErrors
+    }
+}


### PR DESCRIPTION
Adds the public API required for versioned API support as defined [here](https://github.com/mongodb/specifications/blob/master/source/versioned-api/versioned-api.rst#mongoclient-changes).

In a future PR, `MongoClientOptions.ServerAPI` will gain a `withMongocServerAPI` method that will allow it to interoperate with libmongoc.