### PR TITLE
SWIFT-1322 Support batchSize option for listCollections

### DIFF
--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -49,8 +49,7 @@ public class MongoCursor<T: Codable>: CursorProtocol {
     public let id: Int64?
 
     /**
-     * Initializes a new `MongoCursor` instance. Not meant to be instantiated directly by a user. When `forceIO` is
-     * true, this initializer will force a connection to the server if one is not already established.
+     * Initializes a new `MongoCursor` instance. Not meant to be instantiated directly by a user.
      *
      * - Throws:
      *   - `MongoError.InvalidArgumentError` if the options passed to the command that generated this cursor formed an

--- a/Sources/MongoSwift/MongoError.swift
+++ b/Sources/MongoSwift/MongoError.swift
@@ -522,7 +522,7 @@ internal func toErrorString(_ error: bson_error_t) -> String {
     }
 }
 
-internal let failedToRetrieveCursorMessage = "Couldn't get cursor from the server"
+internal let failedToRetrieveCursorMessage = "Expected libmongoc to return a cursor, unexpectedly got nil"
 
 extension MongoErrorProtocol {
     /// Determines whether this error is an "ns not found" error.

--- a/Sources/MongoSwift/Operations/ListCollectionsOperation.swift
+++ b/Sources/MongoSwift/Operations/ListCollectionsOperation.swift
@@ -136,6 +136,8 @@ internal struct ListCollectionsOperation: Operation {
         cursorOpts = try encodeOptions(options: cursorOpts, session: session) ?? BSONDocument()
         cmd["cursor"] = .document(cursorOpts)
 
+        // We don't need to clean up this reply ourselves, as `mongoc_cursor_new_from_command_reply_with_opts` will
+        // consume it.
         var reply = try self.database.withMongocDatabase(from: connection) { dbPtr in
             try readPref.withMongocReadPreference { rpPtr in
                 try runMongocCommandWithCReply(

--- a/Sources/MongoSwift/Operations/MongocCommandHelpers.swift
+++ b/Sources/MongoSwift/Operations/MongocCommandHelpers.swift
@@ -51,6 +51,7 @@ internal func runMongocCommandWithCReply(
             try _runMongocCommand(command: command, options: options, replyPtr: replyPtr, body: body)
         }
     } catch {
+        // on error, we need to clean up the bson_t ourselves here. on success, it is the caller's responsibility.
         withUnsafeMutablePointer(to: &reply) { ptr in
             bson_destroy(ptr)
         }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -230,6 +230,7 @@ extension MongoDatabaseTests {
         ("testDropDatabase", testDropDatabase),
         ("testCreateCollection", testCreateCollection),
         ("testListCollections", testListCollections),
+        ("testListCollectionsBatchSize", testListCollectionsBatchSize),
         ("testAggregate", testAggregate),
         ("testAggregateWithOutputType", testAggregateWithOutputType),
         ("testAggregateWithListLocalSessions", testAggregateWithListLocalSessions),


### PR DESCRIPTION
Reimplements listCollections by running the command and creating a cursor from it. This is necessary because the libmongoc helper ignores the batchSize option.