### PR TITLE
Fix index tests to pass on server latest

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -190,6 +190,7 @@ extension MongoCollection_IndexTests {
     static var allTests = [
         ("testCreateIndexFromModel", testCreateIndexFromModel),
         ("testIndexOptions", testIndexOptions),
+        ("testTextIndex", testTextIndex),
         ("testIndexWithWildCard", testIndexWithWildCard),
         ("testCreateIndexesFromModels", testCreateIndexesFromModels),
         ("testCreateIndexFromKeys", testCreateIndexFromKeys),

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -77,8 +77,6 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             background: true,
             bits: 32,
             collation: ["locale": "fr"],
-            defaultLanguage: "english",
-            languageOverride: "cat",
             max: 30,
             min: 0,
             name: "testOptions",
@@ -125,6 +123,8 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
 
     func testTextIndex() throws {
         let textIndexOpts = IndexOptions(
+            defaultLanguage: "english",
+            languageOverride: "languageOverrideField",
             name: "myTextIndex",
             textIndexVersion: 2,
             weights: ["cat": 2, "dog": 1]

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -85,10 +85,8 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             sparse: false,
             sphereIndexVersion: 2,
             storageEngine: ["wiredTiger": ["configString": "access_pattern_hint=random"]],
-            textIndexVersion: 2,
             unique: true,
-            version: 2,
-            weights: ["cat": 0.5, "_id": 0.5]
+            version: 2
         )
 
         // option is no longer supported as of SERVER-47081
@@ -123,6 +121,18 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         var expectedTtlOptions = ttlOptions
         expectedTtlOptions.version = 2
         expect(indexOptions[2]).to(equal(expectedTtlOptions))
+    }
+
+    func testTextIndex() throws {
+        let textIndexOpts = IndexOptions(
+            name: "myTextIndex",
+            textIndexVersion: 2,
+            weights: ["cat": 2, "dog": 1]
+        )
+
+        defer { try? self.coll.dropIndex("myTextIndex") }
+        let model = IndexModel(keys: ["cat": "text", "dog": "text"], options: textIndexOpts)
+        expect(try self.coll.createIndex(model)).to(equal("myTextIndex"))
     }
 
     func testIndexWithWildCard() throws {


### PR DESCRIPTION
`testIndexOptions` has started failing testing against server latest, because it turns out we were sending an option (index weights) that are only relevant for text indexes, even though the index we create is not a text index.

These used to just be ignored until [SERVER-54712](https://jira.mongodb.org/browse/SERVER-54712). Relatedly, I noticed that the same thing should probably be true for some other text index-specific options, which I filed [SERVER-55863](https://jira.mongodb.org/browse/SERVER-55863) about.

I've solved this by just moving these options out into a new test that actually creates a text index.