### PR TITLE
SWIFT-1610, SWIFT-1378, SWIFT-1632: Spec tests sync + expose clusterTime on ChangeStreamEvent

### DIFF
--- a/Sources/MongoSwift/ChangeStreamEvent.swift
+++ b/Sources/MongoSwift/ChangeStreamEvent.swift
@@ -122,8 +122,8 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
     /// Only present for server versions 6.0 and above.
     public let wallTime: Date?
 
-    /// The cluster time at which the change occurred.
-    public let clusterTime: BSONTimestamp
+    /// The cluster time at which the change occurred. Only present for server versions 4.0 and above.
+    public let clusterTime: BSONTimestamp?
 
     /**
      * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if
@@ -167,7 +167,7 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
 
         self.documentKey = try container.decodeIfPresent(BSONDocument.self, forKey: .documentKey)
         self.wallTime = try container.decodeIfPresent(Date.self, forKey: .wallTime)
-        self.clusterTime = try container.decode(BSONTimestamp.self, forKey: .clusterTime)
+        self.clusterTime = try container.decodeIfPresent(BSONTimestamp.self, forKey: .clusterTime)
         self.updateDescription = try container.decodeIfPresent(UpdateDescription.self, forKey: .updateDescription)
         self.fullDocument = try container.decodeIfPresent(T.self, forKey: .fullDocument)
     }

--- a/Sources/MongoSwift/ChangeStreamEvent.swift
+++ b/Sources/MongoSwift/ChangeStreamEvent.swift
@@ -122,6 +122,9 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
     /// Only present for server versions 6.0 and above.
     public let wallTime: Date?
 
+    /// The cluster time at which the change occurred.
+    public let clusterTime: BSONTimestamp
+
     /**
      * Always present for operations of type `insert` and `replace`. Also present for operations of type `update` if
      * the user has specified `.updateLookup` for the `fullDocument` option in the `ChangeStreamOptions` used to create
@@ -136,7 +139,7 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
     public let fullDocument: T?
 
     private enum CodingKeys: String, CodingKey {
-        case operationType, _id, ns, to, documentKey, updateDescription, wallTime, fullDocument
+        case operationType, _id, ns, to, documentKey, updateDescription, wallTime, clusterTime, fullDocument
     }
 
     // Custom decode method to work around the fact that `invalidate` events do not have an `ns` field in the raw
@@ -164,6 +167,7 @@ public struct ChangeStreamEvent<T: Codable>: Codable {
 
         self.documentKey = try container.decodeIfPresent(BSONDocument.self, forKey: .documentKey)
         self.wallTime = try container.decodeIfPresent(Date.self, forKey: .wallTime)
+        self.clusterTime = try container.decode(BSONTimestamp.self, forKey: .clusterTime)
         self.updateDescription = try container.decodeIfPresent(UpdateDescription.self, forKey: .updateDescription)
         self.fullDocument = try container.decodeIfPresent(T.self, forKey: .fullDocument)
     }

--- a/Sources/TestsCommon/APMUtils.swift
+++ b/Sources/TestsCommon/APMUtils.swift
@@ -82,7 +82,7 @@ public class TestCommandMonitor: CommandEventHandler {
 
 public enum EventType: String, Decodable {
     case commandStartedEvent, commandSucceededEvent, commandFailedEvent, connectionCreatedEvent, connectionReadyEvent,
-        connectionClosedEvent, connectionCheckedInEvent, connectionCheckOutStartedEvent, connectionCheckedOutEvent,
+         connectionClosedEvent, connectionCheckedInEvent, connectionCheckOutStartedEvent, connectionCheckedOutEvent,
          connectionCheckOutFailedEvent, poolCreatedEvent, poolReadyEvent, poolClearedEvent, poolClosedEvent,
          topologyDescriptionChanged, topologyOpening, topologyClosed, serverDescriptionChanged, serverOpening,
          serverClosed, serverHeartbeatStarted, serverHeartbeatSucceeded, serverHeartbeatFailed

--- a/Sources/TestsCommon/APMUtils.swift
+++ b/Sources/TestsCommon/APMUtils.swift
@@ -81,13 +81,11 @@ public class TestCommandMonitor: CommandEventHandler {
 }
 
 public enum EventType: String, Decodable {
-    case commandStartedEvent, commandSucceededEvent, commandFailedEvent,
-         connectionCreatedEvent, connectionReadyEvent, connectionClosedEvent,
-         connectionCheckedInEvent, connectionCheckedOutEvent, connectionCheckOutFailedEvent,
-         poolCreatedEvent, poolReadyEvent, poolClearedEvent, poolClosedEvent,
-         topologyDescriptionChanged, topologyOpening, topologyClosed, serverDescriptionChanged,
-         serverOpening, serverClosed, serverHeartbeatStarted, serverHeartbeatSucceeded,
-         serverHeartbeatFailed
+    case commandStartedEvent, commandSucceededEvent, commandFailedEvent, connectionCreatedEvent, connectionReadyEvent,
+        connectionClosedEvent, connectionCheckedInEvent, connectionCheckOutStartedEvent, connectionCheckedOutEvent,
+         connectionCheckOutFailedEvent, poolCreatedEvent, poolReadyEvent, poolClearedEvent, poolClosedEvent,
+         topologyDescriptionChanged, topologyOpening, topologyClosed, serverDescriptionChanged, serverOpening,
+         serverClosed, serverHeartbeatStarted, serverHeartbeatSucceeded, serverHeartbeatFailed
 }
 
 extension CommandEvent {

--- a/Tests/MongoSwiftTests/AsyncAwaitTestUtils.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTestUtils.swift
@@ -165,9 +165,9 @@ extension MongoClient {
     }
 
     internal func getUnmetRequirement(_ testRequirement: TestRequirement) async throws -> UnmetRequirement? {
-        async let topologyType = try self.topologyType()
-        async let serverVersion = try self.serverVersion()
-        async let params = try self.serverParameters()
+        async let topologyType = try await self.topologyType()
+        async let serverVersion = try await self.serverVersion()
+        async let params = try await self.serverParameters()
         return try await testRequirement.getUnmetRequirement(givenCurrent: serverVersion, topologyType, params)
     }
 

--- a/Tests/MongoSwiftTests/AsyncAwaitTests.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTests.swift
@@ -234,7 +234,7 @@ final class MongoCursorAsyncAwaitTests: MongoSwiftTestCase {
         }
 
         testAsync {
-            let opts = CreateCollectionOptions(capped: true, max: 5, size: 100000)
+            let opts = CreateCollectionOptions(capped: true, max: 5, size: 100_000)
             try await self.withTestNamespace(collectionOptions: opts) { _, _, coll in
                 try await coll.insertMany([["x": 1], ["x": 2], ["x": 3]])
 

--- a/Tests/MongoSwiftTests/AsyncAwaitTests.swift
+++ b/Tests/MongoSwiftTests/AsyncAwaitTests.swift
@@ -234,7 +234,7 @@ final class MongoCursorAsyncAwaitTests: MongoSwiftTestCase {
         }
 
         testAsync {
-            let opts = CreateCollectionOptions(capped: true, size: 5)
+            let opts = CreateCollectionOptions(capped: true, max: 5, size: 100000)
             try await self.withTestNamespace(collectionOptions: opts) { _, _, coll in
                 try await coll.insertMany([["x": 1], ["x": 2], ["x": 3]])
 

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -171,7 +171,9 @@ final class ChangeStreamTests: MongoSwiftTestCase {
             // TODO: SWIFT-1458 Unskip.
             "change-streams-showExpandedEvents.json",
             // TODO: SWIFT-1472 Unskip.
-            "change-streams-pre_and_post_images.json"
+            "change-streams-pre_and_post_images.json",
+            // TODO: SWIFT-1614 Unskip.
+            "change-streams-disambiguatedPaths.json"
         ]
         let tests = try retrieveSpecTestFiles(
             specName: "change-streams",

--- a/Tests/MongoSwiftTests/ChangeStreamTests.swift
+++ b/Tests/MongoSwiftTests/ChangeStreamTests.swift
@@ -187,7 +187,12 @@ final class ChangeStreamTests: MongoSwiftTestCase {
 
     func testClusterTime() async throws {
         try await self.withTestClient { client in
-            let unmetRequirement = try await client.getUnmetRequirement(.changeStreamOnCollectionSupport)
+            // cluster time is only included as of 4.0.
+            let requirement = TestRequirement(
+                minServerVersion: ServerVersion(major: 4, minor: 0, patch: 0),
+                acceptableTopologies: [.replicaSet, .sharded, .shardedReplicaSet, .loadBalanced]
+            )
+            let unmetRequirement = try await client.getUnmetRequirement(requirement)
             guard unmetRequirement == nil else {
                 printSkipMessage(testName: self.name, unmetRequirement: unmetRequirement!)
                 return

--- a/Tests/MongoSwiftTests/Failpoint.swift
+++ b/Tests/MongoSwiftTests/Failpoint.swift
@@ -29,9 +29,10 @@ extension FailPoint {
     /// Enables the failpoint, and returns a `EnabledFailpoint` which can handle disabling when needed
     internal func enable(
         using client: MongoClient,
-        options: RunCommandOptions? = nil
+        options: RunCommandOptions? = nil,
+        session: ClientSession? = nil
     ) async throws -> EnabledFailpoint {
-        try await client.db("admin").runCommand(self.failPoint, options: options)
+        try await client.db("admin").runCommand(self.failPoint, options: options, session: session)
         return EnabledFailpoint(failPoint: self, client: client)
     }
 

--- a/Tests/MongoSwiftTests/UnifiedTestRunner/SpecialTestOperations.swift
+++ b/Tests/MongoSwiftTests/UnifiedTestRunner/SpecialTestOperations.swift
@@ -12,14 +12,18 @@ struct UnifiedFailPoint: UnifiedOperationProtocol {
     /// The client entity to use for setting the failpoint.
     let client: String
 
+    /// Optional name of a session entity to use for setting the failpoint.
+    let session: String?
+
     static var knownArguments: Set<String> {
-        ["failPoint", "client"]
+        ["failPoint", "client", "session"]
     }
 
     func execute(on _: UnifiedOperation.Object, context: Context) async throws -> UnifiedOperationResult {
         let testClient = try context.entities.getEntity(id: self.client).asTestClient()
+        let session = try context.entities.resolveSession(id: self.session)
         let opts = RunCommandOptions(readPreference: .primary)
-        let fpGuard = try await self.failPoint.enable(using: testClient.client, options: opts)
+        let fpGuard = try await self.failPoint.enable(using: testClient.client, options: opts, session: session)
         context.enabledFailPoints.append(fpGuard)
         return .none
     }

--- a/Tests/Specs/change-streams/tests/unified/change-streams-clusterTime.json
+++ b/Tests/Specs/change-streams/tests/unified/change-streams-clusterTime.json
@@ -1,0 +1,81 @@
+{
+  "description": "change-streams-clusterTime",
+  "schemaVersion": "1.3",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced",
+        "sharded"
+      ]
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "clusterTime is present",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "clusterTime": {
+              "$$exists": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/change-streams/tests/unified/change-streams-clusterTime.yml
+++ b/Tests/Specs/change-streams/tests/unified/change-streams-clusterTime.yml
@@ -1,0 +1,40 @@
+description: "change-streams-clusterTime"
+schemaVersion: "1.3"
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: *database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: *collection0
+
+runOnRequirements:
+  - minServerVersion: "4.0.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+
+initialData:
+  - collectionName: *collection0
+    databaseName: *database0
+    documents: []
+
+tests:
+  - description: "clusterTime is present"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          ns: { db: *database0, coll: *collection0 }
+          clusterTime: { $$exists: true }

--- a/Tests/Specs/change-streams/tests/unified/change-streams-disambiguatedPaths.json
+++ b/Tests/Specs/change-streams/tests/unified/change-streams-disambiguatedPaths.json
@@ -1,0 +1,252 @@
+{
+  "description": "disambiguatedPaths",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.1.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "disambiguatedPaths is not present when showExpandedEvents is false/unset",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "$$exists": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "disambiguatedPaths is present on updateDescription when an ambiguous path is present",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "a.1": [
+                  "a",
+                  "1"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "disambiguatedPaths returns array indices as integers",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": [
+                {
+                  "1": 1
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.0.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "a.0.1": [
+                  "a",
+                  {
+                    "$$type": "int"
+                  },
+                  "1"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
+++ b/Tests/Specs/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
@@ -1,0 +1,103 @@
+description: "disambiguatedPaths"
+schemaVersion: "1.4"
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: *database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: *collection0
+
+runOnRequirements:
+  - minServerVersion: "6.1.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+    serverless: forbid
+
+initialData:
+  - collectionName: *collection0
+    databaseName: *database0
+    documents: []
+
+tests:
+  - description: "disambiguatedPaths is not present when showExpandedEvents is false/unset"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': { '1': 1 } }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { $$exists: false }
+
+  - description: "disambiguatedPaths is present on updateDescription when an ambiguous path is present"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': { '1': 1 } }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [], showExpandedEvents: true }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { 'a.1': ['a', '1'] }
+
+  - description: "disambiguatedPaths returns array indices as integers"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': [{'1': 1 }] }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [], showExpandedEvents: true }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.0.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { 'a.0.1': ['a', { $$type: 'int' },  '1'] }

--- a/Tests/Specs/change-streams/tests/unified/change-streams-showExpandedEvents.json
+++ b/Tests/Specs/change-streams/tests/unified/change-streams-showExpandedEvents.json
@@ -275,7 +275,15 @@
           "name": "createChangeStream",
           "object": "collection0",
           "arguments": {
-            "pipeline": [],
+            "pipeline": [
+              {
+                "$match": {
+                  "operationType": {
+                    "$ne": "create"
+                  }
+                }
+              }
+            ],
             "showExpandedEvents": true
           },
           "saveResultAsEntity": "changeStream0"

--- a/Tests/Specs/change-streams/tests/unified/change-streams-showExpandedEvents.yml
+++ b/Tests/Specs/change-streams/tests/unified/change-streams-showExpandedEvents.yml
@@ -160,7 +160,15 @@ tests:
       - name: createChangeStream
         object: *collection0
         arguments:
-          pipeline: []
+          pipeline:
+            # On sharded clusters, the create command run when loading initial
+            # data sometimes is still reported in the change stream. To avoid
+            # this, we exclude the create command when creating the change
+            # stream, but specifically don't exclude other events to still catch
+            # driver errors.
+            - $match:
+                operationType:
+                  $ne: create
           showExpandedEvents: true
         saveResultAsEntity: &changeStream0 changeStream0
       - name: createIndex

--- a/Tests/Specs/transactions/tests/unified/do-not-retry-read-in-transaction.json
+++ b/Tests/Specs/transactions/tests/unified/do-not-retry-read-in-transaction.json
@@ -1,0 +1,115 @@
+{
+  "description": "do not retry read in a transaction",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.2.0",
+      "topologies": [
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "retryReads": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-read-in-transaction-test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "find does not retry in a transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "startTransaction": true
+                },
+                "commandName": "find",
+                "databaseName": "retryable-read-in-transaction-test"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/transactions/tests/unified/do-not-retry-read-in-transaction.yml
+++ b/Tests/Specs/transactions/tests/unified/do-not-retry-read-in-transaction.yml
@@ -1,0 +1,64 @@
+description: "do not retry read in a transaction"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "4.0.0"
+    topologies: [ replicaset ]
+  - minServerVersion: "4.2.0"
+    topologies: [ sharded, load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent]
+      uriOptions: { retryReads: true }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-read-in-transaction-test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - session:
+      id: &session0 session0
+      client: *client0
+
+tests:
+  - description: "find does not retry in a transaction"
+    operations:
+
+      - name: startTransaction
+        object: *session0
+
+      - name: failPoint # fail the following find command
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [find]
+              closeConnection: true
+
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+          session: *session0
+        expectError:
+          isError: true
+          errorLabelsContain: ["TransientTransactionError"]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+                startTransaction: true
+              commandName: find
+              databaseName: *databaseName

--- a/Tests/Specs/transactions/tests/unified/mongos-unpin.yml
+++ b/Tests/Specs/transactions/tests/unified/mongos-unpin.yml
@@ -1,0 +1,172 @@
+description: mongos-unpin
+
+schemaVersion: '1.4'
+
+runOnRequirements:
+  - minServerVersion: '4.2'
+    topologies: [ sharded-replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name mongos-unpin-db
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+_yamlAnchors:
+  anchors:
+    # LockTimeout will cause the server to add a TransientTransactionError label. It is not retryable.
+    &lockTimeoutErrorCode 24
+
+tests:
+  - description: unpin after TransientTransactionError error on commit
+    runOnRequirements:
+        # serverless proxy doesn't append error labels to errors in transactions
+        # caused by failpoints (CLOUDP-88216)
+      - serverless: "forbid"
+    operations:
+      - &startTransaction
+        name: startTransaction
+        object: *session0
+      - &insertOne
+        name: insertOne
+        object: *collection0
+        arguments:
+          document: { x: 1 }
+          session: *session0
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ commitTransaction ]
+              errorCode: *lockTimeoutErrorCode
+      - name: commitTransaction
+        object: *session0
+        expectError:
+          # LockTimeout is not retryable, so the commit fails.
+          errorCode: *lockTimeoutErrorCode
+          errorLabelsContain: [ TransientTransactionError ]
+          errorLabelsOmit: [ UnknownTransactionCommitResult ]
+      - &assertNoPinnedServer
+        name: assertSessionUnpinned
+        object: testRunner
+        arguments:
+          session: *session0
+      # Cleanup the potentionally open server transaction by starting and
+      # aborting a new transaction on the same session.
+      - *startTransaction
+      - *insertOne
+      - &abortTransaction
+        name: abortTransaction
+        object: *session0
+
+  - description: unpin on successful abort
+    operations:
+      - *startTransaction
+      - *insertOne
+      - *abortTransaction
+      - *assertNoPinnedServer
+
+  - description: unpin after non-transient error on abort
+    runOnRequirements:
+        # serverless proxy doesn't append error labels to errors in transactions
+        # caused by failpoints (CLOUDP-88216)
+      - serverless: "forbid"
+    operations:
+      - *startTransaction
+      - *insertOne
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ abortTransaction ]
+              errorCode: *lockTimeoutErrorCode
+      - *abortTransaction
+      - *assertNoPinnedServer
+      # Cleanup the potentionally open server transaction by starting and
+      # aborting a new transaction on the same session.
+      - *startTransaction
+      - *insertOne
+      - *abortTransaction
+
+  - description: unpin after TransientTransactionError error on abort
+    operations:
+      - *startTransaction
+      - *insertOne
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ abortTransaction ]
+              errorCode: 91 # ShutdownInProgress
+      - *abortTransaction
+      - *assertNoPinnedServer
+      # Cleanup the potentionally open server transaction by starting and
+      # aborting a new transaction on the same session.
+      - *startTransaction
+      - *insertOne
+      - *abortTransaction
+
+  - description: unpin when a new transaction is started
+    operations:
+      - *startTransaction
+      - *insertOne
+      - name: commitTransaction
+        object: *session0
+      - &assertPinnedServer
+        name: assertSessionPinned
+        object: testRunner
+        arguments:
+          session: *session0
+      - *startTransaction
+      - *assertNoPinnedServer
+
+  - description: unpin when a non-transaction write operation uses a session
+    operations:
+      - *startTransaction
+      - *insertOne
+      - name: commitTransaction
+        object: *session0
+      - *assertPinnedServer
+      - *insertOne
+      - *assertNoPinnedServer
+
+  - description: unpin when a non-transaction read operation uses a session
+    operations:
+      - *startTransaction
+      - *insertOne
+      - name: commitTransaction
+        object: *session0
+      - *assertPinnedServer
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { x: 1 }
+          session: *session0
+      - *assertNoPinnedServer

--- a/Tests/Specs/transactions/tests/unified/retryable-abort-handshake.json
+++ b/Tests/Specs/transactions/tests/unified/retryable-abort-handshake.json
@@ -1,0 +1,204 @@
+{
+  "description": "retryable abortTransaction on handshake errors",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid",
+      "auth": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent",
+          "connectionCheckOutStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-handshake-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session1",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "retryable-handshake-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "AbortTransaction succeeds after handshake network error",
+      "skipReason": "DRIVERS-2032: Pinned servers need to be checked if they are still selectable",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2,
+              "x": 22
+            }
+          }
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "session": "session1",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "saslContinue",
+                  "ping"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "session": "session1"
+          },
+          "expectError": {
+            "isError": true
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "connectionCheckOutStartedEvent": {}
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "startTransaction": true
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-handshake-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1
+                },
+                "databaseName": "retryable-handshake-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "abortTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "abortTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-handshake-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/transactions/tests/unified/retryable-abort-handshake.yml
+++ b/Tests/Specs/transactions/tests/unified/retryable-abort-handshake.yml
@@ -1,0 +1,118 @@
+description: "retryable abortTransaction on handshake errors"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "4.2"
+    topologies: [replicaset, sharded, load-balanced]
+    serverless: "forbid"
+    auth: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent, connectionCheckOutStartedEvent]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-handshake-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - session:
+      # This session will be used to execute the transaction
+      id: &session0 session0
+      client: *client0
+  - session:
+      # This session will be used to create the failPoint, and empty the pool
+      id: &session1 session1
+      client: *client0
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "AbortTransaction succeeds after handshake network error"
+    skipReason: "DRIVERS-2032: Pinned servers need to be checked if they are still selectable"
+    operations:
+
+      - name: startTransaction
+        object: *session0
+
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2, x: 22 }
+
+      # The following failPoint and ping utilize session1 so that
+      # the transaction won't be failed by the intentional erroring of ping
+      # and it will have an empty pool when it goes to run abortTransaction
+      - name: failPoint # fail the next connection establishment
+        object: testRunner
+        arguments:
+          client: *client0
+          session: *session1
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              # use saslContinue here to avoid SDAM errors
+              # this failPoint itself will create a usable connection in the connection pool
+              # so we run a ping (with closeConnection: true) in order to discard the connection
+              # before testing that abortTransaction will fail a handshake but will get retried
+              failCommands: [saslContinue, ping]
+              closeConnection: true
+
+      - name: runCommand
+        object: *database0
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+          session: *session1
+        expectError:
+          isError: true
+
+      - name: abortTransaction
+        object: *session0
+
+    expectEvents:
+      - client: *client0
+        eventType: cmap
+        events:
+          - { connectionCheckOutStartedEvent: {} } # startTransaction
+          - { connectionCheckOutStartedEvent: {} } # insertOne
+          - { connectionCheckOutStartedEvent: {} } # failPoint
+          - { connectionCheckOutStartedEvent: {} } # abortTransaction
+          - { connectionCheckOutStartedEvent: {} } # abortTransaction retry
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [{ _id: 2, x: 22 }]
+                startTransaction: true
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                ping: 1
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                abortTransaction: 1
+                lsid:
+                  $$sessionLsid: *session0
+              commandName: abortTransaction
+              databaseName: admin
+
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }

--- a/Tests/Specs/transactions/tests/unified/retryable-commit-handshake.json
+++ b/Tests/Specs/transactions/tests/unified/retryable-commit-handshake.json
@@ -1,0 +1,211 @@
+{
+  "description": "retryable commitTransaction on handshake errors",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid",
+      "auth": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent",
+          "connectionCheckOutStartedEvent"
+        ],
+        "uriOptions": {
+          "retryWrites": false
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-handshake-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session1",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "retryable-handshake-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "CommitTransaction succeeds after handshake network error",
+      "skipReason": "DRIVERS-2032: Pinned servers need to be checked if they are still selectable",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2,
+              "x": 22
+            }
+          }
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "session": "session1",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "saslContinue",
+                  "ping"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "session": "session1"
+          },
+          "expectError": {
+            "isError": true
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "connectionCheckOutStartedEvent": {}
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "startTransaction": true
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-handshake-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1
+                },
+                "databaseName": "retryable-handshake-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-handshake-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Specs/transactions/tests/unified/retryable-commit-handshake.yml
+++ b/Tests/Specs/transactions/tests/unified/retryable-commit-handshake.yml
@@ -1,0 +1,118 @@
+description: "retryable commitTransaction on handshake errors"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "4.2"
+    topologies: [replicaset, sharded, load-balanced]
+    serverless: "forbid"
+    auth: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent, connectionCheckOutStartedEvent]
+      uriOptions: { retryWrites: false } # commitTransaction is retryable regardless of this option being set
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-handshake-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - session:
+      id: &session0 session0
+      client: *client0
+  - session:
+      id: &session1 session1
+      client: *client0
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "CommitTransaction succeeds after handshake network error"
+    skipReason: "DRIVERS-2032: Pinned servers need to be checked if they are still selectable"
+    operations:
+
+      - name: startTransaction
+        object: *session0
+
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2, x: 22 }
+
+      # The following failPoint and ping utilize session1 so that
+      # the transaction won't be failed by the intentional erroring of ping
+      # and it will have an empty pool when it goes to run commitTransaction
+      - name: failPoint # fail the next connection establishment
+        object: testRunner
+        arguments:
+          client: *client0
+          session: *session1
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              # use saslContinue here to avoid SDAM errors
+              # this failPoint itself will create a usable connection in the connection pool
+              # so we run a ping (that also fails) in order to discard the connection
+              # before testing that commitTransaction gets retried
+              failCommands: [saslContinue, ping]
+              closeConnection: true
+
+      - name: runCommand
+        object: *database0
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+          session: *session1
+        expectError:
+          isError: true
+
+      - name: commitTransaction
+        object: *session0
+
+    expectEvents:
+      - client: *client0
+        eventType: cmap
+        events:
+          - { connectionCheckOutStartedEvent: {} } # startTransaction
+          - { connectionCheckOutStartedEvent: {} } # insertOne
+          - { connectionCheckOutStartedEvent: {} } # failPoint
+          - { connectionCheckOutStartedEvent: {} } # commitTransaction
+          - { connectionCheckOutStartedEvent: {} } # commitTransaction retry
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [{ _id: 2, x: 22 }]
+                startTransaction: true
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                ping: 1
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid:
+                  $$sessionLsid: *session0
+              commandName: commitTransaction
+              databaseName: admin
+
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 } # The write was still applied


### PR DESCRIPTION
I picked up SWIFT-1610 which was a test sync; the sync also brought in the files from SWIFT-1378.

I also picked up SWIFT-1632 which I thought was just a test sync but it turns out we didn't have a `clusterTime` on `ChangeStreamEvent`. It seems like we decided against that in SWIFT-428 but now that there is a spec test it seems like we'd want to have one for compliance and parity with other drivers. 