### PR TITLE
Only check isAlive() for tailable cursors in async MongoCursor.next()

### DIFF
--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -38,6 +38,8 @@ public class MongoCursor<T: Codable>: CursorProtocol {
 
     private let wrappedCursor: Cursor<MongocCursor>
 
+    internal let cursorType: MongoCursorType
+
     /// The `EventLoop` this `MongoCursor` is bound to.
     internal let eventLoop: EventLoop?
 
@@ -67,6 +69,7 @@ public class MongoCursor<T: Codable>: CursorProtocol {
         self.client = client
         self.decoder = decoder
         self.eventLoop = eventLoop
+        self.cursorType = cursorType ?? .nonTailable
 
         self.wrappedCursor = try Cursor(
             mongocCursor: MongocCursor(referencing: cursorPtr),


### PR DESCRIPTION
I noticed from the benchmarks that iterating through a cursor's results one by one in the async API was about twice as a slow as doing so in the sync API. From using Xcode + Instruments with the time profiler instrument I was able to see that a lot of time was being spent calling `isAlive()`. 

That method and the looping behavior implemented using it is only useful when cursors are tailable, but as written we are currently paying the price of an extra call to `isAlive()` for every call to `next()`.

This updates the implementation of `MongoCursor.next()` so that in the common, non-tailable case we do not perform the unnecessary check, which saves us a journey across the `async`-futures boundary and a trip into the thread pool.

To improve the tailable cursor case (and the equivalent behavior in `ChangeStream.next()`), we could also consider some sort of refactor that allows bundling the calls to `mongoc_cursor_more` and `mongoc_cursor_next` in a single trip into the thread pool via a method that both checks for liveness and returns a doc if one exists. Then the looping logic would be something like
```swift
while true {
    let next = try await self.client.operationExecutor.execute {
        try self.wrappedCursor.tailableNext()
    }
    switch next {
    case .cursorDied: // i.e. `isAlive()` would have returned false
        return nil
    case .doc(document): // `isAlive()` would have returned true and `tryNext()` would have returned a doc
        return doc
   case .cursorAlive: // `isAlive()` would have returned true and `tryNext()` would have returned nil
        continue
    }
}
```
Thoughts?