### PR TITLE
SWIFT-1107 Sync "Mitigate pain of using field names with dots and dollars" tests

### DIFF
--- a/Tests/MongoSwiftSyncTests/CrudTests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudTests.swift
@@ -75,6 +75,9 @@ final class CrudTests: MongoSwiftTestCase {
                 // TODO: SWIFT-560 unskip these files
                 "bulkWrite-updateMany-dots_and_dollars.json",
                 "bulkWrite-updateOne-dots_and_dollars.json",
+                "updateMany-dots_and_dollars.json",
+                "updateOne-dots_and_dollars.json",
+                "findOneAndUpdate-dots_and_dollars.json",
                 "updateWithPipelines.json"
             ],
             asType: UnifiedTestFile.self

--- a/Tests/MongoSwiftSyncTests/CrudTests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudTests.swift
@@ -68,11 +68,19 @@ final class CrudTests: MongoSwiftTestCase {
     }
 
     func testCrudUnified() throws {
-        let files = try retrieveSpecTestFiles(specName: "crud", subdirectory: "unified", asType: UnifiedTestFile.self)
+        let files = try retrieveSpecTestFiles(
+            specName: "crud",
+            subdirectory: "unified",
+            excludeFiles: [
+                // TODO: SWIFT-560 unskip these files
+                "bulkWrite-updateMany-dots_and_dollars.json",
+                "bulkWrite-updateOne-dots_and_dollars.json",
+                "updateWithPipelines.json"
+            ],
+            asType: UnifiedTestFile.self
+        )
         let runner = try UnifiedTestRunner()
         let skipList: [String: [String]] = [
-            // TODO: SWIFT-560 unskip this test
-            "updateWithPipelines": ["*"],
             // libmongoc chose not to implement CDRIVER-3630 in anticipation of DRIVERS-1340,
             // so we cannot pass these tests for now.
             // TODO: DRIVERS-1340 unskip

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/TestWriteModel.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/TestWriteModel.swift
@@ -58,14 +58,14 @@ enum TestWriteModel: Decodable {
         } else if let nested = try? container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .updateOne) {
             let filter = try nested.decode(BSONDocument.self, forKey: .filter)
             // TODO: SWIFT-560 handle decoding pipelines properly
-            let update = (try? nested.decode(BSONDocument.self, forKey: .update)) ?? [:]
+            let update = try nested.decode(BSONDocument.self, forKey: .update)
             let options = try container.decode(UpdateModelOptions.self, forKey: .updateOne)
             self = .updateOne(filter: filter, update: update, options: options)
             matchedKey = .updateOne
         } else if let nested = try? container.nestedContainer(keyedBy: UpdateKeys.self, forKey: .updateMany) {
             let filter = try nested.decode(BSONDocument.self, forKey: .filter)
             // TODO: SWIFT-560 handle decoding pipelines properly
-            let update = (try? nested.decode(BSONDocument.self, forKey: .update)) ?? [:]
+            let update = try nested.decode(BSONDocument.self, forKey: .update)
             let options = try container.decode(UpdateModelOptions.self, forKey: .updateMany)
             self = .updateMany(filter: filter, update: update, options: options)
             matchedKey = .updateMany

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -108,7 +108,7 @@ struct UnifiedBulkWrite: UnifiedOperationProtocol {
         let collection = try context.entities.getEntity(from: object).asCollection()
         let session = try context.entities.resolveSession(id: self.session)
         guard let result = try collection.bulkWrite(self.requests, options: self.options, session: session) else {
-            return .none
+            return .unacknowledgedWrite
         }
         let encodedResult = try BSONEncoder().encode(result)
         return .bson(.document(encodedResult))
@@ -193,7 +193,7 @@ struct UnifiedFindOneAndReplace: UnifiedOperationProtocol {
             options: options,
             session: session
         ) else {
-            return .none
+            return .unacknowledgedWrite
         }
         return .bson(.document(result))
     }
@@ -241,7 +241,7 @@ struct UnifiedFindOneAndUpdate: UnifiedOperationProtocol {
             options: options,
             session: session
         ) else {
-            return .none
+            return .unacknowledgedWrite
         }
         return .rootDocument(result)
     }
@@ -273,7 +273,7 @@ struct UnifiedFindOneAndDelete: UnifiedOperationProtocol {
     func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
         let collection = try context.entities.getEntity(from: object).asCollection()
         guard let result = try collection.findOneAndDelete(filter, options: self.options) else {
-            return .none
+            return .unacknowledgedWrite
         }
         return .rootDocument(result)
     }
@@ -311,7 +311,7 @@ struct UnifiedDeleteOne: UnifiedOperationProtocol {
         let collection = try context.entities.getEntity(from: object).asCollection()
         let session = try context.entities.resolveSession(id: self.session)
         guard let result = try collection.deleteOne(filter, options: options, session: session) else {
-            return .none
+            return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
         return .bson(.document(encoded))
@@ -344,7 +344,7 @@ struct UnifiedDeleteMany: UnifiedOperationProtocol {
     func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
         let collection = try context.entities.getEntity(from: object).asCollection()
         guard let result = try collection.deleteMany(filter, options: self.options) else {
-            return .none
+            return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
         return .bson(.document(encoded))
@@ -383,7 +383,7 @@ struct UnifiedInsertOne: UnifiedOperationProtocol {
         let collection = try context.entities.getEntity(from: object).asCollection()
         let session = try context.entities.resolveSession(id: self.session)
         guard let result = try collection.insertOne(self.document, options: self.options, session: session) else {
-            return .none
+            return .unacknowledgedWrite
         }
         return .rootDocument(try BSONEncoder().encode(result))
     }
@@ -421,7 +421,7 @@ struct UnifiedInsertMany: UnifiedOperationProtocol {
         let collection = try context.entities.getEntity(from: object).asCollection()
         let session = try context.entities.resolveSession(id: self.session)
         guard let result = try collection.insertMany(self.documents, options: options, session: session) else {
-            return .none
+            return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
         return .rootDocument(encoded)
@@ -469,7 +469,7 @@ struct UnifiedReplaceOne: UnifiedOperationProtocol {
             options: options,
             session: session
         ) else {
-            return .none
+            return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
         return .bson(.document(encoded))
@@ -571,7 +571,7 @@ struct UnifiedUpdateOne: UnifiedOperationProtocol {
             options: self.options,
             session: session
         ) else {
-            return .none
+            return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
         return .bson(.document(encoded))
@@ -609,7 +609,7 @@ struct UnifiedUpdateMany: UnifiedOperationProtocol {
     func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
         let collection = try context.entities.getEntity(from: object).asCollection()
         guard let result = try collection.updateMany(filter: filter, update: update, options: self.options) else {
-            return .none
+            return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
         return .bson(.document(encoded))

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -111,7 +111,7 @@ struct UnifiedBulkWrite: UnifiedOperationProtocol {
             return .unacknowledgedWrite
         }
         let encodedResult = try BSONEncoder().encode(result)
-        return .bson(.document(encodedResult))
+        return .rootDocument(encodedResult)
     }
 }
 
@@ -195,7 +195,7 @@ struct UnifiedFindOneAndReplace: UnifiedOperationProtocol {
         ) else {
             return .unacknowledgedWrite
         }
-        return .bson(.document(result))
+        return .rootDocument(result)
     }
 }
 
@@ -314,7 +314,7 @@ struct UnifiedDeleteOne: UnifiedOperationProtocol {
             return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
-        return .bson(.document(encoded))
+        return .rootDocument(encoded)
     }
 }
 
@@ -347,7 +347,7 @@ struct UnifiedDeleteMany: UnifiedOperationProtocol {
             return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
-        return .bson(.document(encoded))
+        return .rootDocument(encoded)
     }
 }
 
@@ -472,7 +472,7 @@ struct UnifiedReplaceOne: UnifiedOperationProtocol {
             return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
-        return .bson(.document(encoded))
+        return .rootDocument(encoded)
     }
 }
 
@@ -574,7 +574,7 @@ struct UnifiedUpdateOne: UnifiedOperationProtocol {
             return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
-        return .bson(.document(encoded))
+        return .rootDocument(encoded)
     }
 }
 
@@ -612,6 +612,6 @@ struct UnifiedUpdateMany: UnifiedOperationProtocol {
             return .unacknowledgedWrite
         }
         let encoded = try BSONEncoder().encode(result)
-        return .bson(.document(encoded))
+        return .rootDocument(encoded)
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedCollectionOperations.swift
@@ -229,7 +229,7 @@ struct UnifiedFindOneAndUpdate: UnifiedOperationProtocol {
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         self.filter = try container.decode(BSONDocument.self, forKey: .filter)
         // TODO: SWIFT-560 handle decoding pipelines properly
-        self.update = (try? container.decode(BSONDocument.self, forKey: .update)) ?? [:]
+        self.update = try container.decode(BSONDocument.self, forKey: .update)
     }
 
     func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
@@ -385,7 +385,7 @@ struct UnifiedInsertOne: UnifiedOperationProtocol {
         guard let result = try collection.insertOne(self.document, options: self.options, session: session) else {
             return .none
         }
-        return .bson(.document(try BSONEncoder().encode(result)))
+        return .rootDocument(try BSONEncoder().encode(result))
     }
 }
 
@@ -424,7 +424,7 @@ struct UnifiedInsertMany: UnifiedOperationProtocol {
             return .none
         }
         let encoded = try BSONEncoder().encode(result)
-        return .bson(.document(encoded))
+        return .rootDocument(encoded)
     }
 }
 
@@ -559,7 +559,7 @@ struct UnifiedUpdateOne: UnifiedOperationProtocol {
         self.options = try decoder.singleValueContainer().decode(UpdateOptions.self)
         self.session = try container.decodeIfPresent(String.self, forKey: .session)
         // TODO: SWIFT-560 handle decoding pipelines properly
-        self.update = (try? container.decode(BSONDocument.self, forKey: .update)) ?? [:]
+        self.update = try container.decode(BSONDocument.self, forKey: .update)
     }
 
     func execute(on object: UnifiedOperation.Object, context: Context) throws -> UnifiedOperationResult {
@@ -602,7 +602,7 @@ struct UnifiedUpdateMany: UnifiedOperationProtocol {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.filter = try container.decode(BSONDocument.self, forKey: .filter)
         // TODO: SWIFT-560 handle decoding pipelines properly
-        self.update = (try? container.decode(BSONDocument.self, forKey: .update)) ?? [:]
+        self.update = try container.decode(BSONDocument.self, forKey: .update)
         self.options = try decoder.singleValueContainer().decode(UpdateOptions.self)
     }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedOperation.swift
@@ -18,6 +18,11 @@ enum UnifiedOperationResult {
     case rootDocumentArray([BSONDocument])
     case none
 
+    /// Some tests for unacknowledged writes assume that the result is non-nil with an "acknowledged" field
+    /// that is $$unsetOrMatches false. Since our CRUD methods return nil, there is nothing to assert
+    /// on, so we need this placeholder result for the corresponding operations to return instead.
+    static let unacknowledgedWrite: Self = .bson(.document(["acknowledged": false]))
+
     func asEntity() throws -> Entity {
         switch self {
         case let .changeStream(cs):

--- a/Tests/Specs/crud/tests/unified/bulkWrite-insertOne-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/bulkWrite-insertOne-dots_and_dollars.json
@@ -1,0 +1,374 @@
+{
+  "description": "bulkWrite-insertOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "$a": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "$a": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/bulkWrite-replaceOne-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/bulkWrite-replaceOne-dots_and_dollars.json
@@ -1,0 +1,532 @@
+{
+  "description": "bulkWrite-replaceOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/bulkWrite-updateMany-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/bulkWrite-updateMany-dots_and_dollars.json
@@ -1,0 +1,452 @@
+{
+  "description": "bulkWrite-updateMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/bulkWrite-updateOne-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/bulkWrite-updateOne-dots_and_dollars.json
@@ -1,0 +1,460 @@
+{
+  "description": "bulkWrite-updateOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/findOneAndReplace-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/findOneAndReplace-dots_and_dollars.json
@@ -1,0 +1,430 @@
+{
+  "description": "findOneAndReplace-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a.b": 1
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a.b": 1
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/findOneAndUpdate-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/findOneAndUpdate-dots_and_dollars.json
@@ -1,0 +1,380 @@
+{
+  "description": "findOneAndUpdate-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/insertMany-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/insertMany-dots_and_dollars.json
@@ -1,0 +1,338 @@
+{
+  "description": "insertMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "$a": 1
+              }
+            ]
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "$a": 1
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a.b": 1
+              }
+            ]
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a": {
+                  "$b": 1
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a": {
+                  "b.c": 1
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/insertOne-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/insertOne-dots_and_dollars.json
@@ -1,0 +1,614 @@
+{
+  "description": "insertOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "$a": 1
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "$a": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in _id yields server-side error",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "$a": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$a": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in _id on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": {
+                  "a.b": 1
+                }
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "a.b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in _id on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "a.b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with DBRef-like keys",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "$db": "foo"
+              }
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$db": "foo"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$db": "foo"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Unacknowledged write using dollar-prefixed or dotted keys may be silently rejected on pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "_id": {
+                "$a": 1
+              }
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "acknowledged": {
+                "$$unsetOrMatches": false
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll1",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$a": 1
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/replaceOne-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/replaceOne-dots_and_dollars.json
@@ -1,0 +1,567 @@
+{
+  "description": "replaceOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Unacknowledged write using dollar-prefixed or dotted keys may be silently rejected on pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection1",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "acknowledged": {
+              "$$unsetOrMatches": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll1",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/updateMany-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/updateMany-dots_and_dollars.json
@@ -1,0 +1,404 @@
+{
+  "description": "updateMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/updateOne-dots_and_dollars.json
+++ b/Tests/Specs/crud/tests/unified/updateOne-dots_and_dollars.json
@@ -1,0 +1,412 @@
+{
+  "description": "updateOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I already synced some of these tests as part of vendoring in libmongoc 1.18; this syncs the rest and makes some related test runner changes.