### PR TITLE
SWIFT-1212, SWIFT-1213: Remove oppressive language

### DIFF
--- a/Examples/VaporExample/README.md
+++ b/Examples/VaporExample/README.md
@@ -62,7 +62,7 @@ extension Request {
 ### Codable Usage
 Throughout the application, we frequently use [`Codable`](https://developer.apple.com/documentation/swift/codable) Swift types. These are very useful as they allow us to convert seamlessly from BSON, the format MongoDB stores data in, to Swift types used in the server, to JSON to send to the client. The same is true for the opposite direction.
 
-Note that Vapor's[`Content`](https://api.vapor.codes/vapor/master/Vapor/Protocols/Content.html) protocol, which specifies types that can be initialized from HTTP requests and serialized to HTTP responses, inherits from `Codable`.
+Note that Vapor's[`Content`](https://api.vapor.codes/vapor/main/Vapor/Content/) protocol, which specifies types that can be initialized from HTTP requests and serialized to HTTP responses, inherits from `Codable`.
 
 #### BSON <-> Swift types
 When creating a `MongoCollection`, you can pass in the name of a `Codable` type:

--- a/Guides/TLS-Guide.md
+++ b/Guides/TLS-Guide.md
@@ -97,7 +97,7 @@ used.
 
 By default, all of these options are set to false.
 
-It is not recommended to change these defaults as it exposes the client to Man In The Middle attacks (when
+It is not recommended to change these defaults as it exposes the client to on-path-attackers (when
 `tlsAllowInvalidHostnames` is set), invalid certificates (when `tlsAllowInvalidCertificates` is set), or potentially
 revoked certificates (when `tlsDisableOCSPEndpointCheck` or `tlsDisableCertificateRevocationCheck` are set).
 

--- a/Sources/AtlasConnectivity/main.swift
+++ b/Sources/AtlasConnectivity/main.swift
@@ -3,9 +3,9 @@ import MongoSwiftSync
 
 private let configs = ["ATLAS_REPL", "ATLAS_SHRD", "ATLAS_FREE", "ATLAS_TLS11", "ATLAS_TLS12"]
 private let srvConfigs = configs.map { $0 + "_SRV" }
-/// Currently, almost all of the Atlas test instances are running server versions that do not yet support the new
-/// "hello" command.
+/// Currently, almost all of the Atlas test instances are running 3.4 which does not support the new "hello" command.
 private let legacyHello = "ismaster"
+private let supportsHello = ["ATLAS_FREE", "ATLAS_FREE_SRV"]
 
 for config in configs + srvConfigs {
     print("Testing config \(config)... ", terminator: "")
@@ -19,7 +19,12 @@ for config in configs + srvConfigs {
         let client = try MongoClient(uri)
         // run legacy hello command
         let db = client.db("test")
-        _ = try db.runCommand([legacyHello: 1])
+        if supportsHello.contains(config) {
+            _ = try db.runCommand(["hello": 1])
+        } else {
+            _ = try db.runCommand([legacyHello: 1])
+        }
+
         // findOne
         let coll = db.collection("test")
         _ = try coll.findOne()

--- a/Sources/AtlasConnectivity/main.swift
+++ b/Sources/AtlasConnectivity/main.swift
@@ -3,6 +3,9 @@ import MongoSwiftSync
 
 private let configs = ["ATLAS_REPL", "ATLAS_SHRD", "ATLAS_FREE", "ATLAS_TLS11", "ATLAS_TLS12"]
 private let srvConfigs = configs.map { $0 + "_SRV" }
+/// Currently, almost all of the Atlas test instances are running server versions that do not yet support the new
+/// "hello" command.
+private let legacyHello = "ismaster"
 
 for config in configs + srvConfigs {
     print("Testing config \(config)... ", terminator: "")
@@ -14,9 +17,9 @@ for config in configs + srvConfigs {
 
     do {
         let client = try MongoClient(uri)
-        // run isMaster
+        // run legacy hello command
         let db = client.db("test")
-        _ = try db.runCommand(["isMaster": 1])
+        _ = try db.runCommand([legacyHello: 1])
         // findOne
         let coll = db.collection("test")
         _ = try coll.findOne()

--- a/Sources/MongoSwift/APM.swift
+++ b/Sources/MongoSwift/APM.swift
@@ -285,14 +285,14 @@ public enum SDAMEvent: Publishable {
     /// Published when a server is removed from a topology and no longer monitored.
     case serverClosed(ServerClosedEvent)
 
-    /// Published when the server monitor’s ismaster command is started - immediately before
-    /// the ismaster command is serialized into raw BSON and written to the socket.
+    /// Published when the server monitor’s "hello" command is started - immediately before
+    /// the "hello" command is serialized into raw BSON and written to the socket.
     case serverHeartbeatStarted(ServerHeartbeatStartedEvent)
 
-    /// Published when the server monitor’s ismaster succeeds.
+    /// Published when the server monitor’s "hello" command succeeds.
     case serverHeartbeatSucceeded(ServerHeartbeatSucceededEvent)
 
-    /// Published when the server monitor’s ismaster fails, either with an “ok: 0” or a socket exception.
+    /// Published when the server monitor’s "hello" command fails, either with an “ok: 0” or a socket exception.
     case serverHeartbeatFailed(ServerHeartbeatFailedEvent)
 
     fileprivate func publish(to client: MongoClient) {
@@ -534,8 +534,8 @@ public struct TopologyClosedEvent: MongoSwiftEvent {
     }
 }
 
-/// Published when the server monitor’s ismaster command is started - immediately before
-/// the ismaster command is serialized into raw BSON and written to the socket.
+/// Published when the server monitor’s "hello" command is started - immediately before
+/// the "hello" command is serialized into raw BSON and written to the socket.
 public struct ServerHeartbeatStartedEvent: MongoSwiftEvent {
     /// Wrapper around a `mongoc_apm_server_heartbeat_started_t`.
     fileprivate struct MongocServerHeartbeatStartedEvent: MongocEvent {
@@ -564,7 +564,7 @@ public struct ServerHeartbeatStartedEvent: MongoSwiftEvent {
     }
 }
 
-/// Published when the server monitor’s ismaster succeeds.
+/// Published when the server monitor’s "hello" command succeeds.
 public struct ServerHeartbeatSucceededEvent: MongoSwiftEvent {
     /// Wrapper around a `mongoc_apm_server_heartbeat_succeeded_t`.
     fileprivate struct MongocServerHeartbeatSucceededEvent: MongocEvent {
@@ -602,7 +602,7 @@ public struct ServerHeartbeatSucceededEvent: MongoSwiftEvent {
     }
 }
 
-/// Published when the server monitor’s ismaster fails, either with an “ok: 0” or a socket exception.
+/// Published when the server monitor’s "hello" command fails, either with an “ok: 0” or a socket exception.
 public struct ServerHeartbeatFailedEvent: MongoSwiftEvent {
     /// Wrapper around a `mongoc_apm_server_heartbeat_failed_t`.
     fileprivate struct MongocServerHeartbeatFailedEvent: MongocEvent {

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -88,15 +88,15 @@ public struct ServerDescription {
         case unknown = "Unknown"
     }
 
-    /// The hostname or IP and the port number that the client connects to. Note that this is not the
-    /// server's ismaster.me field, in the case that the server reports an address different from the
+    /// The hostname or IP and the port number that the client connects to. Note that this is not the "me" field in the
+    /// server's hello or legacy hello response, in the case that the server reports an address different from the
     /// address the client uses.
     public let address: ServerAddress
 
     /// Opaque identifier for this server, used for testing only.
     internal let serverId: UInt32
 
-    /// The duration in milliseconds of the server's last ismaster call.
+    /// The duration in milliseconds of the server's last "hello" call.
     public let roundTripTime: Int?
 
     /// The date of the most recent write operation seen by this server.

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -4,6 +4,10 @@ import Foundation
 import Nimble
 import XCTest
 
+/// We test against server versions that do not yet support the new "hello" command so we need to use the legacy name
+/// sometimes.
+public let LEGACY_HELLO = "ismaster"
+
 extension String {
     /// Removes the first occurrence of the specified substring from the string. If the substring is not present, has
     /// no effect.
@@ -173,20 +177,20 @@ public enum TestTopologyConfiguration: String, Decodable {
         self == .sharded || self == .shardedReplicaSet
     }
 
-    /// Determines the topologyType of a client based on the reply returned by running a "hello"/legacy "hello" command
-    /// and the first document in the config.shards collection.
-    public init(isMasterReply: BSONDocument, shards: [BSONDocument]) throws {
+    /// Determines the topologyType of a client based on the reply returned by running a hello command and the
+    /// first document in the config.shards collection.
+    public init(helloReply: BSONDocument, shards: [BSONDocument]) throws {
         // Check for symptoms of different topologies
-        if isMasterReply["msg"] != "isdbgrid" &&
-            isMasterReply["setName"] == nil &&
-            isMasterReply["isreplicaset"] != true
+        if helloReply["msg"] != "isdbgrid" &&
+            helloReply["setName"] == nil &&
+            helloReply["isreplicaset"] != true
         {
             self = .single
-        } else if isMasterReply["msg"] == "isdbgrid" {
+        } else if helloReply["msg"] == "isdbgrid" {
             // Serverless proxy reports as a mongos but presents no shards
             guard !shards.isEmpty || MongoSwiftTestCase.serverless else {
                 throw TestError(
-                    message: "isMasterReply \(isMasterReply) implies a sharded cluster, but config.shards is empty"
+                    message: "helloReply \(helloReply) implies a sharded cluster, but config.shards is empty"
                 )
             }
             for shard in shards {
@@ -204,12 +208,12 @@ public enum TestTopologyConfiguration: String, Decodable {
                 }
             }
             self = .shardedReplicaSet
-        } else if isMasterReply["ismaster"] == true && isMasterReply["setName"] != nil {
+        } else if helloReply[LEGACY_HELLO] == true && helloReply["setName"] != nil {
             self = .replicaSet
         } else {
             throw TestError(
                 message:
-                "Invalid test topology configuration given by isMaster reply: \(isMasterReply) and shards: \(shards)"
+                "Invalid test topology configuration given by hello reply: \(helloReply) and shards: \(shards)"
             )
         }
     }

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -173,8 +173,8 @@ public enum TestTopologyConfiguration: String, Decodable {
         self == .sharded || self == .shardedReplicaSet
     }
 
-    /// Determines the topologyType of a client based on the reply returned by running an isMaster command and the
-    /// first document in the config.shards collection.
+    /// Determines the topologyType of a client based on the reply returned by running a "hello"/legacy "hello" command
+    /// and the first document in the config.shards collection.
     public init(isMasterReply: BSONDocument, shards: [BSONDocument]) throws {
         // Check for symptoms of different topologies
         if isMasterReply["msg"] != "isdbgrid" &&

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -4,8 +4,6 @@ import Foundation
 import Nimble
 import XCTest
 
-/// We test against server versions that do not yet support the new "hello" command so we need to use the legacy name
-/// sometimes.
 public let LEGACY_HELLO = "ismaster"
 
 extension String {
@@ -208,7 +206,7 @@ public enum TestTopologyConfiguration: String, Decodable {
                 }
             }
             self = .shardedReplicaSet
-        } else if helloReply[LEGACY_HELLO] == true && helloReply["setName"] != nil {
+        } else if helloReply["isWritablePrimary"] == true && helloReply["setName"] != nil {
             self = .replicaSet
         } else {
             throw TestError(

--- a/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
@@ -81,7 +81,7 @@ final class SyncClientSessionTests: MongoSwiftTestCase {
     // list of operations on MongoDatabase that take in a session
     let databaseSessionOps = [
         DatabaseSessionOp(name: "listCollections") { _ = try $0.listCollections(session: $1).next() },
-        DatabaseSessionOp(name: "runCommand") { try $0.runCommand(["isMaster": 0], session: $1) },
+        DatabaseSessionOp(name: "runCommand") { try $0.runCommand([LEGACY_HELLO: 0], session: $1) },
         DatabaseSessionOp(name: "createCollection") { _ = try $0.createCollection("asdf", session: $1) },
         DatabaseSessionOp(name: "createCollection1") {
             _ = try $0.createCollection("asf", withType: BSONDocument.self, session: $1)

--- a/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
@@ -81,7 +81,7 @@ final class SyncClientSessionTests: MongoSwiftTestCase {
     // list of operations on MongoDatabase that take in a session
     let databaseSessionOps = [
         DatabaseSessionOp(name: "listCollections") { _ = try $0.listCollections(session: $1).next() },
-        DatabaseSessionOp(name: "runCommand") { try $0.runCommand([LEGACY_HELLO: 0], session: $1) },
+        DatabaseSessionOp(name: "runCommand") { try $0.runCommand(["hello": 0], session: $1) },
         DatabaseSessionOp(name: "createCollection") { _ = try $0.createCollection("asdf", session: $1) },
         DatabaseSessionOp(name: "createCollection1") {
             _ = try $0.createCollection("asf", withType: BSONDocument.self, session: $1)

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -331,7 +331,7 @@ extension SpecTest {
         let connectionString = MongoSwiftTestCase.getConnectionString(singleMongos: self.useMultipleMongoses != true)
 
         // We need to lower heartbeat frequency to speed up tests on 4.4+ since failpoints don't trigger proper
-        // topology updates when using streamable ismaster. See CDRIVER-3793 for more information.
+        // topology updates when using streamable hello. See CDRIVER-3793 for more information.
         var options = self.clientOptions ?? MongoClientOptions()
 
         if options.heartbeatFrequencyMS == nil {

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -206,7 +206,7 @@ internal struct ChangeStreamTest: Decodable, FailPointConfigured {
 
         if let expectations = self.expectations {
             let commandEvents = monitor.commandStartedEvents()
-                .filter { !["isMaster", "killCursors"].contains($0.commandName) }
+                .filter { ![LEGACY_HELLO, "hello", "killCursors"].contains($0.commandName) }
                 .map { TestCommandStartedEvent(from: $0) }
             expect(commandEvents).to(match(expectations), description: self.description)
         }
@@ -429,8 +429,8 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
     /**
      * Prose test 3 of change stream spec.
      *
-     * `ChangeStream` will automatically resume one time on a resumable error (including not master) with the initial
-     * pipeline and options, except for the addition/update of a resumeToken.
+     * `ChangeStream` will automatically resume one time on a resumable error (including not writable primary) with the
+     * initial pipeline and options, except for the addition/update of a resumeToken.
      */
     func testChangeStreamAutomaticResume() throws {
         let testRequirements = TestRequirement(
@@ -462,7 +462,7 @@ final class SyncChangeStreamTests: MongoSwiftTestCase {
                     try coll.insertOne(["x": .int64(Int64(x))])
                 }
 
-                // notMaster error
+                // notWritablePrimary error
                 let failPoint = FailPoint.failCommand(
                     failCommands: ["getMore"],
                     mode: .times(1),

--- a/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
@@ -248,7 +248,7 @@ final class SyncMongoClientTests: MongoSwiftTestCase {
 
         // db is still alive, so client should be too, and should be open
         expect(weakClientRef).toNot(beNil())
-        expect(try db!.runCommand(["isMaster": 1])).toNot(throwError())
+        expect(try db!.runCommand([LEGACY_HELLO: 1])).toNot(throwError())
 
         // once the DB ref goes away, so should the client
         db = nil
@@ -335,7 +335,7 @@ final class SyncMongoClientTests: MongoSwiftTestCase {
 
         let fp = FailPoint.failCommand(
             // when an API version is declared, "hello" will be used (DRIVERS-1633)
-            failCommands: ["isMaster", "hello"],
+            failCommands: [LEGACY_HELLO, "hello"],
             mode: .alwaysOn,
             blockTimeMS: 500
         )

--- a/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
@@ -248,7 +248,7 @@ final class SyncMongoClientTests: MongoSwiftTestCase {
 
         // db is still alive, so client should be too, and should be open
         expect(weakClientRef).toNot(beNil())
-        expect(try db!.runCommand([LEGACY_HELLO: 1])).toNot(throwError())
+        expect(try db!.runCommand(["hello": 1])).toNot(throwError())
 
         // once the DB ref goes away, so should the client
         db = nil

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -68,9 +68,9 @@ extension MongoClient {
     }
 
     internal func topologyType() throws -> TestTopologyConfiguration {
-        let isMasterReply = try self.db("admin").runCommand(["isMaster": 1])
+        let helloReply = try self.db("admin").runCommand([LEGACY_HELLO: 1])
         let shards = try self.db("config").collection("shards").find().map { try $0.get() }
-        return try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
+        return try TestTopologyConfiguration(helloReply: helloReply, shards: shards)
     }
 
     internal func serverParameters() throws -> BSONDocument {
@@ -94,9 +94,9 @@ extension MongoClient {
     /// Get the max wire version of the primary.
     internal func maxWireVersion() throws -> Int {
         let options = RunCommandOptions(readPreference: .primary)
-        let isMaster = try self.db("admin").runCommand(["isMaster": 1], options: options)
-        guard let max = isMaster["maxWireVersion"]?.toInt() else {
-            throw TestError(message: "isMaster reply missing maxwireversion \(isMaster)")
+        let hello = try self.db("admin").runCommand([LEGACY_HELLO: 1], options: options)
+        guard let max = hello["maxWireVersion"]?.toInt() else {
+            throw TestError(message: "hello reply missing maxwireversion: \(hello)")
         }
         return max
     }

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -68,7 +68,7 @@ extension MongoClient {
     }
 
     internal func topologyType() throws -> TestTopologyConfiguration {
-        let helloReply = try self.db("admin").runCommand([LEGACY_HELLO: 1])
+        let helloReply = try self.db("admin").runCommand(["hello": 1])
         let shards = try self.db("config").collection("shards").find().map { try $0.get() }
         return try TestTopologyConfiguration(helloReply: helloReply, shards: shards)
     }
@@ -94,7 +94,7 @@ extension MongoClient {
     /// Get the max wire version of the primary.
     internal func maxWireVersion() throws -> Int {
         let options = RunCommandOptions(readPreference: .primary)
-        let hello = try self.db("admin").runCommand([LEGACY_HELLO: 1], options: options)
+        let hello = try self.db("admin").runCommand(["hello": 1], options: options)
         guard let max = hello["maxWireVersion"]?.toInt() else {
             throw TestError(message: "hello reply missing maxwireversion: \(hello)")
         }

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -68,7 +68,7 @@ extension MongoClient {
 
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
-        let helloReply = try self.db("admin").runCommand([LEGACY_HELLO: 1]).wait()
+        let helloReply = try self.db("admin").runCommand(["hello": 1]).wait()
         let shards = try self.db("config").collection("shards").find().wait().toArray().wait()
         let topologyType = try TestTopologyConfiguration(helloReply: helloReply, shards: shards)
         let serverVersion = try self.serverVersion().wait()

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -68,9 +68,9 @@ extension MongoClient {
 
     /// Determine whether server version and topology requirements for a certain test are met
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) throws -> UnmetRequirement? {
-        let isMasterReply = try self.db("admin").runCommand(["isMaster": 1]).wait()
+        let helloReply = try self.db("admin").runCommand([LEGACY_HELLO: 1]).wait()
         let shards = try self.db("config").collection("shards").find().wait().toArray().wait()
-        let topologyType = try TestTopologyConfiguration(isMasterReply: isMasterReply, shards: shards)
+        let topologyType = try TestTopologyConfiguration(helloReply: helloReply, shards: shards)
         let serverVersion = try self.serverVersion().wait()
         let params = try self.serverParameters().wait()
         return testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType, params)

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -33,7 +33,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
             var escapedSession: ClientSession?
             let res2: EventLoopFuture<BSONDocument> = client.withSession { session in
                 escapedSession = session
-                return db.runCommand([LEGACY_HELLO: 1], session: session)
+                return db.runCommand(["hello": 1], session: session)
             }
             expect(try res2.wait()).toNot(throwError())
             expect(escapedSession?.active).to(beFalse())

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -33,7 +33,7 @@ final class ClientSessionTests: MongoSwiftTestCase {
             var escapedSession: ClientSession?
             let res2: EventLoopFuture<BSONDocument> = client.withSession { session in
                 escapedSession = session
-                return db.runCommand(["isMaster": 1], session: session)
+                return db.runCommand([LEGACY_HELLO: 1], session: session)
             }
             expect(try res2.wait()).toNot(throwError())
             expect(escapedSession?.active).to(beFalse())


### PR DESCRIPTION
I looked into this while waiting around for Evergreen patches and it ended up being super small so figured we should just go ahead with it and close out the epic. 

Patch with added Atlas connectivity tasks since I changed the code in that target:  https://spruce.mongodb.com/version/610aed5dd6d80a1eba4406e9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC