### PR TITLE
SWIFT-1630 Reduce flakiness of CommandStreamBufferPolicy test

### DIFF
--- a/Tests/MongoSwiftTests/APMTests.swift
+++ b/Tests/MongoSwiftTests/APMTests.swift
@@ -66,7 +66,7 @@ final class APMTests: MongoSwiftTestCase {
             let cmdBufferTask = Task { () -> Int in
                 var i = 0
                 let stream = client.commandEventStream()
-                try await assertIsEventuallyTrue(description: "inserts done") {
+                try await assertIsEventuallyTrue(description: "inserts done", timeout: 10) {
                     insertsDone.load()
                 }
 


### PR DESCRIPTION
SWIFT-1630

This PR doubles the time the test waits for a batch of 60 inserts to complete from 5 seconds to 10 seconds after seeing some flakiness. I will say it is a bit concerning that we can't execute that many in the 5 seconds time, but I think that might have more to do with the hosts at our disposal rather than the driver.