### PR TITLE
SWIFT-1510 Lower #available checks to run automatic cleanup in deinits to macOS 10.15+

### DIFF
--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -29,6 +29,7 @@ if [ "$OS" == "darwin" ]; then
         sudo xcode-select -s /Applications/Xcode12.app
     fi
 
+    # TODO SWIFT-1421: remove this once we have new Xcode on Evergreen to test with
     export DYLD_LIBRARY_PATH=${SWIFTENV_ROOT}/versions/${SWIFT_VERSION}/usr/lib/swift/macosx/
 fi
 

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -28,6 +28,8 @@ if [ "$OS" == "darwin" ]; then
     else
         sudo xcode-select -s /Applications/Xcode12.app
     fi
+
+    export DYLD_LIBRARY_PATH=${SWIFTENV_ROOT}/versions/${SWIFT_VERSION}/usr/lib/swift/macosx/
 fi
 
 # switch to current Swift version

--- a/.github/workflows/test-swift-concurrency.yml
+++ b/.github/workflows/test-swift-concurrency.yml
@@ -1,0 +1,36 @@
+name: Test concurrency APIs on macOS
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  
+env:
+  MONGODB_VERSION: 5.0.6
+
+jobs:
+  test-concurrency:
+    runs-on: macos-latest
+
+    steps:
+    - name: Check out
+      uses: actions/checkout@v2
+    - name: Download MongoDB
+      run: |
+        curl https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-${MONGODB_VERSION}.tgz --output mongodb.tgz
+        tar -xzf mongodb.tgz
+    - name: Start mongod
+      run: |
+        mkdir dbpath
+        ./mongodb-macos-x86_64-${MONGODB_VERSION}/bin/mongod --dbpath dbpath --replSet repl0 &
+    - name: Initiate replica set
+      run: |
+        ./mongodb-macos-x86_64-${MONGODB_VERSION}/bin/mongo --eval "rs.initiate()"
+    - name: Build
+      run: swift build
+    - name: Run tests
+      run: swift test --filter AsyncAwait
+      env:
+        MONGODB_TOPOLOGY: replica_set
+        MONGODB_URI: mongodb://localhost:27017/?replicaSet=repl0

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -288,7 +288,7 @@ public class ChangeStream<T: Codable>: CursorProtocol {
     /// When concurrency is available, we can ensure change streams are always cleaned up properly.
     deinit {
         // We can't do this with an @available check on the method; see https://bugs.swift.org/browse/SR-15537.
-        guard #available(macOS 12, *) else {
+        guard #available(macOS 10.15, *) else {
             return
         }
         let client = self.client

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -334,7 +334,7 @@ public final class ClientSession {
     /// Cleans up internal state.
     deinit {
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-        if #available(macOS 12, *) {
+        if #available(macOS 10.15, *) {
             // Pull out all necessary values into new references to avoid referencing `self` within the `Task`, since
             // the `Task` is going to outlive `self`.
             switch self.state {

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -272,7 +272,7 @@ public class MongoCursor<T: Codable>: CursorProtocol {
     /// When concurrency is available, we can ensure cursors are always cleaned up properly.
     deinit {
         // We can't do this with an @available check on the method; see https://bugs.swift.org/browse/SR-15537.
-        guard #available(macOS 12, *) else {
+        guard #available(macOS 10.15, *) else {
             return
         }
         let client = self.client

--- a/Tests/MongoSwiftTests/AsyncAwaitTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTestUtils.swift
@@ -146,7 +146,7 @@ extension MongoClient {
     }
 }
 
-@available(macOS 12, *)
+@available(macOS 10.15, *)
 extension TestCommandMonitor {
     /// Capture events that occur while the the provided closure executes.
     public func captureEvents<T>(_ f: () async throws -> T) async rethrows -> T {

--- a/Tests/MongoSwiftTests/AsyncAwaitTests.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTests.swift
@@ -1,9 +1,4 @@
-#if compiler(>=5.5.2) && canImport(_Concurrency) && os(Linux)
-// TODO: SWIFT-1421 remove this comment and the os(Linux) check above. if the described bug is not fixed, we'll need to
-// adjust our macOS < 12 testing to skip these tests by providing a filter to `swift test`.
-// we shouldn't have to check the operating system here, but there is a bug currently where on older macOS versions
-// the @available checks don't work. since we don't have support for macOS 12+ in CI, we can work around this by just
-// only defining the tests on Linux for now.
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Foundation
 @testable import MongoSwift


### PR DESCRIPTION
1) Fixes a bug where automatic cleanup in deinit would not happen for cursors/change streams/sessions on macOS < 12, even when concurrency is available

2) Adds a GitHub action to start running concurrency tests on macOS 11 + Xcode 13.2. Once [BUILD-14630](https://jira.mongodb.org/browse/BUILD-14630) is complete we can do this on Evergreen instead.

3) step 2 required removing the compiler directive to only define our concurrency-specific tests on Linux. doing so led our Evergreen tests to start failing, because despite being on macOS 10.15 where concurrency is now available, those still use a very old Xcode version whose bundled macOS SDK does not include the concurrency library. so while the Swift compiler can _import_ `_Concurrency`, the concurrency library is not actually there to _load_. after doing some research, I realized it is possible to work around the old Xcode version by setting the `DYLD_LIBRARY_PATH` manually -- the concurrency library _does_ ship with the Swift 5.5.3 toolchain, but SwiftPM seems to default to looking at the `DYLD_LIBRARY_PATH` for the system Swift version that ships with Xcode. so I have gone ahead and done that, and it actually enables us to run all of our concurrency tests on macOS on Evergreen now! 🥳

my discovery in step 3 perhaps makes the GitHub action less useful, though arguably it is still somewhat valuable to test that things work in the "normal" way with more recent macOS + Xcode without having to set `DYLD_LIBRARY_PATH`, so I left it in for now... thoughts on whether we should keep it?