### PR TITLE
SWIFT-1616 ⁃ Impossible to create a text index with default name

### DIFF
--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -18,7 +18,7 @@ public struct IndexModel: Codable {
     /// Gets the default name for this index.
     internal func getDefaultName() throws -> String {
         try self.keys.map { k, v in
-            guard let vString = v.toInt().map({ String ($0) }) ?? v.stringValue else {
+            guard let vString = v.toInt().map({ String($0) }) ?? v.stringValue else {
                 throw MongoError.InvalidArgumentError(message: "Invalid index value for key: \"\(k)\"=\(v)")
             }
             return "\(k)_\(vString)"

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -18,10 +18,10 @@ public struct IndexModel: Codable {
     /// Gets the default name for this index.
     internal func getDefaultName() throws -> String {
         try self.keys.map { k, v in
-            guard let vInt = v.toInt() else {
+            guard let vString = v.toInt().map({ String ($0) }) ?? v.stringValue else {
                 throw MongoError.InvalidArgumentError(message: "Invalid index value for key: \"\(k)\"=\(v)")
             }
-            return "\(k)_\(vInt)"
+            return "\(k)_\(vString)"
         }.joined(separator: "_")
     }
 

--- a/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
+++ b/Tests/MongoSwiftSyncTests/MongoCollection+IndexTests.swift
@@ -72,6 +72,15 @@ final class MongoCollection_IndexTests: MongoSwiftTestCase {
         expect(try indexes.next()?.get()).to(beNil())
     }
 
+    func testCreateTextIndexFromModel() throws {
+        let model = IndexModel(keys: ["cat": "text"])
+        expect(try self.coll.createIndex(model)).to(equal("cat_text"))
+        let indexes = try coll.listIndexes()
+        expect(try indexes.next()?.get().options?.name).to(equal("_id_"))
+        expect(try indexes.next()?.get().options?.name).to(equal("cat_text"))
+        expect(try indexes.next()?.get()).to(beNil())
+    }
+
     func testIndexOptions() throws {
         var options = IndexOptions(
             background: true,


### PR DESCRIPTION
Fixes https://github.com/mongodb/mongo-swift-driver/issues/768