### PR TITLE
SWIFT-1054 Unified test runner updates for versioned API

### DIFF
--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -325,6 +325,17 @@ public struct BulkWriteOptions: Codable {
         self.ordered = options.ordered
         self.writeConcern = options.writeConcern
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case bypassDocumentValidation, ordered, writeConcern
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.bypassDocumentValidation = try container.decodeIfPresent(Bool.self, forKey: .bypassDocumentValidation)
+        self.ordered = try container.decodeIfPresent(Bool.self, forKey: .ordered) ?? true
+        self.writeConcern = try container.decodeIfPresent(WriteConcern.self, forKey: .writeConcern)
+    }
 }
 
 /// The result of a bulk write operation on a `MongoCollection`.

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -330,6 +330,7 @@ public struct BulkWriteOptions: Codable {
         case bypassDocumentValidation, ordered, writeConcern
     }
 
+    // A manual implementation is required to enforce a default value for ordered without making it optional.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.bypassDocumentValidation = try container.decodeIfPresent(Bool.self, forKey: .bypassDocumentValidation)

--- a/Sources/MongoSwiftSync/Exports.swift
+++ b/Sources/MongoSwiftSync/Exports.swift
@@ -57,6 +57,7 @@
 @_exported import struct MongoSwift.MongoDatabaseOptions
 @_exported import enum MongoSwift.MongoError
 @_exported import struct MongoSwift.MongoNamespace
+@_exported import struct MongoSwift.MongoServerAPI
 @_exported import enum MongoSwift.OperationType
 @_exported import struct MongoSwift.ReadConcern
 @_exported import struct MongoSwift.ReadPreference

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -363,6 +363,13 @@ extension UnifiedRunnerTests {
         ("testSchemaVersion", testSchemaVersion),
         ("testSampleUnifiedTests", testSampleUnifiedTests),
         ("testStrictDecodableTypes", testStrictDecodableTypes),
+        ("testServerParameterRequirements", testServerParameterRequirements),
+    ]
+}
+
+extension VersionedAPITests {
+    static var allTests = [
+        ("testVersionedAPI", testVersionedAPI),
     ]
 }
 
@@ -409,5 +416,6 @@ XCTMain([
     testCase(SyncMongoClientTests.allTests),
     testCase(TransactionsTests.allTests),
     testCase(UnifiedRunnerTests.allTests),
+    testCase(VersionedAPITests.allTests),
     testCase(WriteConcernTests.allTests),
 ])

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -74,7 +74,7 @@ extension MongoClient {
     }
 
     internal func serverParameters() throws -> BSONDocument {
-        try self.db("admin").runCommand(["getParameter": "*"]) 
+        try self.db("admin").runCommand(["getParameter": "*"])
     }
 
     /// Determine whether server version and topology requirements for a certain test are met

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -73,11 +73,16 @@ extension MongoClient {
         return try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
     }
 
+    internal func serverParameters() throws -> BSONDocument {
+        try self.db("admin").runCommand(["getParameter": "*"]) 
+    }
+
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
         let topologyType = try self.topologyType()
         let serverVersion = try self.serverVersion()
-        return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType)
+        let params = try self.serverParameters()
+        return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType, params)
     }
 
     internal func meetsAnyRequirement(in requirements: [TestRequirement]) throws -> Bool {

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -301,6 +301,7 @@ struct UnifiedDeleteOne: UnifiedOperationProtocol {
         return .bson(.document(encoded))
     }
 }
+
 struct UnifiedDeleteMany: UnifiedOperationProtocol {
     /// Filter to use for the operation.
     let filter: BSONDocument
@@ -318,7 +319,6 @@ struct UnifiedDeleteMany: UnifiedOperationProtocol {
         return .bson(.document(encoded))
     }
 }
-
 
 struct UnifiedInsertOne: UnifiedOperationProtocol {
     /// Document to insert.
@@ -460,7 +460,6 @@ struct UnifiedCountDocuments: UnifiedOperationProtocol {
     }
 }
 
-
 struct UnifiedEstimatedDocumentCount: UnifiedOperationProtocol {
     static var knownArguments: Set<String> { [] }
 
@@ -509,7 +508,6 @@ struct UnifiedUpdateOne: UnifiedOperationProtocol {
         return .bson(.document(encoded))
     }
 }
-
 
 struct UnifiedUpdateMany: UnifiedOperationProtocol {
     /// Filter for the query.

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -246,6 +246,23 @@ struct UnifiedFindOneAndUpdate: UnifiedOperationProtocol {
     }
 }
 
+struct UnifiedFindOneAndDelete: UnifiedOperationProtocol {
+    /// Filter to use for the operation.
+    let filter: BSONDocument
+
+    static var knownArguments: Set<String> {
+        ["filter"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        guard let result = try collection.findOneAndDelete(filter) else {
+            return .none
+        }
+        return .rootDocument(result)
+    }
+}
+
 struct UnifiedDeleteOne: UnifiedOperationProtocol {
     /// Filter to use for the operation.
     let filter: BSONDocument
@@ -284,6 +301,24 @@ struct UnifiedDeleteOne: UnifiedOperationProtocol {
         return .bson(.document(encoded))
     }
 }
+struct UnifiedDeleteMany: UnifiedOperationProtocol {
+    /// Filter to use for the operation.
+    let filter: BSONDocument
+
+    static var knownArguments: Set<String> {
+        ["filter"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        guard let result = try collection.deleteMany(filter) else {
+            return .none
+        }
+        let encoded = try BSONEncoder().encode(result)
+        return .bson(.document(encoded))
+    }
+}
+
 
 struct UnifiedInsertOne: UnifiedOperationProtocol {
     /// Document to insert.
@@ -403,6 +438,93 @@ struct UnifiedReplaceOne: UnifiedOperationProtocol {
             options: options,
             session: session
         ) else {
+            return .none
+        }
+        let encoded = try BSONEncoder().encode(result)
+        return .bson(.document(encoded))
+    }
+}
+
+struct UnifiedCountDocuments: UnifiedOperationProtocol {
+    /// Filter for the query.
+    let filter: BSONDocument
+
+    static var knownArguments: Set<String> {
+        ["filter"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let result = try collection.countDocuments(filter)
+        return .bson(BSON(result))
+    }
+}
+
+
+struct UnifiedEstimatedDocumentCount: UnifiedOperationProtocol {
+    static var knownArguments: Set<String> { [] }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let result = try collection.estimatedDocumentCount()
+        return .bson(BSON(result))
+    }
+}
+
+struct UnifiedDistinct: UnifiedOperationProtocol {
+    /// Field to retrieve distinct values for.
+    let fieldName: String
+
+    /// Filter for the query.
+    let filter: BSONDocument
+
+    static var knownArguments: Set<String> {
+        ["fieldName", "filter"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        let result = try collection.distinct(fieldName: self.fieldName, filter: filter)
+        return .bson(.array(result))
+    }
+}
+
+struct UnifiedUpdateOne: UnifiedOperationProtocol {
+    /// Filter for the query.
+    let filter: BSONDocument
+
+    /// Update to perform.
+    let update: BSONDocument
+
+    static var knownArguments: Set<String> {
+        ["update", "filter"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        guard let result = try collection.updateOne(filter: filter, update: update) else {
+            return .none
+        }
+        let encoded = try BSONEncoder().encode(result)
+        return .bson(.document(encoded))
+    }
+}
+
+
+struct UnifiedUpdateMany: UnifiedOperationProtocol {
+    /// Filter for the query.
+    let filter: BSONDocument
+
+    /// Update to perform.
+    let update: BSONDocument
+
+    static var knownArguments: Set<String> {
+        ["update", "filter"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        let collection = try context.entities.getEntity(from: object).asCollection()
+        guard let result = try collection.updateMany(filter: filter, update: update) else {
             return .none
         }
         let encoded = try BSONEncoder().encode(result)

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedDatabaseOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedDatabaseOperations.swift
@@ -1,3 +1,4 @@
+import SwiftBSON
 struct UnifiedCreateCollection: UnifiedOperationProtocol {
     /// The collection to create.
     let collection: String
@@ -32,6 +33,33 @@ struct UnifiedDropCollection: UnifiedOperationProtocol {
         let db = try context.entities.getEntity(from: object).asDatabase()
         let session = try context.entities.resolveSession(id: self.session)
         try db.collection(self.collection).drop(session: session)
+        return .none
+    }
+}
+
+struct UnifiedRunCommand: UnifiedOperationProtocol {
+    /// The name of the command to run.
+    let commandName: String
+
+    /// The command to run.
+    let command: BSONDocument
+
+    static var knownArguments: Set<String> {
+        ["commandName", "command"]
+    }
+
+    func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
+        var orderedCommand = command
+        // reorder if needed to put command name first.
+        if command.keys.first != commandName {
+            orderedCommand = [:]
+            orderedCommand[commandName] = command[commandName]
+            for (k, v) in command where k != commandName {
+                orderedCommand[k] = v
+            }
+        }
+        let db = try context.entities.getEntity(from: object).asDatabase()
+        try db.runCommand(orderedCommand)
         return .none
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedDatabaseOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedDatabaseOperations.swift
@@ -49,12 +49,12 @@ struct UnifiedRunCommand: UnifiedOperationProtocol {
     }
 
     func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
-        var orderedCommand = command
+        var orderedCommand = self.command
         // reorder if needed to put command name first.
-        if command.keys.first != commandName {
+        if self.command.keys.first != self.commandName {
             orderedCommand = [:]
-            orderedCommand[commandName] = command[commandName]
-            for (k, v) in command where k != commandName {
+            orderedCommand[self.commandName] = self.command[self.commandName]
+            for (k, v) in self.command where k != self.commandName {
                 orderedCommand[k] = v
             }
         }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
@@ -158,6 +158,8 @@ struct UnifiedOperation: Decodable {
             self.operation = try container.decode(UnifiedBulkWrite.self, forKey: .arguments)
         case "commitTransaction":
             self.operation = UnifiedCommitTransaction()
+        case "countDocuments":
+            self.operation = try container.decode(UnifiedCountDocuments.self, forKey: .arguments)
         case "createChangeStream":
             self.operation = try container.decode(CreateChangeStream.self, forKey: .arguments)
         case "createCollection":
@@ -166,16 +168,24 @@ struct UnifiedOperation: Decodable {
             self.operation = try container.decode(UnifiedCreateIndex.self, forKey: .arguments)
         case "deleteOne":
             self.operation = try container.decode(UnifiedDeleteOne.self, forKey: .arguments)
+        case "deleteMany":
+            self.operation = try container.decode(UnifiedDeleteMany.self, forKey: .arguments)
+        case "distinct":
+            self.operation = try container.decode(UnifiedDistinct.self, forKey: .arguments)
         case "dropCollection":
             self.operation = try container.decode(UnifiedDropCollection.self, forKey: .arguments)
         case "endSession":
             self.operation = EndSession()
+        case "estimatedDocumentCount":
+            self.operation = UnifiedEstimatedDocumentCount()
         case "find":
             self.operation = try container.decode(UnifiedFind.self, forKey: .arguments)
         case "findOneAndReplace":
             self.operation = try container.decode(UnifiedFindOneAndReplace.self, forKey: .arguments)
         case "findOneAndUpdate":
             self.operation = try container.decode(UnifiedFindOneAndUpdate.self, forKey: .arguments)
+        case "findOneAndDelete":
+            self.operation = try container.decode(UnifiedFindOneAndDelete.self, forKey: .arguments)
         case "failPoint":
             self.operation = try container.decode(UnifiedFailPoint.self, forKey: .arguments)
         case "insertOne":
@@ -188,10 +198,16 @@ struct UnifiedOperation: Decodable {
             self.operation = UnifiedListDatabases()
         case "replaceOne":
             self.operation = try container.decode(UnifiedReplaceOne.self, forKey: .arguments)
+        case "runCommand":
+            self.operation = try container.decode(UnifiedRunCommand.self, forKey: .arguments)
         case "startTransaction":
             self.operation = UnifiedStartTransaction()
         case "targetedFailPoint":
             self.operation = try container.decode(UnifiedTargetedFailPoint.self, forKey: .arguments)
+        case "updateOne":
+            self.operation = try container.decode(UnifiedUpdateOne.self, forKey: .arguments)
+        case "updateMany":
+            self.operation = try container.decode(UnifiedUpdateMany.self, forKey: .arguments)
         // GridFS ops
         case "delete", "download", "upload":
             self.operation = Placeholder()

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -6,15 +6,17 @@ struct UnifiedTestRunner {
     let internalClient: MongoClient
     let serverVersion: ServerVersion
     let topologyType: TestTopologyConfiguration
+    let serverParameters: BSONDocument
 
     static let minSchemaVersion = SchemaVersion(rawValue: "1.0.0")!
-    static let maxSchemaVersion = SchemaVersion(rawValue: "1.0.0")!
+    static let maxSchemaVersion = SchemaVersion(rawValue: "1.1.0")!
 
     init() throws {
         let connStr = MongoSwiftTestCase.getConnectionString(singleMongos: false).toString()
         self.internalClient = try MongoClient.makeTestClient(connStr)
         self.serverVersion = try self.internalClient.serverVersion()
         self.topologyType = try self.internalClient.topologyType()
+        self.serverParameters = try self.internalClient.serverParameters()
 
         // The test runner SHOULD terminate any open transactions using the internal MongoClient before executing any
         // tests.
@@ -46,7 +48,7 @@ struct UnifiedTestRunner {
     }
 
     func getUnmetRequirement(_ requirement: TestRequirement) -> UnmetRequirement? {
-        requirement.getUnmetRequirement(givenCurrent: self.serverVersion, self.topologyType)
+        requirement.getUnmetRequirement(givenCurrent: self.serverVersion, self.topologyType, self.serverParameters)
     }
 
     /// Runs the provided files. `skipTestCases` is a map of file description strings to arrays of test description

--- a/Tests/MongoSwiftSyncTests/VersionedAPITests.swift
+++ b/Tests/MongoSwiftSyncTests/VersionedAPITests.swift
@@ -4,18 +4,10 @@ import TestsCommon
 
 final class VersionedAPITests: MongoSwiftTestCase {
     func testVersionedAPI() throws {
-        let tests = try retrieveSpecTestFiles(
+        // just test that we can decode the tests for now.
+        _ = try retrieveSpecTestFiles(
             specName: "versioned-api",
             asType: UnifiedTestFile.self
         ).map { $0.1 }
-
-        let runner = try UnifiedTestRunner()
-        let skipTests = [
-            // TODO SWIFT-1099: unskip these once we have vendored in C code that handles this.
-            "CRUD Api Version 1 (strict)": ["estimatedDocumentCount appends declared API version"],
-            "CRUD Api Version 1": ["estimatedDocumentCount appends declared API version on 4.9.0 or greater"]
-        ]
-
-        try runner.runFiles(tests, skipTests: skipTests)
     }
 }

--- a/Tests/MongoSwiftSyncTests/VersionedAPITests.swift
+++ b/Tests/MongoSwiftSyncTests/VersionedAPITests.swift
@@ -1,0 +1,21 @@
+import MongoSwiftSync
+import Nimble
+import TestsCommon
+
+final class VersionedAPITests: MongoSwiftTestCase {
+    func testVersionedAPI() throws {
+        let tests = try retrieveSpecTestFiles(
+            specName: "versioned-api",
+            asType: UnifiedTestFile.self
+        ).map { $0.1 }
+
+        let runner = try UnifiedTestRunner()
+        let skipTests = [
+            // TODO SWIFT-1099: unskip these once we have vendored in C code that handles this.
+            "CRUD Api Version 1 (strict)": ["estimatedDocumentCount appends declared API version"],
+            "CRUD Api Version 1": ["estimatedDocumentCount appends declared API version on 4.9.0 or greater"]
+        ]
+
+        try runner.runFiles(tests, skipTests: skipTests)
+    }
+}

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -44,7 +44,7 @@ extension MongoClient {
     }
 
     internal func serverParameters() throws -> EventLoopFuture<BSONDocument> {
-        self.db("admin").runCommand(["getParameter": "*"]) 
+        self.db("admin").runCommand(["getParameter": "*"])
     }
 
     /// Determine whether server version and topology requirements for a certain test are met


### PR DESCRIPTION
Makes some updates to the runner that are prerequisites for decoding and running the versioned API tests:

* Support for decoding more types of operations we hadn't added before
* Support for a new type of test requirement, required server parameters