### PR TITLE
Double timeouts for recent server sharded cluster tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -557,6 +557,7 @@ tasks:
 
     - name: "test-4.4-sharded_cluster"
       tags: ["4.4", "sharded_cluster"]
+      exec_timeout_secs: 3600 # TODO SWIFT-1410: remove
       commands:
         - func: "prepare resources"
         - func: "fix absolute paths"
@@ -590,6 +591,7 @@ tasks:
 
     - name: "test-5.0-sharded_cluster"
       tags: ["5.0", "sharded_cluster"]
+      exec_timeout_secs: 3600 # TODO SWIFT-1410: remove
       commands:
         - func: "prepare resources"
         - func: "fix absolute paths"
@@ -623,6 +625,7 @@ tasks:
 
     - name: "test-latest-sharded_cluster"
       tags: ["latest", "sharded_cluster"]
+      exec_timeout_secs: 3600 # TODO SWIFT-1410: remove
       commands:
         - func: "prepare resources"
         - func: "fix absolute paths"


### PR DESCRIPTION
This issue only seems to come up on more recent server versions, I think because they have more tests for newer functionality.

It seems we can only set these on a per task level, so it will apply to these tasks on any OS. filed SWIFT-1410 so we remember to revert to the project's default task timeout of 30 minutes if/when the issue with the slow macOS hosts is resolved.