### PR TITLE
SWIFT-1214 Error on maxPoolSize <= 0 in connection string

### DIFF
--- a/Sources/MongoSwift/ConnectionString.swift
+++ b/Sources/MongoSwift/ConnectionString.swift
@@ -300,6 +300,17 @@ internal class ConnectionString {
             }
 
             try self.setInt32Option(MONGOC_URI_MAXPOOLSIZE, to: value)
+            // libmongoc treats a maxPoolSize of 0 as 1, which is not spec-compliant (it should be treated as "no max"),
+            // so we error if a user tries to set that via the connection string. See SWIFT-1339
+        } else if let uriMaxPoolSize = self.options?[MONGOC_URI_MAXPOOLSIZE]?.int32Value {
+            guard uriMaxPoolSize > 0 else {
+                throw self.int32OutOfRangeError(
+                    option: MONGOC_URI_MAXPOOLSIZE,
+                    value: uriMaxPoolSize,
+                    min: 1,
+                    max: Int32.max
+                )
+            }
         }
 
         if let connectTimeoutMS = options?.connectTimeoutMS {

--- a/Tests/MongoSwiftTests/ConnectionStringTests.swift
+++ b/Tests/MongoSwiftTests/ConnectionStringTests.swift
@@ -115,7 +115,9 @@ let skipUnsupported: [String: [String]] = [
         "Non-numeric maxIdleTimeMS causes a warning",
         "Valid connection pool options are parsed correctly",
         // We don't support minPoolSize.
-        "minPoolSize=0 does not error"
+        "minPoolSize=0 does not error",
+        // We don't allow maxPoolSize=0, see SWIFT-1339.
+        "maxPoolSize=0 does not error"
     ],
     // requires maxIdleTimeMS
     "connection-options.json": [


### PR DESCRIPTION
Makes the behavior for specifying maxPoolSize <= 0 in the connection string the same as it is when the option is provided via options struct (error).