### PR TITLE
SWIFT-1188 Vendor libmongoc 1.18.0

### DIFF
--- a/Sources/CLibMongoC/bson/bson-json.c
+++ b/Sources/CLibMongoC/bson/bson-json.c
@@ -107,7 +107,6 @@ static const char *read_state_names[] = {FOREACH_READ_STATE (GENERATE_STRING)};
    BS (DECIMAL128)                                                   \
    BS (DBPOINTER)                                                    \
    BS (SYMBOL)                                                       \
-   BS (DBREF)                                                        \
    BS (UUID)
 
 typedef enum {
@@ -135,8 +134,6 @@ typedef enum {
 typedef struct {
    int i;
    bson_json_frame_type_t type;
-   bool has_ref;
-   bool has_id;
    bson_t bson;
 } bson_json_stack_frame_t;
 
@@ -283,8 +280,6 @@ _noop (void)
 #define FRAME_TYPE_HAS_BSON(_type) \
    ((_type) == BSON_JSON_FRAME_SCOPE || (_type) == BSON_JSON_FRAME_DBPOINTER)
 #define STACK_HAS_BSON FRAME_TYPE_HAS_BSON (STACK_FRAME_TYPE)
-#define STACK_HAS_REF STACK_ELE (0, has_ref)
-#define STACK_HAS_ID STACK_ELE (0, has_id)
 #define STACK_PUSH(frame_type)                       \
    do {                                              \
       if (bson->n >= (STACK_MAX - 1)) {              \
@@ -313,8 +308,6 @@ _noop (void)
 #define STACK_PUSH_DOC(statement)       \
    do {                                 \
       STACK_PUSH (BSON_JSON_FRAME_DOC); \
-      STACK_HAS_REF = false;            \
-      STACK_HAS_ID = false;             \
       if (bson->n != 0) {               \
          statement;                     \
       }                                 \
@@ -717,7 +710,6 @@ _bson_json_read_integer (bson_json_reader_t *reader, uint64_t val, int64_t sign)
       case BSON_JSON_LF_DECIMAL128:
       case BSON_JSON_LF_DBPOINTER:
       case BSON_JSON_LF_SYMBOL:
-      case BSON_JSON_LF_DBREF:
       default:
          _bson_json_read_set_error (reader,
                                     "Unexpected integer %s%" PRIu64
@@ -1127,12 +1119,6 @@ _bson_json_read_string (bson_json_reader_t *reader, /* IN */
          bson_append_symbol (
             STACK_BSON_CHILD, key, (int) len, (const char *) val, (int) vlen);
          break;
-      case BSON_JSON_LF_DBREF:
-         /* the "$ref" of a {$ref: "...", $id: ... }, append normally */
-         bson_append_utf8 (
-            STACK_BSON_CHILD, key, (int) len, (const char *) val, (int) vlen);
-         bson->read_state = BSON_JSON_REGULAR;
-         break;
       case BSON_JSON_LF_SCOPE:
       case BSON_JSON_LF_TIMESTAMP_T:
       case BSON_JSON_LF_TIMESTAMP_I:
@@ -1406,20 +1392,6 @@ _bson_json_read_map_key (bson_json_reader_t *reader, /* IN */
       }
    } else {
       _bson_json_save_map_key (bson, val, len);
-
-      /* in x: {$ref: "collection", $id: {$oid: "..."}, $db: "..." } */
-      if (bson->n > 0) {
-         if (!strcmp ("$ref", (const char *) val)) {
-            STACK_HAS_REF = true;
-            bson->read_state = BSON_JSON_IN_BSON_TYPE;
-            bson->bson_state = BSON_JSON_LF_DBREF;
-         } else if (!strcmp ("$id", (const char *) val)) {
-            STACK_HAS_ID = true;
-         } else if (!strcmp ("$db", (const char *) val)) {
-            bson->read_state = BSON_JSON_IN_BSON_TYPE;
-            bson->bson_state = BSON_JSON_LF_DBREF;
-         }
-      }
    }
 }
 
@@ -1824,11 +1796,6 @@ _bson_json_read_end_map (bson_json_reader_t *reader) /* IN */
          bson->read_state = BSON_JSON_IN_BSON_TYPE_DBPOINTER_STARTMAP;
          STACK_POP_DBPOINTER;
       } else {
-         if (STACK_HAS_ID != STACK_HAS_REF) {
-            _bson_json_read_set_error (
-               reader, "%s", "DBRef object must have both $ref and $id keys");
-         }
-
          STACK_POP_DOC (
             bson_append_document_end (STACK_BSON_PARENT, STACK_BSON_CHILD));
       }

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-client.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-client.h
@@ -269,9 +269,6 @@ mongoc_client_enable_auto_encryption (mongoc_client_t *client,
                                       mongoc_auto_encryption_opts_t *opts,
                                       bson_error_t *error);
 
-MONGOC_EXPORT (int64_t)
-mongoc_client_get_timeout_ms (const mongoc_client_t *client);
-
 MONGOC_EXPORT (bool)
 mongoc_client_set_server_api (mongoc_client_t *client,
                               const mongoc_server_api_t *api,

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-collection.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-collection.h
@@ -351,14 +351,6 @@ mongoc_collection_estimated_document_count (
    bson_t *reply,
    bson_error_t *error);
 
-MONGOC_EXPORT (bool)
-mongoc_collection_set_timeout_ms (mongoc_collection_t *coll,
-                                  int64_t timeout_ms,
-                                  bson_error_t *error);
-
-MONGOC_EXPORT (int64_t)
-mongoc_collection_get_timeout_ms (const mongoc_collection_t *coll);
-
 BSON_END_DECLS
 
 

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-database.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-database.h
@@ -155,13 +155,6 @@ mongoc_database_watch (const mongoc_database_t *db,
                        const bson_t *pipeline,
                        const bson_t *opts);
 
-MONGOC_EXPORT (bool)
-mongoc_database_set_timeout_ms (mongoc_database_t *db,
-                                int64_t timeout_ms,
-                                bson_error_t *error);
-MONGOC_EXPORT (int64_t)
-mongoc_database_get_timeout_ms (const mongoc_database_t *db);
-
 BSON_END_DECLS
 
 

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-error.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-error.h
@@ -49,7 +49,6 @@ typedef enum {
    MONGOC_ERROR_SERVER, /* Error API Version 2 only */
    MONGOC_ERROR_TRANSACTION,
    MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION, /* An error coming from libmongocrypt */
-   MONGOC_ERROR_TIMEOUT,
    MONGOC_ERROR_POOL
 } mongoc_error_domain_t;
 
@@ -124,9 +123,9 @@ typedef enum {
 
    /* An error related to initializing client side encryption. */
    MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+
    MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
 
-   MONGOC_ERROR_TIMEOUT_INVALID,
 
    /* An error related to server version api */
    MONGOC_ERROR_CLIENT_API_ALREADY_SET,

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-uri.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-uri.h
@@ -33,8 +33,6 @@
 #define MONGOC_DEFAULT_PORT 27017
 #endif
 
-#define MONGOC_TIMEOUTMS_UNSET -1
-
 #define MONGOC_URI_APPNAME "appname"
 #define MONGOC_URI_AUTHMECHANISM "authmechanism"
 #define MONGOC_URI_AUTHMECHANISMPROPERTIES "authmechanismproperties"
@@ -63,7 +61,6 @@
 #define MONGOC_URI_SLAVEOK "slaveok"
 #define MONGOC_URI_SOCKETCHECKINTERVALMS "socketcheckintervalms"
 #define MONGOC_URI_SOCKETTIMEOUTMS "sockettimeoutms"
-#define MONGOC_URI_TIMEOUTMS "timeoutms"
 #define MONGOC_URI_TLS "tls"
 #define MONGOC_URI_TLSCERTIFICATEKEYFILE "tlscertificatekeyfile"
 #define MONGOC_URI_TLSCERTIFICATEKEYFILEPASSWORD "tlscertificatekeyfilepassword"

--- a/Sources/CLibMongoC/mongoc/mongoc-apm-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-apm-private.h
@@ -60,7 +60,8 @@ struct _mongoc_apm_command_started_t {
 
 struct _mongoc_apm_command_succeeded_t {
    int64_t duration;
-   const bson_t *reply;
+   bson_t *reply;
+   bool reply_owned;
    const char *command_name;
    int64_t request_id;
    int64_t operation_id;
@@ -73,7 +74,8 @@ struct _mongoc_apm_command_failed_t {
    int64_t duration;
    const char *command_name;
    const bson_error_t *error;
-   const bson_t *reply;
+   bson_t *reply;
+   bool reply_owned;
    int64_t request_id;
    int64_t operation_id;
    const mongoc_host_list_t *host;
@@ -153,12 +155,14 @@ mongoc_apm_command_started_init (mongoc_apm_command_started_t *event,
                                  int64_t operation_id,
                                  const mongoc_host_list_t *host,
                                  uint32_t server_id,
+                                 bool *is_redacted, /* out */
                                  void *context);
 
 void
 mongoc_apm_command_started_init_with_cmd (mongoc_apm_command_started_t *event,
                                           struct _mongoc_cmd_t *cmd,
                                           int64_t request_id,
+                                          bool *is_redacted, /* out */
                                           void *context);
 
 void
@@ -173,6 +177,7 @@ mongoc_apm_command_succeeded_init (mongoc_apm_command_succeeded_t *event,
                                    int64_t operation_id,
                                    const mongoc_host_list_t *host,
                                    uint32_t server_id,
+                                   bool force_redaction,
                                    void *context);
 
 void
@@ -188,10 +193,18 @@ mongoc_apm_command_failed_init (mongoc_apm_command_failed_t *event,
                                 int64_t operation_id,
                                 const mongoc_host_list_t *host,
                                 uint32_t server_id,
+                                bool force_redaction,
                                 void *context);
 
 void
 mongoc_apm_command_failed_cleanup (mongoc_apm_command_failed_t *event);
+
+bool
+mongoc_apm_is_sensitive_command (const char *command_name,
+                                 const bson_t *command);
+
+bool
+mongoc_apm_is_sensitive_reply (const char *command_name, const bson_t *reply);
 
 BSON_END_DECLS
 

--- a/Sources/CLibMongoC/mongoc/mongoc-client-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-client-private.h
@@ -43,7 +43,7 @@ BSON_BEGIN_DECLS
 
 /* protocol versions this driver can speak */
 #define WIRE_VERSION_MIN 3
-#define WIRE_VERSION_MAX 9
+#define WIRE_VERSION_MAX 13
 
 /* first version that supported "find" and "getMore" commands */
 #define WIRE_VERSION_FIND_CMD 4
@@ -92,6 +92,8 @@ BSON_BEGIN_DECLS
 #define WIRE_VERSION_HEDGED_READS 9
 /* first version to support estimatedDocumentCount with collStats */
 #define WIRE_VERSION_4_9 12
+/* version corresponding to server 5.0 release */
+#define WIRE_VERSION_5_0 13
 
 struct _mongoc_collection_t;
 
@@ -126,8 +128,6 @@ struct _mongoc_client_t {
    /* mongoc_client_session_t's in use, to look up lsids and clusterTimes */
    mongoc_set_t *client_sessions;
    unsigned int csid_rand_seed;
-
-   int64_t timeout_ms;
 
    uint32_t generation;
 };

--- a/Sources/CLibMongoC/mongoc/mongoc-cluster.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cluster.c
@@ -508,6 +508,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
    bson_t encrypted = BSON_INITIALIZER;
    bson_t decrypted = BSON_INITIALIZER;
    mongoc_cmd_t encrypted_cmd;
+   bool is_redacted = false;
 
    server_stream = cmd->server_stream;
    server_id = server_stream->sd->id;
@@ -534,8 +535,11 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
    }
 
    if (callbacks->started) {
-      mongoc_apm_command_started_init_with_cmd (
-         &started_event, cmd, request_id, cluster->client->apm_context);
+      mongoc_apm_command_started_init_with_cmd (&started_event,
+                                                cmd,
+                                                request_id,
+                                                &is_redacted,
+                                                cluster->client->apm_context);
 
       callbacks->started (&started_event);
       mongoc_apm_command_started_cleanup (&started_event);
@@ -579,6 +583,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
                                          cmd->operation_id,
                                          &server_stream->sd->host,
                                          server_id,
+                                         is_redacted,
                                          cluster->client->apm_context);
 
       callbacks->succeeded (&succeeded_event);
@@ -595,6 +600,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
                                       cmd->operation_id,
                                       &server_stream->sd->host,
                                       server_id,
+                                      is_redacted,
                                       cluster->client->apm_context);
 
       callbacks->failed (&failed_event);

--- a/Sources/CLibMongoC/mongoc/mongoc-collection-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-collection-private.h
@@ -37,7 +37,6 @@ struct _mongoc_collection_t {
    mongoc_read_concern_t *read_concern;
    mongoc_write_concern_t *write_concern;
    bson_t *gle;
-   int64_t timeout_ms;
 };
 
 
@@ -47,8 +46,7 @@ _mongoc_collection_new (mongoc_client_t *client,
                         const char *collection,
                         const mongoc_read_prefs_t *read_prefs,
                         const mongoc_read_concern_t *read_concern,
-                        const mongoc_write_concern_t *write_concern,
-                        int64_t timeout_ms);
+                        const mongoc_write_concern_t *write_concern);
 
 bool
 _mongoc_collection_create_index_if_not_exists (mongoc_collection_t *collection,

--- a/Sources/CLibMongoC/mongoc/mongoc-collection.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-collection.c
@@ -22,25 +22,23 @@
 #include "mongoc-bulk-operation-private.h"
 #include "mongoc-change-stream-private.h"
 #include "mongoc-client-private.h"
+#include "mongoc-find-and-modify-private.h"
+#include "CLibMongoC_mongoc-find-and-modify.h"
 #include "CLibMongoC_mongoc-collection.h"
 #include "mongoc-collection-private.h"
 #include "mongoc-cursor-private.h"
-#include "mongoc-database-private.h"
 #include "CLibMongoC_mongoc-error.h"
-#include "mongoc-error-private.h"
-#include "mongoc-find-and-modify-private.h"
-#include "CLibMongoC_mongoc-find-and-modify.h"
 #include "CLibMongoC_mongoc-index.h"
 #include "CLibMongoC_mongoc-log.h"
-#include "mongoc-opts-private.h"
-#include "mongoc-read-concern-private.h"
-#include "mongoc-read-prefs-private.h"
 #include "mongoc-trace-private.h"
-#include "CLibMongoC_mongoc-uri.h"
+#include "mongoc-read-concern-private.h"
+#include "mongoc-write-concern-private.h"
+#include "mongoc-read-prefs-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-write-command-private.h"
+#include "mongoc-opts-private.h"
 #include "mongoc-write-command-private.h"
-#include "mongoc-write-concern-private.h"
+#include "mongoc-error-private.h"
 
 #if !defined(_MSC_VER) || (_MSC_VER >= 1800)
 #include <inttypes.h>
@@ -172,8 +170,7 @@ _mongoc_collection_new (mongoc_client_t *client,
                         const char *collection,
                         const mongoc_read_prefs_t *read_prefs,
                         const mongoc_read_concern_t *read_concern,
-                        const mongoc_write_concern_t *write_concern,
-                        int64_t timeout_ms)
+                        const mongoc_write_concern_t *write_concern)
 {
    mongoc_collection_t *col;
 
@@ -201,8 +198,6 @@ _mongoc_collection_new (mongoc_client_t *client,
    col->nslen = (uint32_t) strlen (col->ns);
 
    col->gle = NULL;
-
-   col->timeout_ms = timeout_ms;
 
    RETURN (col);
 }
@@ -289,8 +284,7 @@ mongoc_collection_copy (mongoc_collection_t *collection) /* IN */
                                    collection->collection,
                                    collection->read_prefs,
                                    collection->read_concern,
-                                   collection->write_concern,
-                                   collection->timeout_ms));
+                                   collection->write_concern));
 }
 
 
@@ -3594,32 +3588,4 @@ mongoc_collection_watch (const mongoc_collection_t *coll,
                          const bson_t *opts)
 {
    return _mongoc_change_stream_new_from_collection (coll, pipeline, opts);
-}
-
-bool
-mongoc_collection_set_timeout_ms (mongoc_collection_t *coll,
-                                  int64_t timeout_ms,
-                                  bson_error_t *error)
-{
-   BSON_ASSERT_PARAM (coll);
-
-   if (timeout_ms < 0) {
-      bson_set_error (error,
-                      MONGOC_ERROR_TIMEOUT,
-                      MONGOC_ERROR_TIMEOUT_INVALID,
-                      "timeoutMS must be a non-negative integer");
-      return false;
-   }
-
-   coll->timeout_ms = timeout_ms;
-
-   return true;
-}
-
-int64_t
-mongoc_collection_get_timeout_ms (const mongoc_collection_t *coll)
-{
-   BSON_ASSERT_PARAM (coll);
-
-   return coll->timeout_ms;
 }

--- a/Sources/CLibMongoC/mongoc/mongoc-cursor-legacy.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cursor-legacy.c
@@ -62,6 +62,7 @@ _mongoc_cursor_monitor_legacy_get_more (mongoc_cursor_t *cursor,
                                     cursor->operation_id,
                                     &server_stream->sd->host,
                                     server_stream->sd->id,
+                                    NULL,
                                     client->apm_context);
 
    client->apm_callbacks.started (&event);

--- a/Sources/CLibMongoC/mongoc/mongoc-cursor.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-cursor.c
@@ -711,6 +711,7 @@ _mongoc_cursor_monitor_command (mongoc_cursor_t *cursor,
                                     cursor->operation_id,
                                     &server_stream->sd->host,
                                     server_stream->sd->id,
+                                    NULL,
                                     client->apm_context);
 
    client->apm_callbacks.started (&event);
@@ -791,6 +792,7 @@ _mongoc_cursor_monitor_succeeded (mongoc_cursor_t *cursor,
                                       cursor->operation_id,
                                       &stream->sd->host,
                                       stream->sd->id,
+                                      false,
                                       client->apm_context);
 
    client->apm_callbacks.succeeded (&event);
@@ -835,6 +837,7 @@ _mongoc_cursor_monitor_failed (mongoc_cursor_t *cursor,
                                    cursor->operation_id,
                                    &stream->sd->host,
                                    stream->sd->id,
+                                   false,
                                    client->apm_context);
 
    client->apm_callbacks.failed (&event);
@@ -1709,7 +1712,7 @@ _mongoc_cursor_prepare_getmore_command (mongoc_cursor_t *cursor,
       bson_append_int64 (command,
                          MONGOC_CURSOR_BATCH_SIZE,
                          MONGOC_CURSOR_BATCH_SIZE_LEN,
-                         batch_size);
+                         abs (_mongoc_n_return (cursor)));
    }
 
    /* Find, getMore And killCursors Commands Spec: "In the case of a tailable

--- a/Sources/CLibMongoC/mongoc/mongoc-database-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-database-private.h
@@ -35,7 +35,6 @@ struct _mongoc_database_t {
    mongoc_read_prefs_t *read_prefs;
    mongoc_read_concern_t *read_concern;
    mongoc_write_concern_t *write_concern;
-   int64_t timeout_ms;
 };
 
 
@@ -44,8 +43,7 @@ _mongoc_database_new (mongoc_client_t *client,
                       const char *name,
                       const mongoc_read_prefs_t *read_prefs,
                       const mongoc_read_concern_t *read_concern,
-                      const mongoc_write_concern_t *write_concern,
-                      int64_t timeout_ms);
+                      const mongoc_write_concern_t *write_concern);
 
 BSON_END_DECLS
 

--- a/Sources/CLibMongoC/mongoc/mongoc-database.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-database.c
@@ -59,8 +59,7 @@ _mongoc_database_new (mongoc_client_t *client,
                       const char *name,
                       const mongoc_read_prefs_t *read_prefs,
                       const mongoc_read_concern_t *read_concern,
-                      const mongoc_write_concern_t *write_concern,
-                      int64_t timeout_ms)
+                      const mongoc_write_concern_t *write_concern)
 {
    mongoc_database_t *db;
 
@@ -79,7 +78,6 @@ _mongoc_database_new (mongoc_client_t *client,
                                : mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
    db->name = bson_strdup (name);
-   db->timeout_ms = timeout_ms;
 
    RETURN (db);
 }
@@ -178,8 +176,7 @@ mongoc_database_copy (mongoc_database_t *database)
                                  database->name,
                                  database->read_prefs,
                                  database->read_concern,
-                                 database->write_concern,
-                                 database->timeout_ms));
+                                 database->write_concern));
 }
 
 mongoc_cursor_t *
@@ -991,8 +988,7 @@ mongoc_database_create_collection (mongoc_database_t *database,
                                            name,
                                            database->read_prefs,
                                            database->read_concern,
-                                           database->write_concern,
-                                           database->timeout_ms);
+                                           database->write_concern);
    }
 
    bson_destroy (&cmd);
@@ -1013,8 +1009,7 @@ mongoc_database_get_collection (mongoc_database_t *database,
                                   collection,
                                   database->read_prefs,
                                   database->read_concern,
-                                  database->write_concern,
-                                  database->timeout_ms);
+                                  database->write_concern);
 }
 
 
@@ -1033,31 +1028,4 @@ mongoc_database_watch (const mongoc_database_t *db,
                        const bson_t *opts)
 {
    return _mongoc_change_stream_new_from_database (db, pipeline, opts);
-}
-
-bool
-mongoc_database_set_timeout_ms (mongoc_database_t *db,
-                                int64_t timeout_ms,
-                                bson_error_t *error)
-{
-   BSON_ASSERT_PARAM (db);
-
-   if (timeout_ms < 0) {
-      bson_set_error (error,
-                      MONGOC_ERROR_TIMEOUT,
-                      MONGOC_ERROR_TIMEOUT_INVALID,
-                      "timeoutMS must be a non-negative integer");
-      return false;
-   }
-
-   db->timeout_ms = timeout_ms;
-   return true;
-}
-
-int64_t
-mongoc_database_get_timeout_ms (const mongoc_database_t *db)
-{
-   BSON_ASSERT_PARAM (db);
-
-   return db->timeout_ms;
 }

--- a/Sources/CLibMongoC/mongoc/mongoc-gridfs-bucket.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-gridfs-bucket.c
@@ -471,8 +471,8 @@ mongoc_gridfs_bucket_find (mongoc_gridfs_bucket_t *bucket,
    BSON_ASSERT (filter);
 
    cursor =
-      mongoc_collection_find_with_opts (bucket->files, filter, NULL, NULL);
-   if (!cursor->error.code && bson_has_field (opts, "sessionId")) {
+      mongoc_collection_find_with_opts (bucket->files, filter, opts, NULL);
+   if (!cursor->error.code && opts && bson_has_field (opts, "sessionId")) {
       bson_set_error (&cursor->error,
                       MONGOC_ERROR_CURSOR,
                       MONGOC_ERROR_CURSOR_INVALID_CURSOR,

--- a/Sources/CLibMongoC/mongoc/mongoc-opts-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-opts-private.h
@@ -185,6 +185,7 @@ typedef struct _mongoc_aggregate_opts_t {
    uint32_t serverId;
    int32_t batchSize;
    bool batchSize_is_set;
+   bson_t let;
    bson_t extra;
 } mongoc_aggregate_opts_t;
 

--- a/Sources/CLibMongoC/mongoc/mongoc-opts.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-opts.c
@@ -1885,6 +1885,7 @@ _mongoc_aggregate_opts_parse (
    mongoc_aggregate_opts->serverId = 0;
    mongoc_aggregate_opts->batchSize = 0;
    mongoc_aggregate_opts->batchSize_is_set = false;
+   bson_init (&mongoc_aggregate_opts->let);
    bson_init (&mongoc_aggregate_opts->extra);
 
    if (!opts) {
@@ -1967,6 +1968,15 @@ _mongoc_aggregate_opts_parse (
 
          mongoc_aggregate_opts->batchSize_is_set = true;
       }
+      else if (!strcmp (bson_iter_key (&iter), "let")) {
+         if (!_mongoc_convert_document (
+               client,
+               &iter,
+               &mongoc_aggregate_opts->let,
+               error)) {
+            return false;
+         }
+      }
       else {
          /* unrecognized values are copied to "extra" */
          if (!BSON_APPEND_VALUE (
@@ -1993,6 +2003,7 @@ _mongoc_aggregate_opts_cleanup (mongoc_aggregate_opts_t *mongoc_aggregate_opts)
       mongoc_write_concern_destroy (mongoc_aggregate_opts->writeConcern);
    }
    bson_destroy (&mongoc_aggregate_opts->collation);
+   bson_destroy (&mongoc_aggregate_opts->let);
    bson_destroy (&mongoc_aggregate_opts->extra);
 }
 

--- a/Sources/CLibMongoC/mongoc/mongoc-rand-openssl.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-rand-openssl.c
@@ -28,6 +28,18 @@
 int
 _mongoc_rand_bytes (uint8_t *buf, int num)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+   /* Versions of OpenSSL before 1.1.1 can potentially produce the same random
+    * sequences in processes with the same PID. Rather than attempt to detect
+    * PID changes (useful for parent/child forking but not if PIDs wrap), mix
+    * the current time into the generator's state.
+    * See also: https://wiki.openssl.org/index.php/Random_fork-safety */
+   struct timeval tv;
+
+   bson_gettimeofday (&tv);
+   RAND_add (&tv, sizeof(tv), 0.0);
+#endif
+
    return RAND_bytes (buf, num);
 }
 

--- a/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
@@ -64,6 +64,7 @@ struct _mongoc_server_description_t {
    int64_t last_update_time_usec;
    bson_t last_hello_response;
    bool has_hello_response;
+   bool hello_ok;
    const char *connection_address;
    /* SDAM dictates storing me/hosts/passives/arbiters after being "normalized
     * to lower-case" Instead, they are stored in the casing they are received,

--- a/Sources/CLibMongoC/mongoc/mongoc-server-description.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-description.c
@@ -68,6 +68,7 @@ mongoc_server_description_reset (mongoc_server_description_t *sd)
    sd->max_write_batch_size = MONGOC_DEFAULT_WRITE_BATCH_SIZE;
    sd->session_timeout_minutes = MONGOC_NO_SESSIONS;
    sd->last_write_date_ms = -1;
+   sd->hello_ok = false;
 
    /* always leave last hello in an init-ed state until we destroy sd */
    bson_destroy (&sd->last_hello_response);
@@ -592,6 +593,10 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
          if (!BSON_ITER_HOLDS_BOOL (&iter))
             goto failure;
          is_primary = bson_iter_bool (&iter);
+      } else if (strcmp ("helloOk", bson_iter_key (&iter)) == 0) {
+         if (!BSON_ITER_HOLDS_BOOL (&iter))
+            goto failure;
+         sd->hello_ok = bson_iter_bool (&iter);
       } else if (strcmp ("me", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
             goto failure;

--- a/Sources/CLibMongoC/mongoc/mongoc-topology-scanner-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology-scanner-private.h
@@ -54,6 +54,7 @@ typedef struct mongoc_topology_scanner_node {
    int64_t last_used;
    int64_t last_failed;
    bool has_auth;
+   bool hello_ok;
    mongoc_host_list_t host;
    struct mongoc_topology_scanner *ts;
 
@@ -84,7 +85,8 @@ typedef struct mongoc_topology_scanner {
    int64_t connect_timeout_msec;
    mongoc_topology_scanner_node_t *nodes;
    bson_t hello_cmd;
-   bson_t hello_cmd_with_handshake;
+   bson_t legacy_hello_cmd;
+   bson_t handshake_cmd;
    bson_t cluster_time;
    bool handshake_ok_to_send;
    const char *appname;
@@ -130,7 +132,8 @@ mongoc_topology_scanner_valid (mongoc_topology_scanner_t *ts);
 void
 mongoc_topology_scanner_add (mongoc_topology_scanner_t *ts,
                              const mongoc_host_list_t *host,
-                             uint32_t id);
+                             uint32_t id,
+                             bool hello_ok);
 
 void
 mongoc_topology_scanner_scan (mongoc_topology_scanner_t *ts, uint32_t id);
@@ -194,7 +197,8 @@ _mongoc_topology_scanner_get_speculative_auth_mechanism (
    const mongoc_uri_t *uri);
 
 const bson_t *
-_mongoc_topology_scanner_get_hello_cmd (mongoc_topology_scanner_t *ts);
+_mongoc_topology_scanner_get_monitoring_cmd (mongoc_topology_scanner_t *ts,
+                                             bool hello_ok);
 
 const bson_t *
 _mongoc_topology_scanner_get_handshake_cmd (mongoc_topology_scanner_t *ts);

--- a/Sources/CLibMongoC/mongoc/mongoc-topology.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-topology.c
@@ -43,12 +43,15 @@ _mongoc_topology_reconcile_add_nodes (mongoc_server_description_t *sd,
                                       mongoc_topology_t *topology)
 {
    mongoc_topology_scanner_t *scanner = topology->scanner;
+   mongoc_topology_scanner_node_t *node;
 
-   /* quickly search by id, then check if a node for this host was retired in
-    * this scan. */
-   if (!mongoc_topology_scanner_get_node (scanner, sd->id) &&
-       !mongoc_topology_scanner_has_node_for_host (scanner, &sd->host)) {
-      mongoc_topology_scanner_add (scanner, &sd->host, sd->id);
+   /* Search by ID and update hello_ok */
+   node = mongoc_topology_scanner_get_node (scanner, sd->id);
+   if (node) {
+      node->hello_ok = sd->hello_ok;
+   } else if (!mongoc_topology_scanner_has_node_for_host (scanner, &sd->host)) {
+      /* A node for this host was retired in this scan. */
+      mongoc_topology_scanner_add (scanner, &sd->host, sd->id, sd->hello_ok);
       mongoc_topology_scanner_scan (scanner, sd->id);
    }
 
@@ -189,9 +192,9 @@ _mongoc_topology_scanner_cb (uint32_t id,
       _mongoc_topology_update_no_lock (
          id, hello_response, rtt_msec, topology, error);
 
-      /* The processing of the hello results above may have added/removed
-       * server descriptions. We need to reconcile that with our monitoring
-       * agents
+      /* The processing of the hello results above may have added, changed, or
+       * removed server descriptions. We need to reconcile that with our
+       * monitoring agents
        */
       mongoc_topology_reconcile (topology);
 
@@ -442,7 +445,7 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
    while (hl) {
       mongoc_topology_description_add_server (
          &topology->description, hl->host_and_port, &id);
-      mongoc_topology_scanner_add (topology->scanner, hl, id);
+      mongoc_topology_scanner_add (topology->scanner, hl, id, false);
 
       hl = hl->next;
    }

--- a/Sources/CLibMongoC/mongoc/mongoc-uri.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-uri.c
@@ -727,23 +727,21 @@ mongoc_uri_option_is_int32 (const char *key)
           !strcasecmp (key, MONGOC_URI_HEARTBEATFREQUENCYMS) ||
           !strcasecmp (key, MONGOC_URI_SERVERSELECTIONTIMEOUTMS) ||
           !strcasecmp (key, MONGOC_URI_SOCKETCHECKINTERVALMS) ||
+          !strcasecmp (key, MONGOC_URI_SOCKETTIMEOUTMS) ||
           !strcasecmp (key, MONGOC_URI_LOCALTHRESHOLDMS) ||
           !strcasecmp (key, MONGOC_URI_MAXPOOLSIZE) ||
           !strcasecmp (key, MONGOC_URI_MAXSTALENESSSECONDS) ||
           !strcasecmp (key, MONGOC_URI_MINPOOLSIZE) ||
           !strcasecmp (key, MONGOC_URI_MAXIDLETIMEMS) ||
           !strcasecmp (key, MONGOC_URI_WAITQUEUEMULTIPLE) ||
-          !strcasecmp (key, MONGOC_URI_ZLIBCOMPRESSIONLEVEL) ||
-          /* deprecated options */
           !strcasecmp (key, MONGOC_URI_WAITQUEUETIMEOUTMS) ||
-          !strcasecmp (key, MONGOC_URI_SOCKETTIMEOUTMS);
+          !strcasecmp (key, MONGOC_URI_ZLIBCOMPRESSIONLEVEL);
 }
 
 bool
 mongoc_uri_option_is_int64 (const char *key)
 {
-   return !strcasecmp (key, MONGOC_URI_WTIMEOUTMS) ||
-          !strcasecmp (key, MONGOC_URI_TIMEOUTMS);
+   return !strcasecmp (key, MONGOC_URI_WTIMEOUTMS);
 }
 
 bool
@@ -1132,8 +1130,7 @@ mongoc_uri_apply_options (mongoc_uri_t *uri,
                                MONGOC_ERROR_COMMAND,
                                MONGOC_ERROR_COMMAND_INVALID_ARG,
                                "Failed to set %s to %d",
-                               canon,
-                               bval);
+                               canon, bval);
                return false;
             }
          } else {
@@ -2500,30 +2497,6 @@ mongoc_uri_get_option_as_int32 (const mongoc_uri_t *uri,
    return (int32_t) retval;
 }
 
-
-static void
-_mongoc_uri_warn_for_bad_int_option_combos (const mongoc_uri_t *uri,
-					    const char *option)
-{
-   /* Warn for deprecated option combinations */
-   if (!strcasecmp (option, MONGOC_URI_TIMEOUTMS)) {
-      if (mongoc_uri_get_option_as_int64 (uri, MONGOC_URI_WAITQUEUETIMEOUTMS, -1) > 0 ||
-	  mongoc_uri_get_option_as_int64 (uri, MONGOC_URI_SOCKETTIMEOUTMS, -1) > 0 ||
-	  mongoc_uri_get_option_as_int64 (uri, MONGOC_URI_WTIMEOUTMS, -1) > 0) {
-	 MONGOC_WARNING ("Setting a deprecated timeout option %s in combination with timeoutMS", option);
-      }
-   }
-
-   if (!strcasecmp (option, MONGOC_URI_WAITQUEUETIMEOUTMS) ||
-       !strcasecmp (option, MONGOC_URI_SOCKETTIMEOUTMS) ||
-       !strcasecmp (option, MONGOC_URI_WTIMEOUTMS)) {
-      if (mongoc_uri_get_option_as_int64 (uri, MONGOC_URI_TIMEOUTMS, -1) > 0) {
-	 MONGOC_WARNING ("Setting a deprecated timeout option %s in combination with timeoutMS", option);
-      }
-   }
-}
-
-
 /*
  *--------------------------------------------------------------------------
  *
@@ -2646,8 +2619,6 @@ _mongoc_uri_set_option_as_int32_with_error (mongoc_uri_t *uri,
       }
    }
 
-   _mongoc_uri_warn_for_bad_int_option_combos (uri, option);
-   
    option_lowercase = lowercase_str_new (option);
    if (!bson_append_int32 (&uri->options, option_lowercase, -1, value)) {
       bson_free (option_lowercase);
@@ -2841,16 +2812,6 @@ _mongoc_uri_set_option_as_int64_with_error (mongoc_uri_t *uri,
 
    option = mongoc_uri_canonicalize_option (option_orig);
 
-   /* timeoutMS may not be a negative number. */
-   if (!bson_strcasecmp (option, MONGOC_URI_TIMEOUTMS) && value < 0) {
-      MONGOC_URI_ERROR (
-         error,
-         "Invalid \"%s\" of %" "lld" ": must be a non-negative integer",
-         option_orig,
-         value);
-      return false;
-   }
-
    if ((options = mongoc_uri_get_options (uri)) &&
        bson_iter_init_find_case (&iter, options, option)) {
       if (BSON_ITER_HOLDS_INT64 (&iter)) {
@@ -2866,8 +2827,6 @@ _mongoc_uri_set_option_as_int64_with_error (mongoc_uri_t *uri,
          return false;
       }
    }
-
-   _mongoc_uri_warn_for_bad_int_option_combos (uri, option);
 
    option_lowercase = lowercase_str_new (option);
    if (!bson_append_int64 (&uri->options, option_lowercase, -1, value)) {

--- a/Sources/CLibMongoC/mongoc/mongoc-write-command-legacy.c
+++ b/Sources/CLibMongoC/mongoc/mongoc-write-command-legacy.c
@@ -55,6 +55,7 @@ _mongoc_monitor_legacy_write (mongoc_client_t *client,
       command->operation_id,
       &stream->sd->host,
       stream->sd->id,
+      NULL,
       client->apm_context);
 
    client->apm_callbacks.started (&event);
@@ -104,6 +105,7 @@ _mongoc_monitor_legacy_write_succeeded (mongoc_client_t *client,
       command->operation_id,
       &stream->sd->host,
       stream->sd->id,
+      false,
       client->apm_context);
 
    client->apm_callbacks.succeeded (&event);
@@ -380,16 +382,13 @@ _mongoc_write_command_update_legacy (mongoc_write_command_t *command,
    int32_t max_bson_obj_size;
    mongoc_rpc_t rpc;
    uint32_t request_id = 0;
-   bson_iter_t subiter, subsubiter;
-   bson_t doc;
+   bson_iter_t subiter;
    bson_t update, selector;
    const uint8_t *data = NULL;
    uint32_t len = 0;
-   size_t err_offset;
    bool val = false;
    char *ns;
-   int vflags = (BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL |
-                 BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS);
+   bool r;
    bson_reader_t *reader;
    const bson_t *bson;
    bool eof;
@@ -406,45 +405,19 @@ _mongoc_write_command_update_legacy (mongoc_write_command_t *command,
 
    max_bson_obj_size = mongoc_server_stream_max_bson_obj_size (server_stream);
 
-   reader =
-      bson_reader_new_from_data (command->payload.data, command->payload.len);
-   while ((bson = bson_reader_read (reader, &eof))) {
-      if (bson_iter_init (&subiter, bson) && bson_iter_find (&subiter, "u") &&
-          BSON_ITER_HOLDS_DOCUMENT (&subiter)) {
-         bson_iter_document (&subiter, &len, &data);
-         BSON_ASSERT (bson_init_static (&doc, data, len));
-
-         if (bson_iter_init (&subsubiter, &doc) &&
-             bson_iter_next (&subsubiter) &&
-             (bson_iter_key (&subsubiter)[0] != '$') &&
-             !bson_validate (
-                &doc, (bson_validate_flags_t) vflags, &err_offset)) {
-            result->failed = true;
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "update document is corrupt or contains "
-                            "invalid keys including $ or .");
-            bson_reader_destroy (reader);
-            EXIT;
-         }
-      } else {
-         result->failed = true;
-         bson_set_error (error,
-                         MONGOC_ERROR_BSON,
-                         MONGOC_ERROR_BSON_INVALID,
-                         "updates is malformed.");
-         bson_reader_destroy (reader);
-         EXIT;
-      }
-   }
-
    ns = bson_strdup_printf ("%s.%s", database, collection);
 
-   bson_reader_destroy (reader);
    reader =
       bson_reader_new_from_data (command->payload.data, command->payload.len);
    while ((bson = bson_reader_read (reader, &eof))) {
+      /* ensure the document has "q" and "u" document fields in that order */
+      r = (bson_iter_init (&subiter, bson) && bson_iter_find (&subiter, "q") &&
+           BSON_ITER_HOLDS_DOCUMENT (&subiter) &&
+           bson_iter_find (&subiter, "u") &&
+           BSON_ITER_HOLDS_DOCUMENT (&subiter));
+
+      BSON_ASSERT (r);
+
       request_id = ++client->cluster.request_id;
 
       rpc.header.msg_len = 0;
@@ -459,6 +432,10 @@ _mongoc_write_command_update_legacy (mongoc_write_command_t *command,
       while (bson_iter_next (&subiter)) {
          if (strcmp (bson_iter_key (&subiter), "u") == 0) {
             bson_iter_document (&subiter, &len, &data);
+
+            BSON_ASSERT (data);
+            BSON_ASSERT (len >= 5);
+
             if (len > max_bson_obj_size) {
                _mongoc_write_command_too_large_error (
                   error, 0, len, max_bson_obj_size);
@@ -472,6 +449,10 @@ _mongoc_write_command_update_legacy (mongoc_write_command_t *command,
             BSON_ASSERT (bson_init_static (&update, data, len));
          } else if (strcmp (bson_iter_key (&subiter), "q") == 0) {
             bson_iter_document (&subiter, &len, &data);
+
+            BSON_ASSERT (data);
+            BSON_ASSERT (len >= 5);
+
             if (len > max_bson_obj_size) {
                _mongoc_write_command_too_large_error (
                   error, 0, len, max_bson_obj_size);

--- a/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollectionTests.swift
@@ -90,7 +90,6 @@ final class MongoCollectionTests: MongoSwiftTestCase {
         )
 
         expect(try self.coll.insertOne(["_id": 1])).to(throwError(expectedError))
-        expect(try self.coll.insertOne(["$asf": 12])).to(throwError(errorType: MongoError.InvalidArgumentError.self))
     }
 
     func testInsertOneWithUnacknowledgedWriteConcern() throws {

--- a/Tests/Specs/transactions/tests/legacy/error-labels.json
+++ b/Tests/Specs/transactions/tests/legacy/error-labels.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "description": "NotMaster errors contain transient label",
+      "description": "NotWritablePrimary errors contain transient label",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/Tests/Specs/transactions/tests/legacy/errors-client.json
+++ b/Tests/Specs/transactions/tests/legacy/errors-client.json
@@ -25,14 +25,15 @@
           "object": "session0"
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "error": true
@@ -60,22 +61,23 @@
           "arguments": {
             "session": "session0",
             "document": {
-              "_id": 4
+              "_id": 1
             }
           },
           "result": {
-            "insertedId": 4
+            "insertedId": 1
           }
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "error": true

--- a/Tests/Specs/transactions/tests/legacy/mongos-recovery-token.json
+++ b/Tests/Specs/transactions/tests/legacy/mongos-recovery-token.json
@@ -307,7 +307,8 @@
               "data": {
                 "failCommands": [
                   "commitTransaction",
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "closeConnection": true
               }

--- a/Tests/Specs/transactions/tests/legacy/pin-mongos.json
+++ b/Tests/Specs/transactions/tests/legacy/pin-mongos.json
@@ -1107,7 +1107,8 @@
               "data": {
                 "failCommands": [
                   "insert",
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "closeConnection": true
               }

--- a/Tests/Specs/transactions/tests/legacy/retryable-abort.json
+++ b/Tests/Specs/transactions/tests/legacy/retryable-abort.json
@@ -402,7 +402,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMaster",
+      "description": "abortTransaction succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -506,7 +506,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMasterOrSecondary",
+      "description": "abortTransaction succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -610,7 +610,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMasterNoSlaveOk",
+      "description": "abortTransaction succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/Tests/Specs/transactions/tests/legacy/retryable-commit.json
+++ b/Tests/Specs/transactions/tests/legacy/retryable-commit.json
@@ -624,7 +624,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMaster",
+      "description": "commitTransaction succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -735,7 +735,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMasterOrSecondary",
+      "description": "commitTransaction succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -846,7 +846,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMasterNoSlaveOk",
+      "description": "commitTransaction succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/Tests/Specs/unified-test-format/tests/valid-pass/poc-transactions.json
+++ b/Tests/Specs/unified-test-format/tests/valid-pass/poc-transactions.json
@@ -61,14 +61,15 @@
           "object": "session0"
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection0",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "expectError": {

--- a/etc/inttypes-non-modular-header-workaround.diff
+++ b/etc/inttypes-non-modular-header-workaround.diff
@@ -127,13 +127,14 @@ index 92a10b2..35159b1 100644
  
  #undef MONGOC_LOG_DOMAIN
  #define MONGOC_LOG_DOMAIN "client"
+ 
 diff --git a/Sources/CLibMongoC/mongoc/mongoc-collection.c b/Sources/CLibMongoC/mongoc/mongoc-collection.c
-index 200f9c2..2c05ba1 100644
+index f82d3ab1..90f1afb5 100644
 --- a/Sources/CLibMongoC/mongoc/mongoc-collection.c
 +++ b/Sources/CLibMongoC/mongoc/mongoc-collection.c
-@@ -42,6 +42,10 @@
+@@ -40,6 +40,10 @@
  #include "mongoc-write-command-private.h"
- #include "mongoc-write-concern-private.h"
+ #include "mongoc-error-private.h"
 
 +#if !defined(_MSC_VER) || (_MSC_VER >= 1800)
 +#include <inttypes.h>

--- a/etc/vendor-libmongoc.sh
+++ b/etc/vendor-libmongoc.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 PWD=`pwd`
-LIBMONGOC_VERSION=1.18.0-alpha2
+LIBMONGOC_VERSION=1.18.0
 TARBALL_URL=https://github.com/mongodb/mongo-c-driver/releases/download/$LIBMONGOC_VERSION/mongo-c-driver-$LIBMONGOC_VERSION.tar.gz
 TARBALL_NAME=`basename $TARBALL_URL`
 TARBALL_DIR=`basename -s .tar.gz $TARBALL_NAME`


### PR DESCRIPTION
Vendors in the latest libmongoc version. Getting this to pass on Evergreen required some small test changes:
* Sync some tests to account for libmongoc changes for DRIVERS-1237
* One of these changes required supporting a session in `UnifiedUpdateOne`, updated to do that

Evergreen patch:
https://evergreen.mongodb.com/version/60f0830832f4171f5c896e4d

There continue to be timeouts on macOS sharded clusters with SSL+auth which I hope to investigate soon, and some existing OCSP failures, but all looks to still pass otherwise. 