### PR TITLE
SWIFT-1116 Sync in some unified runner tests

### DIFF
--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -60,7 +60,10 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
             // Because we use an enum to represent ReturnDocument, the invalid string present in this file "Invalid"
             // gives us a decoding error, and therefore we cannot decode it. Other drivers may not report an error
             // until runtime.
-            "returnDocument-enum-invalid.json"
+            "returnDocument-enum-invalid.json",
+            // This has the same problem as the previous file, where an invalid string is provided and we fail
+            // while decoding rather than at runtime.
+            "entity-client-apiVersion-unsupported.json"
         ]
 
         let validFailTests = try retrieveSpecTestFiles(

--- a/Tests/Specs/unified-test-format/tests/valid-fail/entity-client-apiVersion-unsupported.json
+++ b/Tests/Specs/unified-test-format/tests/valid-fail/entity-client-apiVersion-unsupported.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-apiVersion-unsupported",
+  "schemaVersion": "1.1",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "serverApi": {
+          "version": "server_will_never_support_this_api_version"
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/Tests/Specs/unified-test-format/tests/valid-fail/operation-failure.json
+++ b/Tests/Specs/unified-test-format/tests/valid-fail/operation-failure.json
@@ -1,0 +1,56 @@
+{
+  "description": "operation-failure",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "operation-failure"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Unsupported command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "unsupportedCommand",
+            "command": {
+              "unsupportedCommand": 1
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Unsupported query operator",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$unsupportedQueryOperator": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/unified-test-format/tests/valid-pass/poc-retryable-writes.json
+++ b/Tests/Specs/unified-test-format/tests/valid-pass/poc-retryable-writes.json
@@ -297,13 +297,15 @@
             "ordered": true
           },
           "expectResult": {
-            "insertedCount": {
-              "$$unsetOrMatches": 2
-            },
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 3,
-                "1": 4
+            "$$unsetOrMatches": {
+              "insertedCount": {
+                "$$unsetOrMatches": 2
+              },
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 3,
+                  "1": 4
+                }
               }
             }
           }


### PR DESCRIPTION
This brings in the test added by DRIVERS-1538 as well as a couple other newish test files/test file changes. I did not bother syncing anything that our runner isn't able to run yet due to schema version, or any of the "invalid" test files since we don't actually do anything with those. (Arguably we should delete those altogether since they exist for testing the schema, not testing runners?)