### PR TITLE
SWIFT-1553: Always report `wallTime` in the change stream event output

### DIFF
--- a/Sources/MongoSwift/ChangeStreamEvent.swift
+++ b/Sources/MongoSwift/ChangeStreamEvent.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftBSON
+
 /// An `UpdateDescription` containing fields that will be present in the change stream document for
 /// operations of type `update`.
 public struct UpdateDescription: Codable {

--- a/Sources/MongoSwift/ChangeStreamEvent.swift
+++ b/Sources/MongoSwift/ChangeStreamEvent.swift
@@ -1,3 +1,5 @@
+import Foundation
+import SwiftBSON
 /// An `UpdateDescription` containing fields that will be present in the change stream document for
 /// operations of type `update`.
 public struct UpdateDescription: Codable {
@@ -115,6 +117,10 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
     /// type`update`.
     public let updateDescription: UpdateDescription?
 
+    /// The wall time from the `mongod` that the change event originated from.
+    /// Only present for server versions 6.0 and above
+    public let wallTime: Date?
+
     /**
      * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if
      * the user has specified `.updateLookup` for the `fullDocument` option in the `ChangeStreamOptions` used to create
@@ -129,7 +135,7 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
     public let fullDocument: T?
 
     private enum CodingKeys: String, CodingKey {
-        case operationType, _id, ns, to, documentKey, updateDescription, fullDocument
+        case operationType, _id, ns, to, documentKey, updateDescription, wallTime, fullDocument
     }
 
     // Custom decode method to work around the fact that `invalidate` events do not have an `ns` field in the raw
@@ -156,6 +162,7 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
         }
 
         self.documentKey = try container.decodeIfPresent(BSONDocument.self, forKey: .documentKey)
+        self.wallTime = try container.decodeIfPresent(Date.self, forKey: .wallTime)
         self.updateDescription = try container.decodeIfPresent(UpdateDescription.self, forKey: .updateDescription)
         self.fullDocument = try container.decodeIfPresent(T.self, forKey: .fullDocument)
     }

--- a/Sources/MongoSwift/ChangeStreamEvent.swift
+++ b/Sources/MongoSwift/ChangeStreamEvent.swift
@@ -118,7 +118,7 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
     public let updateDescription: UpdateDescription?
 
     /// The wall time from the `mongod` that the change event originated from.
-    /// Only present for server versions 6.0 and above
+    /// Only present for server versions 6.0 and above.
     public let wallTime: Date?
 
     /**

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -308,7 +308,20 @@ final class ChangeStreamSpecTests: MongoSwiftTestCase {
                     "Test with document comment",
                     "Test with string comment",
                     "Test that comment is set on getMore",
-                    "Test that comment is not set on getMore - pre 4.4"
+                    "Test that comment is not set on getMore - pre 4.4",
+                    // excluded for now bc of libmongoc vendoring
+                    "$changeStream must be the first stage in a change stream pipeline sent to the server",
+                    "Executing a watch helper on a Collection results in notifications for "
+                        + "changes to the specified collection",
+                    "Change Stream should allow valid aggregate pipeline stages",
+                    "Executing a watch helper on a Database results in notifications for "
+                        + "changes to all collections in the specified database.",
+                    "Executing a watch helper on a MongoClient results in notifications for "
+                        + "changes to all collections in all databases in the cluster.",
+                    "Test insert, update, replace, and delete event types",
+                    "Test rename and invalidate event types",
+                    "Test drop and invalidate event types",
+                    "Test consecutive resume"
                 ]
         ])
     }

--- a/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
+++ b/Tests/MongoSwiftSyncTests/SyncChangeStreamTests.swift
@@ -308,20 +308,7 @@ final class ChangeStreamSpecTests: MongoSwiftTestCase {
                     "Test with document comment",
                     "Test with string comment",
                     "Test that comment is set on getMore",
-                    "Test that comment is not set on getMore - pre 4.4",
-                    // excluded for now bc of libmongoc vendoring
-                    "$changeStream must be the first stage in a change stream pipeline sent to the server",
-                    "Executing a watch helper on a Collection results in notifications for "
-                        + "changes to the specified collection",
-                    "Change Stream should allow valid aggregate pipeline stages",
-                    "Executing a watch helper on a Database results in notifications for "
-                        + "changes to all collections in the specified database.",
-                    "Executing a watch helper on a MongoClient results in notifications for "
-                        + "changes to all collections in all databases in the cluster.",
-                    "Test insert, update, replace, and delete event types",
-                    "Test rename and invalidate event types",
-                    "Test drop and invalidate event types",
-                    "Test consecutive resume"
+                    "Test that comment is not set on getMore - pre 4.4"
                 ]
         ])
     }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
@@ -18,8 +18,13 @@ struct ExpectedEventsForClient: Decodable {
     /// (excluding ignored events).
     let events: [ExpectedEvent]
 
+    /// Specifies how the `events` array is matched against observed events.  If false, observed events after all
+    /// specified events have matched MUST cause a test failure; if true, observed events after all specified events
+    /// have been matched MUST NOT cause a test failure. Defaults to false.
+    let ignoreExtraEvents: Bool?
+
     enum CodingKeys: String, CodingKey {
-        case client, eventType, events
+        case client, eventType, events, ignoreExtraEvents
     }
 
     init(from decoder: Decoder) throws {
@@ -34,6 +39,7 @@ struct ExpectedEventsForClient: Decodable {
             // TODO: SWIFT-1321 actually parse these out.
             self.events = []
         }
+        self.ignoreExtraEvents = try container.decodeIfPresent(Bool.self, forKey: .ignoreExtraEvents) ?? false
     }
 }
 
@@ -77,8 +83,11 @@ enum ExpectedEvent: Decodable {
         /// Name of the database the command is run against.
         let databaseName: String?
 
-        /// Specifies whether the serviceId field of the event is set.
+        /// Specifies whether the `serviceId` field of the event is set.
         let hasServiceId: Bool?
+
+        /// Specifies whether the `serviceConnectionId` field of an event is set.
+        let hasServerConnectionId: Bool?
     }
 
     /// Represents expectations for a CommandSucceededEvent.
@@ -91,6 +100,9 @@ enum ExpectedEvent: Decodable {
 
         /// Specifies whether the serviceId field of the event is set.
         let hasServiceId: Bool?
+
+        /// Specifies whether the `serviceConnectionId` field of an event is set.
+        let hasServerConnectionId: Bool?
     }
 
     /// Represents expectations for a CommandStartedEvent.
@@ -100,5 +112,8 @@ enum ExpectedEvent: Decodable {
 
         /// Specifies whether the serviceId field of the event is set.
         let hasServiceId: Bool?
+
+        /// Specifies whether the `serviceConnectionId` field of an event is set.
+        let hasServerConnectionId: Bool?
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
@@ -87,6 +87,7 @@ enum ExpectedEvent: Decodable {
         let hasServiceId: Bool?
 
         /// Specifies whether the `serviceConnectionId` field of an event is set.
+        // TODO: SWIFT-1262: update unified test runner to use this value.
         let hasServerConnectionId: Bool?
     }
 
@@ -102,6 +103,7 @@ enum ExpectedEvent: Decodable {
         let hasServiceId: Bool?
 
         /// Specifies whether the `serviceConnectionId` field of an event is set.
+        // TODO: SWIFT-1262: update unified test runner to use this value.
         let hasServerConnectionId: Bool?
     }
 
@@ -114,7 +116,7 @@ enum ExpectedEvent: Decodable {
         let hasServiceId: Bool?
 
         /// Specifies whether the `serviceConnectionId` field of an event is set.
-        // TODO: SWIFT-1262: update unified test runner to use this value
+        // TODO: SWIFT-1262: update unified test runner to use this value.
         let hasServerConnectionId: Bool?
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
@@ -21,7 +21,7 @@ struct ExpectedEventsForClient: Decodable {
     /// Specifies how the `events` array is matched against observed events.  If false, observed events after all
     /// specified events have matched MUST cause a test failure; if true, observed events after all specified events
     /// have been matched MUST NOT cause a test failure. Defaults to false.
-    let ignoreExtraEvents = false
+    let ignoreExtraEvents: Bool
 
     enum CodingKeys: String, CodingKey {
         case client, eventType, events, ignoreExtraEvents
@@ -39,7 +39,7 @@ struct ExpectedEventsForClient: Decodable {
             // TODO: SWIFT-1321 actually parse these out.
             self.events = []
         }
-        self.ignoreExtraEvents = try container.decodeIfPresent(Bool.self, forKey: .ignoreExtraEvents)
+        self.ignoreExtraEvents = try container.decodeIfPresent(Bool.self, forKey: .ignoreExtraEvents) ?? false
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
@@ -114,6 +114,7 @@ enum ExpectedEvent: Decodable {
         let hasServiceId: Bool?
 
         /// Specifies whether the `serviceConnectionId` field of an event is set.
+        // TODO: SWIFT-1262: update unified test runner to use this value
         let hasServerConnectionId: Bool?
     }
 }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/ExpectedEventsForClient.swift
@@ -21,7 +21,7 @@ struct ExpectedEventsForClient: Decodable {
     /// Specifies how the `events` array is matched against observed events.  If false, observed events after all
     /// specified events have matched MUST cause a test failure; if true, observed events after all specified events
     /// have been matched MUST NOT cause a test failure. Defaults to false.
-    let ignoreExtraEvents: Bool?
+    let ignoreExtraEvents = false
 
     enum CodingKeys: String, CodingKey {
         case client, eventType, events, ignoreExtraEvents
@@ -39,7 +39,7 @@ struct ExpectedEventsForClient: Decodable {
             // TODO: SWIFT-1321 actually parse these out.
             self.events = []
         }
-        self.ignoreExtraEvents = try container.decodeIfPresent(Bool.self, forKey: .ignoreExtraEvents) ?? false
+        self.ignoreExtraEvents = try container.decodeIfPresent(Bool.self, forKey: .ignoreExtraEvents)
     }
 }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
@@ -309,12 +309,18 @@ enum SpecialOperator {
 }
 
 /// Determines if the events in `actual` match the events in `expected`.
-func matchesEvents(expected: [ExpectedEvent], actual: [CommandEvent], context: Context) throws {
-    guard actual.count == expected.count else {
+func matchesEvents(
+    expected: [ExpectedEvent],
+    actual: [CommandEvent],
+    context: Context,
+    ignoreExtraEvents: Bool
+) throws {
+    // (Actual = expected AND the two must match) or (the two don't have to match)
+    guard (actual.count == expected.count && !ignoreExtraEvents) || ignoreExtraEvents else {
         throw NonMatchingError(expected: expected, actual: actual, context: context)
     }
 
-    for i in 0..<actual.count {
+    for i in 0..<expected.count {
         try context.withPushedElt(String(i)) {
             let expectedEvent = expected[i]
             let actualEvent = actual[i]

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
@@ -315,12 +315,8 @@ func matchesEvents(
     context: Context,
     ignoreExtraEvents: Bool
 ) throws {
-    // (Actual = expected AND the two must match) or (the two don't have to match)
-    guard (actual.count == expected.count && !ignoreExtraEvents) || ignoreExtraEvents else {
-        throw NonMatchingError(expected: expected, actual: actual, context: context)
-    }
-    // Additional check to ensure no indexing errors
-    guard actual.count >= expected.count else {
+    // Ensure correct amount of events present (or more than enough if ignorable)
+    guard (actual.count == expected.count) || (ignoreExtraEvents && actual.count >= expected.count) else {
         throw NonMatchingError(expected: expected, actual: actual, context: context)
     }
 

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/Matching.swift
@@ -319,6 +319,10 @@ func matchesEvents(
     guard (actual.count == expected.count && !ignoreExtraEvents) || ignoreExtraEvents else {
         throw NonMatchingError(expected: expected, actual: actual, context: context)
     }
+    // Additional check to ensure no indexing errors
+    guard actual.count >= expected.count else {
+        throw NonMatchingError(expected: expected, actual: actual, context: context)
+    }
 
     for i in 0..<expected.count {
         try context.withPushedElt(String(i)) {

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -219,7 +219,8 @@ struct UnifiedTestRunner {
                                 try matchesEvents(
                                     expected: expectedEventList.events,
                                     actual: actualEvents,
-                                    context: context
+                                    context: context,
+                                    ignoreExtraEvents: expectedEventList.ignoreExtraEvents ?? false
                                 )
                             }
                         }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -220,7 +220,7 @@ struct UnifiedTestRunner {
                                     expected: expectedEventList.events,
                                     actual: actualEvents,
                                     context: context,
-                                    ignoreExtraEvents: expectedEventList.ignoreExtraEvents ?? false
+                                    ignoreExtraEvents: expectedEventList.ignoreExtraEvents
                                 )
                             }
                         }

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -38,7 +38,7 @@ struct UnifiedTestRunner {
     let serverParameters: BSONDocument
 
     static let minSchemaVersion = SchemaVersion(rawValue: "1.0.0")!
-    static let maxSchemaVersion = SchemaVersion(rawValue: "1.5.0")!
+    static let maxSchemaVersion = SchemaVersion(rawValue: "1.7.0")!
 
     init() throws {
         switch MongoSwiftTestCase.topologyType {

--- a/Tests/Specs/change-streams/tests/unified/change-streams.json
+++ b/Tests/Specs/change-streams/tests/unified/change-streams.json
@@ -1,13 +1,13 @@
 {
   "description": "change-streams",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.7",
   "runOnRequirements": [
     {
       "minServerVersion": "3.6",
       "topologies": [
-        "replicaset",
-        "sharded-replicaset"
-      ]
+        "replicaset"
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [
@@ -16,7 +16,17 @@
         "id": "client0",
         "observeEvents": [
           "commandStartedEvent"
-        ]
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "killCursors"
+        ],
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "client": {
+        "id": "globalClient",
+        "useMultipleMongoses": false
       }
     },
     {
@@ -31,6 +41,62 @@
         "id": "collection0",
         "database": "database0",
         "collectionName": "collection0"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client0",
+        "databaseName": "database1"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "collection1"
+      }
+    },
+    {
+      "database": {
+        "id": "globalDatabase0",
+        "client": "globalClient",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "globalCollection0",
+        "database": "globalDatabase0",
+        "collectionName": "collection0"
+      }
+    },
+    {
+      "database": {
+        "id": "globalDatabase1",
+        "client": "globalClient",
+        "databaseName": "database1"
+      }
+    },
+    {
+      "collection": {
+        "id": "globalCollection1",
+        "database": "globalDatabase1",
+        "collectionName": "collection1"
+      }
+    },
+    {
+      "collection": {
+        "id": "globalDb1Collection0",
+        "database": "globalDatabase1",
+        "collectionName": "collection0"
+      }
+    },
+    {
+      "collection": {
+        "id": "globalDb0Collection1",
+        "database": "globalDatabase0",
+        "collectionName": "collection1"
       }
     }
   ],
@@ -247,10 +313,7 @@
       "description": "Test that comment is set on getMore",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.4.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.4.0"
         }
       ],
       "operations": [
@@ -338,10 +401,7 @@
       "description": "Test that comment is not set on getMore - pre 4.4",
       "runOnRequirements": [
         {
-          "maxServerVersion": "4.3.99",
-          "topologies": [
-            "replicaset"
-          ]
+          "maxServerVersion": "4.3.99"
         }
       ],
       "operations": [
@@ -554,6 +614,15 @@
     },
     {
       "description": "Test new structure in ns document MUST NOT err",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "maxServerVersion": "5.2.99"
+        },
+        {
+          "minServerVersion": "6.0"
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",
@@ -641,10 +710,10 @@
     {
       "description": "Test server error on projecting out _id",
       "runOnRequirements": [
-              {
-                "minServerVersion": "4.2"
-              }
-            ],
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",
@@ -722,6 +791,1002 @@
               "coll": "collection0"
             },
             "newField": "value"
+          }
+        }
+      ]
+    },
+    {
+      "description": "$changeStream must be the first stage in a change stream pipeline sent to the server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "_id": {
+              "$$exists": true
+            },
+            "documentKey": {
+              "$$exists": true
+            },
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "x": 1,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "The server returns change stream responses in the specified server response format",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "_id": {
+              "$$exists": true
+            },
+            "documentKey": {
+              "$$exists": true
+            },
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "x": 1,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Executing a watch helper on a Collection results in notifications for changes to the specified collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "globalDb0Collection1",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalDb1Collection0",
+          "arguments": {
+            "document": {
+              "y": 2
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "z": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "z": 3,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change Stream should allow valid aggregate pipeline stages",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "fullDocument.z": 3
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "y": 2
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "z": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "z": 3,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    },
+                    {
+                      "$match": {
+                        "fullDocument.z": 3
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Executing a watch helper on a Database results in notifications for changes to all collections in the specified database.",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.8.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "database0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "globalDb0Collection1",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalDb1Collection0",
+          "arguments": {
+            "document": {
+              "y": 2
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "z": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection1"
+            },
+            "fullDocument": {
+              "x": 1,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "z": 3,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster.",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.8.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "client0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "globalDb0Collection1",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalDb1Collection0",
+          "arguments": {
+            "document": {
+              "y": 2
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "z": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection1"
+            },
+            "fullDocument": {
+              "x": 1,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database1",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "y": 2,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "z": 3,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "allChangesForCluster": true
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test insert, update, replace, and delete event types",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "updateOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "filter": {
+              "x": 1
+            },
+            "update": {
+              "$set": {
+                "x": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "filter": {
+              "x": 2
+            },
+            "replacement": {
+              "x": 3
+            }
+          }
+        },
+        {
+          "name": "deleteOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "filter": {
+              "x": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "x": 1,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "x": 2
+              },
+              "removedFields": [],
+              "truncatedArrays": {
+                "$$unsetOrMatches": {
+                  "$$exists": true
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "replace",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "x": 3,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "delete",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test rename and invalidate event types",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.1"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "collection1"
+          }
+        },
+        {
+          "name": "rename",
+          "object": "globalCollection0",
+          "arguments": {
+            "to": "collection1"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "rename",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "to": {
+              "db": "database0",
+              "coll": "collection1"
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "invalidate"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test drop and invalidate event types",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.1"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "collection0"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "drop",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "invalidate"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test consecutive resume",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.1.7"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "globalClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "batchSize": 1
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "globalCollection0",
+          "arguments": {
+            "document": {
+              "x": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "x": 1,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "x": 2,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "fullDocument": {
+              "x": 3,
+              "_id": {
+                "$$exists": true
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test wallTime field is set in a change event",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "6.0.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "wallTime": {
+              "$$exists": true
+            }
           }
         }
       ]

--- a/Tests/Specs/change-streams/tests/unified/change-streams.yml
+++ b/Tests/Specs/change-streams/tests/unified/change-streams.yml
@@ -1,13 +1,23 @@
 description: "change-streams"
-schemaVersion: "1.0"
+
+schemaVersion: "1.7"
+
 runOnRequirements:
   - minServerVersion: "3.6"
-    topologies: [ replicaset, sharded-replicaset ]
+    # TODO(DRIVERS-2323): Run all possible tests against sharded clusters once we know the
+    # cause of unexpected command monitoring events.
+    topologies: [ replicaset ]
+    serverless: forbid
+
 createEntities:
   - client:
       id: &client0 client0
-      observeEvents:
-        - commandStartedEvent
+      observeEvents: [ commandStartedEvent ]
+      ignoreCommandMonitoringEvents: [ killCursors ]
+      useMultipleMongoses: false
+  - client:
+      id: &globalClient globalClient
+      useMultipleMongoses: false
   - database:
       id: &database0 database0
       client: *client0
@@ -16,6 +26,40 @@ createEntities:
       id: &collection0 collection0
       database: *database0
       collectionName: *collection0
+  - database:
+      id: &database1 database1
+      client: *client0
+      databaseName: *database1
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: *collection1
+  - database:
+      id: &globalDatabase0 globalDatabase0
+      client: *globalClient
+      databaseName: *database0
+  - collection:
+      id: &globalCollection0 globalCollection0
+      database: *globalDatabase0
+      collectionName: *collection0
+  - database:
+      id: &globalDatabase1 globalDatabase1
+      client: *globalClient
+      databaseName: *database1
+  - collection:
+      id: &globalCollection1 globalCollection1
+      database: *globalDatabase1
+      collectionName: *collection1
+  # Some tests run operations against db1.coll0 or db0.coll1
+  - collection:
+      id: &globalDb1Collection0 globalDb1Collection0
+      database: *globalDatabase1
+      collectionName: *collection0
+  - collection:
+      id: &globalDb0Collection1 globalDb0Collection1
+      database: *globalDatabase0
+      collectionName: *collection1
+
 initialData:
   - collectionName: *collection0
     databaseName: *database0
@@ -36,8 +80,7 @@ tests:
           }
       - name: createChangeStream
         object: *collection0
-        arguments:
-          pipeline: []
+        arguments: { pipeline: [] }
         saveResultAsEntity: &changeStream0 changeStream0
       - name: updateOne
         object: *collection0
@@ -138,10 +181,6 @@ tests:
   - description: "Test that comment is set on getMore"
     runOnRequirements:
       - minServerVersion: "4.4.0"
-        # Topologies are limited because of potentially empty getMore responses
-        # on sharded clusters.
-        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -183,10 +222,6 @@ tests:
   - description: "Test that comment is not set on getMore - pre 4.4"
     runOnRequirements:
       - maxServerVersion: "4.3.99"
-        # Topologies are limited because of potentially empty getMore responses
-        # on sharded clusters.
-        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -230,8 +265,7 @@ tests:
     operations:
       - name: createChangeStream
         object: *collection0
-        arguments:
-          pipeline: []
+        arguments: { pipeline: [] }
         saveResultAsEntity: &changeStream0 changeStream0
       - name: dropCollection
         object: *database0
@@ -294,6 +328,10 @@ tests:
           newField: "newFieldValue"
 
   - description: "Test new structure in ns document MUST NOT err"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+        maxServerVersion: "5.2.99"
+      - minServerVersion: "6.0"
     operations:
       - name: createChangeStream
         object: *collection0
@@ -334,7 +372,7 @@ tests:
             viewOn: "db.coll"
 
   - description: "Test server error on projecting out _id"
-  runOnRequirements:
+    runOnRequirements:
       - minServerVersion: "4.2"
         # Server returns an error if _id is modified on versions 4.2 and higher
     operations:
@@ -353,7 +391,6 @@ tests:
           errorCode: 280
           errorCodeName: "ChangeStreamFatalError"
           errorLabelsContain: [ "NonResumableChangeStreamError" ]
-
 
   - description: "Test projection in change stream returns expected fields"
     operations:
@@ -375,3 +412,516 @@ tests:
             coll: *collection0
           newField: "value"
 
+  - description: $changeStream must be the first stage in a change stream pipeline sent to the server
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { x: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          _id: { $$exists: true }
+          documentKey: { $$exists: true }
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            x: 1
+            _id: { $$exists: true }
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                cursor: {}
+                pipeline: [ { $changeStream: {} } ]
+              commandName: aggregate
+              databaseName: *database0
+
+  - description: The server returns change stream responses in the specified server response format
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { x: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          _id: { $$exists: true }
+          documentKey: { $$exists: true }
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            x: 1
+            _id: { $$exists: true }
+
+  - description: Executing a watch helper on a Collection results in notifications for changes to the specified collection
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *globalDb0Collection1
+        arguments:
+          document: { x: 1 }
+      - name: insertOne
+        object: *globalDb1Collection0
+        arguments:
+          document: { y: 2 }
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { z: 3 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            z: 3
+            _id: { $$exists: true }
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                cursor: {}
+                pipeline: [ { $changeStream: {} } ]
+              commandName: aggregate
+              databaseName: *database0
+
+  - description: Change Stream should allow valid aggregate pipeline stages
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline:
+            - $match:
+                fullDocument.z: 3
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { y: 2 }
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { z: 3 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            z: 3
+            _id: { $$exists: true }
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                cursor: {}
+                pipeline:
+                  - $changeStream: {}
+                  - $match:
+                      fullDocument.z: 3
+              commandName: aggregate
+              databaseName: *database0
+
+  - description: Executing a watch helper on a Database results in notifications for changes to all collections in the specified database.
+    runOnRequirements:
+      - minServerVersion: "3.8.0"
+    operations:
+      - name: createChangeStream
+        object: *database0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *globalDb0Collection1
+        arguments:
+          document: { x: 1 }
+      - name: insertOne
+        object: *globalDb1Collection0
+        arguments:
+          document: { y: 2 }
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { z: 3 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection1
+          fullDocument:
+            x: 1
+            _id: { $$exists: true }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            z: 3
+            _id: { $$exists: true }
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                cursor: {}
+                pipeline: [ { $changeStream: {} } ]
+              commandName: aggregate
+              databaseName: *database0
+
+  - description: Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster.
+    runOnRequirements:
+      - minServerVersion: "3.8.0"
+    operations:
+      - name: createChangeStream
+        object: *client0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *globalDb0Collection1
+        arguments:
+          document: { x: 1 }
+      - name: insertOne
+        object: *globalDb1Collection0
+        arguments:
+          document: { y: 2 }
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { z: 3 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection1
+          fullDocument:
+            x: 1
+            _id: { $$exists: true }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1
+            coll: *collection0
+          fullDocument:
+            y: 2
+            _id: { $$exists: true }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            z: 3
+            _id: { $$exists: true }
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                cursor: {}
+                pipeline:
+                  - $changeStream: { allChangesForCluster: true }
+              commandName: aggregate
+              databaseName: admin
+
+  - description: "Test insert, update, replace, and delete event types"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { x: 1 }
+      - name: updateOne
+        object: *globalCollection0
+        arguments:
+          filter: { x: 1 }
+          update:
+            $set: { x: 2 }
+      - name: replaceOne
+        object: *globalCollection0
+        arguments:
+          filter: { x: 2 }
+          replacement: { x: 3 }
+      - name: deleteOne
+        object: *globalCollection0
+        arguments:
+          filter: { x: 3 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            x: 1
+            _id: { $$exists: true }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: update
+          ns:
+            db: *database0
+            coll: *collection0
+          updateDescription:
+            updatedFields: { x: 2 }
+            removedFields: []
+            truncatedArrays: { $$unsetOrMatches: { $$exists: true } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: replace
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            x: 3
+            _id: { $$exists: true }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: delete
+          ns:
+            db: *database0
+            coll: *collection0
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                cursor: {}
+                pipeline: [ { $changeStream: {} } ]
+              commandName: aggregate
+              databaseName: *database0
+
+  - description: Test rename and invalidate event types
+    runOnRequirements:
+      - minServerVersion: "4.0.1"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection1
+      - name: rename
+        object: *globalCollection0
+        arguments:
+          to: *collection1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: rename
+          ns:
+            db: *database0
+            coll: *collection0
+          to:
+            db: *database0
+            coll: *collection1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: invalidate
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                cursor: {}
+                pipeline: [ { $changeStream: {} } ]
+              commandName: aggregate
+              databaseName: *database0
+
+  - description: Test drop and invalidate event types
+    runOnRequirements:
+      - minServerVersion: "4.0.1"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: drop
+          ns:
+            db: *database0
+            coll: *collection0
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: invalidate
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                cursor: {}
+                pipeline: [ { $changeStream: {} } ]
+              commandName: aggregate
+              databaseName: *database0
+
+  # Test that resume logic works correctly even after consecutive retryable failures of a getMore command,
+  # with no intervening events. This is ensured by setting the batch size of the change stream to 1,
+  - description: Test consecutive resume
+    runOnRequirements:
+      - minServerVersion: "4.1.7"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *globalClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              failCommands: [ getMore ]
+              closeConnection: true
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          batchSize: 1
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { x: 1 }
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { x: 2 }
+      - name: insertOne
+        object: *globalCollection0
+        arguments:
+          document: { x: 3 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            x: 1
+            _id: { $$exists: true }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            x: 2
+            _id: { $$exists: true }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database0
+            coll: *collection0
+          fullDocument:
+            x: 3
+            _id: { $$exists: true }
+    expectEvents:
+      - client: *client0
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                cursor:
+                  batchSize: 1
+                pipeline: [ { $changeStream: {} } ]
+              commandName: aggregate
+              databaseName: *database0
+
+  - description: "Test wallTime field is set in a change event"
+    runOnRequirements:
+      - minServerVersion: "6.0.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+          wallTime: { $$exists: true }


### PR DESCRIPTION
Adding a field and impl for optional Date `wallTime`. Incorporated updated spec tests as outlined by `e1a513fe027afb7706485a1e79c53a96acc2ec22`. This involved upgrading the `UnifiedTestRunner` from `maxSchema` 1.5 to 1.7
Made associated changes and bumped version up. Excluded several tests that fail because of an old version of `libmongoc`, potentially resolved with beta vendoring