### PR TITLE
SWIFT-1383 Test that driver only creates implicit session after connection checkout

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1399,7 +1399,7 @@ buildvariants:
   display_name: "${sanitize} ${os-fully-featured} ${ssl-auth}"
   matrix_spec:
     os-fully-featured: "ubuntu-18.04"
-    swift-version: "5.5"
+    swift-version: "5.4" # TODO SWIFT-1499: update to Swift 5.5
     ssl-auth: "*"
     sanitize: "tsan"
   tasks:

--- a/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftSyncTests/ClientSessionTests.swift
@@ -320,6 +320,8 @@ final class SyncClientSessionTests: MongoSwiftTestCase {
         }
     }
 
+    /// Sessions spec test 13 was easier to write with concurrency and lives in MongoSwiftTests/AsyncAwaitTests.swift.
+
     /// Test that causal consistency guarantees are met on deployments that support cluster time.
     func testCausalConsistency() throws {
         guard MongoSwiftTestCase.topologyType != .single else {
@@ -511,17 +513,6 @@ final class SyncClientSessionTests: MongoSwiftTestCase {
             let startedEvents = monitor.commandStartedEvents()
             expect(startedEvents).to(haveCount(1))
             expect(startedEvents[0].command["readConcern"]?.documentValue?["afterClusterTime"]).to(beNil())
-        }
-
-        // Causal consistency spec test 10: When an unacknowledged write is executed in a causally consistent
-        // ClientSession the operationTime property of the ClientSession is not updated
-        try client.withSession(options: ClientSessionOptions(causalConsistency: true)) { session in
-            let collection1 = db.collection(
-                self.getCollectionName(),
-                options: MongoCollectionOptions(writeConcern: try WriteConcern(w: .number(0)))
-            )
-            try collection1.insertOne(["x": 3])
-            expect(session.operationTime).to(beNil())
         }
     }
 


### PR DESCRIPTION
This didn't require any driver changes, but there was a prose test added so I went ahead with writing that. 

Prose test description:
```
To confirm that implicit sessions only allocate their server session after a successful connection checkout

    * Create a MongoClient with the following options: ``maxPoolSize=1`` and ``retryWrites=true``
    * Attach a command started listener that collects each command's lsid
    * Initiate the following concurrent operations
      * insertOne
      * deleteOne
      * updateOne
      * bulkWrite ``[ { updateOne } ]``
      * findOneAndDelete
      * findOneAndUpdate
      * findOneAndReplace
      * find
    * Wait for all operations to complete
    * Assert that all commands contain the same lsid
```
