### PR TITLE
SWIFT-1347 Fix memory leak in tests caused by ClientSession.pinnedServerAddress

### DIFF
--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -94,8 +94,11 @@ public final class ClientSession {
             return nil
         }
         return connection.withMongocConnection { client in
-            let serverDescription =
-                ServerDescription(mongoc_client_get_server_description(client, serverID))
+            guard let sd = mongoc_client_get_server_description(client, serverID) else {
+                return nil
+            }
+            defer { mongoc_server_description_destroy(sd) }
+            let serverDescription = ServerDescription(sd)
             return serverDescription.address
         }
     }


### PR DESCRIPTION
As discovered via adding `leaks` to CI in my other PR. After this gets merged in I will rebase over there to get the new tasks passing.