### PR TITLE
SWIFT-1414 Update release script to not only work on main

### DIFF
--- a/etc/build-examples.sh
+++ b/etc/build-examples.sh
@@ -4,12 +4,16 @@ exit_code=0
 
 examples=("BugReport" "Docs" "KituraExample" "PerfectExample" "VaporExample" "Atlas")
 
+branch=${1}
+# Ensure branch is non-empty
+[ ! -z "${branch}" ] || { echo "ERROR: Missing branch name"; exit 1; }
+
 for example_project in ${examples[@]}; do
     echo "Building $example_project"
     example_dir="Examples/${example_project}"
 
-    # replace version string with main
-    etc/sed.sh -i 's/swift-driver", .upToNextMajor[^)]*)/swift-driver", .branch("main")/' "${example_dir}/Package.swift"
+    # replace version string with release branch name
+    etc/sed.sh -i "s/swift-driver\", .upToNextMajor[^)]*)/swift-driver\", .branch(\"${branch}\")/" "${example_dir}/Package.swift"
 
     pushd "${example_dir}"
 
@@ -32,6 +36,7 @@ for example_project in ${examples[@]}; do
     else
         echo "================= Building $example_project failed ================="
         exit_code=1
+        exit "${exit_code}"
     fi
 done
 

--- a/etc/release.sh
+++ b/etc/release.sh
@@ -10,7 +10,7 @@ version=${1}
 [ ! -z "${version}" ] || { echo "ERROR: Missing version string"; exit 1; }
 
 # verify that the examples build with the current branch we're releasing on
-current_branch=$(git rev-parse --abbrev-ref HEAD)
+current_branch=$(git branch --show-current)
 ./etc/build-examples.sh ${current_branch}
 
 # regenerate documentation with new version string

--- a/etc/release.sh
+++ b/etc/release.sh
@@ -9,8 +9,9 @@ version=${1}
 # Ensure version is non-empty
 [ ! -z "${version}" ] || { echo "ERROR: Missing version string"; exit 1; }
 
-# verify that the examples build
-./etc/build-examples.sh
+# verify that the examples build with the current branch we're releasing on
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+./etc/build-examples.sh ${current_branch}
 
 # regenerate documentation with new version string
 ./etc/generate-docs.sh ${version}
@@ -30,7 +31,7 @@ git commit -m "${version} docs"
 git push
 
 # go back to our original branch
-git checkout -
+git checkout ${current_branch}
 
 # update version string for libmongoc handshake
 sourcery --sources Sources/MongoSwift \


### PR DESCRIPTION
This script previously assumed you were running it from `main`; this generalizes it to work regardless of branch. 

I'll cherry-pick this onto r1.2 as well.