### PR TITLE
SWIFT-1228 Unskip server kills cursor tests

### DIFF
--- a/Tests/MongoSwiftSyncTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftSyncTests/CommandMonitoringTests.swift
@@ -44,11 +44,6 @@ final class CommandMonitoringTests: MongoSwiftTestCase {
                     continue
                 }
 
-                if test.description == "A successful find event with a getmore and the server kills the cursor" {
-                    print("Skipping test case \(test.description), see SWIFT-1228")
-                    continue
-                }
-
                 print("Test case: \(test.description)")
 
                 // Setup the specified DB and collection with provided data

--- a/Tests/MongoSwiftSyncTests/UnifiedTests.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTests.swift
@@ -50,9 +50,7 @@ final class UnifiedRunnerTests: MongoSwiftTestCase {
         let skipRunningValid: [String: [String]] = [
             // unsupported APIs
             "poc-transactions-convenient-api": ["*"],
-            "poc-gridfs": ["*"],
-            // temporarily skipped due to SWIFT-1228
-            "poc-command-monitoring": ["A successful find event with a getmore and the server kills the cursor"]
+            "poc-gridfs": ["*"]
         ]
 
         let runner = try UnifiedTestRunner()


### PR DESCRIPTION
These were being skipped because libmongoc had temporarily changed their cursor behavior to work around test failures. They have reverted those changes, and the tests have been updated (synced via #651) so we can unskip these now.