### PR TITLE
SWIFT-1208, SWIFT-1209, SWIFT-1221, SWIFT-1005 Various Evergreen configuration updates 

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1087,16 +1087,16 @@ buildvariants:
      - ".4.0"
      - ".3.6"
   rules:
-  # pre 4.0 we are just using legacy linux mongoDB since ubuntu 18.04 didn't
-  # exist when 3.6 came out. legacy doesn't link to OpenSSL so we can't run
-  # SSL tests there.
+  # MongoDB 3.6 does not have Ubuntu 18.04-specific Linux releases, so we just use
+  # generic Linux there. This do not link to OpenSSL, so we have to skip SSL tests.
   - if:
       os-fully-featured:
         - "ubuntu-18.04"
       swift-version: "*"
       ssl-auth: "ssl-auth"
     then:
-      remove_tasks: ".3.6"
+      remove_tasks:
+      - ".3.6"
 
 - matrix_name: "tests-all"
   matrix_spec:
@@ -1116,17 +1116,29 @@ buildvariants:
      - ".4.0"
      - ".3.6"
   rules:
-  # pre 4.0 we are just using legacy linux mongoDB since ubuntu 18.04/20.04 didn't
-  # exist when 3.6 came out. legacy doesn't link to OpenSSL so we can't run
-  # SSL tests there.
+  # MongoDB 3.6 does not have Ubuntu 18.04-specific Linux releases, so we just use
+  # generic Linux there. This do not link to OpenSSL, so we have to skip SSL tests.
   - if:
       os-fully-featured:
         - "ubuntu-18.04"
-        - "ubuntu-20.04"
       swift-version: "*"
       ssl-auth: "ssl-auth"
     then:
-      remove_tasks: ".3.6"
+      remove_tasks:
+        - ".3.6"
+  # There are no  Ubuntu 20.04-specific Linux releases until 4.4, and the last server
+  # version with generic Linux releases is 4.0, so we can't just use generic releases
+  # for earlier versions. For simplicity, and since we already have Ubuntu and < 4.4
+  # coverage on Ubuntu 18.04, we only test 4.4+ on Ubuntu 20.04.
+  - if:
+      os-fully-featured: "ubuntu-20.04"
+      swift-version: "*"
+      ssl-auth: "*"
+    then:
+      remove_tasks:
+        - ".3.6"
+        - ".4.0"
+        - ".4.2"
 
 - matrix_name: "atlas-connect"
   matrix_spec:
@@ -1145,6 +1157,7 @@ buildvariants:
       - "ubuntu-20.04"
     versions:
       - latest
+      - 5.0
       - 4.4
     swift-version:
       - 5.2
@@ -1152,6 +1165,13 @@ buildvariants:
   batchtime: 20160 # 14 days
   tasks:
     - ".ocsp"
+  rules:
+  - if:
+      os-fully-featured: "ubuntu-18.04"
+    then:
+      remove_tasks:
+        # OCSP stapling support was removed from Ubuntu 18.04, see SERVER-51364
+        - ".ocsp-staple"
 
 - matrix_name: "ocsp-macos"
   matrix_spec:
@@ -1161,6 +1181,7 @@ buildvariants:
       - 5.2
     versions:
       - latest
+      - 5.0
       - 4.4
   display_name: "OCSP ${swift-version} ${os-fully-featured} ${versions}"
   batchtime: 20160 # 14 days

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1140,12 +1140,26 @@ buildvariants:
         - ".4.0"
         - ".4.2"
 
+# there are no 5.1 toolchains for Ubuntu 20.04. unfortunately as of now we cannot remove
+# entire buildvariants via rule from the main matrix so we need to split this up. see EVG-13092
+- matrix_name: "atlas-connect-5.1"
+  matrix_spec:
+    os-fully-featured:
+      - "macos-10.15"
+      - "ubuntu-18.04"
+    swift-version: "5.1"
+  display_name: "Atlas Connectivity ${swift-version} ${os-fully-featured}"
+  tasks:
+    - ".atlas-connect"
+
 - matrix_name: "atlas-connect"
   matrix_spec:
     os-fully-featured: "*"
     swift-version:
-      - "5.1"
       - "5.2"
+      - "5.3"
+      - "5.4"
+      - "5.5-dev"
   display_name: "Atlas Connectivity ${swift-version} ${os-fully-featured}"
   tasks:
     - ".atlas-connect"
@@ -1201,19 +1215,6 @@ buildvariants:
   tasks:
     # Versioned API was introduced in MongoDB 4.7
     - "test-latest-standalone"
-
-- matrix_name: "atlas-connect-5.3+"
-  matrix_spec:
-    os-fully-featured:
-      - "ubuntu-18.04"
-      - "ubuntu-20.04"
-    swift-version:
-      - "5.3"
-      - "5.4"
-      - "5.5-dev"
-  display_name: "Atlas Connectivity ${swift-version} ${os-fully-featured}"
-  tasks:
-    - ".atlas-connect"
 
 - matrix_name: "format-lint"
   display_name: "Format and Lint"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1168,6 +1168,8 @@ buildvariants:
   rules:
   - if:
       os-fully-featured: "ubuntu-18.04"
+      versions: "*"
+      swift-version: "*"
     then:
       remove_tasks:
         # OCSP stapling support was removed from Ubuntu 18.04, see SERVER-51364

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -498,6 +498,39 @@ tasks:
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
 
+    - name: "test-5.0-standalone"
+      tags: ["5.0", "standalone"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "5.0"
+            TOPOLOGY: "server"
+        - func: "run tests"
+
+    - name: "test-5.0-replica_set"
+      tags: ["5.0", "replica_set"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "5.0"
+            TOPOLOGY: "replica_set"
+        - func: "run tests"
+
+    - name: "test-5.0-sharded_cluster"
+      tags: ["5.0", "sharded_cluster"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "5.0"
+            TOPOLOGY: "sharded_cluster"
+        - func: "run tests"
+
     - name: "test-latest-standalone"
       tags: ["latest", "standalone"]
       commands:
@@ -904,6 +937,10 @@ axes:
         display_name: "latest"
         variables:
            MONGODB_VERSION: "latest"
+      - id: "5.0"
+        display_name: "5.0"
+        variables:
+          MONGODB_VERSION: "5.0"
       - id: "4.4"
         display_name: "4.4"
         variables:
@@ -978,7 +1015,7 @@ axes:
       - id: "5.4"
         display_name: "Swift 5.4"
         variables:
-          SWIFT_VERSION: "5.4.1"
+          SWIFT_VERSION: "5.4"
       - id: "5.5-dev"
         display_name: "Swift 5.5-dev"
         variables:
@@ -1032,15 +1069,48 @@ axes:
           TEST_FILTER: "VersionedAPITests"
 
 buildvariants:
-
-- matrix_name: "tests-all"
+# there are no 5.1 toolchains for Ubuntu 20.04. unfortunately as of now we cannot remove
+# entire buildvariants via rule from the main matrix so we need to split this up. see EVG-13092
+- matrix_name: "tests-5.1"
   matrix_spec:
-    os-fully-featured: "*"
-    swift-version: "*"
+    os-fully-featured:
+      - "ubuntu-18.04"
+      - "macos-10.15"
+    swift-version: "5.1"
     ssl-auth: "*"
   display_name: "${swift-version} ${os-fully-featured} ${ssl-auth}"
   tasks:
      - ".latest"
+     - ".5.0"
+     - ".4.4"
+     - ".4.2"
+     - ".4.0"
+     - ".3.6"
+  rules:
+  # pre 4.0 we are just using legacy linux mongoDB since ubuntu 18.04 didn't
+  # exist when 3.6 came out. legacy doesn't link to OpenSSL so we can't run
+  # SSL tests there.
+  - if:
+      os-fully-featured:
+        - "ubuntu-18.04"
+      swift-version: "*"
+      ssl-auth: "ssl-auth"
+    then:
+      remove_tasks: ".3.6"
+
+- matrix_name: "tests-all"
+  matrix_spec:
+    os-fully-featured: "*"
+    swift-version:
+      - "5.2"
+      - "5.3"
+      - "5.4"
+      - "5.5-dev"
+    ssl-auth: "*"
+  display_name: "${swift-version} ${os-fully-featured} ${ssl-auth}"
+  tasks:
+     - ".latest"
+     - ".5.0"
      - ".4.4"
      - ".4.2"
      - ".4.0"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -931,16 +931,16 @@ axes:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
 
-      - id: ubuntu-16.04
-        display_name: "Ubuntu 16.04"
-        run_on: ubuntu1604-test
+      - id: ubuntu-20.04
+        display_name: "Ubuntu 20.04"
+        run_on: ubuntu2004-test
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
 
-      - id: macos-10.14
-        display_name: "macOS 10.14"
-        run_on: macos-1014
+      - id: macos-10.15
+        display_name: "macOS 10.15"
+        run_on: macos-1015
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
@@ -974,11 +974,15 @@ axes:
       - id: "5.3"
         display_name: "Swift 5.3"
         variables:
-          SWIFT_VERSION: "5.3.3"
-      - id: "5.4-dev"
-        display_name: "Swift 5.4-dev"
+          SWIFT_VERSION: "5.3.3"      
+      - id: "5.4"
+        display_name: "Swift 5.4"
         variables:
-          SWIFT_VERSION: "5.4-DEVELOPMENT-SNAPSHOT-2021-03-25-a"
+          SWIFT_VERSION: "5.4.1"
+      - id: "5.5-dev"
+        display_name: "Swift 5.5-dev"
+        variables:
+          SWIFT_VERSION: "DEVELOPMENT-SNAPSHOT-2021-04-26-a"
 
   - id: ssl-auth
     display_name: SSL and Auth
@@ -1032,9 +1036,7 @@ buildvariants:
 - matrix_name: "tests-all"
   matrix_spec:
     os-fully-featured: "*"
-    swift-version:
-      - "5.1"
-      - "5.2"
+    swift-version: "*"
     ssl-auth: "*"
   display_name: "${swift-version} ${os-fully-featured} ${ssl-auth}"
   tasks:
@@ -1044,11 +1046,13 @@ buildvariants:
      - ".4.0"
      - ".3.6"
   rules:
-  # pre 4.0 we are just using legacy linux mongoDB since ubuntu 18.04 didn't
+  # pre 4.0 we are just using legacy linux mongoDB since ubuntu 18.04/20.04 didn't
   # exist when 3.6 came out. legacy doesn't link to OpenSSL so we can't run
   # SSL tests there.
   - if:
-      os-fully-featured: "ubuntu-18.04"
+      os-fully-featured:
+        - "ubuntu-18.04"
+        - "ubuntu-20.04"
       swift-version: "*"
       ssl-auth: "ssl-auth"
     then:
@@ -1068,7 +1072,7 @@ buildvariants:
   matrix_spec:
     os-fully-featured:
       - "ubuntu-18.04"
-      - "ubuntu-16.04"
+      - "ubuntu-20.04"
     versions:
       - latest
       - 4.4
@@ -1082,7 +1086,7 @@ buildvariants:
 - matrix_name: "ocsp-macos"
   matrix_spec:
     os-fully-featured:
-      - macos-10.14
+      - macos-10.15
     swift-version:
       - 5.2
     versions:
@@ -1105,45 +1109,15 @@ buildvariants:
     # Versioned API was introduced in MongoDB 4.7
     - "test-latest-standalone"
 
-# define separate matrices for swift 5.3 that excludes macOS 10.14. unfortunately
-# as of now we cannot remove entire buildvariants via rule from the matrices above
-# so we need to split this up due to inability to test 5.3 on macOS 10.14.
-# see EVG-13092
-- matrix_name: "tests-all-5.3+"
-  matrix_spec:
-    os-fully-featured:
-      - "ubuntu-18.04"
-      - "ubuntu-16.04"
-    swift-version:
-      - "5.3"
-      - "5.4-dev"
-    ssl-auth: "*"
-  display_name: "${swift-version} ${os-fully-featured} ${ssl-auth}"
-  tasks:
-     - ".latest"
-     - ".4.4"
-     - ".4.2"
-     - ".4.0"
-     - ".3.6"
-  rules:
-  # pre 4.0 we are just using legacy linux mongoDB since ubuntu 18.04 didn't
-  # exist when 3.6 came out. legacy doesn't link to OpenSSL so we can't run
-  # SSL tests there.
-  - if:
-      os-fully-featured: "ubuntu-18.04"
-      swift-version: "*"
-      ssl-auth: "ssl-auth"
-    then:
-      remove_tasks: ".3.6"
-
 - matrix_name: "atlas-connect-5.3+"
   matrix_spec:
     os-fully-featured:
       - "ubuntu-18.04"
-      - "ubuntu-16.04"
+      - "ubuntu-20.04"
     swift-version:
       - "5.3"
-      - "5.4-dev"
+      - "5.4"
+      - "5.5-dev"
   display_name: "Atlas Connectivity ${swift-version} ${os-fully-featured}"
   tasks:
     - ".atlas-connect"
@@ -1160,7 +1134,7 @@ buildvariants:
 - matrix_name: "check-sourcery"
   display_name: "Check Sourcery"
   matrix_spec:
-    os-fully-featured: "macos-10.14"
+    os-fully-featured: "macos-10.15"
     swift-version: "5.2"
   tasks:
     - name: "check-sourcery"

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -13,6 +13,15 @@ export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
 export PATH="${SWIFTENV_ROOT}/bin:$PATH"
 eval "$(swiftenv init -)"
 
+if [ "$OS" == "darwin" ]; then
+    # 5.1, 5.2 require an older version of Xcode/Command Line Tools
+    if [[ "$SWIFT_VERSION" == 5.1.* || "$SWIFT_VERSION" == 5.2.* ]]; then
+        sudo xcode-select -s /Applications/Xcode11.3.app
+    else
+        sudo xcode-select -s /Applications/Xcode12.app
+    fi
+fi
+
 swiftenv local $SWIFT_VERSION
 
 # run the tests

--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -32,9 +32,13 @@ export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
 export PATH="${SWIFTENV_ROOT}/bin:$PATH"
 eval "$(swiftenv init -)"
 
-# select the latest Xcode for Swift 5.1 support on MacOS
 if [ "$OS" == "darwin" ]; then
-    sudo xcode-select -s /Applications/Xcode11.3.app
+    # 5.1, 5.2 require an older version of Xcode/Command Line Tools
+    if [[ "$SWIFT_VERSION" == 5.1.* || "$SWIFT_VERSION" == 5.2.* ]]; then
+        sudo xcode-select -s /Applications/Xcode11.3.app
+    else
+        sudo xcode-select -s /Applications/Xcode12.app
+    fi
 fi
 
 # switch swift version, and run tests

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -33,9 +33,9 @@ export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
 export PATH="${SWIFTENV_ROOT}/bin:$PATH"
 eval "$(swiftenv init -)"
 
-# select the latest Xcode for Swift 5.1 support on MacOS
+# select the latest Xcode for Swift 5.3+ support on MacOS
 if [ "$OS" == "darwin" ]; then
-    sudo xcode-select -s /Applications/Xcode11.3.app
+    sudo xcode-select -s /Applications/Xcode12.app
 fi
 
 # switch swift version, and run tests

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -33,9 +33,13 @@ export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
 export PATH="${SWIFTENV_ROOT}/bin:$PATH"
 eval "$(swiftenv init -)"
 
-# select the latest Xcode for Swift 5.3+ support on MacOS
 if [ "$OS" == "darwin" ]; then
-    sudo xcode-select -s /Applications/Xcode12.app
+    # 5.1, 5.2 require an older version of Xcode/Command Line Tools
+    if [[ "$SWIFT_VERSION" == 5.1.* || "$SWIFT_VERSION" == 5.2.* ]]; then
+        sudo xcode-select -s /Applications/Xcode11.3.app
+    else
+        sudo xcode-select -s /Applications/Xcode12.app
+    fi
 fi
 
 # switch swift version, and run tests


### PR DESCRIPTION
This PR addresses a backlog of necessary Evergreen changes that have piled up recently:
- Since MongoDB 5.0 is no longer “latest” we need to test it separately
- Swift 5.4 has been released, so test against that and start testing against 5.5 development snapshots
- Stop testing on Ubuntu 16.04 and start testing on Ubuntu 20.04 (note that as discussed we don't test on < 4.4 on 20.04 now due to lack of specific builds and the end of generic builds w/ 4.0)
- Skip OCSP stapling tests on Ubuntu 18.04
- Use macOS 10.15 for all tests since it supports all of our Swift versions

complete patch: https://evergreen.mongodb.com/version/60baef80d1fe070beb0641c8

It looks kind of bad, but (I think) all the failures are expected:
- All tasks testing against 5.0 and latest, and the versioned API-specific tests, are red, which is also true on the waterfall already and is because we are missing recent C driver work to address late-breaking changes around versioned API, and also because https://jira.mongodb.org/browse/DRIVERS-1781 is still being worked on to change now-failing command monitoring tests.
- OCSP on macOS
    - The "soft fail" tests have frequently failed on macOS (SWIFT-1134)
    - The other failures are OCSP test 3, "valid cert + server that does not staple", which CDRIVER-3759 also notes to be flaky on macOS (though maybe it's not merely flaky and is just straight up broken on 10.15?)

Let me know what you think about the OCSP ones as I'm not super familiar with those tests.

As an aside, we probably want to vendor in libmongoc changes sooner rather than later to get things more green. 