### PR TITLE
Fix 5.1 compilation

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,1 @@
+// This is a placeholder file which is required for compilation on Swift 5.1.


### PR DESCRIPTION
Add a placeholder LinuxMain.swift so the driver will still compile on Swift 5.1. 