### PR TITLE
SWIFT-1519 Test Swift 5.6 in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1093,7 +1093,7 @@ axes:
         run_on: macos-1100
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
-          VENV_BIN_DIR: "bin"    
+          VENV_BIN_DIR: "bin"
 
   - id: topology
     display_name: Topology
@@ -1251,7 +1251,7 @@ buildvariants:
 
 - matrix_name: "min-version-compile"
   matrix_spec:
-  # Ubuntu 20.04 does not have Swift 5.1 toolchains
+  # Ubuntu 20.04 does not have Swift 5.1 toolchains.
     os-fully-featured:
       - "macos-11"
       - "ubuntu-18.04"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1133,8 +1133,12 @@ axes:
         display_name: "Swift 5.5"
         variables:
           SWIFT_MINOR_VERSION: "5.5"
-      - id: "5.6-dev"
-        display_name: "Swift 5.6-dev"
+      - id: "5.6"
+        display_name: "Swift 5.6"
+        variables:
+          SWIFT_MINOR_VERSION: "5.6"
+      - id: "5.7-dev"
+        display_name: "Swift 5.7-dev"
         variables:
           SWIFT_MINOR_VERSION: "main-snapshot"
 
@@ -1260,9 +1264,9 @@ buildvariants:
   matrix_spec:
     os-fully-featured: "*"
     swift-version:
-      - "5.4"
       - "5.5"
-      - "5.6-dev"
+      - "5.6"
+      - "5.7-dev"
     ssl-auth: "*"
   display_name: "${swift-version} ${os-fully-featured} ${ssl-auth}"
   tasks:
@@ -1301,8 +1305,8 @@ buildvariants:
   matrix_spec:
     os-fully-featured: "*"
     swift-version:
-      - "5.4"
       - "5.5"
+      - "5.6"
   display_name: "Atlas Connectivity ${swift-version} ${os-fully-featured}"
   tasks:
     - ".atlas-connect"
@@ -1314,8 +1318,8 @@ buildvariants:
       - "ubuntu-20.04"
     ssl-auth: "*"
     swift-version:
-      - "5.4"
       - "5.5"
+      - "5.6"
   display_name: "Load Balancer ${swift-version} ${os-fully-featured} ${ssl-auth}"
   tasks:
     - ".load-balancer"
@@ -1325,7 +1329,7 @@ buildvariants:
     os-fully-featured:
       - "ubuntu-18.04"
     swift-version:
-      - 5.4
+      - "5.6"
   display_name: "Serverless ${swift-version} ${os-fully-featured}"
   tasks:
     - "serverless_task_group"
@@ -1339,7 +1343,7 @@ buildvariants:
       - latest
       - 5.0
       - 4.4
-    swift-version: "5.5"
+    swift-version: "5.6"
   display_name: "OCSP ${swift-version} ${os-fully-featured} ${versions}"
   batchtime: 20160 # 14 days
   tasks:
@@ -1357,7 +1361,7 @@ buildvariants:
 - matrix_name: "ocsp-macos"
   matrix_spec:
     os-fully-featured: "macos-10.15"
-    swift-version: "5.5"
+    swift-version: "5.6"
     versions:
       - latest
       - 5.0
@@ -1372,7 +1376,7 @@ buildvariants:
 - matrix_name: "versioned-api-tests"
   matrix_spec:
     os-fully-featured: ubuntu-18.04
-    swift-version: "5.5"
+    swift-version: "5.6"
     versionedAPI: "*"
   display_name: "Versioned API ${versionedAPI} ${swift-version} ${os-fully-featured}"
   batchtime: 10080  # 7 days
@@ -1384,7 +1388,7 @@ buildvariants:
   display_name: "Format and Lint"
   matrix_spec:
     os-fully-featured: "ubuntu-18.04"
-    swift-version: "5.5"
+    swift-version: "5.6"
   tasks:
     - name: "check-format"
     - name: "check-lint"
@@ -1393,7 +1397,7 @@ buildvariants:
   display_name: "Check Sourcery"
   matrix_spec:
     os-fully-featured: "macos-10.15"
-    swift-version: "5.5"
+    swift-version: "5.6"
   tasks:
     - name: "check-sourcery"
 
@@ -1411,7 +1415,7 @@ buildvariants:
   display_name: "Leak Checker ${os-fully-featured} ${ssl-auth}"
   matrix_spec:
     os-fully-featured: "macos-10.15"
-    swift-version: "5.5"
+    swift-version: "5.6"
     ssl-auth: "*"
     check-leaks: "leaks"
   tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1088,12 +1088,12 @@ axes:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
 
-      - id: macos-10.15
-        display_name: "macOS 10.15"
-        run_on: macos-1015
+      - id: macos-11
+        display_name: "macOS 11"
+        run_on: macos-1100
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
-          VENV_BIN_DIR: "bin"
+          VENV_BIN_DIR: "bin"    
 
   - id: topology
     display_name: Topology
@@ -1251,9 +1251,9 @@ buildvariants:
 
 - matrix_name: "min-version-compile"
   matrix_spec:
-  # Ubuntu 20.04 does not have Swift 5.1 toolchains.
+  # Ubuntu 20.04 does not have Swift 5.1 toolchains
     os-fully-featured:
-      - "macos-10.15"
+      - "macos-11"
       - "ubuntu-18.04"
     swift-version: "5.1"
   display_name: "Compile ${swift-version} ${os-fully-featured}"
@@ -1360,7 +1360,7 @@ buildvariants:
 
 - matrix_name: "ocsp-macos"
   matrix_spec:
-    os-fully-featured: "macos-10.15"
+    os-fully-featured: "macos-11"
     swift-version: "5.6"
     versions:
       - latest
@@ -1396,7 +1396,7 @@ buildvariants:
 - matrix_name: "check-sourcery"
   display_name: "Check Sourcery"
   matrix_spec:
-    os-fully-featured: "macos-10.15"
+    os-fully-featured: "macos-11"
     swift-version: "5.6"
   tasks:
     - name: "check-sourcery"
@@ -1414,7 +1414,7 @@ buildvariants:
 - matrix_name: "leaks"
   display_name: "Leak Checker ${os-fully-featured} ${ssl-auth}"
   matrix_spec:
-    os-fully-featured: "macos-10.15"
+    os-fully-featured: "macos-11"
     swift-version: "5.6"
     ssl-auth: "*"
     check-leaks: "leaks"

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -22,13 +22,7 @@ if [ "$SWIFT_VERSION" = "main-snapshot" ]; then
 fi
 
 if [ "$OS" == "darwin" ]; then
-    ls /Applications
-    # 5.1, 5.2 require an older version of Xcode/Command Line Tools
-    if [[ "$SWIFT_VERSION" == 5.1.* || "$SWIFT_VERSION" == 5.2.* ]]; then
-        sudo xcode-select -s /Applications/Xcode12.app
-    else
-        sudo xcode-select -s /Applications/Xcode12.app
-    fi
+    sudo xcode-select -s /Applications/Xcode12.app
 
     # TODO SWIFT-1421: remove this once we have new Xcode on Evergreen to test with
     export DYLD_LIBRARY_PATH=${SWIFTENV_ROOT}/versions/${SWIFT_VERSION}/usr/lib/swift/macosx/

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -22,6 +22,7 @@ if [ "$SWIFT_VERSION" = "main-snapshot" ]; then
 fi
 
 if [ "$OS" == "darwin" ]; then
+    ls /Applications
     # 5.1, 5.2 require an older version of Xcode/Command Line Tools
     if [[ "$SWIFT_VERSION" == 5.1.* || "$SWIFT_VERSION" == 5.2.* ]]; then
         sudo xcode-select -s /Applications/Xcode11.3.app

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -25,7 +25,7 @@ if [ "$OS" == "darwin" ]; then
     ls /Applications
     # 5.1, 5.2 require an older version of Xcode/Command Line Tools
     if [[ "$SWIFT_VERSION" == 5.1.* || "$SWIFT_VERSION" == 5.2.* ]]; then
-        sudo xcode-select -s /Applications/Xcode11.3.app
+        sudo xcode-select -s /Applications/Xcode12.app
     else
         sudo xcode-select -s /Applications/Xcode12.app
     fi

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -24,7 +24,7 @@ fi
 if [ "$OS" == "darwin" ]; then
     # latest snapshots require a newer version of Xcode/Command Line Tools
     if [[ "$SWIFT_VERSION" == DEVELOPMENT-SNAPSHOT* ]]; then
-        sudo xcode-select -s /Applications/Xcode13.app
+        sudo xcode-select -s /Applications/Xcode13.1.app
     else
         sudo xcode-select -s /Applications/Xcode12.app
     fi

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -22,7 +22,12 @@ if [ "$SWIFT_VERSION" = "main-snapshot" ]; then
 fi
 
 if [ "$OS" == "darwin" ]; then
-    sudo xcode-select -s /Applications/Xcode12.app
+    # latest snapshots require a newer version of Xcode/Command Line Tools
+    if [[ "$SWIFT_VERSION" == DEVELOPMENT-SNAPSHOT* ]]; then
+        sudo xcode-select -s /Applications/Xcode13.app
+    else
+        sudo xcode-select -s /Applications/Xcode12.app
+    fi
 
     # TODO SWIFT-1421: remove this once we have new Xcode on Evergreen to test with
     export DYLD_LIBRARY_PATH=${SWIFTENV_ROOT}/versions/${SWIFT_VERSION}/usr/lib/swift/macosx/

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -40,6 +40,7 @@ if [ "$SANITIZE" != "false" ]; then
 fi
 
 # TODO SWIFT-1421: remove this, it is currently needed due to a bug in Xcode 13.0/13.1.
+# see: https://bugs.swift.org/browse/SR-14968
 if [ "$OS" == "darwin" ]; then
     if [[ "$SWIFT_VERSION" == DEVELOPMENT-SNAPSHOT* ]]; then
         EXTRA_FLAGS="-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"

--- a/Tests/MongoSwiftTests/AsyncAwaitTests.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTests.swift
@@ -224,6 +224,11 @@ final class MongoCursorAsyncAwaitTests: MongoSwiftTestCase {
 
     // Test that a tailable cursor that is continually polling the server can be killed by cancelling the parent Task.
     func testTailableCursorHandlesTaskCancellation() throws {
+        guard !MongoSwiftTestCase.serverless else {
+            printSkipMessage(testName: self.name, reason: "Serverless does not support capped collections")
+            return
+        }
+
         testAsync {
             let opts = CreateCollectionOptions(capped: true, size: 5)
             try await self.withTestNamespace(collectionOptions: opts) { _, _, coll in


### PR DESCRIPTION
SWIFT-1519

Updates so that the two latest versions we test against are 5.5 and 5.6, and renames the dev snapshot testing to 5.7-dev. 

successful evergreen patch: https://spruce.mongodb.com/version/62598ff4d1fe075aedb68b20/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC