### PR TITLE
SWIFT-1464 Test server selection read preference validation

### DIFF
--- a/Sources/MongoSwift/ServerSelection.swift
+++ b/Sources/MongoSwift/ServerSelection.swift
@@ -107,7 +107,7 @@ extension TopologyDescription {
         readPreference: ReadPreference,
         heartbeatFrequencyMS: Int
     ) throws -> [ServerDescription] {
-        try readPreference.validateMaxStalenessSeconds(
+        try readPreference.validateForServerSelection(
             heartbeatFrequencyMS: heartbeatFrequencyMS,
             topologyType: self.type
         )
@@ -267,7 +267,7 @@ extension ServerDescription {
 }
 
 extension ReadPreference {
-    fileprivate func validateMaxStalenessSeconds(
+    fileprivate func validateForServerSelection(
         heartbeatFrequencyMS: Int,
         topologyType: TopologyDescription.TopologyType
     ) throws {
@@ -293,6 +293,11 @@ extension ReadPreference {
                     )
                 }
             }
+        }
+        if let tagSets = self.tagSets, tagSets.contains(where: { !$0.isEmpty }) && self.mode == .primary {
+            throw MongoError.InvalidArgumentError(
+                message: "A non-empty tag set cannot be specified when the read preference mode is primary"
+            )
         }
     }
 }

--- a/Tests/MongoSwiftTests/ServerSelectionTests.swift
+++ b/Tests/MongoSwiftTests/ServerSelectionTests.swift
@@ -209,5 +209,23 @@ final class ServerSelectionTests: MongoSwiftTestCase {
             }
         }
     }
+    
+    func testReadPreferenceValidation() throws {
+        var readPreference = ReadPreference.primary
+        readPreference.tagSets = [["tag": "set"]]
+        let topology = TopologyDescription(type: .single, servers: [])
+        expect(try topology.findSuitableServers(readPreference: readPreference, heartbeatFrequencyMS: 0))
+            .to(throwError(errorType: MongoError.InvalidArgumentError.self))
+
+        readPreference.tagSets = [[:]]
+        expect(try topology.findSuitableServers(readPreference: readPreference, heartbeatFrequencyMS: 0))
+            .toNot(throwError())
+
+        readPreference.tagSets = nil
+        expect(try topology.findSuitableServers(readPreference: readPreference, heartbeatFrequencyMS: 0))
+            .toNot(throwError())
+    }
+
+    // TODO: SWIFT-1496: Implement the remaining server selection tests
 }
 #endif

--- a/Tests/MongoSwiftTests/ServerSelectionTests.swift
+++ b/Tests/MongoSwiftTests/ServerSelectionTests.swift
@@ -209,7 +209,7 @@ final class ServerSelectionTests: MongoSwiftTestCase {
             }
         }
     }
-    
+
     func testReadPreferenceValidation() throws {
         var readPreference = ReadPreference.primary
         readPreference.tagSets = [["tag": "set"]]


### PR DESCRIPTION
This PR adds the remaining unimplemented test work defined in the [server selection test plan](https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection-tests.rst).