### PR TITLE
SWIFT-1122 Keep libmongoc version up-to-date in generated headers

### DIFF
--- a/Sources/CLibMongoC/include/CLibMongoC_bson-version.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_bson-version.h
@@ -31,7 +31,7 @@
  *
  * BSON minor version component (e.g. 2 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MINOR_VERSION (17)
+#define BSON_MINOR_VERSION (18)
 
 
 /**
@@ -39,7 +39,7 @@
  *
  * BSON micro version component (e.g. 3 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MICRO_VERSION (4)
+#define BSON_MICRO_VERSION (0)
 
 
 /**
@@ -54,7 +54,7 @@
  *
  * BSON version.
  */
-#define BSON_VERSION (1.17.4)
+#define BSON_VERSION (1.18.0)
 
 
 /**
@@ -63,7 +63,7 @@
  * BSON version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define BSON_VERSION_S "1.17.4"
+#define BSON_VERSION_S "1.18.0"
 
 
 /**

--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-version.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-version.h
@@ -31,7 +31,7 @@
  *
  * MONGOC minor version component (e.g. 2 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MINOR_VERSION (17)
+#define MONGOC_MINOR_VERSION (18)
 
 
 /**
@@ -39,7 +39,7 @@
  *
  * MONGOC micro version component (e.g. 3 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MICRO_VERSION (4)
+#define MONGOC_MICRO_VERSION (0)
 
 
 /**
@@ -55,7 +55,7 @@
  *
  * MONGOC version.
  */
-#define MONGOC_VERSION (1.17.4)
+#define MONGOC_VERSION (1.18.0)
 
 
 /**
@@ -64,7 +64,7 @@
  * MONGOC version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define MONGOC_VERSION_S "1.17.4"
+#define MONGOC_VERSION_S "1.18.0"
 
 
 /**

--- a/etc/generated_headers/bson-version.h
+++ b/etc/generated_headers/bson-version.h
@@ -23,7 +23,7 @@
  *
  * BSON major version component (e.g. 1 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MAJOR_VERSION (1)
+#define BSON_MAJOR_VERSION (__LIBMONGOC_MAJOR_VERSION__)
 
 
 /**
@@ -31,7 +31,7 @@
  *
  * BSON minor version component (e.g. 2 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MINOR_VERSION (17)
+#define BSON_MINOR_VERSION (__LIBMONGOC_MINOR_VERSION__)
 
 
 /**
@@ -39,7 +39,7 @@
  *
  * BSON micro version component (e.g. 3 if %BSON_VERSION is 1.2.3)
  */
-#define BSON_MICRO_VERSION (4)
+#define BSON_MICRO_VERSION (__LIBMONGOC_PATCH_VERSION__)
 
 
 /**
@@ -47,14 +47,14 @@
  *
  * BSON prerelease version component (e.g. pre if %BSON_VERSION is 1.2.3-pre)
  */
-#define BSON_PRERELEASE_VERSION ()
+#define BSON_PRERELEASE_VERSION (__LIBMONGOC_PRERELEASE_VERSION__)
 
 /**
  * BSON_VERSION:
  *
  * BSON version.
  */
-#define BSON_VERSION (1.17.4)
+#define BSON_VERSION (__LIBMONGOC_FULL_VERSION__)
 
 
 /**
@@ -63,7 +63,7 @@
  * BSON version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define BSON_VERSION_S "1.17.4"
+#define BSON_VERSION_S "__LIBMONGOC_FULL_VERSION__"
 
 
 /**

--- a/etc/generated_headers/mongoc-version.h
+++ b/etc/generated_headers/mongoc-version.h
@@ -23,7 +23,7 @@
  *
  * MONGOC major version component (e.g. 1 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MAJOR_VERSION (1)
+#define MONGOC_MAJOR_VERSION (__LIBMONGOC_MAJOR_VERSION__)
 
 
 /**
@@ -31,7 +31,7 @@
  *
  * MONGOC minor version component (e.g. 2 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MINOR_VERSION (17)
+#define MONGOC_MINOR_VERSION (__LIBMONGOC_MINOR_VERSION__)
 
 
 /**
@@ -39,7 +39,7 @@
  *
  * MONGOC micro version component (e.g. 3 if %MONGOC_VERSION is 1.2.3)
  */
-#define MONGOC_MICRO_VERSION (4)
+#define MONGOC_MICRO_VERSION (__LIBMONGOC_PATCH_VERSION__)
 
 
 /**
@@ -47,7 +47,7 @@
  *
  * MONGOC prerelease version component (e.g. pre if %MONGOC_VERSION is 1.2.3-pre)
  */
-#define MONGOC_PRERELEASE_VERSION ()
+#define MONGOC_PRERELEASE_VERSION (__LIBMONGOC_PRERELEASE_VERSION__)
 
 
 /**
@@ -55,7 +55,7 @@
  *
  * MONGOC version.
  */
-#define MONGOC_VERSION (1.17.4)
+#define MONGOC_VERSION (__LIBMONGOC_FULL_VERSION__)
 
 
 /**
@@ -64,7 +64,7 @@
  * MONGOC version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define MONGOC_VERSION_S "1.17.4"
+#define MONGOC_VERSION_S "__LIBMONGOC_FULL_VERSION__"
 
 
 /**

--- a/etc/vendor-libmongoc.sh
+++ b/etc/vendor-libmongoc.sh
@@ -3,8 +3,14 @@
 set -eou pipefail
 
 PWD=`pwd`
-LIBMONGOC_VERSION=1.18.0
-TARBALL_URL=https://github.com/mongodb/mongo-c-driver/releases/download/$LIBMONGOC_VERSION/mongo-c-driver-$LIBMONGOC_VERSION.tar.gz
+LIBMONGOC_MAJOR_VERSION=1
+LIBMONGOC_MINOR_VERSION=18
+LIBMONGOC_PATCH_VERSION=0
+LIBMONGOC_PRERELEASE_VERSION=
+
+LIBMONGOC_FULL_VERSION=${LIBMONGOC_MAJOR_VERSION}.${LIBMONGOC_MINOR_VERSION}.${LIBMONGOC_PATCH_VERSION}${LIBMONGOC_PRERELEASE_VERSION:+-$LIBMONGOC_PRERELEASE_VERSION}
+
+TARBALL_URL=https://github.com/mongodb/mongo-c-driver/releases/download/$LIBMONGOC_FULL_VERSION/mongo-c-driver-$LIBMONGOC_FULL_VERSION.tar.gz
 TARBALL_NAME=`basename $TARBALL_URL`
 TARBALL_DIR=`basename -s .tar.gz $TARBALL_NAME`
 
@@ -79,6 +85,17 @@ echo "COPYING libmongoc"
 # the config files
 echo "COPYING generated files"
 cp $ETC_DIR/generated_headers/* $CLIBMONGOC_INCLUDE_PATH
+
+# Embed libmongoc version info in generated headers
+echo "PATCHING header files to include libmongoc version info"
+(
+  find $CLIBMONGOC_INCLUDE_PATH -name "*.h" | \
+    xargs $sed -i -e "s+__LIBMONGOC_MAJOR_VERSION__+${LIBMONGOC_MAJOR_VERSION}+" \
+                  -e "s+__LIBMONGOC_MINOR_VERSION__+${LIBMONGOC_MINOR_VERSION}+" \
+                  -e "s+__LIBMONGOC_PATCH_VERSION__+${LIBMONGOC_PATCH_VERSION}+" \
+                  -e "s+__LIBMONGOC_PRERELEASE_VERSION__+${LIBMONGOC_PRERELEASE_VERSION}+" \
+                  -e "s+__LIBMONGOC_FULL_VERSION__+${LIBMONGOC_FULL_VERSION}+" \
+)
 
 # This is perhaps the most complicated step of the vendoring process. In the previous step
 # we are building a single, monolithic version of `libmongoc` and `libbson` in our `CLibMongoC`


### PR DESCRIPTION
This includes some changes to the vendoring script as well as files in the `generated_headers/` directory, along with the resulting diff in `Sources/CLibMongoC/` from running the updating vendoring script.
