### PR TITLE
SWIFT-1337, SWIFT-1629, SWIFT-1557, SWIFT-1566: Various maintenance-related changes 

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -631,55 +631,55 @@ tasks:
             TOPOLOGY: "load_balanced"
         - func: stop-load-balancer
 
-  - name: "test-6.0-standalone"
-    tags: ["6.0", "standalone"]
-    commands:
-      - func: "prepare resources"
-      - func: "fix absolute paths"
-      - func: "bootstrap mongo-orchestration"
-        vars:
-          MONGODB_VERSION: "6.0"
-          TOPOLOGY: "server"
-      - func: "run tests"
+    - name: "test-6.0-standalone"
+      tags: ["6.0", "standalone"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "6.0"
+            TOPOLOGY: "server"
+        - func: "run tests"
 
     - name: "test-6.0-replica_set"
-    tags: ["6.0", "replica_set"]
-    commands:
-      - func: "prepare resources"
-      - func: "fix absolute paths"
-      - func: "bootstrap mongo-orchestration"
-        vars:
-          MONGODB_VERSION: "6.0"
-          TOPOLOGY: "replica_set"
-      - func: "run tests"
+      tags: ["6.0", "replica_set"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "6.0"
+            TOPOLOGY: "replica_set"
+        - func: "run tests"
 
     - name: "test-6.0-sharded_cluster"
-    tags: ["6.0", "sharded_cluster"]
-    exec_timeout_secs: 3600 # TODO SWIFT-1410: remove
-    commands:
-      - func: "prepare resources"
-      - func: "fix absolute paths"
-      - func: "bootstrap mongo-orchestration"
-        vars:
-          MONGODB_VERSION: "6.0"
-          TOPOLOGY: "sharded_cluster"
-      - func: "run tests"
+      tags: ["6.0", "sharded_cluster"]
+      exec_timeout_secs: 3600 # TODO SWIFT-1410: remove
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "6.0"
+            TOPOLOGY: "sharded_cluster"
+        - func: "run tests"
 
     - name: "test-6.0-load_balancer"
-    tags: ["6.0", "load-balancer"]
-    commands:
-      - func: "prepare resources"
-      - func: "fix absolute paths"
-      - func: "bootstrap mongo-orchestration"
-        vars:
-          MONGODB_VERSION: "6.0"
-          TOPOLOGY: "sharded_cluster"
-          LOAD_BALANCER: "true"
-      - func: start-load-balancer
-      - func: "run-lb-tests"
-        vars:
-          TOPOLOGY: "load_balanced"
-      - func: stop-load-balancer
+      tags: ["6.0", "load-balancer"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "6.0"
+            TOPOLOGY: "sharded_cluster"
+            LOAD_BALANCER: "true"
+        - func: start-load-balancer
+        - func: "run-lb-tests"
+          vars:
+            TOPOLOGY: "load_balanced"
+        - func: stop-load-balancer
 
     - name: "test-latest-standalone"
       tags: ["latest", "standalone"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1112,10 +1112,6 @@ axes:
   - id: swift-version
     display_name: "Swift"
     values:
-      - id: "5.1"
-        display_name: "Swift 5.1"
-        variables:
-           SWIFT_MINOR_VERSION: "5.1"
       - id: "5.2"
         display_name: "Swift 5.2"
         variables:
@@ -1250,11 +1246,8 @@ buildvariants:
 
 - matrix_name: "min-version-compile"
   matrix_spec:
-  # Ubuntu 20.04 does not have Swift 5.1 toolchains.
-    os-fully-featured:
-      - "macos-11"
-      - "ubuntu-18.04"
-    swift-version: "5.1"
+    os-fully-featured: "*"
+    swift-version: "5.2"
   display_name: "Compile ${swift-version} ${os-fully-featured}"
   tasks:
     - "compile"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -336,15 +336,9 @@ functions:
         script: |
           set -o xtrace
           set -o errexit
-
-          if [ "${SWIFT_MINOR_VERSION}" = "main-snapshot" ]; then
-              export SWIFT_VERSION="${SWIFT_MINOR_VERSION}"
-          else
-              # otherwise, find the latest patch release for the specified version
-              ${PYTHON} -m virtualenv ./requests-env
-              ./requests-env/${VENV_BIN_DIR}/python3 -m pip install requests
-              export SWIFT_VERSION="$(./requests-env/${VENV_BIN_DIR}/python3 .evergreen/get_latest_swift_patch.py ${SWIFT_MINOR_VERSION})"
-          fi
+          ${PYTHON} -m virtualenv ./requests-env
+          ./requests-env/${VENV_BIN_DIR}/python3 -m pip install requests
+          export SWIFT_VERSION="$(./requests-env/${VENV_BIN_DIR}/python3 .evergreen/get_latest_swift_patch.py ${SWIFT_MINOR_VERSION})"
           echo "SWIFT_VERSION: $SWIFT_VERSION" > swift-version.yml
           cat swift-version.yml
     - command: expansions.update
@@ -620,6 +614,72 @@ tasks:
             MONGODB_VERSION: "5.0"
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
+  
+    - name: "test-5.0-load_balancer"
+      tags: ["5.0", "load-balancer"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "5.0"
+            TOPOLOGY: "sharded_cluster"
+            LOAD_BALANCER: "true"
+        - func: start-load-balancer
+        - func: "run-lb-tests"
+          vars:
+            TOPOLOGY: "load_balanced"
+        - func: stop-load-balancer
+
+  - name: "test-6.0-standalone"
+    tags: ["6.0", "standalone"]
+    commands:
+      - func: "prepare resources"
+      - func: "fix absolute paths"
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "6.0"
+          TOPOLOGY: "server"
+      - func: "run tests"
+
+    - name: "test-6.0-replica_set"
+    tags: ["6.0", "replica_set"]
+    commands:
+      - func: "prepare resources"
+      - func: "fix absolute paths"
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "6.0"
+          TOPOLOGY: "replica_set"
+      - func: "run tests"
+
+    - name: "test-6.0-sharded_cluster"
+    tags: ["6.0", "sharded_cluster"]
+    exec_timeout_secs: 3600 # TODO SWIFT-1410: remove
+    commands:
+      - func: "prepare resources"
+      - func: "fix absolute paths"
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "6.0"
+          TOPOLOGY: "sharded_cluster"
+      - func: "run tests"
+
+    - name: "test-6.0-load_balancer"
+    tags: ["6.0", "load-balancer"]
+    commands:
+      - func: "prepare resources"
+      - func: "fix absolute paths"
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "6.0"
+          TOPOLOGY: "sharded_cluster"
+          LOAD_BALANCER: "true"
+      - func: start-load-balancer
+      - func: "run-lb-tests"
+        vars:
+          TOPOLOGY: "load_balanced"
+      - func: stop-load-balancer
 
     - name: "test-latest-standalone"
       tags: ["latest", "standalone"]
@@ -663,6 +723,56 @@ tasks:
         - func: "bootstrap mongo-orchestration"
           vars:
             MONGODB_VERSION: "latest"
+            TOPOLOGY: "sharded_cluster"
+            LOAD_BALANCER: "true"
+        - func: start-load-balancer
+        - func: "run-lb-tests"
+          vars:
+            TOPOLOGY: "load_balanced"
+        - func: stop-load-balancer
+
+    - name: "test-rapid-standalone"
+      tags: ["rapid", "standalone"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "rapid"
+            TOPOLOGY: "server"
+        - func: "run tests"
+
+    - name: "test-rapid-replica_set"
+      tags: ["rapid", "replica_set"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "rapid"
+            TOPOLOGY: "replica_set"
+        - func: "run tests"
+
+    - name: "test-rapid-sharded_cluster"
+      tags: ["rapid", "sharded_cluster"]
+      exec_timeout_secs: 3600 # TODO SWIFT-1410: remove
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "rapid"
+            TOPOLOGY: "sharded_cluster"
+        - func: "run tests"
+  
+    - name: "test-rapid-load_balancer"
+      tags: ["rapid", "load-balancer"]
+      commands:
+        - func: "prepare resources"
+        - func: "fix absolute paths"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            MONGODB_VERSION: "rapid"
             TOPOLOGY: "sharded_cluster"
             LOAD_BALANCER: "true"
         - func: start-load-balancer
@@ -1049,6 +1159,14 @@ axes:
         display_name: "latest"
         variables:
            MONGODB_VERSION: "latest"
+      - id: "rapid"
+        display_name: "rapid"
+        variables:
+           MONGODB_VERSION: "rapid"
+      - id: "6.0"
+        display_name: "6.0"
+        variables:
+          MONGODB_VERSION: "6.0"
       - id: "5.0"
         display_name: "5.0"
         variables:
@@ -1083,6 +1201,13 @@ axes:
       - id: ubuntu-20.04
         display_name: "Ubuntu 20.04"
         run_on: ubuntu2004-test
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
+          VENV_BIN_DIR: "bin"
+
+      - id: macos-10.14
+        display_name: "macOS 10.14"
+        run_on: macos-1014
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
@@ -1246,7 +1371,10 @@ buildvariants:
 
 - matrix_name: "min-version-compile"
   matrix_spec:
-    os-fully-featured: "*"
+    os-fully-featured:
+      - macos-10.14
+      - ubuntu-18.04
+      - ubuntu-20.04
     swift-version: "5.2"
   display_name: "Compile ${swift-version} ${os-fully-featured}"
   tasks:
@@ -1254,7 +1382,10 @@ buildvariants:
 
 - matrix_name: "tests-all"
   matrix_spec:
-    os-fully-featured: "*"
+    os-fully-featured:
+      - macos-11
+      - ubuntu-18.04
+      - ubuntu-20.04
     swift-version:
       - "5.5"
       - "5.6"
@@ -1262,8 +1393,10 @@ buildvariants:
     ssl-auth: "*"
   display_name: "${swift-version} ${os-fully-featured} ${ssl-auth}"
   tasks:
+     - ".rapid !.load-balancer"
      - ".latest !.load-balancer"
-     - ".5.0"
+     - ".6.0 !.load-balancer"
+     - ".5.0 !.load-balancer"
      - ".4.4"
      - ".4.2"
      - ".4.0"
@@ -1295,7 +1428,10 @@ buildvariants:
 
 - matrix_name: "atlas-connect"
   matrix_spec:
-    os-fully-featured: "*"
+    os-fully-featured:
+      - macos-11
+      - ubuntu-18.04
+      - ubuntu-20.04
     swift-version:
       - "5.5"
       - "5.6"
@@ -1333,6 +1469,8 @@ buildvariants:
       - "ubuntu-20.04"
     versions:
       - latest
+      - rapid
+      - 6.0
       - 5.0
       - 4.4
     swift-version: "5.6"
@@ -1356,6 +1494,8 @@ buildvariants:
     swift-version: "5.6"
     versions:
       - latest
+      - rapid
+      - 6.0
       - 5.0
       - 4.4
   display_name: "OCSP ${swift-version} ${os-fully-featured} ${versions}"
@@ -1375,6 +1515,9 @@ buildvariants:
   tasks:
     # Versioned API was introduced in MongoDB 4.7
     - "test-latest-standalone"
+    - "test-rapid-standalone"
+    - "test-6.0-standalone"
+    - "test-5.0-standalone"
 
 - matrix_name: "format-lint"
   display_name: "Format and Lint"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1554,4 +1554,4 @@ buildvariants:
     ssl-auth: "*"
     check-leaks: "leaks"
   tasks:
-     - ".5.0"
+     - ".6.0 !.load-balancer"

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -16,20 +16,16 @@ export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
 export PATH="${SWIFTENV_ROOT}/bin:$PATH"
 eval "$(swiftenv init -)"
 
-# dynamically determine latest available snapshot if needed
-if [ "$SWIFT_VERSION" = "main-snapshot" ]; then
-    SWIFT_VERSION=$(swiftenv install --list-snapshots | tail -1)
-fi
-
 if [ "$OS" == "darwin" ]; then
-    # latest snapshots require a newer version of Xcode/Command Line Tools
-    if [[ "$SWIFT_VERSION" == DEVELOPMENT-SNAPSHOT* ]]; then
-        sudo xcode-select -s /Applications/Xcode13.1.app
+    # 5.2 requires an older version of Xcode/Command Line Tools
+    if [[ "$SWIFT_VERSION" == 5.2.* ]]; then
+        sudo xcode-select -s /Applications/Xcode11.3.app
     else
-        sudo xcode-select -s /Applications/Xcode12.app
+        sudo xcode-select -s /Applications/Xcode13.2.1.app
     fi
 
-    # TODO SWIFT-1421: remove this once we have new Xcode on Evergreen to test with
+    # required to use the toolchain's concurrency library rather than the one which ships with Xcode
+    # and may not necessarily match the Swift version being used.
     export DYLD_LIBRARY_PATH=${SWIFTENV_ROOT}/versions/${SWIFT_VERSION}/usr/lib/swift/macosx/
 fi
 

--- a/.evergreen/get_latest_swift_patch.py
+++ b/.evergreen/get_latest_swift_patch.py
@@ -18,7 +18,7 @@ version = sys.argv[1]
 if version == "main-snapshot":
     tag_data = requests.get('https://api.github.com/repos/apple/swift/tags').json()
     latest_snapshot = next(filter(lambda tag: 'swift-DEVELOPMENT-SNAPSHOT' in tag['name'], tag_data))
-    print(latest_snapshot['name'])
+    print(latest_snapshot['name'][6:])
 else:
     components = version.split('.')
     if len(components) != 2:

--- a/.evergreen/get_latest_swift_patch.py
+++ b/.evergreen/get_latest_swift_patch.py
@@ -2,33 +2,43 @@ import re
 import requests
 import sys
 
-# This script accepts a version number in the form "x.y" as an argument. It will query the Swift Github
-# repo for releases and find the latest x.y.z patch release if available, and print out the matching tag.
+# This script accepts a single argument which can be either:
+# 1) a version number in the form "x.y", or 
+# 2) the string "snapshot"
+# If a version number is provided the script will query the Swift GitHub repo for releases and find the latest x.y.z patch
+# release if available, and print out the matching tag.
+# If "main-snapshot" is provided the script will find the latest development snapshot tagged on the Swift GitHub repo.
 
 if len(sys.argv) != 2:
     print("Expected 1 argument, but got: {}".format(sys.argv[1:]))
     exit(1)
 
 version = sys.argv[1]
-components = version.split('.')
-if len(components) != 2:
-    print("Expected version number in form x.y, got {}".format(version))
-    exit(1)
 
-major = components[0]
-minor = components[1]
+if version == "main-snapshot":
+    tag_data = requests.get('https://api.github.com/repos/apple/swift/tags').json()
+    latest_snapshot = next(filter(lambda tag: 'swift-DEVELOPMENT-SNAPSHOT' in tag['name'], tag_data))
+    print(latest_snapshot['name'])
+else:
+    components = version.split('.')
+    if len(components) != 2:
+        print("Expected version number in form x.y, got {}".format(version))
+        exit(1)
 
-version_regex = '^swift-({}\.{}(\.(\d+))?)-RELEASE$'.format(major, minor)
+    major = components[0]
+    minor = components[1]
 
-release_data = requests.get('https://api.github.com/repos/apple/swift/releases').json()
-tag_names = map(lambda release: release['tag_name'], release_data)
+    version_regex = '^swift-({}\.{}(\.(\d+))?)-RELEASE$'.format(major, minor)
 
-# find tags matching the specified regexes
-matches = filter(lambda match: match is not None, map(lambda tag: re.match(version_regex, tag), tag_names))
+    release_data = requests.get('https://api.github.com/repos/apple/swift/releases').json()
+    tag_names = map(lambda release: release['tag_name'], release_data)
 
-# sort matches by their patch versions. patch versions of 0 are omitted so substitute 0 when the group is None.
-sorted_matches = sorted(matches, key=lambda match: int(match.group(2)[1:]) if match.group(2) is not None else 0, reverse=True)
+    # find tags matching the specified regexes
+    matches = filter(lambda match: match is not None, map(lambda tag: re.match(version_regex, tag), tag_names))
 
-# map to the first match group which contains the full version number.
-sorted_version_numbers = map(lambda match: match.group(1), sorted_matches)
-print(next(sorted_version_numbers))
+    # sort matches by their patch versions. patch versions of 0 are omitted so substitute 0 when the group is None.
+    sorted_matches = sorted(matches, key=lambda match: int(match.group(2)[1:]) if match.group(2) is not None else 0, reverse=True)
+
+    # map to the first match group which contains the full version number.
+    sorted_version_numbers = map(lambda match: match.group(1), sorted_matches)
+    print(next(sorted_version_numbers))

--- a/.evergreen/install-swift.sh
+++ b/.evergreen/install-swift.sh
@@ -20,8 +20,4 @@ git clone --depth 1 -b "osx-install-path" https://github.com/kmahar/swiftenv.git
 # install swift
 eval "$(swiftenv init -)"
 
-if [ "$SWIFT_VERSION" = "main-snapshot" ]; then
-    SWIFT_VERSION=$(swiftenv install --list-snapshots | tail -1)
-fi
-
 swiftenv install --install-local $SWIFT_VERSION

--- a/.evergreen/install-tools.sh
+++ b/.evergreen/install-tools.sh
@@ -35,10 +35,10 @@ install_from_gh () {
 
 if [ $1 == "swiftlint" ]
 then
-    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.46.3"
+    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.48.0"
 elif [ $1 == "swiftformat" ]
 then
-    build_from_gh swiftformat https://github.com/nicklockwood/SwiftFormat "0.49.4"
+    build_from_gh swiftformat https://github.com/nicklockwood/SwiftFormat "0.49.17"
 elif [ $1 == "sourcery" ]
 then
     install_from_gh sourcery https://github.com/krzysztofzablocki/Sourcery/releases/download/1.6.1/Sourcery-1.6.1.zip

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -9,6 +9,13 @@ INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 # configure Swift
 . ${PROJECT_DIRECTORY}/.evergreen/configure-swift.sh
 
+
+# work around https://github.com/mattgallagher/CwlPreconditionTesting/issues/22 (bug still exists in version 1.x
+# when using Xcode 13.2)
+if [ "$OS" == "darwin" ]; then
+    EXTRA_FLAGS="-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
+fi
+
 # run the tests
 ATLAS_REPL="$ATLAS_REPL" ATLAS_SHRD="$ATLAS_SHRD" ATLAS_FREE="$ATLAS_FREE" ATLAS_TLS11="$ATLAS_TLS11" ATLAS_TLS12="$ATLAS_TLS12" \
 ATLAS_REPL_SRV="$ATLAS_REPL_SRV" ATLAS_SHRD_SRV="$ATLAS_SHRD_SRV" ATLAS_FREE_SRV="$ATLAS_FREE_SRV" ATLAS_TLS11_SRV="$ATLAS_TLS11_SRV" ATLAS_TLS12_SRV="$ATLAS_TLS12_SRV" \

--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -29,11 +29,18 @@ INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 # configure Swift
 . ${PROJECT_DIRECTORY}/.evergreen/configure-swift.sh
 
+
+# work around https://github.com/mattgallagher/CwlPreconditionTesting/issues/22 (bug still exists in version 1.x
+# when using Xcode 13.2)
+if [ "$OS" == "darwin" ]; then
+    EXTRA_FLAGS="-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
+fi
+
 # build the driver
-swift build
+swift build $EXTRA_FLAGS
 
 # test the driver
 set +o errexit # even if tests fail we want to parse the results, so disable errexit
 set -o pipefail # propagate error codes in the following pipes
 
-swift test --enable-test-discovery --filter=OCSP
+swift test --enable-test-discovery $EXTRA_FLAGS --filter=OCSP

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -18,8 +18,15 @@ fi
 # configure Swift
 . ${PROJECT_DIRECTORY}/.evergreen/configure-swift.sh
 
+
+# work around https://github.com/mattgallagher/CwlPreconditionTesting/issues/22 (bug still exists in version 1.x
+# when using Xcode 13.2)
+if [ "$OS" == "darwin" ]; then
+    EXTRA_FLAGS="-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
+fi
+
 # build the driver
-swift build
+swift build $EXTRA_FLAGS
 
 MONGODB_TOPOLOGY="load_balanced" \
   MONGODB_URI=${MONGODB_URI} \
@@ -30,4 +37,4 @@ MONGODB_TOPOLOGY="load_balanced" \
   MONGODB_SCRAM_PASSWORD=${SERVERLESS_ATLAS_PASSWORD} \
   AUTH="auth" \
   SSL="ssl" \
-    swift test --enable-test-discovery --filter="(Crud|Retryable|Transactions|Versioned|Session|LoadBalancer|MongoCursor|Unified)"
+    swift test --enable-test-discovery $EXTRA_FLAGS --filter="(Crud|Retryable|Transactions|Versioned|Session|LoadBalancer|MongoCursor|Unified)"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -39,12 +39,10 @@ if [ "$SANITIZE" != "false" ]; then
     SANITIZE_STATEMENT="--sanitize ${SANITIZE}"
 fi
 
-# TODO SWIFT-1421: remove this, it is currently needed due to a bug in Xcode 13.0/13.1.
-# see: https://bugs.swift.org/browse/SR-14968
+# work around https://github.com/mattgallagher/CwlPreconditionTesting/issues/22 (bug still exists in version 1.x
+# when using Xcode 13.2)
 if [ "$OS" == "darwin" ]; then
-    if [[ "$SWIFT_VERSION" == DEVELOPMENT-SNAPSHOT* ]]; then
-        EXTRA_FLAGS="-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
-    fi
+    EXTRA_FLAGS="-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
 fi
 
 # build the driver

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "MongoSwiftSync", targets: ["MongoSwiftSync"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")),
+        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "8.0.0")),
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.36.0")),
         .package(url: "https://github.com/mongodb/swift-bson", .upToNextMajor(from: "3.0.0"))
     ],
@@ -57,6 +57,7 @@ let package = Package(
                 "MongoSwiftSync",
                 "TestsCommon",
                 "MongoSwift",
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "Nimble", package: "Nimble")
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,4 @@
-// swift-tools-version:5.1
-
-///  To avoid breaking Swift 5.1 compatibility, only require newer NIO versions when we need NIO's concurrency APIs.
-func getMinNIOVersion() -> PackageDescription.Package.Dependency.Requirement {
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-    return .upToNextMajor(from: "2.36.0")
-#else
-    return .upToNextMajor(from: "2.15.0")
-#endif
-}
+// swift-tools-version:5.2
 
 import PackageDescription
 let package = Package(
@@ -21,16 +12,54 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")),
-        .package(url: "https://github.com/apple/swift-nio", getMinNIOVersion()),
+        .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.36.0")),
         .package(url: "https://github.com/mongodb/swift-bson", .upToNextMajor(from: "3.0.0"))
     ],
     targets: [
-        .target(name: "MongoSwiftSync", dependencies: ["MongoSwift", "NIO"]),
+        .target(
+            name: "MongoSwiftSync",
+            dependencies: [
+                "MongoSwift",
+                .product(name: "NIOPosix", package: "swift-nio"),
+            ]
+        ),
         .target(name: "AtlasConnectivity", dependencies: ["MongoSwiftSync"]),
-        .target(name: "TestsCommon", dependencies: ["MongoSwift", "Nimble"]),
-        .testTarget(name: "BSONTests", dependencies: ["MongoSwift", "TestsCommon", "Nimble", "CLibMongoC"]),
-        .testTarget(name: "MongoSwiftTests", dependencies: ["MongoSwift", "TestsCommon", "Nimble", "NIO", "NIOConcurrencyHelpers"]),
-        .testTarget(name: "MongoSwiftSyncTests", dependencies: ["MongoSwiftSync", "TestsCommon", "Nimble", "MongoSwift"]),
+        .target(
+            name: "TestsCommon",
+            dependencies: [
+                "MongoSwift",
+                .product(name: "Nimble", package: "Nimble"),
+            ]
+        ),
+        .testTarget(
+            name: "BSONTests",
+            dependencies: [
+                "MongoSwift",
+                "TestsCommon",
+                "CLibMongoC",
+                .product(name: "Nimble", package: "Nimble")
+            ]
+        ),
+        .testTarget(
+            name: "MongoSwiftTests",
+            dependencies: [
+                "MongoSwift",
+                "TestsCommon",
+                "Nimble",
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio")
+            ]
+        ),
+        .testTarget(
+            name: "MongoSwiftSyncTests",
+            dependencies: [
+                "MongoSwiftSync",
+                "TestsCommon",
+                "MongoSwift",
+                .product(name: "Nimble", package: "Nimble")
+            ]
+        ),
         .target(
             name: "CLibMongoC",
             dependencies: [],
@@ -46,7 +75,30 @@ let package = Package(
 
 #if compiler(>=5.3)
 package.dependencies += [.package(url: "https://github.com/apple/swift-atomics", .upToNextMajor(from: "1.0.0"))]
-package.targets += [.target(name: "MongoSwift", dependencies: ["Atomics", "CLibMongoC", "NIO", "NIOConcurrencyHelpers", "SwiftBSON"])]
+package.targets += [
+    .target(
+        name: "MongoSwift",
+        dependencies: [
+            "CLibMongoC",
+            .product(name: "Atomics", package: "swift-atomics"),
+            .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+            .product(name: "NIOCore", package: "swift-nio"),
+            .product(name: "NIOPosix", package: "swift-nio"),
+            .product(name: "SwiftBSON", package: "swift-bson")
+        ]
+    )
+]
 #else
-package.targets += [.target(name: "MongoSwift", dependencies: ["CLibMongoC", "NIO", "NIOConcurrencyHelpers", "SwiftBSON"])]
+package.targets += [
+    .target(
+        name: "MongoSwift",
+        dependencies: [
+            "CLibMongoC",
+            .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+            .product(name: "NIOCore", package: "swift-nio"),
+            .product(name: "NIOPosix", package: "swift-nio"),
+            .product(name: "SwiftBSON", package: "swift-bson")
+        ]
+    )
+]
 #endif

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Note: You should call `cleanupMongoSwift()` exactly once at the end of your appl
 **Async/Await (recommended)**:
 ```swift
 import MongoSwift
-import NIO
+import NIOPosix
 
 let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
 let client = try MongoClient("mongodb://localhost:27017", using: elg)
@@ -107,7 +107,7 @@ let collection = try await db.createCollection("myCollection")
 **Async (`EventLoopFuture`s)**:
 ```swift
 import MongoSwift
-import NIO
+import NIOPosix
 
 let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
 let client = try MongoClient("mongodb://localhost:27017", using: elg)

--- a/Sources/MongoSwift/BSON/BSONPointerUtils.swift
+++ b/Sources/MongoSwift/BSON/BSONPointerUtils.swift
@@ -1,6 +1,6 @@
 import CLibMongoC
 import Foundation
-import NIO
+import NIOCore
 
 internal typealias BSONPointer = UnsafePointer<bson_t>
 internal typealias MutableBSONPointer = UnsafeMutablePointer<bson_t>

--- a/Sources/MongoSwift/ChangeStream.swift
+++ b/Sources/MongoSwift/ChangeStream.swift
@@ -1,6 +1,6 @@
 import CLibMongoC
 import Foundation
-import NIO
+import NIOCore
 
 /// Direct wrapper of a `mongoc_change_stream_t`.
 private struct MongocChangeStream: MongocCursorWrapper {

--- a/Sources/MongoSwift/ClientSession.swift
+++ b/Sources/MongoSwift/ClientSession.swift
@@ -1,6 +1,6 @@
 import CLibMongoC
 import Foundation
-import NIO
+import NIOCore
 
 // sourcery: skipSyncExport
 /**

--- a/Sources/MongoSwift/ConnectionPool.swift
+++ b/Sources/MongoSwift/ConnectionPool.swift
@@ -1,7 +1,7 @@
 import CLibMongoC
 import Foundation
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 import SwiftBSON
 
 /// A connection to the database.

--- a/Sources/MongoSwift/CursorCommon.swift
+++ b/Sources/MongoSwift/CursorCommon.swift
@@ -1,7 +1,7 @@
 import CLibMongoC
 import Foundation
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 
 /// A protocol describing the common public API between cursor-like objects in the driver.
 internal protocol CursorProtocol {

--- a/Sources/MongoSwift/EventLoopBoundMongoClient.swift
+++ b/Sources/MongoSwift/EventLoopBoundMongoClient.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 // sourcery: skipSyncExport
 /// A wrapper around a `MongoClient` that will return `EventLoopFuture`s on the specified `EventLoop`.

--- a/Sources/MongoSwift/MongoClient.swift
+++ b/Sources/MongoSwift/MongoClient.swift
@@ -1,7 +1,7 @@
 import CLibMongoC
 import Foundation
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 
 /// Options to use when creating a `MongoClient`.
 public struct MongoClientOptions: CodingStrategyProvider {

--- a/Sources/MongoSwift/MongoCollection+BulkWrite.swift
+++ b/Sources/MongoSwift/MongoCollection+BulkWrite.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 
 /// An extension of `MongoCollection` encapsulating bulk write operations.
 extension MongoCollection {

--- a/Sources/MongoSwift/MongoCollection+ChangeStreams.swift
+++ b/Sources/MongoSwift/MongoCollection+ChangeStreams.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 
 extension MongoCollection {
     /**

--- a/Sources/MongoSwift/MongoCollection+FindAndModify.swift
+++ b/Sources/MongoSwift/MongoCollection+FindAndModify.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 
 /// An extension of `MongoCollection` encapsulating find and modify operations.
 extension MongoCollection {

--- a/Sources/MongoSwift/MongoCollection+Indexes.swift
+++ b/Sources/MongoSwift/MongoCollection+Indexes.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 
 /// A struct representing an index on a `MongoCollection`.
 public struct IndexModel: Codable {

--- a/Sources/MongoSwift/MongoCollection+Read.swift
+++ b/Sources/MongoSwift/MongoCollection+Read.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 
 /// An extension of `MongoCollection` encapsulating read operations.
 extension MongoCollection {

--- a/Sources/MongoSwift/MongoCollection+Write.swift
+++ b/Sources/MongoSwift/MongoCollection+Write.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 import SwiftBSON
 
 /// An extension of `MongoCollection` encapsulating write operations.

--- a/Sources/MongoSwift/MongoCollection.swift
+++ b/Sources/MongoSwift/MongoCollection.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 
 /// Options to use when dropping a collection.
 public struct DropCollectionOptions: Codable {

--- a/Sources/MongoSwift/MongoConnectionString.swift
+++ b/Sources/MongoSwift/MongoConnectionString.swift
@@ -467,12 +467,10 @@ public struct MongoConnectionString: Codable, LosslessStringConvertible {
         // Parse the defaultAuthDB if present.
         if userHostsAndAuthDB.count == 2 && !userHostsAndAuthDB[1].isEmpty {
             let defaultAuthDB = try userHostsAndAuthDB[1].getPercentDecoded(forKey: "defaultAuthDB")
-            for character in Self.forbiddenDBCharacters {
-                if defaultAuthDB.contains(character) {
-                    throw MongoError.InvalidArgumentError(
-                        message: "defaultAuthDB contains invalid character: \(character)"
-                    )
-                }
+            for character in Self.forbiddenDBCharacters where defaultAuthDB.contains(character) {
+                throw MongoError.InvalidArgumentError(
+                    message: "defaultAuthDB contains invalid character: \(character)"
+                )
             }
             self.defaultAuthDB = defaultAuthDB
             // If no other authentication options were provided, we should use the defaultAuthDB as the credential
@@ -1347,13 +1345,11 @@ extension StringProtocol {
     }
 
     fileprivate func getValidatedUserInfo(forKey key: String) throws -> String {
-        for character in MongoConnectionString.genDelims {
-            if self.contains(character) {
-                throw MongoError.InvalidArgumentError(
-                    message: "\(key) in the connection string contains invalid character that must be percent-encoded:"
-                        + " \(character)"
-                )
-            }
+        for character in MongoConnectionString.genDelims where self.contains(character) {
+            throw MongoError.InvalidArgumentError(
+                message: "\(key) in the connection string contains invalid character that must be percent-encoded:"
+                    + " \(character)"
+            )
         }
         return try self.getPercentDecoded(forKey: key)
     }

--- a/Sources/MongoSwift/MongoCursor.swift
+++ b/Sources/MongoSwift/MongoCursor.swift
@@ -1,7 +1,7 @@
 import CLibMongoC
 import Foundation
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 
 /// Direct wrapper of a `mongoc_cursor_t`.
 internal struct MongocCursor: MongocCursorWrapper {

--- a/Sources/MongoSwift/MongoDatabase.swift
+++ b/Sources/MongoSwift/MongoDatabase.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 
 /// Options to set on a retrieved `MongoCollection`.
 public struct MongoCollectionOptions: CodingStrategyProvider {

--- a/Sources/MongoSwift/Operations/AggregateOperation.swift
+++ b/Sources/MongoSwift/Operations/AggregateOperation.swift
@@ -1,6 +1,6 @@
 import CLibMongoC
 import Foundation
-import NIO
+import NIOCore
 
 /// The entity on which to execute the `aggregate` command against.
 internal enum AggregateTarget<CollectionType: Codable> {

--- a/Sources/MongoSwift/Operations/Operation.swift
+++ b/Sources/MongoSwift/Operations/Operation.swift
@@ -1,4 +1,5 @@
-import NIO
+import NIOCore
+import NIOPosix
 
 /// A protocol for operation types to conform to. An `Operation` instance corresponds to any single operation a user
 /// can perform with the driver's API that requires I/O.

--- a/Sources/MongoSwift/Operations/WatchOperation.swift
+++ b/Sources/MongoSwift/Operations/WatchOperation.swift
@@ -1,5 +1,5 @@
 import CLibMongoC
-import NIO
+import NIOCore
 
 /// The entity on which to start a change stream.
 internal enum ChangeStreamTarget<CollectionType: Codable> {

--- a/Sources/MongoSwiftSync/MongoClient.swift
+++ b/Sources/MongoSwiftSync/MongoClient.swift
@@ -1,5 +1,5 @@
 import MongoSwift
-import NIO
+import NIOPosix
 
 /// A MongoDB Client providing a synchronous API.
 public class MongoClient {

--- a/Sources/TestsCommon/SpecTestUtils.swift
+++ b/Sources/TestsCommon/SpecTestUtils.swift
@@ -1,6 +1,5 @@
 import Foundation
-@testable import MongoSwift
-import NIO
+import MongoSwift
 import XCTest
 
 extension MongoSwiftTestCase {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,1 @@
+// This is a placeholder file which is required for compilation on Swift 5.2.

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,1 +1,0 @@
-// This is a placeholder file which is required for compilation on Swift 5.1.

--- a/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
+++ b/Tests/MongoSwiftSyncTests/UnifiedTestRunner/UnifiedTestRunner.swift
@@ -183,9 +183,13 @@ struct UnifiedTestRunner {
                     let collEntities = context.entities.values.compactMap { try? $0.asCollection() }
                     for (_, client) in try self.internalClient.asMongosClients() {
                         for entity in collEntities {
-                            _ = try client.db(entity.namespace.db).runCommand(
-                                ["distinct": .string(entity.name), "key": "_id"]
-                            )
+                            do {
+                                _ = try client.db(entity.namespace.db).runCommand(
+                                    ["distinct": .string(entity.name), "key": "_id"]
+                                )
+                            } catch let commandError as MongoError.CommandError where commandError.code == 26 {
+                                // ignore NamespaceNotFound errors from distinct.
+                            }
                         }
                     }
                 }

--- a/Tests/MongoSwiftTests/APMTests.swift
+++ b/Tests/MongoSwiftTests/APMTests.swift
@@ -1,8 +1,8 @@
 #if compiler(>=5.5.2) && canImport(_Concurrency)
 import MongoSwift
 import Nimble
-import NIOPosix
 import NIOConcurrencyHelpers
+import NIOPosix
 import TestsCommon
 
 private protocol StreamableEvent {
@@ -177,10 +177,8 @@ final class APMTests: MongoSwiftTestCase {
             let sdamTask = Task { () -> [EventType] in
                 var eventTypeSdam: [EventType] = []
                 taskStarted.store(true)
-                for try await event in client.sdamEventStream() {
-                    if !event.isHeartbeatEvent {
-                        eventTypeSdam.append(event.type)
-                    }
+                for try await event in client.sdamEventStream() where !event.isHeartbeatEvent {
+                    eventTypeSdam.append(event.type)
                 }
                 return eventTypeSdam
             }

--- a/Tests/MongoSwiftTests/APMTests.swift
+++ b/Tests/MongoSwiftTests/APMTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5.2) && canImport(_Concurrency)
 import MongoSwift
 import Nimble
-import NIO
+import NIOPosix
 import NIOConcurrencyHelpers
 import TestsCommon
 

--- a/Tests/MongoSwiftTests/AsyncAwaitTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTestUtils.swift
@@ -2,7 +2,8 @@
 
 import Foundation
 import MongoSwift
-import NIO
+import NIOCore
+import NIOPosix
 import TestsCommon
 import XCTest
 

--- a/Tests/MongoSwiftTests/AsyncAwaitTests.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTests.swift
@@ -3,8 +3,9 @@
 import Foundation
 @testable import MongoSwift
 import Nimble
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
 import TestsCommon
 import XCTest
 

--- a/Tests/MongoSwiftTests/AsyncTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncTestUtils.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MongoSwift
-import NIO
+import NIOCore
+import NIOPosix
 import TestsCommon
 import XCTest
 

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import MongoSwift
 import Nimble
-import NIO
 import NIOConcurrencyHelpers
 import TestsCommon
 

--- a/Tests/MongoSwiftTests/ClientSessionTests.swift
+++ b/Tests/MongoSwiftTests/ClientSessionTests.swift
@@ -1,6 +1,6 @@
 @testable import MongoSwift
 import Nimble
-import NIO
+import NIOCore
 import TestsCommon
 
 final class ClientSessionTests: MongoSwiftTestCase {

--- a/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
+++ b/Tests/MongoSwiftTests/EventLoopBoundMongoClientTests.swift
@@ -1,6 +1,6 @@
 @testable import MongoSwift
 import Nimble
-import NIO
+import NIOPosix
 import TestsCommon
 
 final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
@@ -320,7 +320,7 @@ final class EventLoopBoundMongoClientTests: MongoSwiftTestCase {
             defer { try? db.drop().wait() }
 
             let wrongEventLoop = MultiThreadedEventLoopGroup(numberOfThreads: 4).next()
-            let withSessionFuture: EventLoopFuture<[String]> = elBoundClient.withSession { session in
+            let withSessionFuture = elBoundClient.withSession { session in
                 db.listCollectionNames(session: session).hop(to: wrongEventLoop)
             }
             expect(withSessionFuture.eventLoop) === expectedEventLoop

--- a/Tests/MongoSwiftTests/MongoClientTests.swift
+++ b/Tests/MongoSwiftTests/MongoClientTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import MongoSwift
 import Nimble
-import NIO
+import NIOPosix
 import TestsCommon
 
 final class MongoClientTests: MongoSwiftTestCase {

--- a/Tests/MongoSwiftTests/MongoCursorTests.swift
+++ b/Tests/MongoSwiftTests/MongoCursorTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import MongoSwift
 import Nimble
-import NIO
 import NIOConcurrencyHelpers
 import TestsCommon
 

--- a/Tests/MongoSwiftTests/ReadWriteConcernSpecTests.swift
+++ b/Tests/MongoSwiftTests/ReadWriteConcernSpecTests.swift
@@ -1,6 +1,6 @@
 import MongoSwift
 import Nimble
-import NIO
+import NIOPosix
 import TestsCommon
 
 extension WriteConcern {

--- a/Tests/MongoSwiftTests/ServerSelectionTests.swift
+++ b/Tests/MongoSwiftTests/ServerSelectionTests.swift
@@ -2,7 +2,6 @@
 import Foundation
 @testable import MongoSwift
 import Nimble
-import NIO
 import TestsCommon
 import XCTest
 


### PR DESCRIPTION
This is a collection of several minor changes; my original motivation here was dropping Swift 5.1 support and only depending on the necessary NIO modules, but in the process I ended up picking up some various greener build and Evergreen maintenance type changes that we've fallen behind on in recent months.

Included changes:
* SWIFT-1337: Drop Swift 5.1 support
* SWIFT-1629: Only depend on necessary NIO modules in the driver
* SWIFT-1557: Test against MongoDB 6.0 in Evergreen 
* SWIFT-1566: Test MongoDB 5.0 + load balancer support
* Test against latest MongoDB rapid release in Evergreen
* Fix broken testing against development snapshots by updating the Python script to dynamically get the latest dev snapshot from GitHub, similar to how it currently queries for patch releases. (I will port this to BSON after)
* bump SwiftLint and SwiftFormat versions (installed new versions on my new laptop that found some new violations)