### PR TITLE
SWIFT-1393 Add concurrent MongoClient usage test

### DIFF
--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -57,7 +57,7 @@ extension MongoClient {
 }
 
 extension MongoDatabase {
-    fileprivate func syncDropOrFail() {
+    internal func syncDropOrFail() {
         do {
             try self.drop().wait()
         } catch {


### PR DESCRIPTION
Adds a test that uses a `MongoClient` in parallel across a number of tasks to verify that works as we expect it to. 