### PR TITLE
SWIFT-1309, SWIFT-1318, SWIFT-1241, SWIFT-1323, SWIFT-1324 Support testing against a load balancer locally

### DIFF
--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
+++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
@@ -66,6 +66,12 @@ MONGOC_EXPORT (int32_t)
 mongoc_server_description_compressor_id (
    const mongoc_server_description_t *description);
 
+/* mongoc_global_mock_service_id is only used for testing. The test runner sets
+ * this to true when testing against a load balanced deployment to mock the
+ * presence of a serviceId field in the "hello" response. The purpose of this is
+ * further described in the Load Balancer test README. */
+extern bool mongoc_global_mock_service_id;
+
 BSON_END_DECLS
 
 #endif

--- a/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
+++ b/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
@@ -200,10 +200,4 @@ bool
 mongoc_server_description_has_service_id (
    const mongoc_server_description_t *description);
 
-/* mongoc_global_mock_service_id is only used for testing. The test runner sets
- * this to true when testing against a load balanced deployment to mock the
- * presence of a serviceId field in the "hello" response. The purpose of this is
- * further described in the Load Balancer test README. */
-extern bool mongoc_global_mock_service_id;
-
 #endif

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -2,7 +2,7 @@ import CLibMongoC
 import Foundation
 
 /// A struct representing a network address, consisting of a host and port.
-public struct ServerAddress: Equatable {
+public struct ServerAddress: Equatable, Hashable {
     /// The hostname or IP address.
     public let host: String
 

--- a/Sources/MongoSwift/SDAM.swift
+++ b/Sources/MongoSwift/SDAM.swift
@@ -67,25 +67,68 @@ private struct HelloResponse: Decodable {
 /// A struct describing a mongod or mongos process.
 public struct ServerDescription {
     /// The possible types for a server.
-    public enum ServerType: String, Equatable {
+    public struct ServerType: RawRepresentable, Equatable {
         /// A standalone mongod server.
-        case standalone = "Standalone"
+        public static let standalone = ServerType(.standalone)
+
         /// A router to a sharded cluster, i.e. a mongos server.
-        case mongos = "Mongos"
+        public static let mongos = ServerType(.mongos)
+
         /// A replica set member which is not yet checked, but another member thinks it is the primary.
-        case possiblePrimary = "PossiblePrimary"
+        public static let possiblePrimary = ServerType(.possiblePrimary)
+
         /// A replica set primary.
-        case rsPrimary = "RSPrimary"
+        public static let rsPrimary = ServerType(.rsPrimary)
+
         /// A replica set secondary.
-        case rsSecondary = "RSSecondary"
+        public static let rsSecondary = ServerType(.rsSecondary)
+
         /// A replica set arbiter.
-        case rsArbiter = "RSArbiter"
+        public static let rsArbiter = ServerType(.rsArbiter)
+
         /// A replica set member that is none of the other types (a passive, for example).
-        case rsOther = "RSOther"
+        public static let rsOther = ServerType(.rsOther)
+
         /// A replica set member that does not report a set name or a hosts list.
-        case rsGhost = "RSGhost"
+        public static let rsGhost = ServerType(.rsGhost)
+
         /// A server type that is not yet known.
-        case unknown = "Unknown"
+        public static let unknown = ServerType(.unknown)
+
+        /// A load balancer.
+        public static let loadBalancer = ServerType(.loadBalancer)
+
+        /// Internal representation of server type. If enums could be marked non-exhaustive in Swift, this would be the
+        /// public representation too.
+        private enum _ServerType: String, Equatable {
+            case standalone = "Standalone"
+            case mongos = "Mongos"
+            case possiblePrimary = "PossiblePrimary"
+            case rsPrimary = "RSPrimary"
+            case rsSecondary = "RSSecondary"
+            case rsArbiter = "RSArbiter"
+            case rsOther = "RSOther"
+            case rsGhost = "RSGhost"
+            case unknown = "Unknown"
+            case loadBalancer = "LoadBalancer"
+        }
+
+        private let _serverType: _ServerType
+
+        private init(_ _type: _ServerType) {
+            self._serverType = _type
+        }
+
+        public var rawValue: String {
+            self._serverType.rawValue
+        }
+
+        public init?(rawValue: String) {
+            guard let _type = _ServerType(rawValue: rawValue) else {
+                return nil
+            }
+            self._serverType = _type
+        }
     }
 
     /// The hostname or IP and the port number that the client connects to. Note that this is not the "me" field in the
@@ -206,17 +249,52 @@ extension ServerDescription: Equatable {
 /// which servers are up, what type of servers they are, which is primary, and so on.
 public struct TopologyDescription: Equatable {
     /// The possible types for a topology.
-    public enum TopologyType: String, Equatable {
+    public struct TopologyType: RawRepresentable, Equatable {
         /// A single mongod server.
-        case single = "Single"
+        public static let single = TopologyType(.single)
+
         /// A replica set with no primary.
-        case replicaSetNoPrimary = "ReplicaSetNoPrimary"
+        public static let replicaSetNoPrimary = TopologyType(.replicaSetNoPrimary)
+
         /// A replica set with a primary.
-        case replicaSetWithPrimary = "ReplicaSetWithPrimary"
+        public static let replicaSetWithPrimary = TopologyType(.replicaSetWithPrimary)
+
         /// Sharded topology.
-        case sharded = "Sharded"
+        public static let sharded = TopologyType(.sharded)
+
         /// A topology whose type is not yet known.
-        case unknown = "Unknown"
+        public static let unknown = TopologyType(.unknown)
+
+        /// A topology with a load balancer in front.
+        public static let loadBalanced = TopologyType(.loadBalanced)
+
+        /// Internal representation of topology type. If enums could be marked non-exhaustive in Swift, this would be
+        /// the public representation too.
+        private enum _TopologyType: String, Equatable {
+            case single = "Single"
+            case replicaSetNoPrimary = "ReplicaSetNoPrimary"
+            case replicaSetWithPrimary = "ReplicaSetWithPrimary"
+            case sharded = "Sharded"
+            case unknown = "Unknown"
+            case loadBalanced = "LoadBalanced"
+        }
+
+        private let _topologyType: _TopologyType
+
+        private init(_ _type: _TopologyType) {
+            self._topologyType = _type
+        }
+
+        public var rawValue: String {
+            self._topologyType.rawValue
+        }
+
+        public init?(rawValue: String) {
+            guard let _type = _TopologyType(rawValue: rawValue) else {
+                return nil
+            }
+            self._topologyType = _type
+        }
     }
 
     /// The type of this topology.

--- a/Sources/TestsCommon/CommonTestUtils.swift
+++ b/Sources/TestsCommon/CommonTestUtils.swift
@@ -680,3 +680,10 @@ extension InsertManyResult {
         InsertManyResult(from: result)
     }
 }
+
+// TODO: SWIFT-1319 Remove this method and usages of it.
+/// Sets the libmongoc global variable indicating whether to include mock serviceIds in hello responses to the
+/// provided value. This is necessary for load balancer testing until SERVER-58500 is complete.
+public func setMockServiceId(to value: Bool) {
+    mongoc_global_mock_service_id = value
+}

--- a/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
+++ b/Tests/MongoSwiftSyncTests/SpecTestRunner/SpecTest.swift
@@ -190,7 +190,7 @@ extension SpecTestFile {
         // if connected to a sharded cluster, use the per-mongos clients to execute killAllSessions on each mongos.
         switch try client.topologyType() {
         case .single,
-             .loadBalancer,
+             .loadBalanced,
              _ where MongoSwiftTestCase.serverless:
             return
         case .replicaSet:
@@ -346,7 +346,7 @@ extension SpecTest {
 
         if let failPoint = self.failPoint {
             // if only using a single mongos, make sure to enable the failpoint on the correct mongos.
-            if MongoSwiftTestCase.topologyType == .sharded, self.useMultipleMongoses != true {
+            if try client.topologyType().isSharded, self.useMultipleMongoses != true {
                 try self.activateFailPoint(failPoint, using: setupClient, on: connectionString.hosts![0])
             } else {
                 try self.activateFailPoint(failPoint, using: setupClient)

--- a/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncMongoClientTests.swift
@@ -45,7 +45,7 @@ final class SyncMongoClientTests: MongoSwiftTestCase {
         let topSize = dbInfo.map { $0.sizeOnDisk }.max()!
         expect(try client.listDatabases(["sizeOnDisk": ["$gt": BSON(topSize)]])).to(beEmpty())
 
-        if try client.topologyType().isSharded {
+        if MongoSwiftTestCase.topologyType == .sharded {
             expect(dbInfo.first?.shards).toNot(beNil())
         }
 

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -118,36 +118,7 @@ extension MongoClient {
         _ uri: String = MongoSwiftTestCase.getConnectionString().toString(),
         options: MongoClientOptions? = nil
     ) throws -> MongoClient {
-        var opts = options ?? MongoClientOptions()
-        if MongoSwiftTestCase.ssl {
-            opts.tls = true
-            if let caPath = MongoSwiftTestCase.sslCAFilePath {
-                opts.tlsCAFile = URL(string: caPath)
-            }
-            if let certPath = MongoSwiftTestCase.sslPEMKeyFilePath {
-                opts.tlsCertificateKeyFile = URL(string: certPath)
-            }
-        }
-
-        if MongoSwiftTestCase.auth {
-            if let scramUser = MongoSwiftTestCase.scramUser, let scramPass = MongoSwiftTestCase.scramPassword {
-                opts.credential = MongoCredential(username: scramUser, password: scramPass)
-            }
-        }
-
-        if let apiVersion = MongoSwiftTestCase.apiVersion {
-            if opts.serverAPI == nil {
-                opts.serverAPI = MongoServerAPI(version: apiVersion)
-            } else {
-                opts.serverAPI!.version = apiVersion
-            }
-        }
-
-        // serverless tests are required to use compression.
-        if MongoSwiftTestCase.serverless {
-            opts.compressors = [.zlib]
-        }
-
+        let opts = resolveClientOptions(options)
         return try MongoClient(uri, options: opts)
     }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -24,7 +24,7 @@ struct UnifiedTestRunner {
         // connected to a sharded cluster, all mongos servers.
         switch self.topologyType {
         case .single,
-             .loadBalancer,
+             .loadBalanced,
              _ where MongoSwiftTestCase.serverless:
             return
         case .replicaSet:

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -10,35 +10,7 @@ extension MongoClient {
         eventLoopGroup: EventLoopGroup,
         options: MongoClientOptions? = nil
     ) throws -> MongoClient {
-        var opts = options ?? MongoClientOptions()
-        // if SSL is on and custom TLS options were not provided, enable them
-        if MongoSwiftTestCase.ssl {
-            opts.tls = true
-            if let caPath = MongoSwiftTestCase.sslCAFilePath {
-                opts.tlsCAFile = URL(string: caPath)
-            }
-            if let certPath = MongoSwiftTestCase.sslPEMKeyFilePath {
-                opts.tlsCertificateKeyFile = URL(string: certPath)
-            }
-        }
-        if let apiVersion = MongoSwiftTestCase.apiVersion {
-            if opts.serverAPI == nil {
-                opts.serverAPI = MongoServerAPI(version: apiVersion)
-            } else {
-                opts.serverAPI!.version = apiVersion
-            }
-        }
-
-        if MongoSwiftTestCase.auth {
-            if let scramUser = MongoSwiftTestCase.scramUser, let scramPass = MongoSwiftTestCase.scramPassword {
-                opts.credential = MongoCredential(username: scramUser, password: scramPass)
-            }
-        }
-
-        // serverless tests are required to use compression.
-        if MongoSwiftTestCase.serverless {
-            opts.compressors = [.zlib]
-        }
+        let opts = resolveClientOptions(options)
         return try MongoClient(uri, using: eventLoopGroup, options: opts)
     }
 

--- a/etc/expose-mock-service-id.diff
+++ b/etc/expose-mock-service-id.diff
@@ -1,0 +1,32 @@
+diff --git a/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h b/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
+index 082521c1..4676c5c4 100644
+--- a/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
++++ b/Sources/CLibMongoC/include/CLibMongoC_mongoc-server-description.h
+@@ -66,6 +66,12 @@ MONGOC_EXPORT (int32_t)
+ mongoc_server_description_compressor_id (
+    const mongoc_server_description_t *description);
+ 
++/* mongoc_global_mock_service_id is only used for testing. The test runner sets
++ * this to true when testing against a load balanced deployment to mock the
++ * presence of a serviceId field in the "hello" response. The purpose of this is
++ * further described in the Load Balancer test README. */
++extern bool mongoc_global_mock_service_id;
++
+ BSON_END_DECLS
+ 
+ #endif
+diff --git a/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h b/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
+index ef75154a..210bc3c2 100644
+--- a/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
++++ b/Sources/CLibMongoC/mongoc/mongoc-server-description-private.h
+@@ -200,10 +200,4 @@ bool
+ mongoc_server_description_has_service_id (
+    const mongoc_server_description_t *description);
+ 
+-/* mongoc_global_mock_service_id is only used for testing. The test runner sets
+- * this to true when testing against a load balanced deployment to mock the
+- * presence of a serviceId field in the "hello" response. The purpose of this is
+- * further described in the Load Balancer test README. */
+-extern bool mongoc_global_mock_service_id;
+-
+ #endif

--- a/etc/vendor-libmongoc.sh
+++ b/etc/vendor-libmongoc.sh
@@ -153,6 +153,8 @@ echo "RENAMING header files"
 echo "PATCHING libmongoc"
 git apply ${ETC_DIR}/lower-minheartbeatfrequencyms.diff
 git apply ${ETC_DIR}/inttypes-non-modular-header-workaround.diff
+# TODO SWIFT-1319: Remove.
+git apply ${ETC_DIR}/expose-mock-service-id.diff
 
 # Clang modules are build by a conventional structure with an `include` folder for public
 # includes, and an umbrella header used as the primary entry point. As part of the vendoring


### PR DESCRIPTION
This contains a hodgepodge of changes which, taken together, are all that is necessary to run our existing test suite against local load balancers. Future PRs will bring in the new load balancer-specific tests and support running load balancer tests in Evergreen.