### PR TITLE
SWIFT-1514 Add 'comment' option to EstimatedDocumentCount and CountDocuments Options

### DIFF
--- a/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
+++ b/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
@@ -5,7 +5,8 @@ public struct CountDocumentsOptions: Codable {
     /// Specifies a collation.
     public var collation: BSONDocument?
 
-    /// Attaches a comment to the query.
+    /// Enables users to specify an arbitrary BSON type to help trace the operation through
+    /// the database profiler, currentOp and logs. The default is to not send a value.
     public var comment: BSON?
 
     /// A hint for the index to use.

--- a/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
+++ b/Sources/MongoSwift/Operations/CountDocumentsOperation.swift
@@ -5,6 +5,9 @@ public struct CountDocumentsOptions: Codable {
     /// Specifies a collation.
     public var collation: BSONDocument?
 
+    /// Attaches a comment to the query.
+    public var comment: BSON?
+
     /// A hint for the index to use.
     public var hint: IndexHint?
 
@@ -28,6 +31,7 @@ public struct CountDocumentsOptions: Codable {
     /// Convenience initializer allowing any/all parameters to be optional
     public init(
         collation: BSONDocument? = nil,
+        comment: BSON? = nil,
         hint: IndexHint? = nil,
         limit: Int? = nil,
         maxTimeMS: Int? = nil,
@@ -36,6 +40,7 @@ public struct CountDocumentsOptions: Codable {
         skip: Int? = nil
     ) {
         self.collation = collation
+        self.comment = comment
         self.hint = hint
         self.limit = limit
         self.maxTimeMS = maxTimeMS
@@ -44,8 +49,8 @@ public struct CountDocumentsOptions: Codable {
         self.skip = skip
     }
 
-    private enum CodingKeys: String, CodingKey {
-        case collation, hint, limit, maxTimeMS, readConcern, skip
+    internal enum CodingKeys: String, CaseIterable, CodingKey {
+        case collation, comment, hint, limit, maxTimeMS, readConcern, skip
     }
 }
 

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -2,10 +2,9 @@ import CLibMongoC
 
 /// Options to use when executing an `estimatedDocumentCount` command on a `MongoCollection`.
 public struct EstimatedDocumentCountOptions: Codable {
-    
     /// Attaches a comment to the query.
     public var comment: String?
-    
+
     /// The maximum amount of time to allow the query to run.
     public var maxTimeMS: Int?
 

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -2,7 +2,8 @@ import CLibMongoC
 
 /// Options to use when executing an `estimatedDocumentCount` command on a `MongoCollection`.
 public struct EstimatedDocumentCountOptions: Codable {
-    /// Attaches a comment to the query.
+    /// Enables users to specify an arbitrary BSON type to help trace the operation through
+    /// the database profiler, currentOp and logs. The default is to not send a value.
     public var comment: BSON?
 
     /// The maximum amount of time to allow the query to run.

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -2,6 +2,10 @@ import CLibMongoC
 
 /// Options to use when executing an `estimatedDocumentCount` command on a `MongoCollection`.
 public struct EstimatedDocumentCountOptions: Codable {
+    
+    /// Attaches a comment to the query.
+    public var comment: String?
+    
     /// The maximum amount of time to allow the query to run.
     public var maxTimeMS: Int?
 
@@ -15,10 +19,12 @@ public struct EstimatedDocumentCountOptions: Codable {
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(
+        comment: String? = nil,
         maxTimeMS: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil
     ) {
+        self.comment = comment
         self.maxTimeMS = maxTimeMS
         self.readConcern = readConcern
         self.readPreference = readPreference

--- a/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
+++ b/Sources/MongoSwift/Operations/EstimatedDocumentCountOperation.swift
@@ -3,7 +3,7 @@ import CLibMongoC
 /// Options to use when executing an `estimatedDocumentCount` command on a `MongoCollection`.
 public struct EstimatedDocumentCountOptions: Codable {
     /// Attaches a comment to the query.
-    public var comment: String?
+    public var comment: BSON?
 
     /// The maximum amount of time to allow the query to run.
     public var maxTimeMS: Int?
@@ -18,7 +18,7 @@ public struct EstimatedDocumentCountOptions: Codable {
 
     /// Convenience initializer allowing any/all parameters to be optional
     public init(
-        comment: String? = nil,
+        comment: BSON? = nil,
         maxTimeMS: Int? = nil,
         readConcern: ReadConcern? = nil,
         readPreference: ReadPreference? = nil
@@ -30,7 +30,7 @@ public struct EstimatedDocumentCountOptions: Codable {
     }
 
     internal enum CodingKeys: String, CodingKey, CaseIterable {
-        case maxTimeMS, readConcern
+        case maxTimeMS, readConcern, comment
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/CrudTests.swift
+++ b/Tests/MongoSwiftSyncTests/CrudTests.swift
@@ -81,7 +81,9 @@ final class CrudTests: MongoSwiftTestCase {
             "deleteOne-let.json",
             "deleteMany-let.json",
             "updateOne-let.json",
-            "updateMany-let.json"
+            "updateMany-let.json",
+            // TODO: SWIFT-1515 unskip
+            "estimatedDocumentCount-comment.json"
         ]
         let files = try retrieveSpecTestFiles(
             specName: "crud",

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -55,11 +55,6 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
             EstimatedDocumentCountOptions(readConcern: .majority)
         )).toNot(throwError())
 
-        expect(try coll.estimatedDocumentCount(
-            options:
-            EstimatedDocumentCountOptions(comment: "hello world", readConcern: .majority)
-        )).toNot(throwError())
-
         expect(try coll.distinct(
             fieldName: "a",
             options: DistinctOptions(readConcern: .local)

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -54,6 +54,11 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
             options:
             EstimatedDocumentCountOptions(readConcern: .majority)
         )).toNot(throwError())
+        
+        expect(try coll.estimatedDocumentCount(
+            options:
+                EstimatedDocumentCountOptions(comment: "hello world", readConcern: .majority)
+        )).toNot(throwError())
 
         expect(try coll.distinct(
             fieldName: "a",

--- a/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
+++ b/Tests/MongoSwiftSyncTests/ReadWriteConcernOperationTests.swift
@@ -54,10 +54,10 @@ final class ReadWriteConcernOperationTests: MongoSwiftTestCase {
             options:
             EstimatedDocumentCountOptions(readConcern: .majority)
         )).toNot(throwError())
-        
+
         expect(try coll.estimatedDocumentCount(
             options:
-                EstimatedDocumentCountOptions(comment: "hello world", readConcern: .majority)
+            EstimatedDocumentCountOptions(comment: "hello world", readConcern: .majority)
         )).toNot(throwError())
 
         expect(try coll.distinct(

--- a/Tests/Specs/crud/tests/unified/countDocuments-comment.json
+++ b/Tests/Specs/crud/tests/unified/countDocuments-comment.json
@@ -1,0 +1,208 @@
+{
+  "description": "countDocuments-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "countDocuments-comments-test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "countDocuments-comments-test",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "countDocuments with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": 3
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": 1
+                        }
+                      }
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "countDocuments-comments-test"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "countDocuments with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "comment": "comment"
+          },
+          "expectResult": 3
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": 1
+                        }
+                      }
+                    }
+                  ],
+                  "comment": "comment"
+                },
+                "commandName": "aggregate",
+                "databaseName": "countDocuments-comments-test"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "countDocuments with document comment on less than 4.4.0 - server error",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.3.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": 1
+                        }
+                      }
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "countDocuments-comments-test"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/countDocuments-comment.yml
+++ b/Tests/Specs/crud/tests/unified/countDocuments-comment.yml
@@ -1,0 +1,92 @@
+description: "countDocuments-comment"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name countDocuments-comments-test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: "countDocuments with document comment"
+    runOnRequirements:
+      - minServerVersion: 4.4.0
+    operations:
+      - name: countDocuments
+        object: *collection0
+        arguments:
+          filter: {}
+          comment: &documentComment { key: "value" }
+        expectResult: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: &pipeline
+                  - $match: {}
+                  - $group: { _id: 1, n: { $sum: 1 } }
+                comment: *documentComment
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: "countDocuments with string comment"
+    runOnRequirements:
+      - minServerVersion: 3.6.0
+    operations:
+      - name: countDocuments
+        object: *collection0
+        arguments:
+          filter: {}
+          comment: &stringComment "comment"
+        expectResult: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline
+                comment: *stringComment
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: "countDocuments with document comment on less than 4.4.0 - server error"
+    runOnRequirements:
+      - minServerVersion: 3.6.0
+        maxServerVersion: 4.3.99
+    operations:
+      - name: countDocuments
+        object: *collection0
+        arguments:
+          filter: {}
+          comment: *documentComment
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline
+                comment: *documentComment
+              commandName: aggregate
+              databaseName: *database0Name

--- a/Tests/Specs/crud/tests/unified/estimatedDocumentCount-comment.json
+++ b/Tests/Specs/crud/tests/unified/estimatedDocumentCount-comment.json
@@ -1,0 +1,170 @@
+{
+  "description": "estimatedDocumentCount-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "edc-comment-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "edc-comment-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "estimatedDocumentCount with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.14"
+        }
+      ],
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection0",
+          "arguments": {
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": 3
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0",
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "count",
+                "databaseName": "edc-comment-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "estimatedDocumentCount with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection0",
+          "arguments": {
+            "comment": "comment"
+          },
+          "expectResult": 3
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0",
+                  "comment": "comment"
+                },
+                "commandName": "count",
+                "databaseName": "edc-comment-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "estimatedDocumentCount with document comment - pre 4.4.14, server error",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.4.13",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection0",
+          "arguments": {
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0",
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "count",
+                "databaseName": "edc-comment-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/crud/tests/unified/estimatedDocumentCount-comment.yml
+++ b/Tests/Specs/crud/tests/unified/estimatedDocumentCount-comment.yml
@@ -1,0 +1,95 @@
+description: "estimatedDocumentCount-comment"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name edc-comment-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: "estimatedDocumentCount with document comment"
+    runOnRequirements:
+      # https://jira.mongodb.org/browse/SERVER-63315
+      # Server supports count with comment of any type for comment starting from 4.4.14.
+      - minServerVersion: "4.4.14"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection0
+        arguments:
+          comment: &documentComment { key: "value"}
+        expectResult: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+                comment: *documentComment
+              commandName: count
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4.0"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection0
+        arguments:
+          comment: &stringComment "comment"
+        expectResult: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+                comment: *stringComment
+              commandName: count
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount with document comment - pre 4.4.14, server error"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.4.13"
+        # Server does not raise an error if topology is sharded.
+        # https://jira.mongodb.org/browse/SERVER-65954
+        topologies: [ single, replicaset ]
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection0
+        arguments:
+          # Even though according to the docs count command does not support any
+          # comment for server version less than 4.4, no error is raised by such
+          # servers. Therefore, we have only one test with a document comment
+          # to test server errors.
+          # https://jira.mongodb.org/browse/SERVER-63315
+          # Server supports count with comment of any type for comment starting from 4.4.14.
+          comment: *documentComment
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+                comment: *documentComment
+              commandName: count
+              databaseName: *database0Name


### PR DESCRIPTION
Added `comment` field (of type `BSON`) to the EstimatedDocumentCountOptions and updated spec tests. In doing so, encountered some problems with the `UnifiedCollectionOperations` structs for `UnifiedCountDocuments` and `UnifiedEstimatedDocumentCount`. Changed those files to reflect the added comnment/modified tests. Some tests were still problematic and were temporarily excluded after discussion with @patrickfreed 