### PR TITLE
Create user so ping succeeds in DNS seedlist tests

### DIFF
--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -167,9 +167,12 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                     // eventually matches the list of hosts."
                     // This needs to be done before the client leaves scope to ensure the SDAM machinery
                     // keeps running.
-                    if let expectedHosts = testCase.hosts {
-                        expect(topologyWatcher.getLastDescription()?.servers.map { $0.address })
-                            .toEventually(equal(expectedHosts), timeout: 5)
+                    if let expectedHosts = testCase.hosts?.sorted(by: { $0.description < $1.description }) {
+                        expect(
+                            topologyWatcher.getLastDescription()?
+                                .servers.map { $0.address }
+                                .sorted { $0.description < $1.description }
+                        ).toEventually(equal(expectedHosts), timeout: 5)
                     } else if let expectedNumHosts = testCase.numHosts {
                         expect(topologyWatcher.getLastDescription()?.servers)
                             .toEventually(haveCount(expectedNumHosts), timeout: 5)


### PR DESCRIPTION
It seems like I forgot to re-run these with auth on after adding the ping command. This led tests to start failing because the user we attempt to authenticate as doesn't exist.

Added logic to create the missing user if needed, inspired by corresponding Rust logic: https://github.com/mongodb/mongo-rust-driver/blob/0a50512aa0178f88bec2a1dc651f93e0b08a4f12/src/test/spec/initial_dns_seedlist_discovery.rs#L139-L157
