### PR TITLE
SWIFT-1277, SWIFT-1263, SWIFT-1507 Sync latest initial DNS seedlist discovery tests

### DIFF
--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -77,6 +77,14 @@ public struct MongoClientOptions: CodingStrategyProvider {
     /// seconds (30000 ms).
     public var serverSelectionTimeoutMS: Int?
 
+    /// The maximum number of SRV results to randomly select when initially populating the seedlist or, during SRV
+    /// polling, adding new hosts to the topology.
+    public var srvMaxHosts: Int?
+
+    /// The service name to use for SRV lookup. Must be a valid SRV service name according to RFC 6335.
+    /// -SeeAlso: https://datatracker.ietf.org/doc/html/rfc6335#section-5.1
+    public var srvServiceName: String?
+
     /**
      * `MongoSwift.MongoClient` provides an asynchronous API by running all blocking operations off of their
      * originating threads in a thread pool. `MongoSwiftSync.MongoClient` is implemented as a wrapper of the async
@@ -158,6 +166,8 @@ public struct MongoClientOptions: CodingStrategyProvider {
         retryWrites: Bool? = nil,
         serverAPI: MongoServerAPI? = nil,
         serverSelectionTimeoutMS: Int? = nil,
+        srvMaxHosts: Int? = nil,
+        srvServiceName: String? = nil,
         threadPoolSize: Int? = nil,
         tls: Bool? = nil,
         tlsAllowInvalidCertificates: Bool? = nil,
@@ -187,6 +197,8 @@ public struct MongoClientOptions: CodingStrategyProvider {
         self.retryWrites = retryWrites
         self.retryReads = retryReads
         self.serverAPI = serverAPI
+        self.srvMaxHosts = srvMaxHosts
+        self.srvServiceName = srvServiceName
         self.serverSelectionTimeoutMS = serverSelectionTimeoutMS
         self.threadPoolSize = threadPoolSize
         self.tls = tls

--- a/Sources/MongoSwift/MongoConnectionString.swift
+++ b/Sources/MongoSwift/MongoConnectionString.swift
@@ -604,6 +604,12 @@ public struct MongoConnectionString: Codable, LosslessStringConvertible {
         if let serverSelectionTimeoutMS = options.serverSelectionTimeoutMS {
             self.serverSelectionTimeoutMS = serverSelectionTimeoutMS
         }
+        if let srvMaxHosts = options.srvMaxHosts {
+            self.srvMaxHosts = srvMaxHosts
+        }
+        if let srvServiceName = options.srvServiceName {
+            self.srvServiceName = srvServiceName
+        }
         if let tls = options.tls {
             self.tls = tls
         }

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -90,11 +90,6 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
 
     func runDNSSeedlistTests(_ tests: [(String, DNSSeedlistTestCase)]) throws {
         for (fileName, testCase) in tests {
-            // TODO: SWIFT-1455: unskip these test
-            if fileName == "loadBalanced-no-results.json" || fileName == "loadBalanced-true-multiple-hosts.json" {
-                continue
-            }
-
             // this particular test case requires SSL is disabled. see DRIVERS-1324.
             let requiresTLS = fileName != "txt-record-with-overridden-ssl-option.json"
 
@@ -108,14 +103,8 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
 
             let topologyWatcher = TopologyDescriptionWatcher()
 
-            let opts: MongoClientOptions?
-            if requiresTLS {
-                opts = MongoClientOptions(tlsAllowInvalidCertificates: true)
-            } else {
-                opts = nil
-            }
             do {
-                try self.withTestClient(testCase.uri, options: opts) { client in
+                try self.withTestClient(testCase.uri) { client in
                     client.addSDAMEventHandler(topologyWatcher)
 
                     // try selecting a server to trigger SDAM

--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -103,12 +103,17 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
 
             let topologyWatcher = TopologyDescriptionWatcher()
 
+            let opts: MongoClientOptions?
+            if requiresTLS {
+                opts = MongoClientOptions(tlsAllowInvalidCertificates: true)
+            } else {
+                opts = nil
+            }
             do {
-                try self.withTestClient(testCase.uri) { client in
+                try self.withTestClient(testCase.uri, options: opts) { client in
                     client.addSDAMEventHandler(topologyWatcher)
 
-                    // try selecting a server to trigger SDAM
-                    _ = try client.connectionPool.selectServer(forWrites: false)
+                    _ = try client.db("admin").runCommand(["ping": 1]).wait()
 
                     guard testCase.error != true else {
                         XCTFail("Expected error for test case \(testCase.comment ?? ""), got none")

--- a/Tests/Specs/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/Tests/Specs/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -10,8 +10,8 @@ Initial DNS Seedlist Discovery
 :Authors: Derick Rethans
 :Status: Draft
 :Type: Standards
-:Last Modified: 2019-03-07
-:Version: 1.3.2
+:Last Modified: 2021-10-14
+:Version: 1.6.0
 :Spec Lead: Matt Broadstone
 :Advisory Group: \A. Jesse Jiryu Davis
 :Approver(s): Bernie Hackett, David Golden, Jeff Yemin, Matt Broadstone, A. Jesse Jiryu Davis
@@ -48,6 +48,9 @@ interpreted as described in `RFC 2119 <https://www.ietf.org/rfc/rfc2119.txt>`_.
 Specification
 =============
 
+Connection String Format
+------------------------
+
 The connection string parser in the driver is extended with a new protocol
 ``mongodb+srv`` as a logical pre-processing step before it considers the
 connection string and SDAM specifications. In this protocol, the comma
@@ -61,33 +64,59 @@ format is::
 specification following the ``Host Information``. This includes the ``Auth
 database`` and ``Connection Options``.
 
+
+MongoClient Configuration
+-------------------------
+
+srvMaxHosts
+~~~~~~~~~~~
+
+This option is used to limit the number of mongos connections that may be
+created for sharded topologies. This option limits the number of SRV records
+used to populate the seedlist during initial discovery, as well as the number of
+additional hosts that may be added during
+`SRV polling <../polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst>`_.
+This option requires a non-negative integer and defaults to zero (i.e. no
+limit). This option MUST only be configurable at the level of a ``MongoClient``.
+
+
+srvServiceName
+~~~~~~~~~~~~~~
+
+This option specifies a valid SRV service name according to
+`RFC 6335 <https://datatracker.ietf.org/doc/html/rfc6335#section-5.1>`_, with
+the exception that it may exceed 15 characters as long as the 63rd (62nd with
+prepended underscore) character DNS query limit is not surpassed. This option
+requires a string value and defaults to "mongodb". This option MUST only be
+configurable at the level of a ``MongoClient``.
+
+
+URI Validation
+~~~~~~~~~~~~~~
+
+The driver MUST report an error if either the ``srvServiceName`` or
+``srvMaxHosts`` URI options are specified with a non-SRV URI (i.e. scheme other
+than ``mongodb+srv``). The driver MUST allow specifying the ``srvServiceName``
+and ``srvMaxHosts`` URI options with an SRV URI (i.e. ``mongodb+srv`` scheme).
+
+If ``srvMaxHosts`` is a positive integer, the driver MUST throw an error in the
+following cases:
+
+- The connection string contains a ``replicaSet`` option.
+- The connection string contains a ``loadBalanced`` option with a value of
+  ``true``.
+
+When validating URI options, the driver MUST first do the SRV and TXT lookup and
+then perform the validation. For drivers that do SRV lookup asynchronously this
+may result in a ``MongoClient`` being instantiated but erroring later during
+operation execution.
+
+
 Seedlist Discovery
 ------------------
 
-In this preprocessing step, the driver will query the DNS server for SRV
-records on ``{hostname}.{domainname}``, prefixed with ``_mongodb._tcp.``:
-``_mongodb._tcp.{hostname}.{domainname}``. This DNS query is expected to
-respond with one or more SRV records. From the DNS result, the driver now MUST
-behave the same as if an ``mongodb://`` URI was provided with all the host
-names and port numbers that were returned as part of the DNS SRV query result.
-
-The priority and weight fields in returned SRV records MUST be ignored.
-
-If ``mongodb+srv`` is used, a driver MUST implicitly also enable TLS. Clients
-can turn this off by passing ``ssl=false`` in either the Connection String,
-or options passed in as parameters in code to the MongoClient constructor (or
-equivalent API for each driver), but not through a TXT record (discussed in
-the next section).
-
-A driver MUST verify that in addition to the ``{hostname}``, the
-``{domainname}`` consists of at least two parts: the domain name, and a TLD.
-Drivers MUST raise an error and MUST NOT contact the DNS server to obtain SRV
-(or TXT records) if the full URI does not consists of at least three parts.
-
-A driver MUST verify that the host names returned through SRV records have the
-same parent ``{domainname}``. Drivers MUST raise an error and MUST NOT
-initiate a connection to any returned host name which does not share the same
-``{domainname}``.
+Validation Before Querying DNS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is an error to specify a port in a connection string with the
 ``mongodb+srv`` protocol, and the driver MUST raise a parse error and MUST NOT
@@ -97,13 +126,53 @@ It is an error to specify more than one host name in a connection string with
 the ``mongodb+srv`` protocol, and the driver MUST raise a parse error and MUST
 NOT do DNS resolution or contact hosts.
 
-The driver MUST NOT attempt to connect to any hosts until the DNS query has
-returned its results.
+A driver MUST verify that in addition to the ``{hostname}``, the
+``{domainname}`` consists of at least two parts: the domain name, and a TLD.
+Drivers MUST raise an error and MUST NOT contact the DNS server to obtain SRV
+(or TXT records) if the full URI does not consist of at least three parts.
+
+If ``mongodb+srv`` is used, a driver MUST implicitly also enable TLS. Clients
+can turn this off by passing ``tls=false`` in either the Connection String,
+or options passed in as parameters in code to the MongoClient constructor (or
+equivalent API for each driver), but not through a TXT record (discussed in a
+later section).
+
+
+Querying DNS
+~~~~~~~~~~~~
+
+In this preprocessing step, the driver will query the DNS server for SRV records
+on ``{hostname}.{domainname}``, prefixed with the SRV service name and protocol.
+The SRV service name is provided in the ``srvServiceName`` URI option and
+defaults to ``mongodb``. The protocol is always ``tcp``. After prefixing, the
+URI should look like: ``_{srvServiceName}._tcp.{hostname}.{domainname}``. This
+DNS query is expected to respond with one or more SRV records.
+
+The priority and weight fields in returned SRV records MUST be ignored.
 
 If the DNS result returns no SRV records, or no records at all, or a DNS error
 happens, an error MUST be raised indicating that the URI could not be used to
 find hostnames. The error SHALL include the reason why they could not be
 found.
+
+A driver MUST verify that the host names returned through SRV records have the
+same parent ``{domainname}``. Drivers MUST raise an error and MUST NOT
+initiate a connection to any returned host name which does not share the same
+``{domainname}``.
+
+The driver MUST NOT attempt to connect to any hosts until the DNS query has
+returned its results.
+
+If ``srvMaxHosts`` is zero or greater than or equal to the number of hosts in
+the DNS result, the driver MUST populate the seedlist with all hosts.
+
+If ``srvMaxHosts`` is greater than zero and less than the number of hosts in the
+DNS result, the driver MUST randomly select that many hosts and use them to
+populate the seedlist. Drivers SHOULD use the `Fisher-Yates shuffle`_ for
+randomization.
+
+.. _`Fisher-Yates shuffle`: https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+
 
 Default Connection String Options
 ---------------------------------
@@ -122,8 +191,8 @@ raise an error when multiple TXT records are encountered.
 Information returned within a TXT record is a simple URI string, just like
 the ``{options}`` in a connection string.
 
-A Client MUST only support the ``authSource`` and ``replicaSet`` options
-through a TXT record, and MUST raise an error if any other option is
+A Client MUST only support the ``authSource``, ``replicaSet``, and ``loadBalanced``
+options through a TXT record, and MUST raise an error if any other option is
 encountered. Although using ``mongodb+srv://`` implicitly enables TLS, a
 Client MUST NOT allow the ``ssl`` option to be set through a TXT record
 option.
@@ -273,6 +342,18 @@ SRV records.
 
 ChangeLog
 =========
+
+2021-10-14 - 1.6.0
+    Add ``srvMaxHosts`` MongoClient option and restructure Seedlist Discovery
+    section. Improve documentation for the ``srvServiceName`` MongoClient
+    option and add a new URI Validation section.
+
+2021-09-15 - 1.5.0
+    Clarify that service name only defaults to ``mongodb``, and should be
+    defined by the ``srvServiceName`` URI option.
+
+2021-04-15 - 1.4.0
+    Adding in behaviour for load balancer mode.
 
 2019-03-07 - 1.3.2
     Clarify that CNAME is not supported

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true (TXT)"
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true"
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0",
   "seeds": [
     "localhost.test.build.10gen.cc:8000"
   ],
@@ -8,7 +8,7 @@
   ],
   "options": {
     "loadBalanced": true,
-    "ssl": true,
-    "directConnection": false
+    "srvMaxHosts": 0,
+    "ssl": true
   }
 }

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false",
+  "uri": "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
   "seeds": [
     "localhost.test.build.10gen.cc:8000"
   ],
@@ -8,7 +8,7 @@
   ],
   "options": {
     "loadBalanced": true,
-    "ssl": true,
-    "directConnection": false
+    "srvMaxHosts": 0,
+    "ssl": true
   }
 }

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true,
+    "srvServiceName": "customname"
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with replicaSet option (TXT)"
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-conflicts_with_replicaSet.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-conflicts_with_replicaSet.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with replicaSet option"
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-equal_to_srv_records.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-equal_to_srv_records.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
+  "numSeeds": 2,
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 2,
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-greater_than_srv_records.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-greater_than_srv_records.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 3,
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-less_than_srv_records.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-less_than_srv_records.json
@@ -1,0 +1,13 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1",
+  "numSeeds": 1,
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 1,
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero-txt.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero-txt.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "authSource": "thisDB",
+    "replicaSet": "repl0",
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-equal_to_srv_records.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-equal_to_srv_records.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
+  "numSeeds": 2,
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 2,
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-greater_than_srv_records.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-greater_than_srv_records.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 3,
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-less_than_srv_records.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-less_than_srv_records.json
@@ -1,0 +1,9 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1",
+  "numSeeds": 1,
+  "numHosts": 1,
+  "options": {
+    "srvMaxHosts": 1,
+    "ssl": true
+  }
+}

--- a/Tests/Specs/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-zero.json
+++ b/Tests/Specs/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-zero.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}


### PR DESCRIPTION
This sync the latest copy of the initial DNS seedlist discovery tests and makes some modifications to the runner to support running them.

With this PR we can also close out SWIFT-1277 and SWIFT-1263 -- Isabel added Swift support for these options in the new connection string type and our latest vendor of libmongoc brought in the libmongoc support. We already have synced the corresponding URI options tests. I did notice that we didn't add these options to `MongoClientOptions` though so I went ahead with doing that here for completeness.

See mongodb/mongo-rust-driver#595 for equivalent Rust changes. 