### PR TITLE
SWIFT-477: standardize copyright formatting

### DIFF
--- a/Sources/CLibMongoC/bson/bcon.c
+++ b/Sources/CLibMongoC/bson/bcon.c
@@ -3,7 +3,7 @@
  * @brief BCON (BSON C Object Notation) Implementation
  */
 
-/*    Copyright 2009-2013 MongoDB, Inc.
+/*    Copyright 2009-present MongoDB, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-atomic.c
+++ b/Sources/CLibMongoC/bson/bson-atomic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-clock.c
+++ b/Sources/CLibMongoC/bson/bson-clock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-context-private.h
+++ b/Sources/CLibMongoC/bson/bson-context-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-context.c
+++ b/Sources/CLibMongoC/bson/bson-context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-decimal128.c
+++ b/Sources/CLibMongoC/bson/bson-decimal128.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-error.c
+++ b/Sources/CLibMongoC/bson/bson-error.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-iso8601-private.h
+++ b/Sources/CLibMongoC/bson/bson-iso8601-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-iso8601.c
+++ b/Sources/CLibMongoC/bson/bson-iso8601.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-iter.c
+++ b/Sources/CLibMongoC/bson/bson-iter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-json-private.h
+++ b/Sources/CLibMongoC/bson/bson-json-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MongoDB, Inc.
+ * Copyright 2020-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-json.c
+++ b/Sources/CLibMongoC/bson/bson-json.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-keys.c
+++ b/Sources/CLibMongoC/bson/bson-keys.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-memory.c
+++ b/Sources/CLibMongoC/bson/bson-memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-oid.c
+++ b/Sources/CLibMongoC/bson/bson-oid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-private.h
+++ b/Sources/CLibMongoC/bson/bson-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-reader.c
+++ b/Sources/CLibMongoC/bson/bson-reader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-string.c
+++ b/Sources/CLibMongoC/bson/bson-string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-timegm-private.h
+++ b/Sources/CLibMongoC/bson/bson-timegm-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-utf8.c
+++ b/Sources/CLibMongoC/bson/bson-utf8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-value.c
+++ b/Sources/CLibMongoC/bson/bson-value.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-version-functions.c
+++ b/Sources/CLibMongoC/bson/bson-version-functions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson-writer.c
+++ b/Sources/CLibMongoC/bson/bson-writer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/bson/bson.c
+++ b/Sources/CLibMongoC/bson/bson.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bcon.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bcon.h
@@ -5,7 +5,7 @@
 
 #include "CLibMongoC_bson-prelude.h"
 
-/*    Copyright 2009-2013 MongoDB, Inc.
+/*    Copyright 2009-present MongoDB, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-atomic.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-atomic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-clock.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-compat.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-context.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-decimal128.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-decimal128.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-endian.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-endian.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-error.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-iter.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-iter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-json.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-json.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-keys.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-keys.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-macros.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-macros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-memory.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-oid.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-oid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-reader.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-reader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-string.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-string.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-types.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-utf8.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-utf8.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-value.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-value.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-version-functions.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-version-functions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-version.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson-writer.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-writer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_bson.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_common-b64-private.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_common-b64-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-present MongoDB Inc.
+ * Copyright 2018-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-apm.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-apm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-bulk-operation.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-bulk-operation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-client-pool.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-client-pool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-client-session.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-client-session.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-client.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-collection.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-collection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-config.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-cursor.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-cursor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-database.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-database.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-error.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-find-and-modify.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-find-and-modify.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-flags.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-flags.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-gridfs-file-list.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-gridfs-file-list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-gridfs-file-page.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-gridfs-file-page.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-gridfs-file.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-gridfs-file.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-gridfs.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-gridfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-handshake.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-handshake.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-host-list.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-host-list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-index.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-index.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-init.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-init.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-iovec.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-iovec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-log.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-macros.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-macros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-matcher.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-matcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-opcode.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-opcode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-optional.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-optional.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 MongoDB, Inc.
+ * Copyright 2021-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-rand.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-rand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-read-concern.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-read-concern.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-read-prefs.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-read-prefs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-api.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 MongoDB, Inc.
+ * Copyright 2021-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-socket.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-ssl.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-ssl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-buffered.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-buffered.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-file.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-file.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-gridfs.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-gridfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-socket.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls-libressl.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls-libressl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls-openssl.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls-openssl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls-secure-channel.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls-secure-channel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls-secure-transport.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls-secure-transport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream-tls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-stream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-topology-description.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-topology-description.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-uri.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-uri.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-version-functions.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-version-functions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-version.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-write-concern.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-write-concern.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/include/mongoc-counters.defs
+++ b/Sources/CLibMongoC/include/mongoc-counters.defs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-aggregate-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-aggregate-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MongoDB, Inc.
+ * Copyright 2019-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-aggregate.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-aggregate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MongoDB, Inc.
+ * Copyright 2019-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-apm-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-apm-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-apm.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-apm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-array-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-array-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-array.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-array.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-async-cmd-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-async-cmd-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-async-cmd.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-async-cmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-async-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-async-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-async.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-async.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-buffer-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-buffer-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-buffer.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-buffer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-bulk-operation-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-bulk-operation-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-bulk-operation.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-bulk-operation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-client-pool-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-client-pool-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-client-pool.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-client-pool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-client-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-client-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-client-session-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-client-session-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-client-session.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-client-session.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-client.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster-cyrus-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster-cyrus-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster-cyrus.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster-cyrus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster-sasl-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster-sasl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster-sasl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster-sasl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster-sspi-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster-sspi-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster-sspi.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster-sspi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cmd-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-cmd-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cmd.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-collection-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-collection-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-collection.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-collection.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-compression-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-compression-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-compression.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-compression.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-counters-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-counters-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-counters.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-counters.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-crypto-cng-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-crypto-cng-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-crypto-cng.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-crypto-cng.c
@@ -1,4 +1,5 @@
-/* Copyright 2016 MongoDB, Inc.
+/* 
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-crypto-common-crypto-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-crypto-common-crypto-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-crypto-common-crypto.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-crypto-common-crypto.c
@@ -1,4 +1,4 @@
-/* Copyright 2016 MongoDB, Inc.
+/* Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-crypto-openssl-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-crypto-openssl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-crypto-openssl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-crypto-openssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-crypto-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-crypto-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-crypto.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-crypto.c
@@ -1,4 +1,4 @@
-/* Copyright 2016 MongoDB, Inc.
+/* Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cursor-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-cursor-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cursor.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cursor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cyrus-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-cyrus-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-cyrus.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cyrus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-database-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-database-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-database.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-database.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-errno-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-errno-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-error-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-error-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-find-and-modify-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-find-and-modify-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-find-and-modify.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-find-and-modify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-list-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-list-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-list.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-page-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-page-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-page.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-page.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs-file-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs-file.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs-file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-handshake-compiler-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-handshake-compiler-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-handshake-os-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-handshake-os-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-handshake-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-handshake-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-handshake.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-handshake.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-host-list-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-host-list-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-host-list.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-host-list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-index.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-index.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-init.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-libressl-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-libressl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-libressl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-libressl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-linux-distro-scanner-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-linux-distro-scanner-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-linux-distro-scanner.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-linux-distro-scanner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-list-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-list-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-list.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-log-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-log-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-log.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-matcher-op-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-matcher-op-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-matcher-op.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-matcher-op.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-matcher-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-matcher-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-matcher.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-matcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-memcmp-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-memcmp-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-openssl-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-openssl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-openssl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-openssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-optional.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-optional.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 MongoDB, Inc.
+ * Copyright 2021-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-queue-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-queue-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-queue.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-queue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-rand-cng.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-rand-cng.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-rand-common-crypto.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-rand-common-crypto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-rand-openssl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-rand-openssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-rand-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-rand-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-read-concern-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-read-concern-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-read-concern.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-read-concern.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-read-prefs-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-read-prefs-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-read-prefs.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-read-prefs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-rpc-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-rpc-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-rpc.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-rpc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-sasl-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-sasl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-sasl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-sasl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-scram-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-scram-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-scram.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-scram.c
@@ -1,4 +1,4 @@
-/* Copyright 2014 MongoDB, Inc.
+/* Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-secure-channel-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-secure-channel-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-secure-channel.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-secure-channel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-secure-transport-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-secure-transport-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-secure-transport.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-secure-transport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-server-api-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-api-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 MongoDB, Inc.
+ * Copyright 2021-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-server-api.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 MongoDB, Inc.
+ * Copyright 2021-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-server-description.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-description.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-server-stream-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-stream-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-server-stream.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-stream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-set-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-set-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-set.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-set.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-socket-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-socket-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-socket.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-ssl-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-ssl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-ssl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-ssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-sspi-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-sspi-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-sspi.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-sspi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-buffered.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-buffered.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-file.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-gridfs.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-gridfs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-socket.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-libressl-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-libressl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-libressl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-libressl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-openssl-bio-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-openssl-bio-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-openssl-bio.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-openssl-bio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-openssl-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-openssl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-openssl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-openssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-secure-channel-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-secure-channel-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-secure-channel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-secure-transport-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-secure-transport-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls-secure-transport.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls-secure-transport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream-tls.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream-tls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-stream.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-stream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-thread-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-thread-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-present MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-timeout-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-timeout-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MongoDB, Inc.
+ * Copyright 2020-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-timeout.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-timeout.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MongoDB, Inc.
+ * Copyright 2020-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-topology-description-apm-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology-description-apm-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-topology-description-apm.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology-description-apm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-topology-description-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology-description-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-topology-description.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology-description.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-topology-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-topology-scanner-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology-scanner-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-topology-scanner.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology-scanner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-topology.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-trace-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-trace-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-uri-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-uri-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-uri.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-uri.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-util-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-util-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-util.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-version-functions.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-version-functions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-write-command-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-write-command-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-write-command.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-write-command.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-write-concern-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-write-concern-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/CLibMongoC/mongoc/mongoc-write-concern.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-write-concern.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/generated_headers/bson-version.h
+++ b/etc/generated_headers/bson-version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/generated_headers/mongoc-config.h
+++ b/etc/generated_headers/mongoc-config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/generated_headers/mongoc-version.h
+++ b/etc/generated_headers/mongoc-version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2013-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Recently did PHPC-1792 so thought I'd keep on the roll and try and close out this old ticket. Standardized everything to <year>-present and cleaned up a few miscellaneous formatting inconsistencies. 

Lots of files but all super tiny changes, hoping it will be _fairly_ painless to do a visual scroll through. 