### PR TITLE
SWIFT-1210 Add security policy per SSWG requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Think you've found a bug? Want to see a new feature in `mongo-swift-driver`? Ple
 Bug reports in JIRA for all driver projects (i.e. NODE, PYTHON, CSHARP, JAVA) and the
 Core Server (i.e. SERVER) project are **public**.
 
+## Security Concerns
+Please see [SECURITY.md](SECURITY.md) for details on our security process.
+
 ## Installation
 The driver supports use with Swift 5.1+. The minimum macOS version required to build the driver is 10.14. The driver is tested in continuous integration against macOS 10.14, Ubuntu 16.04, and Ubuntu 18.04.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security
+
+## Disclosing a Vulnerability
+If you believe you have discovered a vulnerability in this library, or are aware of a vulnerability you believe might affect this library, please get in touch!
+
+MongoDB the company has a [process](https://docs.mongodb.com/manual/tutorial/create-a-vulnerability-report/) in place for reporting vulnerabilities in all MongoDB projects, which include this library. Please review that page for the most up-to-date information on the process and how to get in touch.
+
+**Please do not open a SWIFT Jira ticket or GitHub issue, as these are publicly viewable.**
+
+As this library is taking part in the Swift Server Work Group (SSWG) incubation process, also note the following: 
+* Vulnerabilities found in this library will be privately reported to the [Swift Server Work Group](https://github.com/swift-server/sswg) as per their [security guidelines](https://github.com/swift-server/sswg/blob/main/security/package-maintainer-received-vulnerability-report.md) within 10 days of the report.
+* Once vulnerabilities are fixed and released, vulnerabilities will also be announced in the Swift Forums [Server > Security Updates](https://forums.swift.org/c/server/security-updates) area.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,4 +9,4 @@ MongoDB the company has a [process](https://docs.mongodb.com/manual/tutorial/cre
 
 As this library is taking part in the Swift Server Work Group (SSWG) incubation process, also note the following: 
 * Vulnerabilities found in this library will be privately reported to the [Swift Server Work Group](https://github.com/swift-server/sswg) as per their [security guidelines](https://github.com/swift-server/sswg/blob/main/security/package-maintainer-received-vulnerability-report.md) within 10 days of the report.
-* Once vulnerabilities are fixed and released, vulnerabilities will also be announced in the Swift Forums [Server > Security Updates](https://forums.swift.org/c/server/security-updates) area.
+* Once vulnerabilities are fixed and released, they will also be announced in the Swift Forums [Server > Security Updates](https://forums.swift.org/c/server/security-updates) area.


### PR DESCRIPTION
Rather than duplicating information from the MongoDB website (which may evolve with time) it seemed best to just reference that link and note the things here that are specific to our library (SSWG reqs) as compared to MongoDB products in general.