### PR TITLE
Update Vapor example to depend on MongoDBVapor 1.0.0+ and pin js-bson version

### DIFF
--- a/Examples/VaporExample/Package.swift
+++ b/Examples/VaporExample/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor", .upToNextMajor(from: "4.7.0")),
         .package(url: "https://github.com/vapor/leaf", .upToNextMajor(from: "4.0.0")),
-        .package(url: "https://github.com/mongodb/mongodb-vapor", .exact("1.0.0-beta.0"))
+        .package(url: "https://github.com/mongodb/mongodb-vapor", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
         .target(

--- a/Examples/VaporExample/Resources/Views/index.leaf
+++ b/Examples/VaporExample/Resources/Views/index.leaf
@@ -15,7 +15,7 @@
     }
   </style>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <script src="https://unpkg.com/bson@^4/dist/bson.browser.umd.js"></script>
+  <script src="https://unpkg.com/bson@4.4.0/dist/bson.browser.umd.js"></script>
 </head>
 <body>
   

--- a/Examples/VaporExample/Resources/Views/kitten.leaf
+++ b/Examples/VaporExample/Resources/Views/kitten.leaf
@@ -15,7 +15,7 @@
     }
   </style>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <script src="https://unpkg.com/bson@^4/dist/bson.browser.umd.js"></script>
+  <script src="https://unpkg.com/bson@4.4.0/dist/bson.browser.umd.js"></script>
 </head>
 <body>
 <h1>#(name) 🐱</h1>


### PR DESCRIPTION
Depend on the new tag of MongoDBVapor, and pin js-bson for the same reasons we had to in the template as discussed in SWIFT-1264 (I updated that ticket to cover un-pinning here as well when the Node issue is resolved)