### PR TITLE
SWIFT-1303 Sync command monitoring tests to remove modifiers

### DIFF
--- a/Tests/MongoSwiftSyncTests/CommandMonitoringTests.swift
+++ b/Tests/MongoSwiftSyncTests/CommandMonitoringTests.swift
@@ -142,26 +142,7 @@ private struct CMTest: Decodable {
             _ = try? collection.deleteOne(filter)
 
         case "find":
-            let modifiers = self.op.args["modifiers"]?.documentValue
-            var hint: IndexHint?
-            if let hintDoc = modifiers?["$hint"]?.documentValue {
-                hint = .indexSpec(hintDoc)
-            }
-            let options = FindOptions(
-                batchSize: self.op.args["batchSize"]?.toInt(),
-                comment: modifiers?["$comment"]?.stringValue,
-                hint: hint,
-                limit: self.op.args["limit"]?.toInt(),
-                max: modifiers?["$max"]?.documentValue,
-                maxTimeMS: modifiers?["$maxTimeMS"]?.toInt(),
-                min: modifiers?["$min"]?.documentValue,
-                readPreference: self.op.readPreference,
-                returnKey: modifiers?["$returnKey"]?.boolValue,
-                showRecordID: modifiers?["$showDiskLoc"]?.boolValue,
-                skip: self.op.args["skip"]?.toInt(),
-                sort: self.op.args["sort"]?.documentValue
-            )
-
+            let options = try BSONDecoder().decode(FindOptions.self, from: self.op.args)
             do {
                 let cursor = try collection.find(filter, options: options)
                 for _ in cursor {}

--- a/Tests/Specs/command-monitoring/tests/legacy/find.json
+++ b/Tests/Specs/command-monitoring/tests/legacy/find.json
@@ -89,21 +89,19 @@
           "skip": {
             "$numberLong": "2"
           },
-          "modifiers": {
-            "$comment": "test",
-            "$hint": {
-              "_id": 1
-            },
-            "$max": {
-              "_id": 6
-            },
-            "$maxTimeMS": 6000,
-            "$min": {
-              "_id": 0
-            },
-            "$returnKey": false,
-            "$showDiskLoc": false
-          }
+          "comment": "test",
+          "hint": {
+            "_id": 1
+          },
+          "max": {
+            "_id": 6
+          },
+          "maxTimeMS": 6000,
+          "min": {
+            "_id": 0
+          },
+          "returnKey": false,
+          "showRecordId": false
         }
       },
       "expectations": [


### PR DESCRIPTION
I code reviewed this spec update and confirmed the changes worked in Swift, so I figured I would just go ahead and put the changes into review.