### PR TITLE
SWIFT-1249 / SWIFT-1269 Skip serverless tests that use disabled features

### DIFF
--- a/Tests/MongoSwiftSyncTests/CrudTests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudTests.swift
@@ -28,6 +28,13 @@ final class CrudTests: MongoSwiftTestCase {
                 continue
             }
 
+            if let serverlessRequirement = file.serverless {
+                if let unmet = serverlessRequirement.validate() {
+                    print("Skipping tests from file\(filename), unmet serverless requirement: \(unmet)")
+                    continue
+                }
+            }
+
             print("\n------------\nExecuting tests from file \(dir)/\(filename)...\n")
 
             // For each file, execute the test cases contained in it
@@ -103,9 +110,10 @@ private struct CrudTestFile: Decodable {
 
     let minServerVersion: String?
     let maxServerVersion: String?
+    let serverless: TestRequirement.ServerlessRequirement?
 
     enum CodingKeys: String, CodingKey {
-        case data, testDocs = "tests", minServerVersion, maxServerVersion
+        case data, testDocs = "tests", minServerVersion, maxServerVersion, serverless
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -96,6 +96,13 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
             options.hidden = true
         }
 
+        // some options not supported by serverless
+        if MongoSwiftTestCase.serverless {
+            options.storageEngine = nil
+            options.collation = nil
+            options.version = nil
+        }
+
         let model = IndexModel(keys: ["cat": 1, "_id": -1], options: options)
         expect(try self.coll.createIndex(model)).to(equal("testOptions"))
 
@@ -113,6 +120,7 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         // testOptions index
         var expectedTestOptions = options
         expectedTestOptions.name = "testOptions"
+        expectedTestOptions.version = 2
         expect(indexOptions[1]).to(equal(expectedTestOptions))
 
         // ttl index

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -158,11 +158,14 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
             options: UpdateOptions(writeConcern: wc3)
         )).toNot(throwError())
 
-        let coll2 = try db.createCollection(self.getCollectionName(suffix: "2"))
-        defer { try? coll2.drop() }
+        // $out not supported by serverless
+        if !MongoSwiftTestCase.serverless {
+            let coll2 = try db.createCollection(self.getCollectionName(suffix: "2"))
+            defer { try? coll2.drop() }
 
-        let pipeline: [BSONDocument] = [["$out": .string("\(db.name).\(coll2.name)")]]
-        expect(try coll.aggregate(pipeline, options: AggregateOptions(writeConcern: wc1))).toNot(throwError())
+            let pipeline: [BSONDocument] = [["$out": .string("\(db.name).\(coll2.name)")]]
+            expect(try coll.aggregate(pipeline, options: AggregateOptions(writeConcern: wc1))).toNot(throwError())
+        }
 
         expect(try coll.replaceOne(
             filter: ["x": 5],

--- a/Tests/Specs/crud/tests/unified/aggregate-out-readConcern.json
+++ b/Tests/Specs/crud/tests/unified/aggregate-out-readConcern.json
@@ -1,13 +1,14 @@
 {
   "description": "aggregate-out-readConcern",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.1.0",
       "topologies": [
         "replicaset",
         "sharded"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/Tests/Specs/crud/tests/v1/read/aggregate-collation.json
+++ b/Tests/Specs/crud/tests/v1/read/aggregate-collation.json
@@ -6,6 +6,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Aggregate with collation",

--- a/Tests/Specs/crud/tests/v1/read/aggregate-out.json
+++ b/Tests/Specs/crud/tests/v1/read/aggregate-out.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "2.6",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Aggregate with $out",

--- a/Tests/Specs/crud/tests/v1/read/count-collation.json
+++ b/Tests/Specs/crud/tests/v1/read/count-collation.json
@@ -6,6 +6,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Count documents with collation",

--- a/Tests/Specs/crud/tests/v1/read/distinct-collation.json
+++ b/Tests/Specs/crud/tests/v1/read/distinct-collation.json
@@ -10,6 +10,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Distinct with a collation",

--- a/Tests/Specs/crud/tests/v1/read/find-collation.json
+++ b/Tests/Specs/crud/tests/v1/read/find-collation.json
@@ -6,6 +6,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Find with a collation",

--- a/Tests/Specs/crud/tests/v1/write/bulkWrite-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/bulkWrite-collation.json
@@ -22,6 +22,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "BulkWrite with delete operations and collation",

--- a/Tests/Specs/crud/tests/v1/write/deleteMany-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/deleteMany-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "DeleteMany when many documents match with collation",

--- a/Tests/Specs/crud/tests/v1/write/deleteOne-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/deleteOne-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "DeleteOne when many documents matches with collation",

--- a/Tests/Specs/crud/tests/v1/write/findOneAndDelete-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/findOneAndDelete-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "FindOneAndDelete when one document matches with collation",

--- a/Tests/Specs/crud/tests/v1/write/findOneAndReplace-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/findOneAndReplace-collation.json
@@ -10,6 +10,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "FindOneAndReplace when one document matches with collation returning the document after modification",

--- a/Tests/Specs/crud/tests/v1/write/findOneAndUpdate-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/findOneAndUpdate-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "FindOneAndUpdate when many documents match with collation returning the document before modification",

--- a/Tests/Specs/crud/tests/v1/write/replaceOne-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/replaceOne-collation.json
@@ -10,6 +10,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "ReplaceOne when one document matches with collation",

--- a/Tests/Specs/crud/tests/v1/write/updateMany-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/updateMany-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "UpdateMany when many documents match with collation",

--- a/Tests/Specs/crud/tests/v1/write/updateOne-collation.json
+++ b/Tests/Specs/crud/tests/v1/write/updateOne-collation.json
@@ -10,6 +10,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "UpdateOne when one document matches with collation",


### PR DESCRIPTION
SWIFT-1249 / SWIFT-1269

Serverless removed support for some features (`$out`, collation), so we needed to skip some tests and sync some spec tests.
