### PR TITLE
SWIFT-1178 Replace usages of 'acceptAPIVersion2' with 'acceptApiVersion2'

### DIFF
--- a/Tests/Specs/versioned-api/tests/README.rst
+++ b/Tests/Specs/versioned-api/tests/README.rst
@@ -12,7 +12,7 @@ Notes
 This directory contains tests for the Versioned API specification. They are
 implemented in the `Unified Test Format <../../unified-test-format/unified-test-format.rst>`__,
 and require schema version 1.1. Note that to run these tests, the server must be
-started with both ``enableTestCommands`` and ``acceptAPIVersion2`` parameters
+started with both ``enableTestCommands`` and ``acceptApiVersion2`` parameters
 set to true.
 
 Testing with required API version

--- a/Tests/Specs/versioned-api/tests/test-commands-deprecation-errors.json
+++ b/Tests/Specs/versioned-api/tests/test-commands-deprecation-errors.json
@@ -6,7 +6,7 @@
       "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true,
-        "acceptAPIVersion2": true,
+        "acceptApiVersion2": true,
         "requireApiVersion": false
       }
     }


### PR DESCRIPTION
whoops, did this at some point last week but forgot to ever make a PR 🙂

patch: https://evergreen.mongodb.com/version/60887a880ae60623ca636ca8