### PR TITLE
SWIFT-1318 Expose libmongoc support for mocking serviceIds for load balancer testing 

### DIFF
--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
@@ -66,6 +66,12 @@ MONGOC_EXPORT (int32_t)
 mongoc_server_description_compressor_id (
    const mongoc_server_description_t *description);
 
+/* mongoc_global_mock_service_id is only used for testing. The test runner sets
+ * this to true when testing against a load balanced deployment to mock the
+ * presence of a serviceId field in the "hello" response. The purpose of this is
+ * further described in the Load Balancer test README. */
+extern bool mongoc_global_mock_service_id;
+
 BSON_END_DECLS
 
 #endif

--- a/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
@@ -200,10 +200,4 @@ bool
 mongoc_server_description_has_service_id (
    const mongoc_server_description_t *description);
 
-/* mongoc_global_mock_service_id is only used for testing. The test runner sets
- * this to true when testing against a load balanced deployment to mock the
- * presence of a serviceId field in the "hello" response. The purpose of this is
- * further described in the Load Balancer test README. */
-extern bool mongoc_global_mock_service_id;
-
 #endif

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -680,3 +680,10 @@ extension InsertManyResult {
         InsertManyResult(from: result)
     }
 }
+
+// TODO: SWIFT-1319 Remove this method and usages of it.
+/// Sets the libmongoc global variable indicating whether to include mock serviceIds in hello responses to the
+/// provided value. This is necessary for load balancer testing until SERVER-58500 is complete.
+public func setMockServiceId(to value: Bool) {
+    mongoc_global_mock_service_id = value
+}

--- a/etc/expose-mock-service-id.diff
+++ b/etc/expose-mock-service-id.diff
@@ -1,0 +1,32 @@
+diff --git a/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h b/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
+index 082521c1..4676c5c4 100644
+--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
++++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
+@@ -66,6 +66,12 @@ MONGOC_EXPORT (int32_t)
+ mongoc_server_description_compressor_id (
+    const mongoc_server_description_t *description);
+ 
++/* mongoc_global_mock_service_id is only used for testing. The test runner sets
++ * this to true when testing against a load balanced deployment to mock the
++ * presence of a serviceId field in the "hello" response. The purpose of this is
++ * further described in the Load Balancer test README. */
++extern bool mongoc_global_mock_service_id;
++
+ BSON_END_DECLS
+ 
+ #endif
+diff --git a/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h b/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
+index ef75154a..210bc3c2 100644
+--- a/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
++++ b/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
+@@ -200,10 +200,4 @@ bool
+ mongoc_server_description_has_service_id (
+    const mongoc_server_description_t *description);
+ 
+-/* mongoc_global_mock_service_id is only used for testing. The test runner sets
+- * this to true when testing against a load balanced deployment to mock the
+- * presence of a serviceId field in the "hello" response. The purpose of this is
+- * further described in the Load Balancer test README. */
+-extern bool mongoc_global_mock_service_id;
+-
+ #endif

--- a/etc/vendor-libmongoc.sh
+++ b/etc/vendor-libmongoc.sh
@@ -153,6 +153,8 @@ echo "RENAMING header files"
 echo "PATCHING libmongoc"
 git apply ${ETC_DIR}/lower-minheartbeatfrequencyms.diff
 git apply ${ETC_DIR}/inttypes-non-modular-header-workaround.diff
+# TODO SWIFT-1319: Remove.
+git apply ${ETC_DIR}/expose-mock-service-id.diff
 
 # Clang modules are build by a conventional structure with an `include` folder for public
 # includes, and an umbrella header used as the primary entry point. As part of the vendoring


### PR DESCRIPTION
This adds a small patch to the libmongoc vendoring process which makes it possible for us to configure this global variable, by moving it out of the private header we do not include into one that we do.

I did not really know anything about `extern` until today but hopefully all this makes sense:

Per conversation with Kevin, if we had a way to declare an extern variable in Swift, we could do so, set its value, and it would set the value in libmongoc as well. For example, a C program like
```c
#include <mongoc/mongoc.h>
extern bool mongoc_global_mock_service_id;
int main () {
   mongoc_global_mock_service_id = true;
}
```
Would control the value of the global defined in libmongoc itself.

However, apparently this is [not possible in Swift](https://twitter.com/jckarter/status/1157428699123212293?s=20):
>  the only way to declare extern C stuff in Swift is to literally write it in C and import it

And doing what seemed like "the closest" thing (declaring my own global with the same name and setting its value) had no effect on the libmongoc value.

I also could have just included the private header instead, but that seemed like an equal amount of hackiness (as it would require special-casing in the vendoring script to move that header elsewhere) for about the same benefit.

I tested this works locally by running haproxy in front of a sharded cluster (the Evg LB test config) and writing a small test that sends a command to the server. The initial handshake succeeds IFF `setMockServiceId(to: true)` is called before the initial handshake occurs/the command is run.