### PR TITLE
Get rid of compilation warnings for `let` on newer Swift versions

### DIFF
--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -210,8 +210,7 @@ public struct FindOneAndDeleteOptions: FindAndModifyOptionsConvertible, Decodabl
         try FindAndModifyOptions(
             collation: self.collation,
             hint: self.hint,
-            // swiftlint:disable:next colon
-            `let`: self.let,
+            letValue: self.let,
             maxTimeMS: self.maxTimeMS,
             projection: self.projection,
             remove: true,
@@ -278,8 +277,7 @@ public struct FindOneAndReplaceOptions: FindAndModifyOptionsConvertible, Decodab
             bypassDocumentValidation: self.bypassDocumentValidation,
             collation: self.collation,
             hint: self.hint,
-            // swiftlint:disable:next colon
-            `let`: self.let,
+            letValue: self.let,
             maxTimeMS: self.maxTimeMS,
             projection: self.projection,
             returnDocument: self.returnDocument,
@@ -357,8 +355,7 @@ public struct FindOneAndUpdateOptions: FindAndModifyOptionsConvertible, Decodabl
             bypassDocumentValidation: self.bypassDocumentValidation,
             collation: self.collation,
             hint: self.hint,
-            // swiftlint:disable:next colon
-            `let`: self.let,
+            letValue: self.let,
             maxTimeMS: self.maxTimeMS,
             projection: self.projection,
             returnDocument: self.returnDocument,

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -17,6 +17,8 @@ internal class FindAndModifyOptions {
     /// Initializes a new `FindAndModifyOptions` with the given settings.
     ///
     /// - Throws: `MongoError.InvalidArgumentError` if any of the options are invalid.
+    /// We use `letValue` rather than `let` for the parameter label because older Swift versions require escaping `let`
+    // in argument lists, but newer ones do not, and will generate compiler warnings if the label is escaped.
     // swiftlint:disable:next cyclomatic_complexity
     internal init(
         arrayFilters: [BSONDocument]? = nil,

--- a/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
+++ b/Sources/MongoSwift/Operations/FindAndModifyOperation.swift
@@ -23,7 +23,7 @@ internal class FindAndModifyOptions {
         bypassDocumentValidation: Bool? = nil,
         collation: BSONDocument?,
         hint: IndexHint? = nil,
-        `let`: BSONDocument? = nil,
+        letValue: BSONDocument? = nil,
         maxTimeMS: Int?,
         projection: BSONDocument?,
         remove: Bool? = nil,
@@ -89,7 +89,7 @@ internal class FindAndModifyOptions {
             case let .indexSpec(doc): extra["hint"] = .document(doc)
             }
         }
-        if let lt = `let` {
+        if let lt = letValue {
             extra["let"] = .document(lt)
         }
 


### PR DESCRIPTION
On Swift 5.1, keywords such as `let` need to be escaped in argument lists, but this was changed in some intermediate Swift version, and on newer versions of Swift the escape generates a compiler warning.

Initially I thought I would use #if swift to define this code conditionally to avoid the warning on newer versions. However, this problem only happens when calling the initializer for `FindAndModifyOptions` which is an internal type, so it seemed simpler to just change the label and avoid branching logic.