### PR TITLE
SWIFT-1408 Remove conditional definition on Linux for async/await APIs

### DIFF
--- a/Sources/MongoSwift/AsyncAwait/ChangeStream+AsyncSequence.swift
+++ b/Sources/MongoSwift/AsyncAwait/ChangeStream+AsyncSequence.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `ChangeStream` to support async/await APIs.
+@available(macOS 12, *)
 extension ChangeStream: AsyncSequence, AsyncIteratorProtocol {
     public typealias AsyncIterator = ChangeStream
 

--- a/Sources/MongoSwift/AsyncAwait/ClientSession+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/ClientSession+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `ClientSession` to support async/await APIs.
+@available(macOS 12, *)
 extension ClientSession {
     /**
      * Starts a multi-document transaction for all subsequent operations in this session.

--- a/Sources/MongoSwift/AsyncAwait/MongoClient+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoClient+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoClient` to support async/await APIs.
+@available(macOS 12, *)
 extension MongoClient {
     /**
      * Closes this `MongoClient`, closing all connections to the server and cleaning up internal state.

--- a/Sources/MongoSwift/AsyncAwait/MongoCollection+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoCollection+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoCollection` to support async/await APIs.
+@available(macOS 12, *)
 extension MongoCollection {
     /**
      * Drops this collection from its parent database.

--- a/Sources/MongoSwift/AsyncAwait/MongoCollection+ChangeStreams+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoCollection+ChangeStreams+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoCollection` to support async/await change stream APIs.
+@available(macOS 12, *)
 extension MongoCollection {
     /**
      * Starts a `ChangeStream` on a collection. The `CollectionType` will be associated with the `fullDocument`

--- a/Sources/MongoSwift/AsyncAwait/MongoCollection+FindAndModify+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoCollection+FindAndModify+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoCollection` to support async/await find and modify APIs.
+@available(macOS 12, *)
 extension MongoCollection {
     /**
      * Finds a single document and deletes it, returning the original.

--- a/Sources/MongoSwift/AsyncAwait/MongoCollection+Indexes+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoCollection+Indexes+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoCollection` to support async/await index management APIs.
+@available(macOS 12, *)
 extension MongoCollection {
     /**
      * Creates an index over the collection for the provided keys with the provided options.

--- a/Sources/MongoSwift/AsyncAwait/MongoCollection+Read+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoCollection+Read+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoCollection` to support async/await read APIs.
+@available(macOS 12, *)
 extension MongoCollection {
     /**
      * Finds the documents in this collection which match the provided filter.

--- a/Sources/MongoSwift/AsyncAwait/MongoCollection+Write+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoCollection+Write+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoCollection` to support async/await write APIs.
+@available(macOS 12, *)
 extension MongoCollection {
     /**
      * Encodes the provided value to BSON and inserts it. If the value is missing an identifier, one will be generated

--- a/Sources/MongoSwift/AsyncAwait/MongoCursor+AsyncSequence.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoCursor+AsyncSequence.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoCursor` to support async/await APIs.
+@available(macOS 12, *)
 extension MongoCursor: AsyncSequence, AsyncIteratorProtocol {
     public typealias AsyncIterator = MongoCursor
 

--- a/Sources/MongoSwift/AsyncAwait/MongoDatabase+AsyncAwait.swift
+++ b/Sources/MongoSwift/AsyncAwait/MongoDatabase+AsyncAwait.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Extension to `MongoDatabase` to support async/await APIs.
+@available(macOS 12, *)
 extension MongoDatabase {
     /**
      *   Drops this database.
@@ -22,7 +23,7 @@ extension MongoDatabase {
      *   - options: Optional `CreateCollectionOptions` to use for the collection.
      *   - session: Optional `ClientSession` to use when executing this command.
      *
-     * - Returns: the newly created `MongoCollection<Document>`.
+     * - Returns: the newly created `MongoCollection<BSONDocument>`.
      *
      * - Throws:
      *   - `MongoError.CommandError` if an error occurs that prevents the command from executing.

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -286,8 +286,11 @@ public class ChangeStream<T: Codable>: CursorProtocol {
 
 #if compiler(>=5.5) && canImport(_Concurrency)
     /// When concurrency is available, we can ensure change streams are always cleaned up properly.
-    @available(macOS 12, *)
     deinit {
+        // We can't do this with an @available check on the method; see https://bugs.swift.org/browse/SR-15537.
+        guard #available(macOS 12, *) else {
+            return
+        }
         let client = self.client
         let el = self.eventLoop
         let wrappedCursor = self.wrappedCursor

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -284,8 +284,9 @@ public class ChangeStream<T: Codable>: CursorProtocol {
         }
     }
 
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
     /// When concurrency is available, we can ensure change streams are always cleaned up properly.
+    @available(macOS 12, *)
     deinit {
         let client = self.client
         let el = self.eventLoop

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -265,8 +265,9 @@ public class MongoCursor<T: Codable>: CursorProtocol {
         }
     }
 
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
     /// When concurrency is available, we can ensure cursors are always cleaned up properly.
+    @available(macOS 12, *)
     deinit {
         let client = self.client
         let el = self.eventLoop

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -267,8 +267,11 @@ public class MongoCursor<T: Codable>: CursorProtocol {
 
 #if compiler(>=5.5) && canImport(_Concurrency)
     /// When concurrency is available, we can ensure cursors are always cleaned up properly.
-    @available(macOS 12, *)
     deinit {
+        // We can't do this with an @available check on the method; see https://bugs.swift.org/browse/SR-15537.
+        guard #available(macOS 12, *) else {
+            return
+        }
         let client = self.client
         let el = self.eventLoop
         let wrappedCursor = self.wrappedCursor

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -100,7 +100,8 @@ internal class OperationExecutor {
         self.threadPool.runIfActive(eventLoop: eventLoop ?? self.eventLoopGroup.next(), body)
     }
 
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 12, *)
     internal func execute<T>(on eventLoop: EventLoop?, _ body: @escaping () throws -> T) async throws -> T {
         try await self.execute(on: eventLoop, body).get()
     }

--- a/Tests/MongoSwiftTests/AsyncAwaitTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTestUtils.swift
@@ -1,4 +1,4 @@
-#if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import MongoSwift
@@ -7,6 +7,7 @@ import TestsCommon
 import XCTest
 
 /// Temporary utility function until XCTest supports `async` tests.
+@available(macOS 12, *)
 func testAsync(_ block: @escaping () async throws -> Void) {
     let group = DispatchGroup()
     group.enter()
@@ -21,6 +22,7 @@ func testAsync(_ block: @escaping () async throws -> Void) {
     group.wait()
 }
 
+@available(macOS 12, *)
 extension Task where Success == Never, Failure == Never {
     ///  Helper taken from https://www.hackingwithswift.com/quick-start/concurrency/how-to-make-a-task-sleep to support
     /// configuring with seconds rather than nanoseconds.
@@ -32,6 +34,7 @@ extension Task where Success == Never, Failure == Never {
 
 /// Asserts that the provided block returns true within the specified timeout. Nimble's `toEventually` can only be used
 /// rom the main testing thread which is too restrictive for our purposes testing the async/await APIs.
+@available(macOS 12, *)
 func assertIsEventuallyTrue(
     description: String,
     timeout: TimeInterval = 5,
@@ -48,6 +51,7 @@ func assertIsEventuallyTrue(
     XCTFail("Expected condition \"\(description)\" to be true within \(timeout) seconds, but was not")
 }
 
+@available(macOS 12, *)
 extension MongoSwiftTestCase {
     internal func withTestClient<T>(
         _ uri: String = MongoSwiftTestCase.getConnectionString().toString(),
@@ -89,6 +93,7 @@ extension MongoSwiftTestCase {
     // swiftlint:enable large_tuple
 }
 
+@available(macOS 12, *)
 extension MongoClient {
     internal func serverVersion() async throws -> ServerVersion {
         let reply = try await self.db("admin").runCommand(

--- a/Tests/MongoSwiftTests/AsyncAwaitTests.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTests.swift
@@ -1,4 +1,6 @@
 #if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+// TODO: SWIFT-1421 remove this comment and the os(Linux) check above. if the described bug is not fixed, we'll need to
+// adjust our macOS < 12 testing to skip these tests by providing a filter to `swift test`.
 // we shouldn't have to check the operating system here, but there is a bug currently where on older macOS versions
 // the @available checks don't work. since we don't have support for macOS 12+ in CI, we can work around this by just
 // only defining the tests on Linux for now.

--- a/Tests/MongoSwiftTests/AsyncAwaitTests.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTests.swift
@@ -1,4 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency) && os(Linux)
+// we shouldn't have to check the operating system here, but there is a bug currently where on older macOS versions
+// the @available checks don't work. since we don't have support for macOS 12+ in CI, we can work around this by just
+// only defining the tests on Linux for now.
 
 import Foundation
 @testable import MongoSwift
@@ -8,6 +11,7 @@ import NIOConcurrencyHelpers
 import TestsCommon
 import XCTest
 
+@available(macOS 12, *)
 final class AsyncAwaitTests: MongoSwiftTestCase {
     func testMongoClient() throws {
         testAsync {
@@ -115,6 +119,7 @@ final class AsyncAwaitTests: MongoSwiftTestCase {
     }
 }
 
+@available(macOS 12, *)
 final class MongoCursorAsyncAwaitTests: MongoSwiftTestCase {
     func testAsyncSequenceConformance() throws {
         testAsync {
@@ -217,6 +222,7 @@ final class MongoCursorAsyncAwaitTests: MongoSwiftTestCase {
     }
 }
 
+@available(macOS 12, *)
 final class ChangeStreamAsyncAwaitTests: MongoSwiftTestCase {
     func testIteration() throws {
         testAsync {


### PR DESCRIPTION
Due to CI issues, I initially defined all the new APIs on Linux only. This removes that code and switches to using `@available` annotations to indicate macOS compatibility instead.
That said, we still are not testing the new code in CI, since we have no macOS 12 hosts to test on. There is back-deployment support coming for concurrency in Xcode 13.2 (which will allow using concurrency features when targeting as low as macOS 10.15), however I'm still not sure if we'll be able to run tests then since I think Xcode 13.2 requires macOS 11.

Maybe I can get testing on those macOS 11 ARM hosts working by then, or alternatively we can look into getting a simple GH actions setup together to actually be able to run these tests on macOS in CI. I filed SWIFT-1421 about this