### PR TITLE
Skip testChangeStreamAutomaticResume against latest servers

### DIFF
--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -434,6 +434,8 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
      */
     func testChangeStreamAutomaticResume() throws {
         let testRequirements = TestRequirement(
+            // TODO SWIFT-1257: remove server version requirement
+            maxServerVersion: ServerVersion(major: 4, minor: 9, patch: 0),
             acceptableTopologies: [.replicaSet, .sharded]
         )
 

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -434,7 +434,7 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
      */
     func testChangeStreamAutomaticResume() throws {
         let testRequirements = TestRequirement(
-            // TODO SWIFT-1257: remove server version requirement
+            // TODO: SWIFT-1257: remove server version requirement
             maxServerVersion: ServerVersion(major: 4, minor: 9, patch: 0),
             acceptableTopologies: [.replicaSet, .sharded]
         )


### PR DESCRIPTION
This is failing due to CDRIVER-4077. I could have changed the test to test this in a different way e.g. explicitly killing the cursor via runCommand and ensuring a resume happens, however Kevin said he thinks his current work for load balancer (specifically CDRIVER-3653) may fix this issue, so I figured we can wait and try that first before rewriting the test. 