### PR TITLE
SWIFT-1329 Use a client per mongos in unified test runner

### DIFF
--- a/Sources/TestsCommon/SpecTestUtils.swift
+++ b/Sources/TestsCommon/SpecTestUtils.swift
@@ -20,19 +20,6 @@ extension MongoSwiftTestCase {
     }
 }
 
-extension MongoDatabase {
-    @discardableResult
-    public func runCommand(
-        _ command: BSONDocument,
-        on server: ServerAddress,
-        options: RunCommandOptions? = nil,
-        session: ClientSession? = nil
-    ) -> EventLoopFuture<BSONDocument> {
-        let operation = RunCommandOperation(database: self, command: command, options: options, serverAddress: server)
-        return self._client.operationExecutor.execute(operation, client: self._client, on: nil, session: session)
-    }
-}
-
 /// Given a spec folder name (e.g. "crud") and optionally a subdirectory name for a folder (e.g. "read") retrieves an
 /// array of [(filename, file decoded to type T)].
 public func retrieveSpecTestFiles<T: Decodable>(

--- a/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
+++ b/Tests/MongoSwiftSyncTests/SyncTestUtils.swift
@@ -154,18 +154,6 @@ internal func captureCommandEvents(
     return monitor.events(withEventTypes: eventTypes, withNames: commandNames)
 }
 
-extension MongoDatabase {
-    @discardableResult
-    public func runCommand(
-        _ command: BSONDocument,
-        on server: ServerAddress,
-        options: RunCommandOptions? = nil,
-        session: MongoSwiftSync.ClientSession? = nil
-    ) throws -> BSONDocument {
-        try self.asyncDB.runCommand(command, on: server, options: options, session: session?.asyncSession).wait()
-    }
-}
-
 extension MongoSwiftSync.MongoCollection {
     public var _client: MongoSwiftSync.MongoClient {
         self.client

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Context.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Context.swift
@@ -11,9 +11,9 @@ class Context {
     /// Fail points that have been set during test execution and should be disabled on completion.
     var enabledFailPoints: [FailPointGuard] = []
 
-    let internalClient: MongoClient
+    let internalClient: UnifiedTestRunner.InternalClient
 
-    init(path: [String], entities: EntityMap, internalClient: MongoClient) {
+    init(path: [String], entities: EntityMap, internalClient: UnifiedTestRunner.InternalClient) {
         self.path = path
         self.entities = entities
         self.internalClient = internalClient


### PR DESCRIPTION
This removes our (internal) support for targeting a particular host in `runCommand`, given that its bypassing of the server selection loop makes it susceptible to failure, and switches the unified test runner to use a client-per-mongos approach.