### PR TITLE
Fix DNS seedlist tests on 3.6

### DIFF
--- a/Tests/MongoSwiftTests/DNSSeedlistTests.swift
+++ b/Tests/MongoSwiftTests/DNSSeedlistTests.swift
@@ -135,10 +135,6 @@ final class DNSSeedlistTests: MongoSwiftTestCase {
                     _ = try db.runCommand([
                         "createUser": .string(username),
                         "pwd": .string(password),
-                        "mechanisms": [
-                            "SCRAM-SHA-1",
-                            "SCRAM-SHA-256"
-                        ],
                         "roles": []
                     ]).wait()
                 }


### PR DESCRIPTION
I had just copied this logic from the Rust test runner, but it was causing the tests to fail on MongoDB 3.6 because the `createUser` command didn't support the `mechanisms` field until 4.0.  It seems it's not necessary to even specify it at all to get the tests to pass and I'm actually not sure why the Rust code does that, so I just removed it. 