### PR TITLE
Automatically use latest patch for each Swift release in CI

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -334,6 +334,26 @@ functions:
       params:
         working_dir: "src"
         script: |
+          set -o xtrace
+          set -o errexit
+
+          if [ "${SWIFT_MINOR_VERSION}" = "main-snapshot" ]; then
+              export SWIFT_VERSION="${SWIFT_MINOR_VERSION}"
+          else
+              # otherwise, find the latest patch release for the specified version
+              ${PYTHON} -m virtualenv ./requests-env
+              ./requests-env/${VENV_BIN_DIR}/python3 -m pip install requests
+              export SWIFT_VERSION="$(./requests-env/${VENV_BIN_DIR}/python3 .evergreen/get_latest_swift_patch.py ${SWIFT_MINOR_VERSION})"
+          fi
+          echo "SWIFT_VERSION: $SWIFT_VERSION" > swift-version.yml
+          cat swift-version.yml
+    - command: expansions.update
+      params:
+        file: src/swift-version.yml
+    - command: shell.exec
+      params:
+        working_dir: "src"
+        script: |
           ${PREPARE_SHELL}
           SWIFT_VERSION=${SWIFT_VERSION} \
             sh ${PROJECT_DIRECTORY}/.evergreen/install-swift.sh
@@ -1094,27 +1114,27 @@ axes:
       - id: "5.1"
         display_name: "Swift 5.1"
         variables:
-           SWIFT_VERSION: "5.1.5"
+           SWIFT_MINOR_VERSION: "5.1"
       - id: "5.2"
         display_name: "Swift 5.2"
         variables:
-           SWIFT_VERSION: "5.2.5"
+           SWIFT_MINOR_VERSION: "5.2"
       - id: "5.3"
         display_name: "Swift 5.3"
         variables:
-          SWIFT_VERSION: "5.3.3"      
+          SWIFT_MINOR_VERSION: "5.3"      
       - id: "5.4"
         display_name: "Swift 5.4"
         variables:
-          SWIFT_VERSION: "5.4.2"
+          SWIFT_MINOR_VERSION: "5.4"
       - id: "5.5"
         display_name: "Swift 5.5"
         variables:
-          SWIFT_VERSION: "5.5.1"
+          SWIFT_MINOR_VERSION: "5.5"
       - id: "5.6-dev"
         display_name: "Swift 5.6-dev"
         variables:
-          SWIFT_VERSION: "main-snapshot"
+          SWIFT_MINOR_VERSION: "main-snapshot"
 
   - id: ssl-auth
     display_name: SSL and Auth

--- a/.evergreen/get_latest_swift_patch.py
+++ b/.evergreen/get_latest_swift_patch.py
@@ -1,0 +1,33 @@
+import re
+import requests
+import sys
+
+# This script accepts a version number in the form "x.y" as an argument. It will query the Swift Github
+# repo for releases and find the latest x.y.z patch release if available, and print out the matching tag.
+
+if len(sys.argv) != 2:
+    print("Expected 1 argument, but got: {}".format(sys.argv[1:]))
+    exit(1)
+
+version = sys.argv[1]
+components = version.split('.')
+if len(components) != 2:
+    print("Expected version number in form x.y, got {}".format(version))
+    exit(1)
+
+major = components[0]
+minor = components[1]
+
+version_regex = '^swift-{}\.{}(\.\d+)?-RELEASE$'.format(major, minor)
+
+release_data = requests.get('https://api.github.com/repos/apple/swift/releases').json()
+tag_names = map(lambda release: release['tag_name'], release_data)
+
+matching_tags = sorted(filter(lambda tag: re.match(version_regex, tag) is not None, tag_names), reverse=True)
+if len(matching_tags) == 0:
+    print("No tags matching {} found".format(version))
+    exit(1)
+
+# full name is swift-x.y.z-release, drop the prefix and suffix.
+tag_split = matching_tags[0].split('-')
+print(tag_split[1])


### PR DESCRIPTION
We now specify Swift versions of the form x.y, and at installation time query the Swift GitHub repo to find the latest matching release tag and write the value to a file.
We then add an expansion to set the SWIFT_VERSION variable used throughout the config/test scripts.