### PR TITLE
SWIFT-1389 Add async/await APIs for MongoClient and ClientSession

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1358,7 +1358,7 @@ buildvariants:
   display_name: "Format and Lint"
   matrix_spec:
     os-fully-featured: "ubuntu-18.04"
-    swift-version: "5.4" # upgrading is blocked on a SwiftLint release > 0.44
+    swift-version: "5.5"
   tasks:
     - name: "check-format"
     - name: "check-lint"

--- a/.evergreen/install-tools.sh
+++ b/.evergreen/install-tools.sh
@@ -35,7 +35,7 @@ install_from_gh () {
 
 if [ $1 == "swiftlint" ]
 then
-    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.44.0"
+    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.45.0"
 elif [ $1 == "swiftformat" ]
 then
     build_from_gh swiftformat https://github.com/nicklockwood/SwiftFormat "0.48.11"

--- a/Sources/MongoSwift/AsyncAwait/ClientSession+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/ClientSession+AsyncAwait.swift
@@ -1,0 +1,59 @@
+#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+/// Extension to `ClientSession` to support async/await APIs.
+extension ClientSession {
+    /**
+     * Starts a multi-document transaction for all subsequent operations in this session.
+     *
+     * Any options provided in `options` will override the default transaction options for this session and any options
+     * inherited from `MongoClient`.
+     *
+     * Operations executed as part of the transaction will use the options specified on the transaction, and those
+     * options cannot be overridden at a per-operation level. Any options that overlap with the transaction options
+     * which can be specified at a per operation level (e.g. write concern) _will be ignored_ if specified. This
+     * includes options specified at the database or collection level on the object used to execute an operation.
+     *
+     * The transaction must be completed with `commitTransaction` or `abortTransaction`. An in-progress transaction is
+     * automatically aborted if the session goes out of scope before `commitTransaction` is called.
+     *
+     * - Parameters:
+     *   - options: The options to use when starting this transaction
+     *
+     * - Throws:
+     *   - `MongoError.CommandError` if an error occurs that prevents the command from executing.
+     *   - `MongoError.LogicError` if the session already has an in-progress transaction.
+     *
+     * - SeeAlso:
+     *   - https://docs.mongodb.com/manual/core/transactions/
+     */
+    public func startTransaction(options: TransactionOptions? = nil) async throws {
+        try await self.startTransaction(options: options).get()
+    }
+
+    /**
+     * Commits a multi-document transaction for this session. Server and network errors are not ignored.
+     *
+     * - Throws:
+     *   - `MongoError.CommandError` if an error occurs that prevents the command from executing.
+     *   - `MongoError.LogicError` if the session has no in-progress transaction.
+     *
+     * - SeeAlso:
+     *   - https://docs.mongodb.com/manual/core/transactions/
+     */
+    public func commitTransaction() async throws {
+        try await self.commitTransaction().get()
+    }
+
+    /**
+     * Aborts a multi-document transaction for this session. Server and network errors are ignored.
+     *
+     * - Throws:
+     *   - `MongoError.LogicError` if the session has no in-progress transaction.
+     *
+     * - SeeAlso:
+     *   - https://docs.mongodb.com/manual/core/transactions/
+     */
+    public func abortTransaction() async throws {
+        try await self.abortTransaction().get()
+    }
+}
+#endif

--- a/Sources/MongoSwift/AsyncAwait/MongoClient+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoClient+AsyncAwait.swift
@@ -18,7 +18,20 @@ extension MongoClient {
 
     /**
      * Starts a new `ClientSession` with the provided options and passes it to the provided closure. The session must
-     * not escape the provided closure.
+     * be explicitly passed as an argument to each command within the closure that should be executed as part of the
+     * session.
+     *
+     * The session is only valid within the body of the closure and will be ended after the body completes.
+     *
+     * `ClientSession`s are _not_ thread safe so you must ensure the session is not used concurrently for multiple
+     * operations.
+     *
+     * - Parameters:
+     *   - options: Options to use when creating the session.
+     *   - sessionBody: An `async` closure which takes in a `ClientSession` and returns a `T`.
+     *
+     * - Returns:
+     *    A `T`, the return value of the user-provided closure.
      *
      * - Throws:
      *   - `RuntimeError.CompatibilityError` if the deployment does not support sessions.
@@ -64,7 +77,7 @@ extension MongoClient {
      * - Parameters:
      *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
      *   - options: Optional `ListDatabasesOptions` specifying options for listing databases.
-     *   - session: Optional `ClientSession` to use when executing this command
+     *   - session: Optional `ClientSession` to use when executing this command.
      *
      * - Returns: An Array of `MongoDatabase`s that match the provided filter.
      *
@@ -87,7 +100,7 @@ extension MongoClient {
      * - Parameters:
      *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
      *   - options: Optional `ListDatabasesOptions` specifying options for listing databases.
-     *   - session: Optional `ClientSession` to use when executing this command
+     *   - session: Optional `ClientSession` to use when executing this command.
      *
      * - Returns: A `[String]` containing names of databases that match the provided filter.
      *

--- a/Sources/MongoSwift/AsyncAwait/MongoClient+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoClient+AsyncAwait.swift
@@ -1,0 +1,227 @@
+#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+/// Extension to `MongoClient` to support async/await APIs.
+extension MongoClient {
+    /**
+     * Closes this `MongoClient`, closing all connections to the server and cleaning up internal state.
+     *
+     * Call this method exactly once when you are finished using the client.
+     *
+     * This function will not complete until all cursors and change streams created from this client have been
+     * been killed, and all sessions created from this client have been ended.
+     *
+     * You must `await` the result of this method before shutting down the `EventLoopGroup` provided to this client's
+     * constructor.
+     */
+    public func close() async throws {
+        try await self.close().get()
+    }
+
+    /**
+     * Starts a new `ClientSession` with the provided options and passes it to the provided closure. The session must
+     * not escape the provided closure.
+     *
+     * - Throws:
+     *   - `RuntimeError.CompatibilityError` if the deployment does not support sessions.
+     */
+    public func withSession<T>(
+        options: ClientSessionOptions? = nil,
+        _ sessionBody: (ClientSession) async throws -> T
+    ) async throws -> T {
+        let session = self.startSession(options: options)
+        return try await sessionBody(session)
+    }
+
+    /**
+     * Run the `listDatabases` command.
+     *
+     * - Parameters:
+     *   - filter: Optional `Document` specifying a filter that the listed databases must pass. This filter can be based
+     *     on the "name", "sizeOnDisk", "empty", or "shards" fields of the output.
+     *   - options: Optional `ListDatabasesOptions` specifying options for listing databases.
+     *   - session: Optional `ClientSession` to use when executing this command.
+     *
+     * - Returns: A `[DatabaseSpecification]` containing the databases matching provided criteria.
+     *
+     * - Throws:
+     *   - `MongoError.LogicError` if the provided session is inactive.
+     *   - `EncodingError` if an error is encountered while encoding the options to BSON.
+     *   - `MongoError.CommandError` if options.authorizedDatabases is false and the user does not have listDatabases
+     *     permissions.
+     *
+     * - SeeAlso: https://docs.mongodb.com/manual/reference/command/listDatabases/
+     */
+    public func listDatabases(
+        _ filter: BSONDocument? = nil,
+        options: ListDatabasesOptions? = nil,
+        session: ClientSession? = nil
+    ) async throws -> [DatabaseSpecification] {
+        try await self.listDatabases(filter, options: options, session: session).get()
+    }
+
+    /**
+     * Get a list of `MongoDatabase`s.
+     *
+     * - Parameters:
+     *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
+     *   - options: Optional `ListDatabasesOptions` specifying options for listing databases.
+     *   - session: Optional `ClientSession` to use when executing this command
+     *
+     * - Returns: An Array of `MongoDatabase`s that match the provided filter.
+     *
+     * - Throws:
+     *   - `MongoError.LogicError` if the provided session is inactive.
+     *   - `MongoError.CommandError` if options.authorizedDatabases is false and the user does not have listDatabases
+     *     permissions.
+     */
+    public func listMongoDatabases(
+        _ filter: BSONDocument? = nil,
+        options: ListDatabasesOptions? = nil,
+        session: ClientSession? = nil
+    ) async throws -> [MongoDatabase] {
+        try await self.listDatabaseNames(filter, options: options, session: session).map { self.db($0) }
+    }
+
+    /**
+     * Get a list of names of databases.
+     *
+     * - Parameters:
+     *   - filter: Optional `Document` specifying a filter on the names of the returned databases.
+     *   - options: Optional `ListDatabasesOptions` specifying options for listing databases.
+     *   - session: Optional `ClientSession` to use when executing this command
+     *
+     * - Returns: A `[String]` containing names of databases that match the provided filter.
+     *
+     * - Throws:
+     *   - `MongoError.LogicError` if the provided session is inactive.
+     *   - `MongoError.CommandError` if options.authorizedDatabases is false and the user does not have listDatabases
+     *     permissions.
+     */
+    public func listDatabaseNames(
+        _ filter: BSONDocument? = nil,
+        options: ListDatabasesOptions? = nil,
+        session: ClientSession? = nil
+    ) async throws -> [String] {
+        try await self.listDatabaseNames(filter, options: options, session: session).get()
+    }
+
+    /**
+     * Starts a `ChangeStream` on a `MongoClient`. Allows the client to observe all changes in a cluster -
+     * excluding system collections and the "config", "local", and "admin" databases.
+     *
+     * - Parameters:
+     *   - pipeline: An array of aggregation pipeline stages to apply to the events returned by the change stream.
+     *   - options: An optional `ChangeStreamOptions` to use when constructing the change stream.
+     *   - session: An optional `ClientSession` to use with this change stream.
+     *
+     * - Returns: a `ChangeStream` on all collections in all databases in a cluster.
+     *
+     * - Throws:
+     *   - `MongoError.CommandError` if an error occurs on the server while creating the change stream.
+     *   - `MongoError.InvalidArgumentError` if the options passed formed an invalid combination.
+     *   - `MongoError.InvalidArgumentError` if the `_id` field is projected out of the change stream documents by the
+     *     pipeline.
+     *
+     * - SeeAlso:
+     *   - https://docs.mongodb.com/manual/changeStreams/
+     *   - https://docs.mongodb.com/manual/meta/aggregation-quick-reference/
+     *   - https://docs.mongodb.com/manual/reference/system-collections/
+     *
+     * - Note: Supported in MongoDB version 4.0+ only.
+     */
+    public func watch(
+        _ pipeline: [BSONDocument] = [],
+        options: ChangeStreamOptions? = nil,
+        session: ClientSession? = nil
+    ) async throws -> ChangeStream<ChangeStreamEvent<BSONDocument>> {
+        try await self.watch(
+            pipeline,
+            options: options,
+            session: session,
+            withEventType: ChangeStreamEvent<BSONDocument>.self
+        )
+    }
+
+    /**
+     * Starts a `ChangeStream` on a `MongoClient`. Allows the client to observe all changes in a cluster -
+     * excluding system collections and the "config", "local", and "admin" databases. Associates the specified
+     * `Codable` type `T` with the `fullDocument` field in the `ChangeStreamEvent`s emitted by the returned
+     * `ChangeStream`.
+     *
+     * - Parameters:
+     *   - pipeline: An array of aggregation pipeline stages to apply to the events returned by the change stream.
+     *   - options: An optional `ChangeStreamOptions` to use when constructing the change stream.
+     *   - session: An optional `ClientSession` to use with this change stream.
+     *   - withFullDocumentType: The type that the `fullDocument` field of the emitted `ChangeStreamEvent`s will be
+     *                           decoded to.
+     *
+     * - Returns: A `ChangeStream` on all collections in all databases in a cluster.
+     *
+     * - Throws:
+     *   - `MongoError.CommandError` if an error occurs on the server while creating the change stream.
+     *   - `MongoError.InvalidArgumentError` if the options passed formed an invalid combination.
+     *   - `MongoError.InvalidArgumentError` if the `_id` field is projected out of the change stream documents by the
+     *     pipeline.
+     *
+     * - SeeAlso:
+     *   - https://docs.mongodb.com/manual/changeStreams/
+     *   - https://docs.mongodb.com/manual/meta/aggregation-quick-reference/
+     *   - https://docs.mongodb.com/manual/reference/system-collections/
+     *
+     * - Note: Supported in MongoDB version 4.0+ only.
+     */
+    public func watch<FullDocType: Codable>(
+        _ pipeline: [BSONDocument] = [],
+        options: ChangeStreamOptions? = nil,
+        session: ClientSession? = nil,
+        withFullDocumentType _: FullDocType.Type
+    ) async throws -> ChangeStream<ChangeStreamEvent<FullDocType>> {
+        try await self.watch(
+            pipeline,
+            options: options,
+            session: session,
+            withEventType: ChangeStreamEvent<FullDocType>.self
+        )
+    }
+
+    /**
+     * Starts a `ChangeStream` on a `MongoClient`. Allows the client to observe all changes in a cluster -
+     * excluding system collections and the "config", "local", and "admin" databases. Associates the specified
+     * `Codable` type `T` with the returned `ChangeStream`.
+     *
+     * - Parameters:
+     *   - pipeline: An array of aggregation pipeline stages to apply to the events returned by the change stream.
+     *   - options: An optional `ChangeStreamOptions` to use when constructing the change stream.
+     *   - session: An optional `ClientSession` to use with this change stream.
+     *   - withEventType: The type that the entire change stream response will be decoded to and that will be returned
+     *                    when iterating through the change stream.
+     *
+     * - Returns: A `ChangeStream` on all collections in all databases in a cluster.
+     *
+     * - Throws:
+     *   - `MongoError.CommandError` if an error occurs on the server while creating the change stream.
+     *   - `MongoError.InvalidArgumentError` if the options passed formed an invalid combination.
+     *   - `MongoError.InvalidArgumentError` if the `_id` field is projected out of the change stream documents by the
+     *     pipeline.
+     *
+     * - SeeAlso:
+     *   - https://docs.mongodb.com/manual/changeStreams/
+     *   - https://docs.mongodb.com/manual/meta/aggregation-quick-reference/
+     *   - https://docs.mongodb.com/manual/reference/system-collections/
+     *
+     * - Note: Supported in MongoDB version 4.0+ only.
+     */
+    public func watch<EventType: Codable>(
+        _ pipeline: [BSONDocument] = [],
+        options: ChangeStreamOptions? = nil,
+        session: ClientSession? = nil,
+        withEventType _: EventType.Type
+    ) async throws -> ChangeStream<EventType> {
+        try await self.watch(
+            pipeline,
+            options: options,
+            session: session,
+            withEventType: EventType.self
+        ).get()
+    }
+}
+#endif

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -69,11 +69,12 @@ public final class ClientSession {
                 return client.operationExecutor.makeSucceededFuture((), on: eventLoop)
             case let .started(session, connection):
                 return client.operationExecutor.execute(on: eventLoop) {
-                    mongoc_client_session_destroy(session)
                     // reference the connection so it stays alive at least until the session is done being cleaned up.
                     // this is required by libmongoc; we can't put the `mongoc_client_t` back in its pool until all
                     // sessions created from it have been destroyed.
-                    _ = connection
+                    withExtendedLifetime(connection) {
+                        mongoc_client_session_destroy(session)
+                    }
                 }
             }
         }

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -397,15 +397,32 @@ public class MongoClient {
         self.wasClosed = true
     }
 
-    /// Starts a new `ClientSession` with the provided options. When you are done using this session, you must call
-    /// `ClientSession.end()` on it.
+    /**
+     * Starts a new `ClientSession` with the provided options.
+     *
+     * This session must be explicitly as an argument to each command that should be executed as part of the session.
+     *
+     * `ClientSession`s are _not_ thread safe so you must ensure the returned session is not used concurrently for
+     * multiple operations.
+     *
+     * When you are done using this session, you must call `ClientSession.end()` on it, unless if you are on a platform
+     * where structured concurrency is available, in which case the session will be ended automatically when the
+     * object is deinitialized. In that case, you must make sure to maintain a reference to this object until all
+     * operations using it have completed.
+     */
     public func startSession(options: ClientSessionOptions? = nil) -> ClientSession {
         ClientSession(client: self, eventLoop: nil, options: options)
     }
 
     /**
-     * Starts a new `ClientSession` with the provided options and passes it to the provided closure.
+     * Starts a new `ClientSession` with the provided options and passes it to the provided closure. The session must
+     * be explicitly passed as an argument to each command within the closure that should be executed as part of the
+     * session.
+     *
      * The session is only valid within the body of the closure and will be ended after the body completes.
+     *
+     * `ClientSession`s are _not_ thread safe so you must ensure the session is not used concurrently for multiple
+     * operations.
      *
      * - Parameters:
      *   - options: Options to use when creating the session.

--- a/Sources/MongoSwiftSync/MongoClient.swift
+++ b/Sources/MongoSwiftSync/MongoClient.swift
@@ -65,17 +65,34 @@ public class MongoClient {
         }
     }
 
-    /// Starts a new `ClientSession` with the provided options.
+    /**
+     * Starts a new `ClientSession` with the provided options.
+     *
+     * This session must be explicitly as an argument to each command that should be executed as part of the session.
+     *
+     * `ClientSession`s are _not_ thread safe so you must ensure the returned session is not used concurrently for
+     * multiple operations.
+     */
     public func startSession(options: ClientSessionOptions? = nil) -> ClientSession {
         ClientSession(client: self, options: options)
     }
 
     /**
-     * Starts a new `ClientSession` with the provided options and passes it to the provided closure.
+     * Starts a new `ClientSession` with the provided options and passes it to the provided closure. The session must
+     * be explicitly passed as an argument to each command within the closure that should be executed as part of the
+     * session.
+     *
      * The session is only valid within the body of the closure and will be ended after the body completes.
      *
+     * `ClientSession`s are _not_ thread safe so you must ensure the session is not used concurrently for multiple
+     * operations.
+     *
+     * - Parameters:
+     *   - options: Options to use when creating the session.
+     *   - sessionBody: A closure which takes in a `ClientSession` and returns a `T`.
+     *
      * - Throws:
-     *   - `RuntimeError.compatibilityError` if the deployment does not support sessions.
+     *   - `RuntimeError.CompatibilityError` if the deployment does not support sessions.
      */
     public func withSession<T>(
         options: ClientSessionOptions? = nil,

--- a/Tests/MongoSwiftTests/AsyncAwaitTests.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTests.swift
@@ -1,0 +1,90 @@
+#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+
+import Foundation
+@testable import MongoSwift
+import Nimble
+import NIO
+import TestsCommon
+import XCTest
+
+/// Temporary utility function until XCTest supports `async` tests.
+func testAsync(_ block: @escaping () async throws -> Void) {
+    let group = DispatchGroup()
+    group.enter()
+    Task.detached {
+        try await block()
+        group.leave()
+    }
+    group.wait()
+}
+
+/// Asserts that the provided block returns true within the specified timeout. Nimble's `toEventually` can only be used
+/// rom the main testing thread which is too restrictive for our purposes testing the async/await APIs.
+func assertIsEventuallyTrue(_ block: () -> Bool, description: String, timeout: TimeInterval = 5) {
+    let start = DispatchTime.now()
+    while DispatchTime.now() < start + timeout {
+        if block() {
+            return
+        }
+    }
+    XCTFail("Expected condition \"\(description)\" to be true within \(timeout) seconds, but was not")
+}
+
+extension MongoSwiftTestCase {
+    internal func withTestClient<T>(
+        _ uri: String = MongoSwiftTestCase.getConnectionString().toString(),
+        options: MongoClientOptions? = nil,
+        eventLoopGroup: EventLoopGroup? = nil,
+        f: (MongoClient) async throws -> T
+    ) async throws -> T {
+        let elg = eventLoopGroup ?? MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { elg.syncShutdownOrFail() }
+        let client = try MongoClient.makeTestClient(uri, eventLoopGroup: elg, options: options)
+        defer { client.syncCloseOrFail() }
+        return try await f(client)
+    }
+}
+
+final class AsyncAwaitTests: MongoSwiftTestCase {
+    func testMongoClient() throws {
+        testAsync {
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            let client = try MongoClient.makeTestClient(eventLoopGroup: elg)
+            let databases = try await client.listDatabases()
+            expect(databases).toNot(beEmpty())
+            // We don't use `withTestClient` here so we can explicity test the `async` version of `close()``.
+            try await client.close()
+        }
+    }
+
+    func testClientSession() throws {
+        testAsync {
+            try await self.withTestClient { client in
+                let dbs = try await client.withSession { session -> [DatabaseSpecification] in
+                    try await client.listDatabases(session: session)
+                }
+                expect(dbs).toNot(beEmpty())
+
+                // the session's connection should be back in the pool.
+                assertIsEventuallyTrue(
+                    { client.connectionPool.checkedOutConnections == 0 },
+                    description: "Session's underlying connection should be returned to the pool"
+                )
+
+                // test session is cleaned up even if closure throws an error.
+                try? await client.withSession { session in
+                    _ = try await client.listDatabases(session: session)
+                    throw TestError(message: "intentional error thrown from withSession closure")
+                }
+                assertIsEventuallyTrue(
+                    { client.connectionPool.checkedOutConnections == 0 },
+                    description: "Session's underlying connection should be returned to the pool"
+                )
+
+                // TODO: SWIFT-1391 once we have more API methods available, test transaction usage here.
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
[this is atop #694, will rebase once that goes in]

Adds `async` versions of the API methods on these types and adds automatic cleanup for `ClientSession`s on Swift 5.5+. The cleanup was a slightly trickier refactor than I initially anticipated, some comments inline.

For now, due to the issue with the macOS Evergreen hosts, everything new is conditionally defined on Linux only. Whenever we can test on macOS again I will return and fix things up.
